### PR TITLE
test: add 11 missing test cases from coverage audit

### DIFF
--- a/crates/ascii-agents-core/src/layout/compute.rs
+++ b/crates/ascii-agents-core/src/layout/compute.rs
@@ -372,7 +372,7 @@ pub(super) fn compute_with_seed(
         wall_decor.push((
             WallDecor::MeetingScreen,
             Point {
-                x: mr.x + mr.width / 2 - 7,
+                x: mr.x + (mr.width / 2).saturating_sub(7),
                 y: top_margin.saturating_sub(12),
             },
         ));

--- a/crates/ascii-agents-core/src/layout/mod.rs
+++ b/crates/ascii-agents-core/src/layout/mod.rs
@@ -146,6 +146,24 @@ mod tests {
     }
 
     #[test]
+    fn compute_returns_none_at_exact_boundary() {
+        let min_w = DESK_W + DESK_GAP_X * 2; // 34
+        let min_h: u16 = 40 + MIN_TOP_MARGIN; // 60
+        assert!(
+            SceneLayout::compute(min_w - 1, min_h, 1).is_none(),
+            "one pixel below MIN_W should return None"
+        );
+        assert!(
+            SceneLayout::compute(min_w, min_h - 1, 1).is_none(),
+            "one pixel below min_h should return None"
+        );
+        assert!(
+            SceneLayout::compute(min_w, min_h, 1).is_some(),
+            "exactly at boundary should return Some"
+        );
+    }
+
+    #[test]
     fn compute_zones_are_ordered_top_to_bottom_and_nonoverlapping() {
         let l = SceneLayout::compute(120, 80, 6).expect("fits");
         assert!(l.cubicle_band.y < l.walkway.y);

--- a/crates/ascii-agents-core/src/state/mod.rs
+++ b/crates/ascii-agents-core/src/state/mod.rs
@@ -306,4 +306,18 @@ mod tests {
         let oob = s.floor_range(MAX_FLOORS + 10);
         assert_eq!(last, oob);
     }
+
+    #[test]
+    fn floor_local_desk_oob_lands_on_last_nonempty_floor() {
+        let s = SceneState::new([4, 8, 6, 4, 2]);
+        let total = s.total_capacity(); // 24
+                                        // desk_index 100 is beyond capacity — floor_of returns the last
+                                        // floor with nonzero capacity (floor 4, offset 22).
+        let oob = total + 76; // 100
+        let floor = s.floor_of(oob);
+        assert_eq!(floor, 4, "OOB desk lands on last nonempty floor");
+        let local = s.floor_local_desk(oob);
+        // offsets[4] = 22, so local = 100 - 22 = 78
+        assert_eq!(local, oob - 22);
+    }
 }

--- a/crates/ascii-agents-core/tests/decoder.rs
+++ b/crates/ascii-agents-core/tests/decoder.rs
@@ -376,3 +376,51 @@ fn detect_parent_id_returns_none_for_regular_path() {
         "regular path should not match subagent pattern"
     );
 }
+
+#[test]
+fn decode_hook_payload_missing_session_id_returns_err() {
+    let payload = serde_json::json!({
+        "hook_event_name": "SessionStart",
+        "transcript_path": "/tmp/t.jsonl",
+        "cwd": "/repo"
+    });
+    assert!(
+        decode_hook_payload(payload).is_err(),
+        "missing session_id must return Err"
+    );
+}
+
+#[test]
+fn decode_hook_payload_missing_transcript_path_returns_err() {
+    let payload = serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "session_id": "ses-abc",
+        "cwd": "/repo",
+        "tool_name": "Bash",
+        "tool_input": { "command": "ls" }
+    });
+    assert!(
+        decode_hook_payload(payload).is_err(),
+        "missing transcript_path must return Err"
+    );
+}
+
+#[test]
+fn decode_hook_payload_missing_tool_name_still_succeeds() {
+    let payload = serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "session_id": "ses-abc",
+        "transcript_path": "/tmp/t.jsonl"
+    });
+    let ev = decode_hook_payload(payload).unwrap();
+    match ev {
+        AgentEvent::ActivityStart { detail, .. } => {
+            let d = detail.expect("detail set");
+            assert!(
+                d.display().contains("?"),
+                "missing tool_name should fall back to '?'"
+            );
+        }
+        other => panic!("expected ActivityStart, got {other:?}"),
+    }
+}

--- a/crates/ascii-agents-core/tests/jsonl_watcher.rs
+++ b/crates/ascii-agents-core/tests/jsonl_watcher.rs
@@ -403,6 +403,44 @@ async fn stale_file_emits_session_start_when_written_to() {
     handle.abort();
 }
 
