### PR TITLE
fix: six release-blockers for 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,7 +1373,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pixtuoid"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1398,7 +1398,7 @@ dependencies = [
 
 [[package]]
 name = "pixtuoid-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1415,7 +1415,7 @@ dependencies = [
 
 [[package]]
 name = "pixtuoid-hook"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members  = [
 ]
 
 [workspace.package]
-version      = "0.4.0"
+version      = "0.4.1"
 edition      = "2021"
 rust-version = "1.78"
 license      = "MIT"

--- a/crates/pixtuoid/src/install/merge.rs
+++ b/crates/pixtuoid/src/install/merge.rs
@@ -1,6 +1,13 @@
 use serde_json::{json, Map, Value};
 
 pub const SENTINEL_KEY: &str = "_pixtuoid";
+
+/// Legacy sentinel keys from previous tool names. Entries tagged with any of
+/// these are stripped on install/uninstall so a v0.3.x → v0.4.x upgrade does
+/// not leave orphan hooks pointing at missing binaries (or worse, a live
+/// legacy hook racing the new shim).
+pub const LEGACY_SENTINEL_KEYS: &[&str] = &["_ascii_agents"];
+
 pub const EVENTS: &[&str] = &[
     "SessionStart",
     "PreToolUse",
@@ -8,6 +15,15 @@ pub const EVENTS: &[&str] = &[
     "Notification",
     "SessionEnd",
 ];
+
+fn is_managed_entry(entry: &Value) -> bool {
+    if entry.get(SENTINEL_KEY).and_then(|v| v.as_bool()) == Some(true) {
+        return true;
+    }
+    LEGACY_SENTINEL_KEYS
+        .iter()
+        .any(|k| entry.get(*k).and_then(|v| v.as_bool()) == Some(true))
+}
 
 /// Merge pixtuoid hook entries into a CC settings.json document.
 /// Idempotent: re-running replaces existing pixtuoid entries.
@@ -35,7 +51,7 @@ pub fn merge_install(doc: Value, hook_command: &str) -> Value {
                 list.as_array_mut().expect("just stored Value::Array")
             }
         };
