### PR TITLE
feat: thinking pose for idle agents + smaller ? bubble

### DIFF
--- a/crates/ascii-agents-core/src/pose.rs
+++ b/crates/ascii-agents-core/src/pose.rs
@@ -200,11 +200,12 @@ pub fn derive(slot: &AgentSlot, now: SystemTime, layout: &SceneLayout) -> Option
         }
         ActivityState::Waiting { .. } => Some(Pose::StandingAtDesk),
         ActivityState::Idle => {
+            let was_active = slot.last_event_at > slot.created_at;
             let since_last_event = now
                 .duration_since(slot.last_event_at)
                 .unwrap_or(Duration::ZERO)
                 .as_secs();
-            if since_last_event < THINKING_WINDOW_SECS {
+            if was_active && since_last_event < THINKING_WINDOW_SECS {
                 Some(Pose::SeatedThinking)
             } else {
                 Some(idle_pose(slot, desk, layout, elapsed))
@@ -649,5 +650,32 @@ mod tests {
             dest_xs.len() >= 2,
             "destination should vary across cycles, got {dest_xs:?}"
         );
+    }
+
+    #[test]
+    fn idle_within_thinking_window_returns_seated_thinking() {
+        let (mut s, now) = slot(ActivityState::Idle, 5_000);
+        s.last_event_at = now - Duration::from_secs(5);
+        let l = layout();
+        let p = derive(&s, now, &l).unwrap();
+        assert_eq!(p, Pose::SeatedThinking);
+    }
+
+    #[test]
+    fn idle_past_thinking_window_returns_idle_pose() {
+        let (mut s, now) = slot(ActivityState::Idle, 25_000);
+        s.last_event_at = now - Duration::from_secs(25);
+        let l = layout();
+        let p = derive(&s, now, &l).unwrap();
+        assert_ne!(p, Pose::SeatedThinking);
+    }
+
+    #[test]
+    fn freshly_spawned_idle_skips_thinking() {
+        let (s, now) = slot(ActivityState::Idle, 5_000);
+        assert_eq!(s.last_event_at, s.created_at);
+        let l = layout();
+        let p = derive(&s, now, &l).unwrap();
+        assert_ne!(p, Pose::SeatedThinking);
     }
 }

--- a/crates/ascii-agents-core/src/pose.rs
+++ b/crates/ascii-agents-core/src/pose.rs
@@ -19,6 +19,11 @@ use crate::layout::{Bounds, Point, SceneLayout, WaypointKind};
 use crate::state::{ActivityState, AgentSlot};
 use crate::AgentId;
 
+/// How long after the last event an Idle agent stays in the "thinking"
+/// pose (seated, awake, no z's) before entering the wander/sleep cycle.
+/// 20s covers typical CC thinking pauses between tool bursts.
+const THINKING_WINDOW_SECS: u64 = 20;
+
 /// Base cycle length. Each agent's actual cycle = base + per-agent jitter.
 pub const WANDER_CYCLE_BASE_MS: u64 = 7_000;
 /// Maximum extra time added per agent — jitter range is `[0, RANGE)`.
@@ -98,6 +103,9 @@ pub fn waypoint_index_for_cycle(agent_id: AgentId, cycle_n: u64, num_waypoints: 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Pose {
     SeatedIdle,
+    /// Seated at desk, awake but not typing. Used when the agent
+    /// recently finished a tool call and the LLM is likely thinking.
+    SeatedThinking,
     SeatedTyping {
         frame: usize,
     },
@@ -191,7 +199,17 @@ pub fn derive(slot: &AgentSlot, now: SystemTime, layout: &SceneLayout) -> Option
             Some(Pose::SeatedTyping { frame })
         }
         ActivityState::Waiting { .. } => Some(Pose::StandingAtDesk),
-        ActivityState::Idle => Some(idle_pose(slot, desk, layout, elapsed)),
+        ActivityState::Idle => {
+            let since_last_event = now
+                .duration_since(slot.last_event_at)
+                .unwrap_or(Duration::ZERO)
+                .as_secs();
+            if since_last_event < THINKING_WINDOW_SECS {
+                Some(Pose::SeatedThinking)
+            } else {
+                Some(idle_pose(slot, desk, layout, elapsed))
+            }
+        }
     }
 }
 

