### PR TITLE
fix: codebase review findings — bugs, conventions, tests

### DIFF
--- a/crates/ascii-agents-core/src/source/antigravity.rs
+++ b/crates/ascii-agents-core/src/source/antigravity.rs
@@ -107,9 +107,12 @@ pub fn decode_ag_line(transcript_path: &str, source: &str, v: Value) -> Result<V
             }
         }
     } else if step_type != "USER_INPUT" && step_type != "CONVERSATION_HISTORY" && step_index > 0 {
+        // End the first tool from the previous step. Multi-tool steps have
+        // their remaining starts aged out by the reducer's pending_idle
+        // debounce, but the primary (i=0) start always gets a matching end.
         out.push(AgentEvent::ActivityEnd {
             agent_id,
-            tool_use_id: Some(format!("ag-{}", step_index - 1)),
+            tool_use_id: Some(format!("ag-{}-0", step_index - 1)),
         });
     }
 

--- a/crates/ascii-agents-core/src/source/hook.rs
+++ b/crates/ascii-agents-core/src/source/hook.rs
@@ -36,10 +36,12 @@ impl HookSocketListener {
     pub async fn run(self, tx: TaggedSender) -> Result<()> {
         let sem = Arc::new(Semaphore::new(MAX_CONCURRENT_CONNS));
         loop {
-            let permit = Arc::clone(&sem)
-                .acquire_owned()
-                .await
-                .expect("semaphore closed");
+            let permit = match Arc::clone(&sem).acquire_owned().await {
+                Ok(p) => p,
+                Err(_) => {
+                    anyhow::bail!("hook socket semaphore closed unexpectedly");
+                }
+            };
             match self.listener.accept().await {
                 Ok((stream, _addr)) => {
                     let tx = tx.clone();

--- a/crates/ascii-agents-core/src/sprite/format.rs
+++ b/crates/ascii-agents-core/src/sprite/format.rs
@@ -205,7 +205,7 @@ fn build_palette(map: &HashMap<String, String>) -> Result<Palette> {
         if k.chars().count() != 1 {
             bail!("palette key {k:?} must be exactly one character");
         }
-        let key = k.chars().next().unwrap();
+        let key = k.chars().next().expect("palette key validated as single char");
         let pixel = parse_palette_value(v).with_context(|| format!("palette key '{k}'"))?;
         palette.insert(key, pixel);
     }

--- a/crates/ascii-agents-core/src/sprite/format.rs
+++ b/crates/ascii-agents-core/src/sprite/format.rs
@@ -205,7 +205,10 @@ fn build_palette(map: &HashMap<String, String>) -> Result<Palette> {
         if k.chars().count() != 1 {
             bail!("palette key {k:?} must be exactly one character");
         }
-        let key = k.chars().next().expect("palette key validated as single char");
+        let key = k
+            .chars()
+            .next()
+            .expect("palette key validated as single char");
         let pixel = parse_palette_value(v).with_context(|| format!("palette key '{k}'"))?;
         palette.insert(key, pixel);
     }

--- a/crates/ascii-agents-core/src/state/reducer.rs
+++ b/crates/ascii-agents-core/src/state/reducer.rs
@@ -289,6 +289,8 @@ impl Reducer {
                         slot.exiting_at = Some(now);
                     }
                 }
+                let mut visited = HashSet::new();
+                visited.insert(agent_id);
                 let mut frontier = vec![agent_id];
                 while let Some(parent) = frontier.pop() {
                     let children: Vec<AgentId> = scene
@@ -297,12 +299,14 @@ impl Reducer {
                         .filter(|s| s.parent_id == Some(parent) && s.exiting_at.is_none())
                         .map(|s| s.agent_id)
                         .collect();
-                    for cid in &children {
-                        if let Some(slot) = scene.agents.get_mut(cid) {
-                            slot.exiting_at = Some(now);
+                    for cid in children {
+                        if visited.insert(cid) {
+                            if let Some(slot) = scene.agents.get_mut(&cid) {
+                                slot.exiting_at = Some(now);
+                            }
+                            frontier.push(cid);
                         }
                     }
-                    frontier.extend(children);
                 }
             }
         }

--- a/crates/ascii-agents-core/src/state/reducer.rs
+++ b/crates/ascii-agents-core/src/state/reducer.rs
@@ -133,6 +133,12 @@ impl Reducer {
         // Active("Delegating") so it doesn't look idle/asleep while its
         // subagents do the visible work. When the last Task drains, the
         // next normal hook/JSONL event will reset its state.
+        //
+        // `handled_by_task_tracking`: when an ActivityEnd drains
+        // active_tasks, the general ActivityEnd arm below must be
+        // skipped — otherwise it would redundantly re-arm
+        // pending_idle_at or arm it while tasks are still in flight.
+        let mut handled_by_task_tracking = false;
         match &event {
             AgentEvent::ActivityStart {
                 agent_id,
@@ -159,14 +165,17 @@ impl Reducer {
                 tool_use_id: Some(tuid),
             } => {
                 if let Some(set) = self.active_tasks.get_mut(agent_id) {
-                    set.remove(tuid);
-                    if set.is_empty() {
+                    if set.remove(tuid) {
+                        handled_by_task_tracking = true;
                         if let Some(slot) = scene.agents.get_mut(agent_id) {
-                            // Debounce: stay visually Active for
-                            // ACTIVE_GRACE_WINDOW; expire_pending_idles
-                            // flips to Idle if no new tool starts inside
-                            // the window.
-                            slot.pending_idle_at = Some(now);
+                            slot.last_event_at = now;
+                            if set.is_empty() {
+                                // Debounce: stay visually Active for
+                                // ACTIVE_GRACE_WINDOW; expire_pending_idles
+                                // flips to Idle if no new tool starts
+                                // inside the window.
+                                slot.pending_idle_at = Some(now);
+                            }
                         }
                     }
                 }
@@ -260,9 +269,17 @@ impl Reducer {
                 }
             }
             AgentEvent::ActivityEnd { agent_id, .. } => {
-                if let Some(slot) = scene.agents.get_mut(&agent_id) {
-                    slot.pending_idle_at = Some(now);
-                    slot.last_event_at = now;
+                // Skip if this end was already processed by task tracking above.
+                if !handled_by_task_tracking {
+                    if let Some(slot) = scene.agents.get_mut(&agent_id) {
+                        // Only arm the idle debounce when actually Active — an
+                        // ActivityEnd arriving while Idle or Waiting is a stale
+                        // duplicate and should not re-arm the timer.
+                        if matches!(slot.state, ActivityState::Active { .. }) {
+                            slot.pending_idle_at = Some(now);
+                        }
+                        slot.last_event_at = now;
+                    }
                 }
             }
             AgentEvent::Waiting { agent_id, reason } => {

--- a/crates/ascii-agents-core/tests/decoder.rs
+++ b/crates/ascii-agents-core/tests/decoder.rs
@@ -261,7 +261,7 @@ fn ag_tool_result_emits_activity_end() {
     assert_eq!(events.len(), 1);
     match &events[0] {
         AgentEvent::ActivityEnd { tool_use_id, .. } => {
-            assert_eq!(tool_use_id.as_deref(), Some("ag-2"));
+            assert_eq!(tool_use_id.as_deref(), Some("ag-2-0"));
         }
         other => panic!("got {other:?}"),
     }

--- a/crates/ascii-agents-core/tests/reducer.rs
+++ b/crates/ascii-agents-core/tests/reducer.rs
@@ -1103,3 +1103,163 @@ fn unknown_cwd_agent_uses_faster_stale_timeout() {
         "unknown_cwd agent should reap after STALE_UNKNOWN_CWD_TIMEOUT"
     );
 }
+
+// --- parent-child cascade --------------------------------------------------
+
+#[test]
+fn session_end_cascade_marks_all_descendants_exiting() {
+    let mut scene = SceneState::new(8);
+    let mut r = Reducer::new();
+    let parent = AgentId::from_transcript_path("/p/cascade-parent.jsonl");
+    let child_a = AgentId::from_parts("claude-code", "/p/cascade-parent/subagents/agent-a.jsonl");
+    let child_b = AgentId::from_parts("claude-code", "/p/cascade-parent/subagents/agent-b.jsonl");
+    let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(2_000_000);
+
+    r.apply(
+        &mut scene,
+        AgentEvent::SessionStart {
+            agent_id: parent,
+            source: "claude-code".into(),
+            session_id: "p".into(),
+            cwd: PathBuf::from("/repo"),
+            parent_id: None,
+        },
+        t0,
+        Transport::Hook,
+    );
+    r.apply(
+        &mut scene,
+        AgentEvent::SessionStart {
+            agent_id: child_a,
+            source: "claude-code".into(),
+            session_id: "ca".into(),
+            cwd: PathBuf::from("/repo"),
+            parent_id: Some(parent),
+        },
+        t0 + Duration::from_millis(100),
+        Transport::Jsonl,
+    );
+    r.apply(
+        &mut scene,
+        AgentEvent::SessionStart {
+            agent_id: child_b,
+            source: "claude-code".into(),
+            session_id: "cb".into(),
+            cwd: PathBuf::from("/repo"),
+            parent_id: Some(parent),
+        },
+        t0 + Duration::from_millis(200),
+        Transport::Jsonl,
+    );
+
+    assert!(scene.agents.get(&child_a).unwrap().exiting_at.is_none());
+    assert!(scene.agents.get(&child_b).unwrap().exiting_at.is_none());
+
+    r.apply(
+        &mut scene,
+        AgentEvent::SessionEnd { agent_id: parent },
+        t0 + Duration::from_secs(5),
+        Transport::Hook,
+    );
+
+    assert!(
+        scene.agents.get(&parent).unwrap().exiting_at.is_some(),
+        "parent must be marked exiting"
+    );
+    assert!(
+        scene.agents.get(&child_a).unwrap().exiting_at.is_some(),
+        "child_a must cascade to exiting when parent ends"
+    );
+    assert!(
+        scene.agents.get(&child_b).unwrap().exiting_at.is_some(),
+        "child_b must cascade to exiting when parent ends"
+    );
+}
+
+// --- hook-wins dedup -------------------------------------------------------
+
+#[test]
+fn hook_wins_dedup_drops_jsonl_duplicate_within_window() {
+    let mut scene = SceneState::new(4);
+    let mut r = Reducer::new();
+    let id = AgentId::from_transcript_path("/p/dedup-hw.jsonl");
+    start(&mut r, &mut scene, id);
+
+    let t0 = SystemTime::now();
+
+    // Hook event first — establishes the tool_use_id in the dedup map.
+    r.apply(
+        &mut scene,
+        AgentEvent::ActivityStart {
+            agent_id: id,
+            activity: Activity::Typing,
+            tool_use_id: Some("dedup-1".into()),
+            detail: Some("Edit: hook.rs".into()),
+        },
+        t0,
+        Transport::Hook,
+    );
+    assert_eq!(scene.agents.get(&id).unwrap().tool_call_count, 1);
+
+    // JSONL event with same tool_use_id within 500ms — must be dropped.
+    r.apply(
+        &mut scene,
+        AgentEvent::ActivityStart {
+            agent_id: id,
+            activity: Activity::Reading,
+            tool_use_id: Some("dedup-1".into()),
+            detail: Some("Edit: jsonl.rs".into()),
+        },
+        t0 + Duration::from_millis(200),
+        Transport::Jsonl,
+    );
+
+    // tool_call_count should still be 1 — JSONL duplicate was dropped.
+    assert_eq!(
+        scene.agents.get(&id).unwrap().tool_call_count,
+        1,
+        "JSONL duplicate inside hook-wins window must be dropped"
+    );
+    // State should still reflect the hook event.
+    match &scene.agents.get(&id).unwrap().state {
+        ActivityState::Active { detail, .. } => {
+            assert_eq!(detail.as_deref(), Some("Edit: hook.rs"));
+        }
+        other => panic!("expected Active from hook, got {other:?}"),
+    }
+}
+
+// --- sweep_stale -----------------------------------------------------------
+
+#[test]
+fn sweep_stale_marks_old_agent_exiting_on_tick() {
+    use ascii_agents_core::state::reducer::STALE_IDLE_TIMEOUT;
+    let mut scene = SceneState::new(4);
+    let mut r = Reducer::new();
+    let id = AgentId::from_transcript_path("/p/stale-sweep.jsonl");
+    let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_500_000_000);
+
+    r.apply(
+        &mut scene,
+        AgentEvent::SessionStart {
+            agent_id: id,
+            source: "claude-code".into(),
+            session_id: "sw".into(),
+            cwd: PathBuf::from("/old-project"),
+            parent_id: None,
+        },
+        t0,
+        Transport::Hook,
+    );
+    assert!(scene.agents.get(&id).unwrap().exiting_at.is_none());
+
+    // Tick well past the idle stale timeout with no intervening events.
+    r.tick(
+        &mut scene,
+        t0 + STALE_IDLE_TIMEOUT + Duration::from_secs(60),
+    );
+    assert!(
+        scene.agents.get(&id).unwrap().exiting_at.is_some(),
+        "tick past STALE_IDLE_TIMEOUT should mark agent exiting"
+    );
+}

--- a/crates/ascii-agents/src/runtime.rs
+++ b/crates/ascii-agents/src/runtime.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
@@ -60,14 +60,14 @@ async fn run_async(
     let (tx, rx) = mpsc::channel::<(Transport, AgentEvent)>(256);
     let (scene_tx, scene_rx) = watch::channel(Arc::new(SceneState::new(max_desks)));
 
-    tokio::spawn(reducer_task(rx, scene_tx, max_desks));
+    let max_desks_shared = Arc::new(AtomicUsize::new(max_desks));
+
+    tokio::spawn(reducer_task(rx, scene_tx, Arc::clone(&max_desks_shared)));
 
     let _source_handles = SourceManager::new()
         .with_source(Box::new(cc_src))
         .with_source(Box::new(ag_src))
         .spawn(tx);
-
-    let max_desks_shared = Arc::new(AtomicUsize::new(max_desks));
 
     if headless {
         headless_loop(scene_rx).await
@@ -79,22 +79,23 @@ async fn run_async(
 async fn reducer_task(
     mut rx: TaggedReceiver,
     scene_tx: watch::Sender<Arc<SceneState>>,
-    max_desks: usize,
+    max_desks: Arc<AtomicUsize>,
 ) {
     let mut reducer = Reducer::new();
-    let mut scene = SceneState::new(max_desks);
+    let mut scene = SceneState::new(max_desks.load(Ordering::Relaxed));
     // 1-Hz tick so exit-grace sweeps run even when no new events arrive.
     let mut sweep_interval = tokio::time::interval(Duration::from_secs(1));
     sweep_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     loop {
+        // Sync max_desks from the shared atomic so TUI +/- key changes
+        // are visible to next_free_desk() inside the reducer.
+        scene.max_desks = max_desks.load(Ordering::Relaxed);
         tokio::select! {
             event = rx.recv() => {
                 let Some((transport, ev)) = event else { break };
                 let now = SystemTime::now();
                 tracing::debug!(?transport, ?ev, "event");
                 reducer.apply(&mut scene, ev, now, transport);
-                // Send a fresh Arc snapshot. send() ignores errors when
-                // there are no active receivers — that's fine.
                 let _ = scene_tx.send(Arc::new(scene.clone()));
             }
             _ = sweep_interval.tick() => {

--- a/crates/ascii-agents/src/tui/widgets.rs
+++ b/crates/ascii-agents/src/tui/widgets.rs
@@ -86,10 +86,10 @@ impl TickerQueue {
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_millis() as u64)
             .unwrap_or(0);
-        let char_count = self.buffer.chars().count();
-        let offset = (elapsed_ms / 150) as usize % char_count;
-        let doubled = format!("{}{}", self.buffer, self.buffer);
-        doubled.chars().skip(offset).take(width).collect()
+        let chars: Vec<char> = self.buffer.chars().collect();
+        let len = chars.len();
+        let offset = (elapsed_ms / 150) as usize % len;
+        (0..width).map(|i| chars[(offset + i) % len]).collect()
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes from a full-codebase 3-agent code review (explorer + architect + reviewer).

**Bugs fixed:**
- **max_desks divergence** — reducer now reads `Arc<AtomicUsize>` so TUI +/- key changes propagate to `next_free_desk()`
- **Antigravity ActivityEnd tool_use_id** — was `"ag-{step-1}"`, now `"ag-{step-1}-0"` to match ActivityStart format
- **SessionEnd BFS cycle guard** — added `HashSet<AgentId>` visited set to prevent infinite loop on cyclic parent_id
- **pending_idle_at on Waiting slots** — ActivityEnd now only arms pending_idle when slot is Active; Task ActivityEnd skips general handler

**Convention fixes:**
- `hook.rs` — `expect("semaphore closed")` → `bail!` (no panic in production async tasks)
- `format.rs` — bare `unwrap()` → `expect()` with invariant documentation

**Performance:**
- `TickerQueue::visible()` — modular indexing replaces `format!("{}{}", buf, buf)` (eliminates 1KB/frame allocation)

**New tests (3):**
- Parent-child cascade: SessionEnd on parent marks children exiting
- Hook-wins dedup: duplicate tool_use_id from Jsonl transport is dropped
- sweep_stale: idle agent past timeout gets exiting_at set

## Test plan

- [x] 267 tests pass (`cargo test --workspace --features ascii-agents-core/test-renderer`)
- [x] Clippy clean (`--all-targets -D warnings`)
- [x] rustfmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)