-        arr.retain(|entry| entry.get(SENTINEL_KEY).and_then(|v| v.as_bool()) != Some(true));
+        arr.retain(|entry| !is_managed_entry(entry));
         arr.push(json!({
             SENTINEL_KEY: true,
             "matcher": ".*",
@@ -58,7 +74,7 @@ pub fn merge_uninstall(mut doc: Value) -> Value {
     };
     for (_ev, list) in hooks_obj.iter_mut() {
         if let Some(arr) = list.as_array_mut() {
-            arr.retain(|entry| entry.get(SENTINEL_KEY).and_then(|v| v.as_bool()) != Some(true));
+            arr.retain(|entry| !is_managed_entry(entry));
         }
     }
     let to_remove: Vec<String> = hooks_obj
@@ -140,6 +156,68 @@ mod tests {
         let installed = merge_install(json!({}), "/x");
         let cleaned = merge_uninstall(installed);
         assert!(cleaned.get("hooks").is_none(), "got {cleaned}");
+    }
+
+    // Regression for the v0.3.x → v0.4.x upgrade path: legacy entries tagged
+    // `_ascii_agents` must be stripped on install and uninstall. The previous
+    // PR #40 dropped the dual-sentinel cleanup, leaving stale hooks that
+    // point at a missing `ascii-agents-hook` binary.
+    #[test]
+    fn install_strips_legacy_ascii_agents_entries() {
+        let initial = json!({
+            "hooks": {
+                "PreToolUse": [
+                    { "_ascii_agents": true, "matcher": ".*", "hooks": [{"type":"command","command":"/old"}] },
+                    { "matcher": "Write", "hooks": [{"type":"command","command":"/keep"}] }
+                ]
+            }
+        });
+        let merged = merge_install(initial, "/new");
+        let arr = merged["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(
+            arr.len(),
+            2,
+            "legacy stripped, user entry kept, pixtuoid added"
+        );
+        let commands: Vec<&str> = arr
+            .iter()
+            .map(|e| e["hooks"][0]["command"].as_str().unwrap())
+            .collect();
+        assert!(commands.contains(&"/keep"));
+        assert!(commands.contains(&"/new"));
+        assert!(!commands.contains(&"/old"));
+    }
+
+    #[test]
+    fn uninstall_strips_legacy_ascii_agents_entries() {
+        let initial = json!({
+            "hooks": {
+                "PreToolUse": [
+                    { "_ascii_agents": true, "matcher": ".*", "hooks": [{"type":"command","command":"/old"}] }
+                ]
+            }
+        });
+        let cleaned = merge_uninstall(initial);
+        assert!(
+            cleaned.get("hooks").is_none(),
+            "legacy entry should be removed and empty hooks map dropped: {cleaned}"
+        );
+    }
+
+    #[test]
+    fn uninstall_strips_legacy_keeps_user_entries() {
+        let initial = json!({
+            "hooks": {
+                "PreToolUse": [
+                    { "_ascii_agents": true, "matcher": ".*", "hooks": [{"type":"command","command":"/old"}] },
+                    { "matcher": "Write", "hooks": [{"type":"command","command":"/keep"}] }
+                ]
+            }
+        });
+        let cleaned = merge_uninstall(initial);
+        let arr = cleaned["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["hooks"][0]["command"], json!("/keep"));
     }
 
     #[test]

--- a/crates/pixtuoid/src/runtime.rs
+++ b/crates/pixtuoid/src/runtime.rs
@@ -86,17 +86,15 @@ async fn run_async(
     let ag_src = AntigravitySource::default_paths();
 
     let (tx, rx) = mpsc::channel::<(Transport, AgentEvent)>(256);
-    let boot = desk_cap.unwrap_or_else(|| {
-        if headless {
-            FALLBACK_DESKS
-        } else {
-            compute_boot_capacity()
-        }
-    });
-    let (scene_tx, scene_rx) = watch::channel(Arc::new(SceneState::uniform(boot)));
+    let boot_caps: [usize; MAX_FLOORS] = match desk_cap {
+        Some(cap) => [cap; MAX_FLOORS],
+        None if headless => [FALLBACK_DESKS; MAX_FLOORS],
+        None => compute_boot_capacities(),
+    };
+    let (scene_tx, scene_rx) = watch::channel(Arc::new(SceneState::new(boot_caps)));
 
     let floor_caps: Arc<[AtomicUsize; MAX_FLOORS]> =
-        Arc::new(std::array::from_fn(|_| AtomicUsize::new(boot)));
+        Arc::new(std::array::from_fn(|i| AtomicUsize::new(boot_caps[i])));
 
     tokio::spawn(reducer_task(rx, scene_tx, Arc::clone(&floor_caps)));
 
@@ -127,8 +125,9 @@ async fn reducer_task(
     floor_caps: Arc<[AtomicUsize; MAX_FLOORS]>,
 ) {
     let mut reducer = Reducer::new();
-    let initial_cap = floor_caps[0].load(Ordering::Relaxed);
-    let mut scene = SceneState::uniform(initial_cap);
+    let initial_caps: [usize; MAX_FLOORS] =
+        std::array::from_fn(|i| floor_caps[i].load(Ordering::Relaxed));
+    let mut scene = SceneState::new(initial_caps);
     // 1-Hz tick so exit-grace sweeps run even when no new events arrive.
     let mut sweep_interval = tokio::time::interval(Duration::from_secs(1));
     sweep_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -181,20 +180,38 @@ async fn headless_loop(mut scene_rx: SceneRx) -> Result<()> {
     }
 }
 
-fn compute_boot_capacity() -> usize {
-    crossterm::terminal::size()
-        .ok()
-        .map(|(cols, rows)| capacity_for_terminal(cols, rows))
-        .unwrap_or(FALLBACK_DESKS)
+fn compute_boot_capacities() -> [usize; MAX_FLOORS] {
+    match crossterm::terminal::size().ok() {
+        Some((cols, rows)) => boot_capacities_for(cols, rows),
+        None => [FALLBACK_DESKS; MAX_FLOORS],
+    }
 }
 
-pub(crate) fn capacity_for_terminal(cols: u16, rows: u16) -> usize {
+/// Per-floor boot capacities derived from the real terminal size. Each floor
+/// uses its own seed, so different layout variants can yield different desk
+/// counts. When a floor's layout rejects the terminal (e.g. too small), fall
+/// back to `FALLBACK_DESKS` for that floor so the reducer can still seat
+/// agents — they may render off-grid on the tiny terminal, but won't be
+/// silently dropped during the boot race before the first TUI frame.
+pub(crate) fn boot_capacities_for(cols: u16, rows: u16) -> [usize; MAX_FLOORS] {
+    std::array::from_fn(|i| {
+        let seed = (i as u64).wrapping_mul(crate::tui::floor::FLOOR_SEED_MULTIPLIER);
+        let cap = capacity_for_terminal(cols, rows, seed);
+        if cap == 0 {
+            FALLBACK_DESKS
+        } else {
+            cap
+        }
+    })
+}
+
+pub(crate) fn capacity_for_terminal(cols: u16, rows: u16, floor_seed: u64) -> usize {
     let buf_h = rows.saturating_sub(1) * 2;
     pixtuoid_core::layout::SceneLayout::compute_with_seed(
         cols,
         buf_h,
         pixtuoid_core::layout::MAX_VISIBLE_DESKS,
-        0,
+        floor_seed,
     )
     .map(|l| l.home_desks.len())
     .unwrap_or(0)
@@ -222,26 +239,30 @@ fn summarize(scene: &SceneState) -> String {
 mod tests {
     use super::*;
 
+    fn floor_seed(i: u64) -> u64 {
+        i.wrapping_mul(crate::tui::floor::FLOOR_SEED_MULTIPLIER)
+    }
+
     #[test]
     fn capacity_for_normal_terminal() {
-        let cap = capacity_for_terminal(192, 48);
+        let cap = capacity_for_terminal(192, 48, 0);
         assert!(cap > 0 && cap <= pixtuoid_core::layout::MAX_VISIBLE_DESKS);
     }
 
     #[test]
     fn capacity_for_small_terminal() {
-        let cap = capacity_for_terminal(80, 35);
+        let cap = capacity_for_terminal(80, 35, 0);
         assert!(cap > 0, "80x35 should fit at least one desk");
     }
 
     #[test]
     fn capacity_for_tiny_terminal_returns_zero() {
-        assert_eq!(capacity_for_terminal(10, 10), 0);
+        assert_eq!(capacity_for_terminal(10, 10, 0), 0);
     }
 
     #[test]
     fn capacity_for_zero_rows_returns_zero() {
-        assert_eq!(capacity_for_terminal(192, 0), 0);
+        assert_eq!(capacity_for_terminal(192, 0, 0), 0);
     }
 
     #[test]
@@ -257,6 +278,55 @@ mod tests {
         )
         .map(|l| l.home_desks.len())
         .unwrap_or(0);
-        assert_eq!(capacity_for_terminal(cols, rows), expected);
+        assert_eq!(capacity_for_terminal(cols, rows, 0), expected);
+    }
+
+    // Regression for the pre-0.4.1 bug where boot capacity used floor-0's seed
+    // for all floors. Different seeds select different layout variants (mid_x
+    // splits {28%, 18%, 22%, 35%, 22%}) which can yield different desk counts
+    // at the same terminal size; capacity_for_terminal must respect the seed.
+    #[test]
+    fn seed_can_produce_distinct_capacities() {
+        let mut found = false;
+        'outer: for cols in [120u16, 140, 160, 180, 200, 220, 240] {
+            for rows in [30u16, 36, 40, 48, 56, 64] {
+                let mut unique = std::collections::HashSet::new();
+                for i in 0..MAX_FLOORS as u64 {
+                    unique.insert(capacity_for_terminal(cols, rows, floor_seed(i)));
+                }
+                if unique.len() > 1 {
+                    found = true;
+                    break 'outer;
+                }
+            }
+        }
+        assert!(
+            found,
+            "expected at least one terminal size in the swept range where \
+             per-floor seeds produce distinct capacities"
+        );
+    }
+
+    #[test]
+    fn boot_capacities_uses_each_floor_seed() {
+        let caps = boot_capacities_for(192, 48);
+        let expected: [usize; MAX_FLOORS] = std::array::from_fn(|i| {
+            let c = capacity_for_terminal(192, 48, floor_seed(i as u64));
+            if c == 0 {
+                FALLBACK_DESKS
+            } else {
+                c
+            }
+        });
+        assert_eq!(caps, expected);
+    }
+
+    // Regression for the boot-race window where SessionStart events fired
+    // between SourceManager spawn and the first TUI frame's fetch_max were
+    // silently dropped because boot=0 left every floor capacity at zero.
+    #[test]
+    fn boot_capacities_falls_back_to_default_on_tiny_terminal() {
+        let caps = boot_capacities_for(10, 10);
+        assert_eq!(caps, [FALLBACK_DESKS; MAX_FLOORS]);
     }
 }

--- a/crates/pixtuoid/src/tui/mod.rs
+++ b/crates/pixtuoid/src/tui/mod.rs
@@ -40,22 +40,18 @@ pub async fn run_tui(
     let mut version_popup = {
         let current_ver = env!("CARGO_PKG_VERSION");
         let cfg = crate::config::load(&config_path);
-        let should_show = match &cfg.last_seen_version {
-            None => false,
-            Some(last) => {
-                crate::version::is_newer_version(current_ver, last)
-                    && crate::version::release_notes(current_ver).is_some()
-            }
-        };
+        let decision = crate::version::boot_decision(current_ver, cfg.last_seen_version.as_deref());
         // Persist the current version immediately so the popup shows at
         // most once per upgrade, regardless of how the user exits this run
         // (Enter to dismiss, Esc/q/Ctrl+C to quit, or terminal close).
-        if should_show || cfg.last_seen_version.is_none() {
+        // Also overwrites a corrupted/hand-edited last_seen_version so the
+        // popup can't be silently disabled forever.
+        if decision.should_persist {
             if let Err(e) = crate::config::save_version(&config_path, current_ver) {
                 tracing::warn!("failed to persist version: {e}");
             }
         }
-        should_show
+        decision.should_show_popup
     };
     let mut last_layout_sig: Option<(u16, u16)> = None;
     let mut paused = false;

--- a/crates/pixtuoid/src/tui/tui_renderer.rs
+++ b/crates/pixtuoid/src/tui/tui_renderer.rs
@@ -106,7 +106,13 @@ impl<B: Backend<Error: Send + Sync + 'static>> TuiRenderer<B> {
     }
 
     pub fn cancel_transition(&mut self) {
-        self.transition = None;
+        if let Some(tr) = self.transition.take() {
+            // Land on the destination floor: a resize-induced cancel should
+            // not silently revert a user-initiated navigation. Clamp against
+            // the current floor count in case to_floor is now stale.
+            let nf = self.floor_ctxs.len().max(1);
+            self.current_floor = tr.to_floor.min(nf - 1);
+        }
     }
 
     pub fn set_mouse_pos(&mut self, pos: Option<(u16, u16)>) {

--- a/crates/pixtuoid/src/tui/widgets/hud.rs
+++ b/crates/pixtuoid/src/tui/widgets/hud.rs
@@ -363,10 +363,23 @@ pub(in crate::tui) fn version_popup_url_rect(notes_len: usize, bounds: Rect) -> 
     //   x = popup_x + 1 (border) + URL_PREFIX.len()
     let url_y = popup_y + notes_len as u16 + 3;
     let url_x = popup_x + 1 + URL_PREFIX.len() as u16;
+
+    // Clip against the popup's inner content area: when the painter clipped
+    // the envelope (narrow / short terminal), the URL rect must shrink too —
+    // otherwise clicks past the visible popup register as URL clicks.
+    let inner_right = popup_x + w - 1; // bottom-right border column (exclusive)
+    let inner_bottom = popup_y + h - 1; // bottom border row (exclusive)
+    if url_x >= inner_right || url_y >= inner_bottom {
+        return None;
+    }
+    let width = (VERSION_POPUP_URL.len() as u16).min(inner_right - url_x);
+    if width == 0 {
+        return None;
+    }
     Some(Rect {
         x: url_x,
         y: url_y,
-        width: VERSION_POPUP_URL.len() as u16,
+        width,
         height: 1,
     })
 }
@@ -401,5 +414,64 @@ pub(in crate::tui) fn paint_elevator_indicator(
             .bg(to_color(theme.ui.tooltip_bg))
             .add_modifier(Modifier::BOLD);
         f.render_widget(Paragraph::new(Line::from(Span::styled(label, style))), r);
+    }
+}
+
+#[cfg(test)]
+mod hud_tests {
+    use super::*;
+
+    fn full_bounds(w: u16, h: u16) -> Rect {
+        Rect {
+            x: 0,
+            y: 0,
+            width: w,
+            height: h,
+        }
+    }
+
+    #[test]
+    fn url_rect_fits_inside_normal_popup() {
+        let rect = version_popup_url_rect(4, full_bounds(200, 60)).expect("should fit");
+        assert_eq!(rect.width, VERSION_POPUP_URL.len() as u16);
+        assert_eq!(rect.height, 1);
+    }
+
+    // Regression for the phantom-browser-launch bug: on a narrow terminal
+    // the painter clips the popup envelope, but the URL click rect used to
+    // extend past the visible popup's right edge, registering clicks on the
+    // scene behind as URL clicks. The rect must stay inside the envelope.
+    #[test]
+    fn url_rect_does_not_extend_past_clipped_popup_right_edge() {
+        let bounds = full_bounds(50, 30);
+        if let Some(rect) = version_popup_url_rect(4, bounds) {
+            let needed_w = 2 + URL_PREFIX.len() as u16 + VERSION_POPUP_URL.len() as u16 + 2;
+            let w = needed_w.min(bounds.width);
+            let popup_x = bounds.width.saturating_sub(w) / 2;
+            let popup_inner_right = popup_x + w - 1;
+            assert!(
+                rect.x + rect.width <= popup_inner_right,
+                "url rect cols {}..{} extend past popup inner-right {}",
+                rect.x,
+                rect.x + rect.width,
+                popup_inner_right
+            );
+        }
+    }
+
+    // Regression for the off-screen URL row bug: on a too-short terminal,
+    // the painter clips the popup envelope vertically, and the URL row used
+    // to land on or below the clipped bottom border (where ratatui never
+    // paints it). The rect must return None instead.
+    #[test]
+    fn url_rect_returns_none_when_url_row_falls_outside_clipped_popup() {
+        // notes_len=4 → needed h=10. With bounds.height=8 the popup clips
+        // to h=8, leaving room for at most ~3 notes — the URL row at offset
+        // (notes_len + 3) = 7 lands on the bottom border.
+        let rect = version_popup_url_rect(4, full_bounds(200, 8));
+        assert!(
+            rect.is_none(),
+            "expected None when URL row falls on the clipped popup's bottom border: got {rect:?}"
+        );
     }
 }

--- a/crates/pixtuoid/src/version.rs
+++ b/crates/pixtuoid/src/version.rs
@@ -4,6 +4,39 @@ pub fn is_newer_version(current: &str, last_seen: &str) -> bool {
         .is_some_and(|(c, l)| c > l)
 }
 
+pub fn is_valid_version(s: &str) -> bool {
+    parse_semver(s).is_some()
+}
+
+pub struct BootDecision {
+    pub should_show_popup: bool,
+    pub should_persist: bool,
+}
+
+/// Decide whether the version popup should fire on boot and whether to
+/// persist `last_seen_version`. Pure function so the boot logic is testable
+/// without spinning up a terminal.
+///
+/// Persist happens in three cases:
+/// - The popup is firing (record current so it only fires once).
+/// - First-time install (no recorded version yet).
+/// - The recorded version is unparseable — overwrite to recover, otherwise a
+///   corrupted/hand-edited value silently disables the popup forever.
+pub fn boot_decision(current_ver: &str, last_seen: Option<&str>) -> BootDecision {
+    let last_seen_parseable = last_seen.is_some_and(is_valid_version);
+    let should_show_popup = match last_seen {
+        Some(last) if last_seen_parseable => {
+            is_newer_version(current_ver, last) && release_notes(current_ver).is_some()
+        }
+        _ => false,
+    };
+    let should_persist = should_show_popup || last_seen.is_none() || !last_seen_parseable;
+    BootDecision {
+        should_show_popup,
+        should_persist,
+    }
+}
+
 /// Parses `major.minor.patch[-prerelease]` into a tuple where the 4th
 /// component is `0` for a prerelease and `1` for a release, so that
 /// `0.5.0-rc1 < 0.5.0` per semver precedence rules.
@@ -103,5 +136,66 @@ mod tests {
             release_notes(current).is_some(),
             "release_notes({current:?}) returned None — add an arm for the current version"
         );
+    }
+
+    #[test]
+    fn is_valid_version_accepts_well_formed() {
+        assert!(is_valid_version("0.4.0"));
+        assert!(is_valid_version("1.2.3"));
+        assert!(is_valid_version("0.5.0-rc1"));
+    }
+
+    #[test]
+    fn is_valid_version_rejects_corrupted() {
+        assert!(!is_valid_version("v0.4.0"), "leading v is not semver");
+        assert!(!is_valid_version("garbage"));
+        assert!(!is_valid_version(""));
+    }
+
+    // Regression for the silent-disable bug: a hand-edited or corrupted
+    // last_seen_version (e.g. `v0.4.0` matching the git-tag spelling) must
+    // be overwritten on boot, not left in place to suppress every future
+    // popup.
+    #[test]
+    fn boot_decision_overwrites_corrupted_last_seen() {
+        let d = boot_decision("0.4.1", Some("v0.4.0"));
+        assert!(
+            !d.should_show_popup,
+            "can't show popup when comparison fails"
+        );
+        assert!(
+            d.should_persist,
+            "corrupted last_seen must be overwritten to recover"
+        );
+    }
+
+    #[test]
+    fn boot_decision_first_run_persists_silently() {
+        let d = boot_decision("0.4.1", None);
+        assert!(!d.should_show_popup);
+        assert!(d.should_persist);
+    }
+
+    #[test]
+    fn boot_decision_upgrade_shows_popup_and_persists() {
+        // Use 0.4.0 (which has release_notes) as the current version so this
+        // test stays stable across version bumps.
+        let d = boot_decision("0.4.0", Some("0.3.0"));
+        assert!(d.should_show_popup);
+        assert!(d.should_persist);
+    }
+
+    #[test]
+    fn boot_decision_same_version_no_action() {
+        let d = boot_decision("0.4.0", Some("0.4.0"));
+        assert!(!d.should_show_popup);
+        assert!(!d.should_persist);
+    }
+
+    #[test]
+    fn boot_decision_downgrade_no_action() {
+        let d = boot_decision("0.3.0", Some("0.4.0"));
+        assert!(!d.should_show_popup);
+        assert!(!d.should_persist);
     }
 }

--- a/crates/pixtuoid/src/version.rs
+++ b/crates/pixtuoid/src/version.rs
@@ -60,6 +60,13 @@ pub fn release_notes(version: &str) -> Option<&'static [&'static str]> {
             "New env vars: PIXTUOID_SOCKET/HOOK/LOG",
             "Flaky startup test fixed + 250ms rescan",
         ]),
+        "0.4.1" => Some(&[
+            "Per-floor boot capacity fixes invisible-agent edge case",
+            "install-hooks now strips legacy `_ascii_agents` entries again",
+            "Resize mid-slide lands on destination floor, not source",
+            "Version popup URL no longer mis-clicks on narrow terminals",
+            "Corrupted last_seen_version self-heals on next launch",
+        ]),
         _ => None,
     }
 }

--- a/crates/pixtuoid/tests/tui_renderer.rs
+++ b/crates/pixtuoid/tests/tui_renderer.rs
@@ -179,3 +179,69 @@ fn tui_renderer_transition_paints_pets_and_coffee() {
         "transition buffer should have substantial paint (got {nonzero} non-black px)"
     );
 }
