### PR TITLE
fix: path traversal, symlink save, init-pack guard

### DIFF
--- a/crates/ascii-agents-core/src/sprite/format.rs
+++ b/crates/ascii-agents-core/src/sprite/format.rs
@@ -140,13 +140,29 @@ pub fn load_pack(dir: &Path) -> Result<Pack> {
 
     let palette = build_palette(&parsed.palette)?;
 
+    let canon_dir = dir
+        .canonicalize()
+        .with_context(|| format!("canonicalizing {}", dir.display()))?;
+
     let mut animations = HashMap::new();
     for (anim_name, anim) in parsed.animations {
         let mut frames = Vec::new();
         for fname in &anim.frames {
+            if Path::new(fname)
+                .components()
+                .any(|c| c == std::path::Component::ParentDir)
+            {
+                bail!("frame path {:?} contains '..' and is not allowed", fname);
+            }
             let path = dir.join(fname);
-            let src = std::fs::read_to_string(&path)
-                .with_context(|| format!("reading {}", path.display()))?;
+            let canon_path = path
+                .canonicalize()
+                .with_context(|| format!("resolving {}", path.display()))?;
+            if !canon_path.starts_with(&canon_dir) {
+                bail!("frame path {:?} escapes the pack directory", fname);
+            }
+            let src = std::fs::read_to_string(&canon_path)
+                .with_context(|| format!("reading {}", canon_path.display()))?;
             let mut decoded = parse_sprite_file(&src, &palette)
                 .with_context(|| format!("decoding {}", path.display()))?;
             frames.append(&mut decoded);

--- a/crates/ascii-agents-core/tests/sprite_format.rs
+++ b/crates/ascii-agents-core/tests/sprite_format.rs
@@ -106,6 +106,33 @@ fn default_pack_passes_validation() {
 }
 
 #[test]
+fn robot_pack_passes_validation() {
+    let pack = load_pack(Path::new("../ascii-agents/sprites/robot")).unwrap();
+    let report = validate_pack_animations(&pack);
+    assert!(
+        report.missing_required.is_empty(),
+        "missing required: {:?}",
+        report.missing_required
+    );
+    assert!(
+        report.insufficient_frames.is_empty(),
+        "insufficient frames: {:?}",
+        report.insufficient_frames
+    );
+}
+
+#[test]
+fn skeleton_pack_passes_validation() {
+    let pack = load_pack(Path::new("../ascii-agents/sprites/skeleton")).unwrap();
+    let report = validate_pack_animations(&pack);
+    assert!(
+        report.missing_required.is_empty(),
+        "missing required: {:?}",
+        report.missing_required
+    );
+}
+
+#[test]
 fn mini_pack_reports_missing_required() {
     let pack = load_pack(Path::new("tests/fixtures/sprites/mini_pack")).unwrap();
     let report = validate_pack_animations(&pack);

--- a/crates/ascii-agents/src/config.rs
+++ b/crates/ascii-agents/src/config.rs
@@ -64,24 +64,32 @@ pub fn load(path: &Path) -> AppConfig {
 }
 
 pub fn save(path: &Path, theme_name: &str) -> Result<()> {
-    if let Some(parent) = path.parent() {
+    // Resolve symlinks so atomic rename targets the real file,
+    // not the symlink itself (critical for stow-managed configs).
+    // canonicalize handles relative symlink targets correctly.
+    let real_path = if path.is_symlink() {
+        path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+    } else {
+        path.to_path_buf()
+    };
+    if let Some(parent) = real_path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    let lock_path = path.with_extension("toml.lock");
+    let lock_path = real_path.with_extension("toml.lock");
     let lock_file = std::fs::File::create(&lock_path)?;
     fs2::FileExt::lock_exclusive(&lock_file)?;
 
-    let mut cfg = if path.exists() {
-        load(path)
+    let mut cfg = if real_path.exists() {
+        load(&real_path)
     } else {
         AppConfig::default()
     };
     cfg.theme = Some(theme_name.to_string());
 
     let contents = toml::to_string_pretty(&cfg)?;
-    let tmp = path.with_extension("toml.tmp");
+    let tmp = real_path.with_extension("toml.tmp");
     std::fs::write(&tmp, &contents)?;
-    std::fs::rename(&tmp, path)?;
+    std::fs::rename(&tmp, &real_path)?;
     // Lock released on drop
     Ok(())
 }

--- a/crates/ascii-agents/src/init_pack.rs
+++ b/crates/ascii-agents/src/init_pack.rs
@@ -4,6 +4,9 @@ use anyhow::{bail, Result};
 
 pub fn init_pack(dest: &Path, force: bool) -> Result<()> {
     if dest.exists() && !force {
+        if !dest.is_dir() {
+            bail!("{} exists and is not a directory", dest.display());
+        }
         let has_files = std::fs::read_dir(dest)?.next().is_some();
         if has_files {
             bail!(


### PR DESCRIPTION
## Summary
Fixes from post-merge code review of PR #23:

- **Security**: `load_pack` now canonicalizes frame paths and rejects any that escape the pack directory (prevents `../../../etc/passwd` path traversal)
- **Symlink safety**: `config::save` resolves symlinks before atomic rename so stow-managed configs aren't silently replaced
- **UX**: `init-pack` rejects file-as-dest with a clear message instead of an OS error
- **Tests**: added `robot_pack_passes_validation` and `skeleton_pack_passes_validation`

## Test plan
- [x] All tests pass (325 total, 2 new pack validation tests)
- [x] Clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)