--- a/crates/ascii-agents/examples/snapshot.rs
+++ b/crates/ascii-agents/examples/snapshot.rs
@@ -437,10 +437,10 @@ fn sample_scene(now: SystemTime, max_desks: usize) -> SceneState {
             },
             D::from_secs(10),
         ),
-        ("idle-a", ActivityState::Idle, D::from_secs(300)), // 5 min — many cycles completed
+        ("thinking", ActivityState::Idle, D::from_secs(5)), // 5s ago — within thinking window
+        ("idle-a", ActivityState::Idle, D::from_secs(300)), // 5 min — wander/sleep cycle
         ("idle-b", ActivityState::Idle, D::from_secs(301)),
-        ("idle-c", ActivityState::Idle, D::from_secs(302)),
-        ("idle-d", ActivityState::Idle, D::from_secs(303)),
+        ("idle-c", ActivityState::Idle, D::from_secs(303)),
         (
             "couch-act",
             ActivityState::Active {

--- a/crates/ascii-agents/src/tui/pixel_painter/anchors.rs
+++ b/crates/ascii-agents/src/tui/pixel_painter/anchors.rs
@@ -45,7 +45,7 @@ fn breath_offset_y(agent_id: ascii_agents_core::AgentId, now: SystemTime) -> u16
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
         .unwrap_or(0);
-    const CYCLE_MS: u64 = 2800;
+    const CYCLE_MS: u64 = 4500;
     let offset_ms = agent_id.raw() % CYCLE_MS;
     let phase = elapsed_ms.wrapping_add(offset_ms) % CYCLE_MS;
     if phase < CYCLE_MS / 2 {

--- a/crates/ascii-agents/src/tui/pixel_painter/drawable.rs
+++ b/crates/ascii-agents/src/tui/pixel_painter/drawable.rs
@@ -23,7 +23,8 @@ use ascii_agents_core::sprite::{Rgb, RgbBuffer};
 use ascii_agents_core::AgentSlot;
 
 use super::effects::{
-    paint_coffee_steam, paint_screen_glow, paint_sleep_z, paint_waiting_bubble, paint_walking_dust,
+    paint_coffee_steam, paint_screen_glow, paint_sleep_z, paint_thinking_dots,
+    paint_waiting_bubble, paint_walking_dust,
 };
 use super::{
     paint_area_rug, paint_character_at, paint_coffee_table, paint_pantry_chair, paint_pantry_table,
@@ -61,6 +62,7 @@ pub(super) enum DrawableKind<'a> {
         glow_tint: Option<Rgb>,
         sleep_z_seed: Option<u64>,
         waiting_bubble: bool,
+        thinking_dots: bool,
         walking_dust_frame: Option<usize>,
     },
     /// Lounge couch (mirror_vertical'd — back at bottom, seat at top).
@@ -317,6 +319,7 @@ pub(super) fn paint_drawable(
             glow_tint,
             sleep_z_seed,
             waiting_bubble,
+            thinking_dots,
             walking_dust_frame,
         } => {
             if let Some(dust_frame) = walking_dust_frame {
@@ -330,6 +333,9 @@ pub(super) fn paint_drawable(
             }
             if *waiting_bubble {
                 paint_waiting_bubble(buf, *anchor, theme);
+            }
+            if *thinking_dots {
+                paint_thinking_dots(buf, *anchor, now, theme);
             }
         }
         DrawableKind::WaypointCouch { pos } => {

--- a/crates/ascii-agents/src/tui/pixel_painter/effects.rs
+++ b/crates/ascii-agents/src/tui/pixel_painter/effects.rs
@@ -137,6 +137,28 @@ pub(super) fn paint_walking_dust(
     }
 }
 
+pub(super) fn paint_thinking_dots(
+    buf: &mut RgbBuffer,
+    anchor: Point,
+    now: SystemTime,
+    theme: &Theme,
+) {
+    let fg = theme.ui.label_active;
+    let elapsed_ms = now
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    let phase = (elapsed_ms / 800) % 4;
+    let bx = anchor.x + 2;
+    let by = anchor.y.saturating_sub(3);
+    for i in 0..phase {
+        let px = bx + (i as u16) * 2;
+        if px < buf.width && by < buf.height {
+            buf.put(px, by, fg);
+        }
+    }
+}
+
 pub(super) fn paint_waiting_bubble(buf: &mut RgbBuffer, anchor: Point, theme: &Theme) {
     let fg = theme.effects.waiting_bubble;
     const GLYPH: &[&[u8]] = &[b".YYY.", b"...Y.", b"..Y..", b"..Y.."];

--- a/crates/ascii-agents/src/tui/pixel_painter/effects.rs
+++ b/crates/ascii-agents/src/tui/pixel_painter/effects.rs
@@ -139,16 +139,9 @@ pub(super) fn paint_walking_dust(
 
 pub(super) fn paint_waiting_bubble(buf: &mut RgbBuffer, anchor: Point, theme: &Theme) {
     let fg = theme.effects.waiting_bubble;
-    const GLYPH: &[&[u8]] = &[
-        b".YYYYY..",
-        b".YYYYY..",
-        b"....YY..",
-        b"..YY....",
-        b"..YY....",
-        b"..YY....",
-    ];
-    let bx = anchor.x;
-    let by = anchor.y.saturating_sub(7) & !1u16;
+    const GLYPH: &[&[u8]] = &[b".YYY.", b"...Y.", b"..Y..", b"..Y.."];
+    let bx = anchor.x + 1;
+    let by = anchor.y.saturating_sub(5) & !1u16;
     for (dy, row) in GLYPH.iter().enumerate() {
         for (dx, byte) in row.iter().enumerate() {
             if *byte != b'Y' {

--- a/crates/ascii-agents/src/tui/pixel_painter/mod.rs
+++ b/crates/ascii-agents/src/tui/pixel_painter/mod.rs
@@ -894,6 +894,7 @@ pub fn render_to_rgb_buffer(
                             glow_tint: None,
                             sleep_z_seed: None,
                             waiting_bubble: false,
+                            thinking_dots: false,
                             walking_dust_frame: Some(frame_idx),
                         },
                     });
@@ -953,6 +954,7 @@ pub fn render_to_rgb_buffer(
                             None
                         },
                         waiting_bubble: false,
+                        thinking_dots: false,
                         walking_dust_frame: None,
                     },
                 });
@@ -986,6 +988,7 @@ pub fn render_to_rgb_buffer(
                     glow_tint: None,
                     sleep_z_seed: None,
                     waiting_bubble: false,
+                    thinking_dots: false,
                     walking_dust_frame: None,
                 },
             });
@@ -1017,6 +1020,7 @@ pub fn render_to_rgb_buffer(
                         glow_tint: None,
                         sleep_z_seed: Some(agent.agent_id.raw()),
                         waiting_bubble: false,
+                        thinking_dots: false,
                         walking_dust_frame: None,
                     },
                 });
@@ -1031,9 +1035,10 @@ pub fn render_to_rgb_buffer(
                         frame_idx: 0,
                         anchor,
                         flip_x: false,
-                        glow_tint: None,
+                        glow_tint: Some(theme.tool_glow.default),
                         sleep_z_seed: None,
                         waiting_bubble: false,
+                        thinking_dots: true,
                         walking_dust_frame: None,
                     },
                 });