+
+/// Regression: a resize mid-slide previously left `current_floor` at
+/// `from_floor`, silently reverting a user-initiated navigation with no UI
+/// signal. `cancel_transition` must now land the user on `to_floor`.
+#[test]
+fn cancel_transition_lands_on_destination_floor() {
+    let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_716_286_800);
+
+    let mut caps = [0usize; pixtuoid_core::state::MAX_FLOORS];
+    caps[0] = 8;
+    caps[1] = 8;
+    let mut scene = SceneState::new(caps);
+    for (i, name) in ["a", "b"].iter().enumerate() {
+        let id = AgentId::from_transcript_path(&format!("/demo/{name}.jsonl"));
+        scene.agents.insert(
+            id,
+            AgentSlot {
+                agent_id: id,
+                source: std::sync::Arc::from("claude-code"),
+                session_id: std::sync::Arc::from(format!("s-{i}").as_str()),
+                cwd: std::sync::Arc::from(PathBuf::from("/demo").as_path()),
+                label: std::sync::Arc::from(*name),
+                state: ActivityState::Idle,
+                state_started_at: now,
+                created_at: now - Duration::from_secs(60),
+                last_event_at: now - Duration::from_secs(60),
+                exiting_at: None,
+                pending_idle_at: None,
+                desk_index: i * 8,
+                floor_idx: i,
+                tool_call_count: 0,
+                active_ms: 0,
+                unknown_cwd: false,
+                parent_id: None,
+            },
+        );
+    }
+
+    let backend = TestBackend::new(96, 36);
+    let terminal = Terminal::new(backend).expect("terminal");
+    let mut renderer = TuiRenderer::new(
+        terminal,
+        &pixtuoid::tui::theme::NORMAL,
+        pixtuoid::tui::pet::PetKind::ALL.to_vec(),
+    );
+    let pack = load_sprite_pack(None).expect("pack");
+
+    renderer.render(&scene, &pack, now).expect("initial render");
+    assert_eq!(renderer.current_floor(), 0);
+
+    renderer.navigate_floor(1, now);
+    assert!(renderer.transition().is_some());
+    assert_eq!(
+        renderer.current_floor(),
+        0,
+        "current_floor stays at source until transition completes or cancels"
+    );
+
+    renderer.cancel_transition();
+    assert!(renderer.transition().is_none());
+    assert_eq!(
+        renderer.current_floor(),
+        1,
+        "cancel_transition should snap to the destination floor"
+    );
+}


