### PR TITLE
fix(ci): add --no-strip to cargo-deb for cross-compiled ARM64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,10 +132,10 @@ jobs:
           fi
 
       - name: Build deb (pixtuoid)
-        run: cargo deb -p pixtuoid --no-build --target ${{ matrix.target }}
+        run: cargo deb -p pixtuoid --no-build --no-strip --target ${{ matrix.target }}
 
       - name: Build deb (pixtuoid-hook)
-        run: cargo deb -p pixtuoid-hook --no-build --target ${{ matrix.target }}
+        run: cargo deb -p pixtuoid-hook --no-build --no-strip --target ${{ matrix.target }}
 
       - uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
## Summary
- Add `--no-strip` to `cargo deb` commands — the host `strip` can't read ARM64 ELF binaries during cross-compilation
- The release profile already applies `strip = "debuginfo"`, so cargo-deb's strip is redundant

Fixes the ARM64 deb build failure in the v0.4.0 release: https://github.com/IvanWng97/pixtuoid/actions/runs/26540538929

## Test plan
- [x] CI-only change — will verify on next tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)