@@ -1051,6 +1056,7 @@ pub fn render_to_rgb_buffer(
                         glow_tint: palette::tool_glow_tint(agent, &theme.tool_glow),
                         sleep_z_seed: None,
                         waiting_bubble: false,
+                        thinking_dots: false,
                         walking_dust_frame: None,
                     },
                 });
@@ -1069,6 +1075,7 @@ pub fn render_to_rgb_buffer(
                         glow_tint: None,
                         sleep_z_seed: None,
                         waiting_bubble: is_waiting,
+                        thinking_dots: false,
                         walking_dust_frame: None,
                     },
                 });
@@ -1111,6 +1118,7 @@ pub fn render_to_rgb_buffer(
                             glow_tint: None,
                             sleep_z_seed: None,
                             waiting_bubble: false,
+                            thinking_dots: false,
                             walking_dust_frame: None,
                         },
                     });
@@ -1129,6 +1137,7 @@ pub fn render_to_rgb_buffer(
                         glow_tint: None,
                         sleep_z_seed: None,
                         waiting_bubble: false,
+                        thinking_dots: false,
                         walking_dust_frame: None,
                     },
                 });
@@ -1159,6 +1168,7 @@ pub fn render_to_rgb_buffer(
                         glow_tint: None,
                         sleep_z_seed: None,
                         waiting_bubble: false,
+                        thinking_dots: false,
                         walking_dust_frame: Some(frame),
                     },
                 });

