### PR TITLE
chore: remove legacy ascii-agents migration code

### DIFF
--- a/crates/pixtuoid/src/install/io.rs
+++ b/crates/pixtuoid/src/install/io.rs
@@ -84,10 +84,6 @@ pub fn backup_once(path: &Path) -> Result<Option<PathBuf>> {
     if !target.exists() {
         return Ok(None);
     }
-    let legacy_bak = target.with_extension("json.ascii-agents.bak");
-    if legacy_bak.exists() {
-        return Ok(Some(legacy_bak));
-    }
     let bak = target.with_extension("json.pixtuoid.bak");
     if bak.exists() {
         return Ok(Some(bak));

--- a/crates/pixtuoid/src/install/merge.rs
+++ b/crates/pixtuoid/src/install/merge.rs
@@ -1,7 +1,6 @@
 use serde_json::{json, Map, Value};
 
 pub const SENTINEL_KEY: &str = "_pixtuoid";
-pub const LEGACY_SENTINEL_KEY: &str = "_ascii_agents";
 pub const EVENTS: &[&str] = &[
     "SessionStart",
     "PreToolUse",
@@ -36,10 +35,7 @@ pub fn merge_install(doc: Value, hook_command: &str) -> Value {
                 list.as_array_mut().expect("just stored Value::Array")
             }
         };
-        arr.retain(|entry| {
-            entry.get(SENTINEL_KEY).and_then(|v| v.as_bool()) != Some(true)
-                && entry.get(LEGACY_SENTINEL_KEY).and_then(|v| v.as_bool()) != Some(true)
-        });
+        arr.retain(|entry| entry.get(SENTINEL_KEY).and_then(|v| v.as_bool()) != Some(true));
         arr.push(json!({
             SENTINEL_KEY: true,
             "matcher": ".*",
@@ -62,10 +58,7 @@ pub fn merge_uninstall(mut doc: Value) -> Value {
     };
     for (_ev, list) in hooks_obj.iter_mut() {
         if let Some(arr) = list.as_array_mut() {
-            arr.retain(|entry| {
-                entry.get(SENTINEL_KEY).and_then(|v| v.as_bool()) != Some(true)
-                    && entry.get(LEGACY_SENTINEL_KEY).and_then(|v| v.as_bool()) != Some(true)
-            });
+            arr.retain(|entry| entry.get(SENTINEL_KEY).and_then(|v| v.as_bool()) != Some(true));
         }
     }
     let to_remove: Vec<String> = hooks_obj


### PR DESCRIPTION
Remove LEGACY_SENTINEL_KEY and .ascii-agents.bak fallback.