### PR DESCRIPTION
## Summary

Six correctness fixes surfaced by the pre-tag review (10 findings × verifier pass). All small, all TDD-covered, all preflight-clean.

### Fixes
- **fix(runtime)**: per-floor boot capacity + fallback on tiny terminals — boot value was floor 0's count repeated 5× via monotone `fetch_max`; agents on smaller-variant floors went silently invisible. Also: `boot=0` on tiny terminals no longer drops SessionStart in the boot race window.
- **fix(install)**: restore legacy `_ascii_agents` hook cleanup — PR #40 removed it, but the workspace still ships as v0.4.0, so the documented v0.3.x → v0.4.x upgrade path is broken. README claim now accurate again.
- **fix(ui)**: `cancel_transition` lands on destination floor — resize mid-slide previously silently snapped the user back to source.
- **fix(ui)**: clip version-popup URL click rect to envelope — on narrow terminals the rect extended past the visible popup, so clicks on the scene behind opened the browser.
- **fix(config)**: recover from corrupted `last_seen_version` — a hand-edited `v0.4.0` (with leading `v`) silently disabled every future popup. Now self-heals on next launch. Boot decision extracted into a pure `version::boot_decision` for unit-testability.
- **chore(release)**: bump to 0.4.1 + add `release_notes("0.4.1")` arm so 0.4.0 users see what changed.