--- a/crates/ascii-agents/src/tui/pixel_painter/mod.rs
+++ b/crates/ascii-agents/src/tui/pixel_painter/mod.rs
@@ -335,7 +335,7 @@ pub(super) fn character_anchor(
     let desk = *layout.home_desks.get(agent.desk_index)?;
     let pose = pose::derive_with_routing(agent, now, layout, router, overlay, history)?;
     let anchor = match pose {
-        Pose::SeatedIdle | Pose::SeatedTyping { .. } => seated_anchor(desk),
+        Pose::SeatedIdle | Pose::SeatedThinking | Pose::SeatedTyping { .. } => seated_anchor(desk),
         Pose::StandingAtDesk => standing_at_desk_anchor(desk),
         Pose::AtWaypoint { wp, kind } => {
             let wp_obj = layout.waypoints.get(wp)?;
@@ -1016,6 +1016,23 @@ pub fn render_to_rgb_buffer(
                         flip_x: false,
                         glow_tint: None,
                         sleep_z_seed: Some(agent.agent_id.raw()),
+                        waiting_bubble: false,
+                        walking_dust_frame: None,
+                    },
+                });
+            }
+            Pose::SeatedThinking => {
+                let anchor = with_breath(seated_anchor(desk), agent.agent_id, now);
+                drawables.push(Drawable {
+                    anchor_y: anchor.y + 12,
+                    kind: DrawableKind::Character {
+                        agent,
+                        anim_name: "seated",
+                        frame_idx: 0,
+                        anchor,
+                        flip_x: false,
+                        glow_tint: None,
+                        sleep_z_seed: None,
                         waiting_bubble: false,
                         walking_dust_frame: None,
                     },

--- a/crates/ascii-agents/src/tui/pose.rs
+++ b/crates/ascii-agents/src/tui/pose.rs
@@ -92,7 +92,7 @@ pub fn derive_with_routing(
     // rendered position over SNAP_BACK_MS.
     let desk_pose = matches!(
         raw,
-        Pose::SeatedIdle | Pose::SeatedTyping { .. } | Pose::StandingAtDesk
+        Pose::SeatedIdle | Pose::SeatedThinking | Pose::SeatedTyping { .. } | Pose::StandingAtDesk
     );
     let since_state = now
         .duration_since(slot.state_started_at)


### PR DESCRIPTION
## Summary
- Idle agents within 20s of their last event show a **thinking** pose (seated, awake, eyes on screen) instead of falling asleep with z's. After 20s of true inactivity, normal wander/sleep cycle kicks in.
- Waiting `?` bubble shrunk from 8×6 to 5×4 pixels — less visually dominant while still readable.

Addresses user feedback: "it's annoying having a little guy bouncing with a question mark when it's actually waiting for an analysis to finish"

## How it works
- New `Pose::SeatedThinking` variant in `core::pose` — uses the `seated` sprite (awake at desk, no z's, no typing animation)
- `derive()` checks `now - last_event_at < 20s` for Idle agents → returns `SeatedThinking` instead of entering the wander state machine
- No changes to decoder/reducer/hook protocol — purely visual

## Test plan
- [x] All tests pass (including snapshot regression)
- [x] Clippy clean
- [ ] Visual verification with live CC sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)