### PR TITLE
polish: warmer crash message + underlined bug-report URL

### DIFF
--- a/crates/pixtuoid/src/main.rs
+++ b/crates/pixtuoid/src/main.rs
@@ -121,12 +121,17 @@ fn install_crash_hook() {
 
         let issue_url = build_issue_url(version, &panic_msg, &location, &bt_str, &crash_path);
 
-        eprintln!("\n\x1b[1;31mpixtuoid v{version} crashed.\x1b[0m\n");
+        eprintln!("\n\x1b[1;31mpixtuoid v{version} crashed — sorry about that.\x1b[0m\n");
         eprintln!("  \x1b[2m{panic_msg}\x1b[0m");
         eprintln!("  \x1b[2mat {location}\x1b[0m\n");
-        eprintln!("  Report saved to: {}\n", crash_path.display());
-        eprintln!("  \x1b[1mFile a bug report (pre-filled):\x1b[0m");
-        eprintln!("  {issue_url}\n");
+        eprintln!("  \x1b[1mHelp fix it\x1b[0m — open this link to file a pre-filled bug report");
+        eprintln!("  (panic + backtrace already included, no typing needed):\n");
+        eprintln!("  \x1b[4m{issue_url}\x1b[0m\n");
+        eprintln!(
+            "  Full backtrace saved to \x1b[2m{}\x1b[0m",
+            crash_path.display()
+        );
+        eprintln!("  \x1b[2m(attach if the reviewer asks — the link above only carries a truncated trace)\x1b[0m\n");
     }));
 }
 


### PR DESCRIPTION
## Summary
- Open the crash banner with "sorry about that" instead of a curt "crashed."
- Promote the pre-filled GitHub issue URL above the crash.log path and underline it (terminals render it as a cmd-clickable link).
- Reframe `crash.log` as the fallback for full backtraces, since the URL only carries a truncated trace.

Replaces the heavier "add Sentry SDK" idea — sharper messaging covers the same goal (lower-friction crash reports) without adding a network dependency or privacy posture change.

## Test plan
- [x] Build clean (`cargo build -p pixtuoid`).
- [x] Trigger panic locally via temporary env-gated `panic!()`, eyeball output: header / URL / crash.log line all render correctly with bold/dim/underline ANSI.
- [ ] CI: full preflight (rustfmt + machete + deny + clippy -D warnings + workspace tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)