### PR TITLE
test: improve unit test coverage for pure-logic functions

### DIFF
--- a/crates/ascii-agents/src/cli.rs
+++ b/crates/ascii-agents/src/cli.rs
@@ -69,3 +69,41 @@ impl Cli {
         (level, theme, cmd)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cmd_or_default_returns_run_when_no_subcommand() {
+        let cli = Cli {
+            cmd: None,
+            log_level: "info".into(),
+            theme: "normal".into(),
+        };
+        let (level, theme, cmd) = cli.cmd_or_default();
+        assert_eq!(level, "info");
+        assert_eq!(theme, "normal");
+        assert!(matches!(
+            cmd,
+            Cmd::Run {
+                headless: false,
+                max_desks: 16,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn cmd_or_default_preserves_explicit_subcommand() {
+        let cli = Cli {
+            cmd: Some(Cmd::UninstallHooks { settings: None }),
+            log_level: "debug".into(),
+            theme: "cyberpunk".into(),
+        };
+        let (level, theme, cmd) = cli.cmd_or_default();
+        assert_eq!(level, "debug");
+        assert_eq!(theme, "cyberpunk");
+        assert!(matches!(cmd, Cmd::UninstallHooks { .. }));
+    }
+}

--- a/crates/ascii-agents/src/tui/pathfind.rs
+++ b/crates/ascii-agents/src/tui/pathfind.rs
@@ -529,4 +529,77 @@ mod tests {
         let (nx, ny) = result.unwrap();
         assert!(nx <= MAX_SNAP_RADIUS && ny <= MAX_SNAP_RADIUS);
     }
+
+    #[test]
+    fn heuristic_zero_for_same_cell() {
+        assert_eq!(heuristic((5, 5), (5, 5)), 0);
+    }
+
+    #[test]
+    fn heuristic_straight_horizontal() {
+        assert_eq!(heuristic((0, 0), (3, 0)), 30);
+    }
+
+    #[test]
+    fn heuristic_diagonal_uses_octile() {
+        let h = heuristic((0, 0), (2, 2));
+        assert_eq!(h, 28);
+    }
+
+    #[test]
+    fn cell_of_maps_pixel_to_cell() {
+        assert_eq!(cell_of(Point { x: 0, y: 0 }), (0, 0));
+        assert_eq!(cell_of(Point { x: 7, y: 11 }), (1, 2));
+        assert_eq!(cell_of(Point { x: 4, y: 4 }), (1, 1));
+    }
+
+    #[test]
+    fn cell_center_is_midpoint_of_cell() {
+        let c = cell_center(0, 0);
+        assert_eq!(c, Point { x: 2, y: 2 });
+        let c = cell_center(3, 5);
+        assert_eq!(c, Point { x: 14, y: 22 });
+    }
+
+    #[test]
+    fn cell_in_zone_false_when_none() {
+        assert!(!cell_in_zone(None, 5, 5));
+    }
+
+    #[test]
+    fn cell_in_zone_true_when_inside() {
+        let zone = Bounds {
+            x: 0,
+            y: 0,
+            width: 40,
+            height: 40,
+        };
+        assert!(cell_in_zone(Some(zone), 2, 2));
+    }
+
+    #[test]
+    fn cell_in_zone_false_when_outside() {
+        let zone = Bounds {
+            x: 0,
+            y: 0,
+            width: 10,
+            height: 10,
+        };
+        assert!(!cell_in_zone(Some(zone), 20, 20));
+    }
+
+    #[test]
+    fn cell_walkable_on_open_mask() {
+        let mask = WalkableMask::new_open(100, 100);
+        let overlay = OccupancyOverlay::new();
+        assert!(cell_walkable(&mask, &overlay, 5, 5));
+    }
+
+    #[test]
+    fn cell_walkable_false_when_blocked_by_overlay() {
+        let mask = WalkableMask::new_open(100, 100);
+        let mut overlay = OccupancyOverlay::new();
+        overlay.add(20, 20, CELL_SIZE, CELL_SIZE);
+        assert!(!cell_walkable(&mask, &overlay, 5, 5));
+    }
 }

--- a/crates/ascii-agents/src/tui/pose.rs
+++ b/crates/ascii-agents/src/tui/pose.rs
@@ -485,4 +485,27 @@ mod tests {
         let mut router = StubRouter::straight();
         assert!(derive_with_routing(&slot, now, &l, &mut router, &overlay, &mut history).is_none());
     }
+
+    #[test]
+    fn pose_history_record_and_recent() {
+        let id = AgentId::from_transcript_path("/test/a.jsonl");
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+        let pt = Point { x: 42, y: 99 };
+        let mut history = PoseHistory::new();
+        assert!(history.recent(id, 500, now).is_none());
+        history.record(id, pt, now);
+        assert_eq!(history.recent(id, 500, now), Some(pt));
+    }
+
+    #[test]
+    fn pose_history_recent_expires() {
+        let id = AgentId::from_transcript_path("/test/b.jsonl");
+        let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+        let pt = Point { x: 10, y: 20 };
+        let mut history = PoseHistory::new();
+        history.record(id, pt, t0);
+        let t1 = t0 + Duration::from_millis(600);
+        assert_eq!(history.recent(id, 500, t1), None);
+        assert_eq!(history.recent(id, 700, t1), Some(pt));
+    }
 }

--- a/crates/ascii-agents/src/tui/renderer.rs
+++ b/crates/ascii-agents/src/tui/renderer.rs
@@ -1130,4 +1130,40 @@ mod tests {
         let crosses = line.matches('×').count();
         assert_eq!(crosses, 4, "expected ≤4 tools in breakdown: {line:?}");
     }
+
+    #[test]
+    fn coffee_machine_hit_test_returns_false_for_tiny_buffer() {
+        let buf = RgbBuffer::filled(10, 10, Rgb(0, 0, 0));
+        assert!(!hit_test_coffee_machine(&buf, 4, 5, 5));
+    }
+
+    #[test]
+    fn coffee_machine_hit_test_returns_false_for_origin() {
+        let buf = RgbBuffer::filled(160, 200, Rgb(0, 0, 0));
+        assert!(!hit_test_coffee_machine(&buf, 4, 0, 0));
+    }
+
+    #[test]
+    fn coffee_machine_hit_test_returns_true_for_machine_area() {
+        let buf = RgbBuffer::filled(160, 200, Rgb(0, 0, 0));
+        let layout = Layout::compute(160, 200, 4).expect("layout");
+        let pantry_wp = layout
+            .waypoints
+            .iter()
+            .find(|w| w.kind == crate::tui::layout::WaypointKind::Pantry)
+            .expect("pantry");
+        let (cw, ch) = layout.pantry_counter_size;
+        let sprite_x = pantry_wp.pos.x.saturating_sub(cw / 2);
+        let sprite_y = pantry_wp.pos.y.saturating_sub(ch / 2);
+        let mid_x = if cw >= 32 {
+            sprite_x + 14
+        } else {
+            sprite_x + 10
+        };
+        let mid_cell_y = (sprite_y + ch / 2) / 2;
+        assert!(
+            hit_test_coffee_machine(&buf, 4, mid_x, mid_cell_y),
+            "expected hit at coffee machine area ({mid_x}, {mid_cell_y})"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Add 17 new unit tests covering previously untested pure-logic functions
- Binary crate tests: 66 → 83

### New test coverage:
- **pathfind.rs**: `heuristic()`, `cell_of()`, `cell_center()`, `cell_in_zone()`, `cell_walkable()` — geometry helpers used by A* router
- **pose.rs**: `PoseHistory::record()`/`recent()` — state cache with expiry
- **renderer.rs**: `hit_test_coffee_machine()` — BMC Easter egg hit detection
- **cli.rs**: `cmd_or_default()` — default subcommand resolution

## Test plan
- [x] All 83 binary crate tests pass
- [x] Clippy clean
- [x] rustfmt clean
- [ ] Codecov patch coverage check

🤖 Generated with [Claude Code](https://claude.com/claude-code)