+/// A recent file (within the initial window) that has a session_end marker
+/// at its tail must NOT produce a SessionStart on startup — the watcher
+/// must detect the ended session and seed the cursor at EOF.
+#[tokio::test]
+async fn watcher_skips_recent_file_with_session_end_marker() {
+    let dir = TempDir::new().unwrap();
+    let projects_root = dir.path().to_path_buf();
+    let project_dir = projects_root.join("proj-ended");
+    tokio::fs::create_dir_all(&project_dir).await.unwrap();
+
+    let ended = project_dir.join("ended.jsonl");
+    let content = r#"{"type":"system","subtype":"session_start","sessionId":"ended","cwd":"/repo"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu_1","name":"Bash","input":{"command":"ls"}}]}}
+{"type":"system","subtype":"session_end","sessionId":"ended"}
+"#;
+    tokio::fs::write(&ended, content).await.unwrap();
+    // mtime is "now" — well within the initial window.
+
+    let (tx, mut rx) = mpsc::channel::<(Transport, AgentEvent)>(32);
+    let watcher = cc_watcher(projects_root.clone()).with_initial_window(Duration::from_secs(3600));
+    let handle = tokio::spawn(async move { watcher.run(tx).await });
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let mut events = Vec::new();
+    while let Ok(Some(ev)) = tokio::time::timeout(Duration::from_millis(50), rx.recv()).await {
+        events.push(ev);
+    }
+    let has_session_start = events
+        .iter()
+        .any(|(_, ev)| matches!(ev, AgentEvent::SessionStart { .. }));
+    assert!(
+        !has_session_start,
+        "recent file with session_end marker must not produce SessionStart, got {events:?}"
+    );
+    handle.abort();
+}
+
 fn custom_label(_path: &std::path::Path, _source: &str, _cwd: &std::path::Path) -> String {
     "custom-label-ok".to_string()
 }

--- a/crates/ascii-agents-core/tests/reducer.rs
+++ b/crates/ascii-agents-core/tests/reducer.rs
@@ -1381,3 +1381,108 @@ fn session_start_overflows_to_floor1_with_heterogeneous_capacity() {
     );
     assert_eq!(scene.floor_of(2), 1);
 }
+
+#[test]
+fn session_start_dropped_when_all_desks_occupied() {
+    let mut r = Reducer::new();
+    let mut scene = SceneState::new([2, 0, 0, 0, 0]);
+    let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+
+    for i in 0..2 {
+        let id = AgentId::from_transcript_path(&format!("/proj/{i}.jsonl"));
+        r.apply(
+            &mut scene,
+            AgentEvent::SessionStart {
+                agent_id: id,
+                source: "cc".into(),
+                session_id: format!("s{i}"),
+                cwd: PathBuf::from("/repo"),
+                parent_id: None,
+            },
+            t0,
+            Transport::Hook,
+        );
+    }
+    assert_eq!(scene.agents.len(), 2);
+    assert!(scene.next_free_desk().is_none());
+
+    let overflow_id = AgentId::from_transcript_path("/proj/overflow.jsonl");
+    r.apply(
+        &mut scene,
+        AgentEvent::SessionStart {
+            agent_id: overflow_id,
+            source: "cc".into(),
+            session_id: "s-overflow".into(),
+            cwd: PathBuf::from("/repo"),
+            parent_id: None,
+        },
+        t0,
+        Transport::Hook,
+    );
+    assert_eq!(
+        scene.agents.len(),
+        2,
+        "third SessionStart must be silently dropped when desks are full"
+    );
+    assert!(
+        !scene.agents.contains_key(&overflow_id),
+        "overflow agent should not exist"
+    );
+}
+
+#[test]
+fn activity_end_while_waiting_does_not_arm_pending_idle() {
+    let mut scene = SceneState::uniform(4);
+    let mut r = Reducer::new();
+    let id = AgentId::from_transcript_path("/p/wait.jsonl");
+    let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+
+    start(&mut r, &mut scene, id);
+
+    r.apply(
+        &mut scene,
+        AgentEvent::ActivityStart {
+            agent_id: id,
+            activity: Activity::Typing,
+            tool_use_id: Some("t1".into()),
+            detail: None,
+        },
+        t0,
+        Transport::Hook,
+    );
+
+    r.apply(
+        &mut scene,
+        AgentEvent::Waiting {
+            agent_id: id,
+            reason: "permission".into(),
+        },
+        t0 + Duration::from_millis(500),
+        Transport::Hook,
+    );
+    assert!(matches!(
+        scene.agents.get(&id).unwrap().state,
+        ActivityState::Waiting { .. }
+    ));
+
+    r.apply(
+        &mut scene,
+        AgentEvent::ActivityEnd {
+            agent_id: id,
+            tool_use_id: Some("t1".into()),
+        },
+        t0 + Duration::from_millis(1000),
+        Transport::Jsonl,
+    );
+
+    let slot = scene.agents.get(&id).unwrap();
+    assert!(
+        matches!(slot.state, ActivityState::Waiting { .. }),
+        "state should remain Waiting, got {:?}",
+        slot.state
+    );
+    assert!(
+        slot.pending_idle_at.is_none(),
+        "pending_idle_at must not be armed when state is Waiting"
+    );
+}