### Deferred (logged for follow-up)
- **#5** (orphan `.ascii-agents.bak`): no `--restore` CLI exists; harm bounded.
- **#6** (release_notes None freezes version): mitigated by `current_version_has_release_notes` CI test.
- **#7** (0.4.0 notes unreachable for legacy upgraders): needs a UX call on how to disambiguate "fresh install" vs "pre-popup upgrader".
- **#11** (lighting flash on pause/system-sleep): cosmetic; only fires after manual pause or SIGTSTP.

## Test plan

- [x] `scripts/preflight.sh` — fmt + machete + deny + clippy (-D warnings) + workspace tests
- [x] New regression tests per fix (one for each #): `seed_can_produce_distinct_capacities`, `boot_capacities_falls_back_to_default_on_tiny_terminal`, `install_strips_legacy_ascii_agents_entries` + uninstall variants, `cancel_transition_lands_on_destination_floor`, `url_rect_does_not_extend_past_clipped_popup_right_edge` + vertical variant, `boot_decision_overwrites_corrupted_last_seen` + first-run / upgrade / same-version / downgrade
- [ ] Manual: `cargo install --path crates/pixtuoid --path crates/pixtuoid-hook`, run a v0.3.x → v0.4.1 dry-run with seeded `_ascii_agents` entries in `~/.claude/settings.json`
- [ ] Manual: resize terminal mid-slide and confirm the destination floor is reached
- [ ] Manual: hand-edit `~/.config/pixtuoid/config.toml` `last-seen-version = "v0.4.0"`, relaunch, confirm the field is overwritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)