### PR TITLE
fix: pathfind test exercises goal-snap, not start-snap

### DIFF
--- a/crates/ascii-agents/src/tui/pathfind.rs
+++ b/crates/ascii-agents/src/tui/pathfind.rs
@@ -604,13 +604,14 @@ mod tests {
 
     #[test]
     fn find_path_returns_none_when_target_completely_surrounded() {
-        let mask = WalkableMask::new_open(100, 100);
+        // 200×200 mask so the wall around (100,100) doesn't saturate to
+        // origin and accidentally cover from=(4,4). This ensures
+        // snap_to_walkable succeeds on `from` but fails on the goal.
+        let mask = WalkableMask::new_open(200, 200);
         let mut overlay = OccupancyOverlay::new();
-        // Wall off a region around the target so snap_to_walkable can't
-        // find any walkable cell within MAX_SNAP_RADIUS.
-        let target = Point { x: 50, y: 50 };
+        let target = Point { x: 100, y: 100 };
         let wall_size = (MAX_SNAP_RADIUS + 1) * CELL_SIZE * 2;
-        let wall_origin = 50u16.saturating_sub(wall_size / 2);
+        let wall_origin = 100u16 - wall_size / 2;
         overlay.add(wall_origin, wall_origin, wall_size, wall_size);
 
         let from = Point { x: 4, y: 4 };
@@ -623,12 +624,12 @@ mod tests {
 
     #[test]
     fn router_falls_back_to_straight_line_when_path_is_none() {
-        let mask = WalkableMask::new_open(100, 100);
+        let mask = WalkableMask::new_open(200, 200);
         let mut overlay = OccupancyOverlay::new();
         let from = Point { x: 4, y: 4 };
-        let to = Point { x: 50, y: 50 };
+        let to = Point { x: 100, y: 100 };
         let wall_size = (MAX_SNAP_RADIUS + 1) * CELL_SIZE * 2;
-        let wall_origin = 50u16.saturating_sub(wall_size / 2);
+        let wall_origin = 100u16 - wall_size / 2;
         overlay.add(wall_origin, wall_origin, wall_size, wall_size);
 
         let mut router = AStarRouter::new();


### PR DESCRIPTION
## Summary
- Fix from code review finding on PR #29: the `find_path_returns_none_when_target_completely_surrounded` test had `wall_origin` saturate to 0, covering the entire 100×100 mask including `from=(4,4)` — so `snap_to_walkable` failed on the **start** cell, never reaching the goal-snap `→ None` path the test name implied
- Use 200×200 mask with `target=(100,100)` so `wall_origin=48` and `from=(4,4)` stays outside the wall
- Same fix applied to the paired `router_falls_back_to_straight_line_when_path_is_none` test

## Test plan
- [x] Both tests pass and now exercise the correct code path (goal snap failure, not start snap failure)
- [x] Full preflight passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)