--- a/crates/ascii-agents/src/install/merge.rs
+++ b/crates/ascii-agents/src/install/merge.rs
@@ -142,4 +142,22 @@ mod tests {
         let cleaned = merge_uninstall(installed);
         assert!(cleaned.get("hooks").is_none(), "got {cleaned}");
     }
+
+    #[test]
+    fn uninstall_non_array_hook_value_does_not_panic() {
+        let doc = json!({
+            "hooks": {
+                "PreToolUse": "not-an-array",
+                "PostToolUse": 42
+            }
+        });
+        let cleaned = merge_uninstall(doc);
+        let hooks = cleaned["hooks"].as_object().unwrap();
+        assert_eq!(
+            hooks["PreToolUse"],
+            json!("not-an-array"),
+            "non-array values should pass through unchanged"
+        );
+        assert_eq!(hooks["PostToolUse"], json!(42));
+    }
 }

--- a/crates/ascii-agents/src/tui/pathfind.rs
+++ b/crates/ascii-agents/src/tui/pathfind.rs
@@ -601,4 +601,42 @@ mod tests {
         overlay.add(20, 20, CELL_SIZE, CELL_SIZE);
         assert!(!cell_walkable(&mask, &overlay, 5, 5));
     }
+
+    #[test]
+    fn find_path_returns_none_when_target_completely_surrounded() {
+        let mask = WalkableMask::new_open(100, 100);
+        let mut overlay = OccupancyOverlay::new();
+        // Wall off a region around the target so snap_to_walkable can't
+        // find any walkable cell within MAX_SNAP_RADIUS.
+        let target = Point { x: 50, y: 50 };
+        let wall_size = (MAX_SNAP_RADIUS + 1) * CELL_SIZE * 2;
+        let wall_origin = 50u16.saturating_sub(wall_size / 2);
+        overlay.add(wall_origin, wall_origin, wall_size, wall_size);
+
+        let from = Point { x: 4, y: 4 };
+        let result = find_path(&mask, &overlay, None, from, target);
+        assert!(
+            result.is_none(),
+            "completely surrounded target should return None, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn router_falls_back_to_straight_line_when_path_is_none() {
+        let mask = WalkableMask::new_open(100, 100);
+        let mut overlay = OccupancyOverlay::new();
+        let from = Point { x: 4, y: 4 };
+        let to = Point { x: 50, y: 50 };
+        let wall_size = (MAX_SNAP_RADIUS + 1) * CELL_SIZE * 2;
+        let wall_origin = 50u16.saturating_sub(wall_size / 2);
+        overlay.add(wall_origin, wall_origin, wall_size, wall_size);
+
+        let mut router = AStarRouter::new();
+        let path = router.route(&mask, &overlay, from, to);
+        assert_eq!(
+            path,
+            vec![from, to],
+            "router should fall back to [from, to] when find_path returns None"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Add 11 tests covering 8 critical gaps identified by a full test suite audit (3 parallel agents: explorer, reviewer, untested-finder)
- Fix a latent `u16` subtraction overflow in `layout/compute.rs:375` that the boundary test caught — `MeetingScreen` placement panicked at minimum terminal size (34×60)
- Document `floor_local_desk` OOB behavior and `find_path` unreachable-target fallback

## Tests added

| # | File | Test | What it covers |
|---|------|------|----------------|
| 1 | `layout/mod.rs` | `compute_returns_none_at_exact_boundary` | `None` return at MIN_W/min_h boundary (caught overflow bug) |
| 2 | `tests/reducer.rs` | `session_start_dropped_when_all_desks_occupied` | Silent drop when `next_free_desk()` returns `None` |
| 3 | `tests/reducer.rs` | `activity_end_while_waiting_does_not_arm_pending_idle` | Stale `ActivityEnd` while `Waiting` must not arm debounce |
| 4 | `tests/decoder.rs` | `decode_hook_payload_missing_session_id_returns_err` | Missing required field → `Err` |
| 5 | `tests/decoder.rs` | `decode_hook_payload_missing_transcript_path_returns_err` | Missing required field → `Err` |
| 6 | `tests/decoder.rs` | `decode_hook_payload_missing_tool_name_still_succeeds` | Missing optional field → falls back to `?` |
| 7 | `install/merge.rs` | `uninstall_non_array_hook_value_does_not_panic` | Non-array hook values pass through unchanged |
| 8 | `tui/pathfind.rs` | `find_path_returns_none_when_target_completely_surrounded` | Completely surrounded target → `None` |
| 9 | `tui/pathfind.rs` | `router_falls_back_to_straight_line_when_path_is_none` | Router uses `vec![from, to]` fallback |
| 10 | `tests/jsonl_watcher.rs` | `watcher_skips_recent_file_with_session_end_marker` | Recent file with `session_end` tail skipped on startup |
| 11 | `state/mod.rs` | `floor_local_desk_oob_lands_on_last_nonempty_floor` | OOB desk_index → last nonempty floor |

## Test plan
- [x] `cargo test --workspace --features ascii-agents-core/test-renderer` — 246 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] Pre-push preflight passes (fmt, machete, deny, clippy, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)