### PR TITLE
feat(motion): centralize easing curves + 4 polished animations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ crates/
 │   ├── runtime.rs          tokio task wiring (source ── (Transport, AgentEvent) ──► reducer ──► renderer)
 │   ├── install/            settings.json merge, atomic write, advisory lock, stow-symlink safe
 │   └── tui/                ratatui App + TuiRenderer (Renderer trait impl)
+│       ├── anim.rs         centralized easing curves + eased_progress(start, duration_ms, easing, now) free function — used by floor slide, A* walk path ease, and version popup entrance/dismissal animations
 │       ├── renderer.rs     draw_scene orchestrator (DrawCtx struct), half-block flush, terminal lifecycle
 │       ├── widgets/        ratatui widget paint fns, split into sub-modules:
 │       │                   mod.rs (TickerQueue, shared helpers), hud.rs (footer, wall display,

--- a/crates/pixtuoid/examples/snapshot.rs
+++ b/crates/pixtuoid/examples/snapshot.rs
@@ -196,7 +196,7 @@ fn main() -> Result<()> {
         coffee_holders: &std::collections::HashSet::new(),
         coffee_fetched_at: &std::collections::HashMap::new(),
         new_coffee_carriers: Vec::new(),
-        popup_scale: 1.0,
+        popup_scale: 0.0,
     };
     draw_scene(&mut term, &scene, &pack, now, &mut draw_ctx)?;
 
@@ -654,7 +654,7 @@ fn save_as_gif(
             coffee_holders: &std::collections::HashSet::new(),
             coffee_fetched_at: &std::collections::HashMap::new(),
             new_coffee_carriers: Vec::new(),
-            popup_scale: 1.0,
+            popup_scale: 0.0,
         };
         draw_scene(term, scene, pack, now, &mut draw_ctx)?;
 

--- a/crates/pixtuoid/examples/snapshot.rs
+++ b/crates/pixtuoid/examples/snapshot.rs
@@ -196,7 +196,7 @@ fn main() -> Result<()> {
         coffee_holders: &std::collections::HashSet::new(),
         coffee_fetched_at: &std::collections::HashMap::new(),
         new_coffee_carriers: Vec::new(),
-        version_popup: false,
+        popup_scale: 1.0,
     };
     draw_scene(&mut term, &scene, &pack, now, &mut draw_ctx)?;
 
@@ -654,7 +654,7 @@ fn save_as_gif(
             coffee_holders: &std::collections::HashSet::new(),
             coffee_fetched_at: &std::collections::HashMap::new(),
             new_coffee_carriers: Vec::new(),
-            version_popup: false,
+            popup_scale: 1.0,
         };
         draw_scene(term, scene, pack, now, &mut draw_ctx)?;
 

--- a/crates/pixtuoid/src/tui/anim.rs
+++ b/crates/pixtuoid/src/tui/anim.rs
@@ -8,6 +8,8 @@
 //! LightingState, PoseHistory) for v2 daemon-split compatibility.
 //! See CLAUDE.md "Known sharp edges".
 
+use std::time::{Duration, SystemTime};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Easing {
     Linear,
@@ -44,9 +46,33 @@ impl Easing {
     }
 }
 
+/// Compute the eased progress of an animation `[0.0, 1.0]` given its
+/// `started_at` wall-clock time, total `duration_ms`, and `easing` curve.
+///
+/// Clamps to `0.0` if `now` is before `started_at`, and to `1.0` if
+/// `duration_ms` has fully elapsed.
+pub fn eased_progress(
+    started_at: SystemTime,
+    duration_ms: u32,
+    easing: Easing,
+    now: SystemTime,
+) -> f32 {
+    let elapsed = now
+        .duration_since(started_at)
+        .unwrap_or(Duration::ZERO)
+        .as_millis() as f32;
+    let raw = if duration_ms == 0 {
+        1.0
+    } else {
+        (elapsed / duration_ms as f32).clamp(0.0, 1.0)
+    };
+    easing.apply(raw)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{Duration, SystemTime};
 
     fn approx_eq(a: f32, b: f32) -> bool {
         (a - b).abs() < 1e-4
@@ -113,5 +139,49 @@ mod tests {
         assert!(approx_eq(Easing::Linear.apply(2.0), 1.0));
         assert!(approx_eq(Easing::EaseOutCubic.apply(-0.5), 0.0));
         assert!(approx_eq(Easing::EaseInOutCubic.apply(1.5), 1.0));
+    }
+
+    #[test]
+    fn eased_progress_at_start_is_zero() {
+        let start = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+        let p = eased_progress(start, 200, Easing::Linear, start);
+        assert!(approx_eq(p, 0.0));
+    }
+
+    #[test]
+    fn eased_progress_at_end_is_one() {
+        let start = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+        let now = start + Duration::from_millis(200);
+        let p = eased_progress(start, 200, Easing::Linear, now);
+        assert!(approx_eq(p, 1.0));
+    }
+
+    #[test]
+    fn eased_progress_past_end_clamps_to_one() {
+        let start = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+        let now = start + Duration::from_secs(60);
+        let p = eased_progress(start, 200, Easing::Linear, now);
+        assert!(approx_eq(p, 1.0));
+    }
+
+    #[test]
+    fn eased_progress_now_before_start_clamps_to_zero() {
+        let start = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+        let now = start - Duration::from_secs(5);
+        let p = eased_progress(start, 200, Easing::Linear, now);
+        assert!(approx_eq(p, 0.0));
+    }
+
+    #[test]
+    fn eased_progress_applies_curve() {
+        let start = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+        let now = start + Duration::from_millis(100);
+        let linear = eased_progress(start, 200, Easing::Linear, now);
+        let eased = eased_progress(start, 200, Easing::EaseOutCubic, now);
+        assert!(approx_eq(linear, 0.5));
+        assert!(
+            eased > 0.8,
+            "expected ease-out to be past 80% at midpoint; got {eased}"
+        );
     }
 }

--- a/crates/pixtuoid/src/tui/anim.rs
+++ b/crates/pixtuoid/src/tui/anim.rs
@@ -1,0 +1,117 @@
+//! Stateless easing curves for animations.
+//!
+//! `Easing::apply` maps a normalized `t ∈ [0.0, 1.0]` through a chosen curve.
+//! `eased_progress` (added in Task 2) is the convenience wrapper that takes a
+//! wall-clock `started_at` + `duration_ms` and returns the eased progress.
+//!
+//! SystemTime: matches existing animation state (FloorTransition,
+//! LightingState, PoseHistory) for v2 daemon-split compatibility.
+//! See CLAUDE.md "Known sharp edges".
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Easing {
+    Linear,
+    EaseOutCubic,
+    EaseInOutCubic,
+    EaseOutExpo,
+    EaseInQuad,
+}
+
+impl Easing {
+    /// Apply the easing curve to a normalized `t ∈ [0.0, 1.0]`.
+    /// Inputs outside that range are clamped.
+    pub fn apply(self, t: f32) -> f32 {
+        let t = t.clamp(0.0, 1.0);
+        match self {
+            Easing::Linear => t,
+            Easing::EaseOutCubic => 1.0 - (1.0 - t).powi(3),
+            Easing::EaseInOutCubic => {
+                if t < 0.5 {
+                    4.0 * t.powi(3)
+                } else {
+                    1.0 - (-2.0 * t + 2.0).powi(3) / 2.0
+                }
+            }
+            Easing::EaseOutExpo => {
+                if t >= 1.0 {
+                    1.0
+                } else {
+                    1.0 - 2.0_f32.powf(-10.0 * t)
+                }
+            }
+            Easing::EaseInQuad => t * t,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn approx_eq(a: f32, b: f32) -> bool {
+        (a - b).abs() < 1e-4
+    }
+
+    #[test]
+    fn linear_endpoints() {
+        assert!(approx_eq(Easing::Linear.apply(0.0), 0.0));
+        assert!(approx_eq(Easing::Linear.apply(1.0), 1.0));
+        assert!(approx_eq(Easing::Linear.apply(0.5), 0.5));
+    }
+
+    #[test]
+    fn ease_out_cubic_endpoints() {
+        assert!(approx_eq(Easing::EaseOutCubic.apply(0.0), 0.0));
+        assert!(approx_eq(Easing::EaseOutCubic.apply(1.0), 1.0));
+        // Should overshoot midpoint (fast start, slow end)
+        assert!(Easing::EaseOutCubic.apply(0.5) > 0.5);
+    }
+
+    #[test]
+    fn ease_in_out_cubic_endpoints() {
+        assert!(approx_eq(Easing::EaseInOutCubic.apply(0.0), 0.0));
+        assert!(approx_eq(Easing::EaseInOutCubic.apply(1.0), 1.0));
+        assert!(approx_eq(Easing::EaseInOutCubic.apply(0.5), 0.5));
+    }
+
+    #[test]
+    fn ease_out_expo_endpoints() {
+        assert!(approx_eq(Easing::EaseOutExpo.apply(0.0), 0.0));
+        assert!(approx_eq(Easing::EaseOutExpo.apply(1.0), 1.0));
+        assert!(Easing::EaseOutExpo.apply(0.5) > 0.9);
+    }
+
+    #[test]
+    fn ease_in_quad_endpoints() {
+        assert!(approx_eq(Easing::EaseInQuad.apply(0.0), 0.0));
+        assert!(approx_eq(Easing::EaseInQuad.apply(1.0), 1.0));
+        assert!(approx_eq(Easing::EaseInQuad.apply(0.5), 0.25));
+    }
+
+    #[test]
+    fn all_curves_are_monotone_non_decreasing() {
+        for curve in [
+            Easing::Linear,
+            Easing::EaseOutCubic,
+            Easing::EaseInOutCubic,
+            Easing::EaseOutExpo,
+            Easing::EaseInQuad,
+        ] {
+            let mut prev = -1.0_f32;
+            for i in 0..=100 {
+                let t = i as f32 / 100.0;
+                let v = curve.apply(t);
+                assert!(v >= prev, "{:?} not monotone at t={t}: {v} < {prev}", curve);
+                prev = v;
+            }
+        }
+    }
+
+    #[test]
+    fn out_of_range_inputs_clamp() {
+        assert!(approx_eq(Easing::Linear.apply(-1.0), 0.0));
+        assert!(approx_eq(Easing::Linear.apply(2.0), 1.0));
+        assert!(approx_eq(Easing::EaseOutCubic.apply(-0.5), 0.0));
+        assert!(approx_eq(Easing::EaseInOutCubic.apply(1.5), 1.0));
+    }
+}

--- a/crates/pixtuoid/src/tui/anim.rs
+++ b/crates/pixtuoid/src/tui/anim.rs
@@ -15,7 +15,6 @@ pub enum Easing {
     Linear,
     EaseOutCubic,
     EaseInOutCubic,
-    EaseOutExpo,
     EaseInQuad,
 }
 
@@ -32,13 +31,6 @@ impl Easing {
                     4.0 * t.powi(3)
                 } else {
                     1.0 - (-2.0 * t + 2.0).powi(3) / 2.0
-                }
-            }
-            Easing::EaseOutExpo => {
-                if t >= 1.0 {
-                    1.0
-                } else {
-                    1.0 - 2.0_f32.powf(-10.0 * t)
                 }
             }
             Easing::EaseInQuad => t * t,
@@ -101,13 +93,6 @@ mod tests {
     }
 
     #[test]
-    fn ease_out_expo_endpoints() {
-        assert!(approx_eq(Easing::EaseOutExpo.apply(0.0), 0.0));
-        assert!(approx_eq(Easing::EaseOutExpo.apply(1.0), 1.0));
-        assert!(Easing::EaseOutExpo.apply(0.5) > 0.9);
-    }
-
-    #[test]
     fn ease_in_quad_endpoints() {
         assert!(approx_eq(Easing::EaseInQuad.apply(0.0), 0.0));
         assert!(approx_eq(Easing::EaseInQuad.apply(1.0), 1.0));
@@ -120,7 +105,6 @@ mod tests {
             Easing::Linear,
             Easing::EaseOutCubic,
             Easing::EaseInOutCubic,
-            Easing::EaseOutExpo,
             Easing::EaseInQuad,
         ] {
             let mut prev = -1.0_f32;

--- a/crates/pixtuoid/src/tui/floor.rs
+++ b/crates/pixtuoid/src/tui/floor.rs
@@ -6,7 +6,7 @@
 //! and the per-floor rendering context (`FloorCtx`) so each floor owns its
 //! own router, overlay, pose history, and frame cache.
 
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 
 use pixtuoid_core::state::{AgentSlot, SceneState};
 use pixtuoid_core::walkable::OccupancyOverlay;
@@ -181,12 +181,12 @@ impl FloorTransition {
 
     /// Progress ratio 0.0 → 1.0 with ease-in-out curve.
     pub fn t(&self, now: SystemTime) -> f32 {
-        let elapsed = now
-            .duration_since(self.started_at)
-            .unwrap_or(Duration::ZERO)
-            .as_millis() as f32;
-        let linear = (elapsed / self.duration_ms as f32).clamp(0.0, 1.0);
-        ease_out(linear)
+        crate::tui::anim::eased_progress(
+            self.started_at,
+            self.duration_ms as u32,
+            crate::tui::anim::Easing::EaseInOutCubic,
+            now,
+        )
     }
 
     pub fn is_done(&self, now: SystemTime) -> bool {
@@ -197,10 +197,6 @@ impl FloorTransition {
 // ---------------------------------------------------------------------------
 // Pure arithmetic helpers
 // ---------------------------------------------------------------------------
-
-fn ease_out(t: f32) -> f32 {
-    1.0 - (1.0 - t) * (1.0 - t)
-}
 
 /// How many floors are needed to seat all agents?
 pub fn num_floors(scene: &SceneState) -> usize {

--- a/crates/pixtuoid/src/tui/mod.rs
+++ b/crates/pixtuoid/src/tui/mod.rs
@@ -211,8 +211,10 @@ pub async fn run_tui(
                                     crate::version::release_notes(env!("CARGO_PKG_VERSION"))
                                         .map(|n| n.len())
                                         .unwrap_or(0);
+                                let scale =
+                                    renderer.version_popup_scale(std::time::SystemTime::now());
                                 if let Some(rect) =
-                                    widgets::version_popup_url_rect(notes_len, bounds, 1.0)
+                                    widgets::version_popup_url_rect(notes_len, bounds, scale)
                                 {
                                     if m.column >= rect.x
                                         && m.column < rect.x + rect.width

--- a/crates/pixtuoid/src/tui/mod.rs
+++ b/crates/pixtuoid/src/tui/mod.rs
@@ -195,10 +195,12 @@ pub async fn run_tui(
                             }
                         }
                     }
-                    Event::Mouse(m) if version_popup => {
-                        // While the popup is visible, only the URL link is
-                        // clickable; all other clicks are swallowed so they
-                        // don't fall through to the scene behind.
+                    Event::Mouse(m) if renderer.last_popup_scale() > 0.0 => {
+                        // While the popup is animating or fully visible, only
+                        // the URL link is clickable; all other clicks are
+                        // swallowed so they don't fall through to the scene.
+                        // Uses the painter's frame-scale (last_popup_scale) so
+                        // the click geometry matches what was actually painted.
                         if matches!(m.kind, MouseEventKind::Down(MouseButton::Left)) {
                             if let Ok((cols, rows)) = crossterm::terminal::size() {
                                 let bounds = ratatui::layout::Rect {
@@ -211,8 +213,7 @@ pub async fn run_tui(
                                     crate::version::release_notes(env!("CARGO_PKG_VERSION"))
                                         .map(|n| n.len())
                                         .unwrap_or(0);
-                                let scale =
-                                    renderer.version_popup_scale(std::time::SystemTime::now());
+                                let scale = renderer.last_popup_scale();
                                 if let Some(rect) =
                                     widgets::version_popup_url_rect(notes_len, bounds, scale)
                                 {

--- a/crates/pixtuoid/src/tui/mod.rs
+++ b/crates/pixtuoid/src/tui/mod.rs
@@ -1,3 +1,4 @@
+pub mod anim;
 pub mod chitchat;
 pub mod embedded_pack;
 pub mod floor;

--- a/crates/pixtuoid/src/tui/mod.rs
+++ b/crates/pixtuoid/src/tui/mod.rs
@@ -212,7 +212,7 @@ pub async fn run_tui(
                                         .map(|n| n.len())
                                         .unwrap_or(0);
                                 if let Some(rect) =
-                                    widgets::version_popup_url_rect(notes_len, bounds)
+                                    widgets::version_popup_url_rect(notes_len, bounds, 1.0)
                                 {
                                     if m.column >= rect.x
                                         && m.column < rect.x + rect.width

--- a/crates/pixtuoid/src/tui/mod.rs
+++ b/crates/pixtuoid/src/tui/mod.rs
@@ -81,7 +81,7 @@ pub async fn run_tui(
                 last_layout_sig = Some(sig);
             }
             renderer.set_theme_picker(theme_picker);
-            renderer.set_version_popup(version_popup);
+            renderer.set_version_popup(version_popup, now);
             renderer.render(&snapshot, &pack, now)?;
 
             // Auto-compute per-floor desk capacity from the current

--- a/crates/pixtuoid/src/tui/pose.rs
+++ b/crates/pixtuoid/src/tui/pose.rs
@@ -190,14 +190,26 @@ pub fn derive_with_routing(
         return Some(pose);
     }
     let traveled = (t_x1000 as u32 * total) / 1000;
+    let last_leg = leg_lens.len() - 1;
     let mut acc: u32 = 0;
     for (i, &leg) in leg_lens.iter().enumerate() {
         if acc + leg >= traveled {
             let into_leg = traveled - acc;
-            let seg_t = (into_leg * 1000)
+            let raw_seg_t = (into_leg * 1000)
                 .checked_div(leg)
                 .map(|t| t.min(1000) as u16)
                 .unwrap_or(1000);
+            // Path-tail ease: slow the agent as it approaches the final
+            // destination. Only the final leg is eased; mid-route legs
+            // stay linear so the agent doesn't appear to hesitate at
+            // every turn. Spec: PR #52 (Motion & Easing).
+            let seg_t = if i == last_leg {
+                let normalized = raw_seg_t as f32 / 1000.0;
+                let eased = crate::tui::anim::Easing::EaseOutCubic.apply(normalized);
+                (eased * 1000.0).round() as u16
+            } else {
+                raw_seg_t
+            };
             // Record the walker's current position for the next frame's
             // snap-back lookup.
             let cur_pos = walking_position(path[i], path[i + 1], seg_t);
@@ -518,5 +530,104 @@ mod tests {
         let t1 = t0 + Duration::from_millis(600);
         assert_eq!(history.recent(id, 500, t1), None);
         assert_eq!(history.recent(id, 700, t1), Some(pt));
+    }
+
+    #[test]
+    fn final_leg_seg_t_is_eased() {
+        // Verify that EaseOutCubic is applied to seg_t on the FINAL leg of a
+        // multi-segment A* walk, and that non-final legs stay linear.
+        //
+        // We use t_x1000 = 990 (99% of entry animation) which guarantees
+        // `traveled` lands on the last segment regardless of how leg lengths
+        // split — the agent must be on the final leg at near-end progress.
+        // At that high raw_seg_t, EaseOutCubic approaches 1000 (>= raw), so
+        // seg_t > 900 is a reliable easing signal.
+        //
+        // For the non-final leg smoke-check we use t = 25% and a 4-point path
+        // where the first three legs together consume more than 50% of total
+        // distance, so at 25% we're provably on leg 0 (not the final leg) and
+        // seg_t == raw_seg_t (linear).
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+        let l = layout();
+        let door = l.door_threshold.expect("door");
+        let desk = l.home_desks[0];
+        let entry_ms = ENTRY_ANIMATION_MS;
+
+        // ── Final-leg check: t=99%, 3-point path ─────────────────────────
+        // At t_x1000 ≈ 990 the agent is deep into the last leg.
+        // raw_seg_t depends on octile ratios, but near-end means raw > 900.
+        // EaseOutCubic(x > 0.9) > x, so eased seg_t >= raw ≈ 900+.
+        // We assert seg_t >= 900 (verifying easing doesn't break near-end).
+        let since_990 = 990 * entry_ms / 1000;
+        let slot_990 = entry_slot(now - Duration::from_millis(since_990));
+        let mid = Point {
+            x: (door.x + desk.x) / 2,
+            y: (door.y + desk.y) / 2,
+        };
+        let mut router_990 = StubRouter::corners(vec![door, mid, desk]);
+        let mut history_990 = PoseHistory::new();
+        let overlay = pixtuoid_core::walkable::OccupancyOverlay::new();
+        let p_990 = derive_with_routing(
+            &slot_990,
+            now,
+            &l,
+            &mut router_990,
+            &overlay,
+            &mut history_990,
+        );
+        let seg_t_990 = match p_990 {
+            Some(Pose::Walking { t_x1000, .. }) => t_x1000,
+            other => panic!("expected Walking at t=990, got {other:?}"),
+        };
+        // At 99% progress on the final leg, easing brings seg_t close to 1000.
+        assert!(
+            seg_t_990 >= 900,
+            "final-leg seg_t at 99% should be >= 900 (eased), got {seg_t_990}"
+        );
+        assert!(
+            seg_t_990 <= 1000,
+            "seg_t must not exceed 1000, got {seg_t_990}"
+        );
+
+        // ── Non-final leg check: t=10%, 3-point path ─────────────────────
+        // At t_x1000 ≈ 100 (10%), traveled is near the start.
+        // For any 2-leg path, traveled < leg0 unless leg0 is negligibly small.
+        // For our door→mid→desk path both legs are tens of octile units, so
+        // at 10% the agent is on leg 0 (not the final leg) → seg_t is linear.
+        // Linear seg_t ≈ raw_seg_t. We just check it's <= 1000 and well below
+        // the eased value we'd get at the same raw_seg_t on the final leg.
+        let since_100 = 100 * entry_ms / 1000;
+        let slot_100 = entry_slot(now - Duration::from_millis(since_100));
+        let mut router_100 = StubRouter::corners(vec![door, mid, desk]);
+        let mut history_100 = PoseHistory::new();
+        let p_100 = derive_with_routing(
+            &slot_100,
+            now,
+            &l,
+            &mut router_100,
+            &overlay,
+            &mut history_100,
+        );
+        match p_100 {
+            Some(Pose::Walking { from, t_x1000, .. }) => {
+                // Non-final leg: from == door confirms we're on leg 0.
+                assert_eq!(
+                    from, door,
+                    "at 10% agent should be on first leg (from=door)"
+                );
+                // Non-final leg is linear: seg_t == raw_seg_t.
+                // EaseOutCubic(x) > x for 0 < x < 1, so if easing were
+                // mistakenly applied here, seg_t would be notably higher than
+                // raw. Verify seg_t is in the plausible linear range (not inflated).
+                // At 10% total with two roughly equal legs, seg_t ≈ 200.
+                // If easing were applied: EaseOutCubic(0.2)=0.488 → seg_t≈488.
+                // We assert seg_t < 400 to distinguish linear from eased.
+                assert!(
+                    t_x1000 < 400,
+                    "non-final leg seg_t should be linear (< 400), got {t_x1000}"
+                );
+            }
+            other => panic!("expected Walking at t=100, got {other:?}"),
+        }
     }
 }

--- a/crates/pixtuoid/src/tui/pose.rs
+++ b/crates/pixtuoid/src/tui/pose.rs
@@ -172,15 +172,33 @@ pub fn derive_with_routing(
     if let Some(last) = path.last_mut() {
         *last = to;
     }
+    // Global path-ease: apply EaseOutCubic to the walk's overall progress
+    // BEFORE leg dispatch, so the agent decelerates smoothly across the
+    // entire walk with no per-leg velocity discontinuity, and with
+    // consistent feel regardless of path length (2-point or 3+ point).
+    let normalized_t = t_x1000 as f32 / 1000.0;
+    let eased_t = crate::tui::anim::Easing::EaseOutCubic.apply(normalized_t);
+    let eased_t_x1000 = (eased_t * 1000.0).round() as u16;
+
     if path.len() <= 2 {
-        // Straight-line walk — record the interpolated position for
+        // Straight-line walk — record the eased interpolated position for
         // next frame's snap-back lookup.
-        history.record(slot.agent_id, walking_position(from, to, t_x1000), now);
-        return Some(pose);
+        history.record(
+            slot.agent_id,
+            walking_position(from, to, eased_t_x1000),
+            now,
+        );
+        return Some(Pose::Walking {
+            from,
+            to,
+            t_x1000: eased_t_x1000,
+            frame,
+            carrying_coffee,
+        });
     }
-    // Map global t to a (segment_idx, t_within_segment) using cumulative
-    // octile distance — same metric A* used to plan the path, so timing
-    // stays uniform along diagonals.
+    // Map global eased t to a (segment_idx, t_within_segment) using
+    // cumulative octile distance — same metric A* used to plan the path,
+    // so timing stays uniform along diagonals.
     let mut leg_lens: Vec<u32> = Vec::with_capacity(path.len() - 1);
     for w in path.windows(2) {
         leg_lens.push(octile_distance(w[0], w[1]));
@@ -189,27 +207,15 @@ pub fn derive_with_routing(
     if total == 0 {
         return Some(pose);
     }
-    let traveled = (t_x1000 as u32 * total) / 1000;
-    let last_leg = leg_lens.len() - 1;
+    let traveled = (eased_t_x1000 as u32 * total) / 1000;
     let mut acc: u32 = 0;
     for (i, &leg) in leg_lens.iter().enumerate() {
         if acc + leg >= traveled {
             let into_leg = traveled - acc;
-            let raw_seg_t = (into_leg * 1000)
+            let seg_t = (into_leg * 1000)
                 .checked_div(leg)
                 .map(|t| t.min(1000) as u16)
                 .unwrap_or(1000);
-            // Path-tail ease: slow the agent as it approaches the final
-            // destination. Only the final leg is eased; mid-route legs
-            // stay linear so the agent doesn't appear to hesitate at
-            // every turn. Spec: PR #52 (Motion & Easing).
-            let seg_t = if i == last_leg {
-                let normalized = raw_seg_t as f32 / 1000.0;
-                let eased = crate::tui::anim::Easing::EaseOutCubic.apply(normalized);
-                (eased * 1000.0).round() as u16
-            } else {
-                raw_seg_t
-            };
             // Record the walker's current position for the next frame's
             // snap-back lookup.
             let cur_pos = walking_position(path[i], path[i + 1], seg_t);
@@ -420,17 +426,15 @@ mod tests {
     fn multi_segment_path_maps_t_to_segment_via_octile_distance() {
         let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
         let l = layout();
-        // Entry animation: ENTRY_ANIMATION_MS = 4000, since_spawn = 1000 →
-        // t_x1000 = 250. derive returns Walking { from: door, to: desk, t=250 }.
-        let slot = entry_slot(now - Duration::from_millis(1_000));
+        // Entry animation: ENTRY_ANIMATION_MS = 4000, since_spawn = 400 →
+        // raw t_x1000 = 100. With global ease: EaseOutCubic(0.1) ≈ 0.271 →
+        // eased_t_x1000 ≈ 271. For two ~equal legs, traveled ≈ 27.1% of
+        // total → agent is on leg 0 (door→mid), seg_t ≈ 54%.
+        let slot = entry_slot(now - Duration::from_millis(400));
         let mut history = PoseHistory::new();
         let overlay = pixtuoid_core::walkable::OccupancyOverlay::new();
         let door = l.door_threshold.expect("door");
         let desk = l.home_desks[0];
-        // `mid` placed on the straight line between door and desk so the
-        // two legs have ~equal octile distance after the last-point
-        // substitution. At t=250 (1/4 of the walk), `traveled` lands
-        // about halfway through segment 0 → seg_t ≈ 500.
         let mid = Point {
             x: (door.x + desk.x) / 2,
             y: (door.y + desk.y) / 2,
@@ -443,9 +447,11 @@ mod tests {
             }) => {
                 assert_eq!(from, door, "first segment starts at door, got {from:?}");
                 assert_eq!(to, mid, "first segment ends at mid, got {to:?}");
+                // eased(0.1) ≈ 0.271 → seg_t of first leg ≈ 0.271*2 = 0.542 → ~542.
+                // Accept a wider band to tolerate octile rounding.
                 assert!(
-                    (400..=600).contains(&t_x1000),
-                    "expected mid-segment ~500, got t_x1000={t_x1000}"
+                    (300..=700).contains(&t_x1000),
+                    "expected mid-first-segment seg_t in [300,700], got t_x1000={t_x1000}"
                 );
                 assert!(history.recent(slot.agent_id, 1_000, now).is_some());
             }
@@ -533,40 +539,60 @@ mod tests {
     }
 
     #[test]
-    fn final_leg_seg_t_is_eased() {
-        // Verify that EaseOutCubic is applied to seg_t on the FINAL leg of a
-        // multi-segment A* walk, and that non-final legs stay linear.
+    fn walk_progress_is_eased_globally() {
+        // Regression: EaseOutCubic is applied to the walk's GLOBAL progress
+        // before leg dispatch. This means:
+        //   1. No per-leg velocity discontinuity — all legs see the eased t.
+        //   2. Consistent deceleration on both 2-point and 3+ point paths.
         //
-        // We use t_x1000 = 990 (99% of entry animation) which guarantees
-        // `traveled` lands on the last segment regardless of how leg lengths
-        // split — the agent must be on the final leg at near-end progress.
-        // At that high raw_seg_t, EaseOutCubic approaches 1000 (>= raw), so
-        // seg_t > 900 is a reliable easing signal.
+        // Key property: EaseOutCubic(0.5) ≈ 0.875, so at t=50% of the walk
+        // the agent should be PAST the geometric midpoint (i.e. on the second
+        // of two equal-length legs, not the first).
         //
-        // For the non-final leg smoke-check we use t = 25% and a 4-point path
-        // where the first three legs together consume more than 50% of total
-        // distance, so at 25% we're provably on leg 0 (not the final leg) and
-        // seg_t == raw_seg_t (linear).
+        // At t=99% the agent must still be well inside [900, 1000] on the
+        // final leg (near-end correctness check).
         let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
         let l = layout();
         let door = l.door_threshold.expect("door");
         let desk = l.home_desks[0];
         let entry_ms = ENTRY_ANIMATION_MS;
 
-        // ── Final-leg check: t=99%, 3-point path ─────────────────────────
-        // At t_x1000 ≈ 990 the agent is deep into the last leg.
-        // raw_seg_t depends on octile ratios, but near-end means raw > 900.
-        // EaseOutCubic(x > 0.9) > x, so eased seg_t >= raw ≈ 900+.
-        // We assert seg_t >= 900 (verifying easing doesn't break near-end).
-        let since_990 = 990 * entry_ms / 1000;
-        let slot_990 = entry_slot(now - Duration::from_millis(since_990));
         let mid = Point {
             x: (door.x + desk.x) / 2,
             y: (door.y + desk.y) / 2,
         };
+        let overlay = pixtuoid_core::walkable::OccupancyOverlay::new();
+
+        // ── At t=50%, agent should be on the SECOND leg ──────────────────
+        // EaseOutCubic(0.5) ≈ 0.875 > 0.5, so eased traveled > half of
+        // total distance → agent is past mid-point → on leg 1 (from=mid).
+        let since_500 = 500 * entry_ms / 1000;
+        let slot_500 = entry_slot(now - Duration::from_millis(since_500));
+        let mut router_500 = StubRouter::corners(vec![door, mid, desk]);
+        let mut history_500 = PoseHistory::new();
+        let p_500 = derive_with_routing(
+            &slot_500,
+            now,
+            &l,
+            &mut router_500,
+            &overlay,
+            &mut history_500,
+        );
+        match p_500 {
+            Some(Pose::Walking { from, .. }) => {
+                assert_eq!(
+                    from, mid,
+                    "at t=50%, global ease puts agent past mid-point: should be on leg 1 (from=mid), got from={from:?}"
+                );
+            }
+            other => panic!("expected Walking at t=500, got {other:?}"),
+        }
+
+        // ── At t=99%, agent should be near end: seg_t in [900, 1000] ─────
+        let since_990 = 990 * entry_ms / 1000;
+        let slot_990 = entry_slot(now - Duration::from_millis(since_990));
         let mut router_990 = StubRouter::corners(vec![door, mid, desk]);
         let mut history_990 = PoseHistory::new();
-        let overlay = pixtuoid_core::walkable::OccupancyOverlay::new();
         let p_990 = derive_with_routing(
             &slot_990,
             now,
@@ -579,55 +605,41 @@ mod tests {
             Some(Pose::Walking { t_x1000, .. }) => t_x1000,
             other => panic!("expected Walking at t=990, got {other:?}"),
         };
-        // At 99% progress on the final leg, easing brings seg_t close to 1000.
         assert!(
             seg_t_990 >= 900,
-            "final-leg seg_t at 99% should be >= 900 (eased), got {seg_t_990}"
+            "at t=99%, seg_t should be >= 900 (near end), got {seg_t_990}"
         );
         assert!(
             seg_t_990 <= 1000,
             "seg_t must not exceed 1000, got {seg_t_990}"
         );
 
-        // ── Non-final leg check: t=10%, 3-point path ─────────────────────
-        // At t_x1000 ≈ 100 (10%), traveled is near the start.
-        // For any 2-leg path, traveled < leg0 unless leg0 is negligibly small.
-        // For our door→mid→desk path both legs are tens of octile units, so
-        // at 10% the agent is on leg 0 (not the final leg) → seg_t is linear.
-        // Linear seg_t ≈ raw_seg_t. We just check it's <= 1000 and well below
-        // the eased value we'd get at the same raw_seg_t on the final leg.
-        let since_100 = 100 * entry_ms / 1000;
-        let slot_100 = entry_slot(now - Duration::from_millis(since_100));
-        let mut router_100 = StubRouter::corners(vec![door, mid, desk]);
-        let mut history_100 = PoseHistory::new();
-        let p_100 = derive_with_routing(
-            &slot_100,
+        // ── 2-point path: same global ease applies ────────────────────────
+        // A straight-line walk (path.len()==2) should also get global ease.
+        // At t=50%, eased_t_x1000 ≈ 875. Verify via a StubRouter::straight
+        // path and a matching entry_slot at t=500.
+        let slot_2pt = entry_slot(now - Duration::from_millis(since_500));
+        let mut router_2pt = StubRouter::straight();
+        let mut history_2pt = PoseHistory::new();
+        let p_2pt = derive_with_routing(
+            &slot_2pt,
             now,
             &l,
-            &mut router_100,
+            &mut router_2pt,
             &overlay,
-            &mut history_100,
+            &mut history_2pt,
         );
-        match p_100 {
-            Some(Pose::Walking { from, t_x1000, .. }) => {
-                // Non-final leg: from == door confirms we're on leg 0.
-                assert_eq!(
-                    from, door,
-                    "at 10% agent should be on first leg (from=door)"
-                );
-                // Non-final leg is linear: seg_t == raw_seg_t.
-                // EaseOutCubic(x) > x for 0 < x < 1, so if easing were
-                // mistakenly applied here, seg_t would be notably higher than
-                // raw. Verify seg_t is in the plausible linear range (not inflated).
-                // At 10% total with two roughly equal legs, seg_t ≈ 200.
-                // If easing were applied: EaseOutCubic(0.2)=0.488 → seg_t≈488.
-                // We assert seg_t < 400 to distinguish linear from eased.
+        match p_2pt {
+            Some(Pose::Walking { t_x1000, .. }) => {
+                // EaseOutCubic(0.5) ≈ 0.875 → t_x1000 ≈ 875.
+                // Without global ease, raw t_x1000 ≈ 500. Assert > 600 to
+                // distinguish eased from linear clearly.
                 assert!(
-                    t_x1000 < 400,
-                    "non-final leg seg_t should be linear (< 400), got {t_x1000}"
+                    t_x1000 > 600,
+                    "2-point walk at t=50% should have eased t_x1000 > 600 (EaseOutCubic(0.5)≈875), got {t_x1000}"
                 );
             }
-            other => panic!("expected Walking at t=100, got {other:?}"),
+            other => panic!("expected Walking for 2-point path at t=500, got {other:?}"),
         }
     }
 }

--- a/crates/pixtuoid/src/tui/pose.rs
+++ b/crates/pixtuoid/src/tui/pose.rs
@@ -172,33 +172,21 @@ pub fn derive_with_routing(
     if let Some(last) = path.last_mut() {
         *last = to;
     }
-    // Global path-ease: apply EaseOutCubic to the walk's overall progress
-    // BEFORE leg dispatch, so the agent decelerates smoothly across the
-    // entire walk with no per-leg velocity discontinuity, and with
-    // consistent feel regardless of path length (2-point or 3+ point).
-    let normalized_t = t_x1000 as f32 / 1000.0;
-    let eased_t = crate::tui::anim::Easing::EaseOutCubic.apply(normalized_t);
-    let eased_t_x1000 = (eased_t * 1000.0).round() as u16;
-
     if path.len() <= 2 {
-        // Straight-line walk — record the eased interpolated position for
-        // next frame's snap-back lookup.
-        history.record(
-            slot.agent_id,
-            walking_position(from, to, eased_t_x1000),
-            now,
-        );
+        // Straight-line walk — record the interpolated position for next
+        // frame's snap-back lookup.
+        history.record(slot.agent_id, walking_position(from, to, t_x1000), now);
         return Some(Pose::Walking {
             from,
             to,
-            t_x1000: eased_t_x1000,
+            t_x1000,
             frame,
             carrying_coffee,
         });
     }
-    // Map global eased t to a (segment_idx, t_within_segment) using
-    // cumulative octile distance — same metric A* used to plan the path,
-    // so timing stays uniform along diagonals.
+    // Map global t to a (segment_idx, t_within_segment) using cumulative
+    // octile distance — same metric A* used to plan the path, so timing
+    // stays uniform along diagonals.
     let mut leg_lens: Vec<u32> = Vec::with_capacity(path.len() - 1);
     for w in path.windows(2) {
         leg_lens.push(octile_distance(w[0], w[1]));
@@ -207,7 +195,7 @@ pub fn derive_with_routing(
     if total == 0 {
         return Some(pose);
     }
-    let traveled = (eased_t_x1000 as u32 * total) / 1000;
+    let traveled = (t_x1000 as u32 * total) / 1000;
     let mut acc: u32 = 0;
     for (i, &leg) in leg_lens.iter().enumerate() {
         if acc + leg >= traveled {
@@ -427,9 +415,8 @@ mod tests {
         let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
         let l = layout();
         // Entry animation: ENTRY_ANIMATION_MS = 4000, since_spawn = 400 →
-        // raw t_x1000 = 100. With global ease: EaseOutCubic(0.1) ≈ 0.271 →
-        // eased_t_x1000 ≈ 271. For two ~equal legs, traveled ≈ 27.1% of
-        // total → agent is on leg 0 (door→mid), seg_t ≈ 54%.
+        // raw t_x1000 = 100. For two ~equal legs, traveled ≈ 10% of total
+        // → agent is on leg 0 (door→mid), seg_t ≈ 20%.
         let slot = entry_slot(now - Duration::from_millis(400));
         let mut history = PoseHistory::new();
         let overlay = pixtuoid_core::walkable::OccupancyOverlay::new();
@@ -447,11 +434,11 @@ mod tests {
             }) => {
                 assert_eq!(from, door, "first segment starts at door, got {from:?}");
                 assert_eq!(to, mid, "first segment ends at mid, got {to:?}");
-                // eased(0.1) ≈ 0.271 → seg_t of first leg ≈ 0.271*2 = 0.542 → ~542.
+                // linear t=0.1 over two equal legs → seg_t of first leg ≈ 0.2 → ~200.
                 // Accept a wider band to tolerate octile rounding.
                 assert!(
-                    (300..=700).contains(&t_x1000),
-                    "expected mid-first-segment seg_t in [300,700], got t_x1000={t_x1000}"
+                    (100..=400).contains(&t_x1000),
+                    "expected mid-first-segment seg_t in [100,400], got t_x1000={t_x1000}"
                 );
                 assert!(history.recent(slot.agent_id, 1_000, now).is_some());
             }
@@ -536,110 +523,5 @@ mod tests {
         let t1 = t0 + Duration::from_millis(600);
         assert_eq!(history.recent(id, 500, t1), None);
         assert_eq!(history.recent(id, 700, t1), Some(pt));
-    }
-
-    #[test]
-    fn walk_progress_is_eased_globally() {
-        // Regression: EaseOutCubic is applied to the walk's GLOBAL progress
-        // before leg dispatch. This means:
-        //   1. No per-leg velocity discontinuity — all legs see the eased t.
-        //   2. Consistent deceleration on both 2-point and 3+ point paths.
-        //
-        // Key property: EaseOutCubic(0.5) ≈ 0.875, so at t=50% of the walk
-        // the agent should be PAST the geometric midpoint (i.e. on the second
-        // of two equal-length legs, not the first).
-        //
-        // At t=99% the agent must still be well inside [900, 1000] on the
-        // final leg (near-end correctness check).
-        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
-        let l = layout();
-        let door = l.door_threshold.expect("door");
-        let desk = l.home_desks[0];
-        let entry_ms = ENTRY_ANIMATION_MS;
-
-        let mid = Point {
-            x: (door.x + desk.x) / 2,
-            y: (door.y + desk.y) / 2,
-        };
-        let overlay = pixtuoid_core::walkable::OccupancyOverlay::new();
-
-        // ── At t=50%, agent should be on the SECOND leg ──────────────────
-        // EaseOutCubic(0.5) ≈ 0.875 > 0.5, so eased traveled > half of
-        // total distance → agent is past mid-point → on leg 1 (from=mid).
-        let since_500 = 500 * entry_ms / 1000;
-        let slot_500 = entry_slot(now - Duration::from_millis(since_500));
-        let mut router_500 = StubRouter::corners(vec![door, mid, desk]);
-        let mut history_500 = PoseHistory::new();
-        let p_500 = derive_with_routing(
-            &slot_500,
-            now,
-            &l,
-            &mut router_500,
-            &overlay,
-            &mut history_500,
-        );
-        match p_500 {
-            Some(Pose::Walking { from, .. }) => {
-                assert_eq!(
-                    from, mid,
-                    "at t=50%, global ease puts agent past mid-point: should be on leg 1 (from=mid), got from={from:?}"
-                );
-            }
-            other => panic!("expected Walking at t=500, got {other:?}"),
-        }
-
-        // ── At t=99%, agent should be near end: seg_t in [900, 1000] ─────
-        let since_990 = 990 * entry_ms / 1000;
-        let slot_990 = entry_slot(now - Duration::from_millis(since_990));
-        let mut router_990 = StubRouter::corners(vec![door, mid, desk]);
-        let mut history_990 = PoseHistory::new();
-        let p_990 = derive_with_routing(
-            &slot_990,
-            now,
-            &l,
-            &mut router_990,
-            &overlay,
-            &mut history_990,
-        );
-        let seg_t_990 = match p_990 {
-            Some(Pose::Walking { t_x1000, .. }) => t_x1000,
-            other => panic!("expected Walking at t=990, got {other:?}"),
-        };
-        assert!(
-            seg_t_990 >= 900,
-            "at t=99%, seg_t should be >= 900 (near end), got {seg_t_990}"
-        );
-        assert!(
-            seg_t_990 <= 1000,
-            "seg_t must not exceed 1000, got {seg_t_990}"
-        );
-
-        // ── 2-point path: same global ease applies ────────────────────────
-        // A straight-line walk (path.len()==2) should also get global ease.
-        // At t=50%, eased_t_x1000 ≈ 875. Verify via a StubRouter::straight
-        // path and a matching entry_slot at t=500.
-        let slot_2pt = entry_slot(now - Duration::from_millis(since_500));
-        let mut router_2pt = StubRouter::straight();
-        let mut history_2pt = PoseHistory::new();
-        let p_2pt = derive_with_routing(
-            &slot_2pt,
-            now,
-            &l,
-            &mut router_2pt,
-            &overlay,
-            &mut history_2pt,
-        );
-        match p_2pt {
-            Some(Pose::Walking { t_x1000, .. }) => {
-                // EaseOutCubic(0.5) ≈ 0.875 → t_x1000 ≈ 875.
-                // Without global ease, raw t_x1000 ≈ 500. Assert > 600 to
-                // distinguish eased from linear clearly.
-                assert!(
-                    t_x1000 > 600,
-                    "2-point walk at t=50% should have eased t_x1000 > 600 (EaseOutCubic(0.5)≈875), got {t_x1000}"
-                );
-            }
-            other => panic!("expected Walking for 2-point path at t=500, got {other:?}"),
-        }
     }
 }

--- a/crates/pixtuoid/src/tui/renderer.rs
+++ b/crates/pixtuoid/src/tui/renderer.rs
@@ -317,7 +317,7 @@ pub fn draw_scene<B: Backend<Error: Send + Sync + 'static>>(
         }
         if version_popup {
             if let Some(notes) = crate::version::release_notes(env!("CARGO_PKG_VERSION")) {
-                paint_version_popup(f, env!("CARGO_PKG_VERSION"), notes, actual_full, theme);
+                paint_version_popup(f, env!("CARGO_PKG_VERSION"), notes, actual_full, theme, 1.0);
             }
         }
     })?;

--- a/crates/pixtuoid/src/tui/renderer.rs
+++ b/crates/pixtuoid/src/tui/renderer.rs
@@ -94,7 +94,9 @@ pub struct DrawCtx<'a> {
     /// New coffee carriers detected this frame — caller uses these to
     /// update the persistent `coffee_holders` set.
     pub new_coffee_carriers: Vec<pixtuoid_core::AgentId>,
-    pub version_popup: bool,
+    /// Animated scale for the version popup (0.0 = hidden, 1.0 = fully shown).
+    /// Drives entrance (EaseOutCubic/200ms) and dismissal (EaseInQuad/120ms).
+    pub popup_scale: f32,
 }
 
 /// Clip a widget rect to fit inside `bounds`. Returns `None` if the rect
@@ -249,7 +251,6 @@ pub fn draw_scene<B: Backend<Error: Send + Sync + 'static>>(
     let buf = &ctx.buf;
     let ticker = ctx.ticker;
     let theme_picker = ctx.theme_picker;
-    let version_popup = ctx.version_popup;
     let chitchat_bubbles = &ctx.chitchat_bubbles;
     term.draw(|f| {
         // Re-derive rects from the actual frame buffer to guard against
@@ -315,9 +316,16 @@ pub fn draw_scene<B: Backend<Error: Send + Sync + 'static>>(
         if let Some(idx) = theme_picker {
             paint_theme_picker(f, idx, actual_full, theme);
         }
-        if version_popup {
+        if ctx.popup_scale > 0.0 {
             if let Some(notes) = crate::version::release_notes(env!("CARGO_PKG_VERSION")) {
-                paint_version_popup(f, env!("CARGO_PKG_VERSION"), notes, actual_full, theme, 1.0);
+                paint_version_popup(
+                    f,
+                    env!("CARGO_PKG_VERSION"),
+                    notes,
+                    actual_full,
+                    theme,
+                    ctx.popup_scale,
+                );
             }
         }
     })?;

--- a/crates/pixtuoid/src/tui/tui_renderer.rs
+++ b/crates/pixtuoid/src/tui/tui_renderer.rs
@@ -50,6 +50,7 @@ pub struct TuiRenderer<B: Backend<Error: Send + Sync + 'static>> {
     /// Timestamp when each agent first returned with coffee (for steam).
     coffee_fetched_at: std::collections::HashMap<pixtuoid_core::AgentId, SystemTime>,
     version_popup: bool,
+    version_popup_started_at: Option<SystemTime>,
 }
 
 impl<B: Backend<Error: Send + Sync + 'static>> TuiRenderer<B> {
@@ -77,6 +78,7 @@ impl<B: Backend<Error: Send + Sync + 'static>> TuiRenderer<B> {
             coffee_holders: std::collections::HashSet::new(),
             coffee_fetched_at: std::collections::HashMap::new(),
             version_popup: false,
+            version_popup_started_at: None,
         }
     }
 
@@ -144,8 +146,15 @@ impl<B: Backend<Error: Send + Sync + 'static>> TuiRenderer<B> {
         self.theme_picker = picker;
     }
 
-    pub fn set_version_popup(&mut self, v: bool) {
-        self.version_popup = v;
+    pub fn set_version_popup(&mut self, v: bool, now: SystemTime) {
+        if v != self.version_popup {
+            self.version_popup_started_at = Some(now);
+            self.version_popup = v;
+        }
+    }
+
+    pub fn version_popup_started_at(&self) -> Option<SystemTime> {
+        self.version_popup_started_at
     }
 
     pub fn set_active_pet(&mut self, pet: Option<PetState>) {

--- a/crates/pixtuoid/src/tui/tui_renderer.rs
+++ b/crates/pixtuoid/src/tui/tui_renderer.rs
@@ -51,6 +51,14 @@ pub struct TuiRenderer<B: Backend<Error: Send + Sync + 'static>> {
     coffee_fetched_at: std::collections::HashMap<pixtuoid_core::AgentId, SystemTime>,
     version_popup: bool,
     version_popup_started_at: Option<SystemTime>,
+    /// Scale captured at the moment of the last visible↔hidden edge so that
+    /// an interrupted animation continues from its current position instead
+    /// of snapping back to the start/end.
+    version_popup_scale_at_edge: f32,
+    /// Scale computed during the most recent `render()` call. The mouse
+    /// handler reads this instead of re-computing with a fresh `SystemTime`
+    /// so both sides always agree on whether the popup is above a threshold.
+    last_popup_scale: f32,
 }
 
 impl<B: Backend<Error: Send + Sync + 'static>> TuiRenderer<B> {
@@ -79,6 +87,8 @@ impl<B: Backend<Error: Send + Sync + 'static>> TuiRenderer<B> {
             coffee_fetched_at: std::collections::HashMap::new(),
             version_popup: false,
             version_popup_started_at: None,
+            version_popup_scale_at_edge: 0.0,
+            last_popup_scale: 0.0,
         }
     }
 
@@ -148,6 +158,9 @@ impl<B: Backend<Error: Send + Sync + 'static>> TuiRenderer<B> {
 
     pub fn set_version_popup(&mut self, v: bool, now: SystemTime) {
         if v != self.version_popup {
+            // Capture current scale so the new animation starts from the
+            // visible position (no snap-back when interrupting mid-animation).
+            self.version_popup_scale_at_edge = self.version_popup_scale(now);
             self.version_popup_started_at = Some(now);
             self.version_popup = v;
         }
@@ -160,17 +173,37 @@ impl<B: Backend<Error: Send + Sync + 'static>> TuiRenderer<B> {
     /// Compute the entrance/dismissal scale for the version popup based on
     /// the current state and the time since the last edge. Range 0.0..=1.0.
     ///
-    /// - false → true (entrance): EaseOutCubic over 200ms, 0 → 1
-    /// - true → false (dismissal): EaseInQuad over 120ms, 1 → 0
+    /// - false → true (entrance): EaseOutCubic over 200ms, scale_at_edge → 1
+    /// - true → false (dismissal): EaseInQuad over 120ms, scale_at_edge → 0
     /// - steady state: 1.0 if visible, 0.0 if hidden
+    ///
+    /// Using `scale_at_edge` as the interpolation start means an interrupted
+    /// animation continues from its current visual position rather than
+    /// snapping to 0 or 1 and re-animating from scratch.
     pub fn version_popup_scale(&self, now: SystemTime) -> f32 {
         use crate::tui::anim::{eased_progress, Easing};
         match (self.version_popup, self.version_popup_started_at) {
-            (true, Some(start)) => eased_progress(start, 200, Easing::EaseOutCubic, now),
-            (false, Some(start)) => 1.0 - eased_progress(start, 120, Easing::EaseInQuad, now),
+            (true, Some(start)) => {
+                let progress = eased_progress(start, 200, Easing::EaseOutCubic, now);
+                // Lerp from the scale at edge time to the target (1.0)
+                self.version_popup_scale_at_edge
+                    + (1.0 - self.version_popup_scale_at_edge) * progress
+            }
+            (false, Some(start)) => {
+                let progress = eased_progress(start, 120, Easing::EaseInQuad, now);
+                // Lerp from the scale at edge time to the target (0.0)
+                self.version_popup_scale_at_edge * (1.0 - progress)
+            }
             (true, None) => 1.0,
             (false, None) => 0.0,
         }
+    }
+
+    /// Returns the scale value computed during the most recent `render()`.
+    /// Prefer this over calling `version_popup_scale(SystemTime::now())` in
+    /// the mouse handler to keep click geometry in sync with what was painted.
+    pub fn last_popup_scale(&self) -> f32 {
+        self.last_popup_scale
     }
 
     pub fn set_active_pet(&mut self, pet: Option<PetState>) {
@@ -446,6 +479,7 @@ impl<B: Backend<Error: Send + Sync + 'static>> Renderer for TuiRenderer<B> {
                 }
             })?;
 
+            self.last_popup_scale = popup_scale;
             self.cached_layout = None;
             return Ok(());
         }
@@ -505,6 +539,7 @@ impl<B: Backend<Error: Send + Sync + 'static>> Renderer for TuiRenderer<B> {
         if let Ok(ref layout_opt) = result {
             self.cached_layout = layout_opt.clone();
         }
+        self.last_popup_scale = popup_scale;
         result.map(|_| ())
     }
 }

--- a/crates/pixtuoid/src/tui/tui_renderer.rs
+++ b/crates/pixtuoid/src/tui/tui_renderer.rs
@@ -157,6 +157,22 @@ impl<B: Backend<Error: Send + Sync + 'static>> TuiRenderer<B> {
         self.version_popup_started_at
     }
 
+    /// Compute the entrance/dismissal scale for the version popup based on
+    /// the current state and the time since the last edge. Range 0.0..=1.0.
+    ///
+    /// - false → true (entrance): EaseOutCubic over 200ms, 0 → 1
+    /// - true → false (dismissal): EaseInQuad over 120ms, 1 → 0
+    /// - steady state: 1.0 if visible, 0.0 if hidden
+    pub fn version_popup_scale(&self, now: SystemTime) -> f32 {
+        use crate::tui::anim::{eased_progress, Easing};
+        match (self.version_popup, self.version_popup_started_at) {
+            (true, Some(start)) => eased_progress(start, 200, Easing::EaseOutCubic, now),
+            (false, Some(start)) => 1.0 - eased_progress(start, 120, Easing::EaseInQuad, now),
+            (true, None) => 1.0,
+            (false, None) => 0.0,
+        }
+    }
+
     pub fn set_active_pet(&mut self, pet: Option<PetState>) {
         self.active_pet = pet;
     }
@@ -282,6 +298,8 @@ impl<B: Backend<Error: Send + Sync + 'static>> Renderer for TuiRenderer<B> {
 
             let buf_w = scene_rect.width;
             let buf_h = scene_rect.height.saturating_mul(2);
+            // Compute popup scale before the split_at_mut borrows.
+            let popup_scale = self.version_popup_scale(now);
 
             // Render both floors into their respective buffers.
             // Use split_at_mut to get mutable access to two different indices.
@@ -387,7 +405,6 @@ impl<B: Backend<Error: Send + Sync + 'static>> Renderer for TuiRenderer<B> {
 
             let theme = self.theme;
             let theme_picker = self.theme_picker;
-            let version_popup = self.version_popup;
             // Floor label tracks the destination floor for the duration of the
             // slide so the per-floor agent count in the footer matches the
             // label (otherwise users see "F1/3 ... 5 agents" with floor 2's
@@ -415,7 +432,7 @@ impl<B: Backend<Error: Send + Sync + 'static>> Renderer for TuiRenderer<B> {
                 if let Some(idx) = theme_picker {
                     crate::tui::renderer::paint_theme_picker(f, idx, actual_full, theme);
                 }
-                if version_popup {
+                if popup_scale > 0.0 {
                     if let Some(notes) = crate::version::release_notes(env!("CARGO_PKG_VERSION")) {
                         crate::tui::renderer::paint_version_popup(
                             f,
@@ -423,7 +440,7 @@ impl<B: Backend<Error: Send + Sync + 'static>> Renderer for TuiRenderer<B> {
                             notes,
                             actual_full,
                             theme,
-                            1.0,
+                            popup_scale,
                         );
                     }
                 }
@@ -447,6 +464,8 @@ impl<B: Backend<Error: Send + Sync + 'static>> Renderer for TuiRenderer<B> {
             .retain(|id, _| scene.agents.contains_key(id));
 
         let floor_meta = FloorMeta::for_floor(self.current_floor, nf);
+        // Compute popup scale before the mutable borrows below.
+        let popup_scale = self.version_popup_scale(now);
         let fctx = &mut self.floor_ctxs[self.current_floor];
         let mut draw_ctx = DrawCtx {
             buf: &mut self.floor_bufs[self.current_floor],
@@ -473,7 +492,7 @@ impl<B: Backend<Error: Send + Sync + 'static>> Renderer for TuiRenderer<B> {
             coffee_holders: &self.coffee_holders,
             coffee_fetched_at: &self.coffee_fetched_at,
             new_coffee_carriers: Vec::new(),
-            version_popup: self.version_popup,
+            popup_scale,
         };
         let result = draw_scene(&mut self.terminal, &floor_scene, pack, now, &mut draw_ctx);
         self.last_pet_pos = draw_ctx.last_pet_pos;

--- a/crates/pixtuoid/src/tui/tui_renderer.rs
+++ b/crates/pixtuoid/src/tui/tui_renderer.rs
@@ -423,6 +423,7 @@ impl<B: Backend<Error: Send + Sync + 'static>> Renderer for TuiRenderer<B> {
                             notes,
                             actual_full,
                             theme,
+                            1.0,
                         );
                     }
                 }

--- a/crates/pixtuoid/src/tui/widgets/hud.rs
+++ b/crates/pixtuoid/src/tui/widgets/hud.rs
@@ -300,8 +300,8 @@ pub(in crate::tui) fn paint_version_popup(
     }
     let w_full = needed_w.min(bounds.width);
     let h_full = (notes.len() as u16 + 6).min(bounds.height);
-    let w = ((w_full as f32 * scale).round() as u16).max(4);
-    let h = ((h_full as f32 * scale).round() as u16).max(3);
+    let w = ((w_full as f32 * scale).round() as u16).max(2);
+    let h = ((h_full as f32 * scale).round() as u16).max(2);
     let x = bounds.x + bounds.width.saturating_sub(w) / 2;
     let y = bounds.y + bounds.height.saturating_sub(h) / 2;
     let area = Rect {
@@ -359,8 +359,8 @@ pub(in crate::tui) fn version_popup_url_rect(
     scale: f32,
 ) -> Option<Rect> {
     let scale = scale.clamp(0.0, 1.0);
-    if scale < 0.99 {
-        return None; // URL not clickable until popup is fully shown
+    if scale < 0.7 {
+        return None; // URL not clickable until popup reaches 70% scale
     }
     let needed_w = 2 + URL_PREFIX.len() as u16 + VERSION_POPUP_URL.len() as u16 + 2;
     let w = needed_w.min(bounds.width);

--- a/crates/pixtuoid/src/tui/widgets/hud.rs
+++ b/crates/pixtuoid/src/tui/widgets/hud.rs
@@ -363,8 +363,14 @@ pub(in crate::tui) fn version_popup_url_rect(
         return None; // URL not clickable until popup reaches 70% scale
     }
     let needed_w = 2 + URL_PREFIX.len() as u16 + VERSION_POPUP_URL.len() as u16 + 2;
-    let w = needed_w.min(bounds.width);
-    let h = (notes_len as u16 + 6).min(bounds.height);
+    // Mirror paint_version_popup's geometry exactly: clamp to bounds first,
+    // then scale, then derive popup_x/popup_y from the SCALED w/h. Centering
+    // off the unscaled w/h leaves the click rect offset from the painted
+    // popup at any scale < 1.0.
+    let w_full = needed_w.min(bounds.width);
+    let h_full = (notes_len as u16 + 6).min(bounds.height);
+    let w = ((w_full as f32 * scale).round() as u16).max(2);
+    let h = ((h_full as f32 * scale).round() as u16).max(2);
     if w < 4 || h < 3 {
         return None;
     }
@@ -469,6 +475,28 @@ mod hud_tests {
                 popup_inner_right
             );
         }
+    }
+
+    // Regression: at scale < 1.0 the URL click rect must center off the
+    // SCALED width, mirroring paint_version_popup. Centering off unscaled
+    // w shifts the click area ~((1-scale)*needed_w)/2 columns left of the
+    // painted URL.
+    #[test]
+    fn url_rect_centering_matches_painter_at_partial_scale() {
+        let bounds = full_bounds(200, 60);
+        let scale = 0.85; // ≥ 0.7 gate and ≥ 0.8 vertical threshold for notes_len=4
+        let needed_w = 2 + URL_PREFIX.len() as u16 + VERSION_POPUP_URL.len() as u16 + 2;
+        let w_full = needed_w.min(bounds.width);
+        let w_scaled = ((w_full as f32 * scale).round() as u16).max(2);
+        let expected_popup_x = bounds.width.saturating_sub(w_scaled) / 2;
+        let expected_url_x = expected_popup_x + 1 + URL_PREFIX.len() as u16;
+        let rect = version_popup_url_rect(4, bounds, scale)
+            .expect("url rect should exist at scale=0.85 with notes_len=4");
+        assert_eq!(
+            rect.x, expected_url_x,
+            "url click rect x={} must match painter's scaled-centering popup_x+1+prefix={}",
+            rect.x, expected_url_x
+        );
     }
 
     // Regression for the off-screen URL row bug: on a too-short terminal,

--- a/crates/pixtuoid/src/tui/widgets/hud.rs
+++ b/crates/pixtuoid/src/tui/widgets/hud.rs
@@ -287,17 +287,21 @@ pub(in crate::tui) fn paint_version_popup(
     notes: &[&str],
     bounds: Rect,
     theme: &crate::tui::theme::Theme,
+    scale: f32,
 ) {
     use ratatui::style::Modifier;
     use ratatui::text::{Line, Span as TSpan};
     use ratatui::widgets::{Block, Borders, Clear};
 
     let needed_w = 2 + URL_PREFIX.len() as u16 + VERSION_POPUP_URL.len() as u16 + 2;
-    let w = needed_w.min(bounds.width);
-    let h = (notes.len() as u16 + 6).min(bounds.height);
-    if w < 4 || h < 3 {
-        return;
+    let scale = scale.clamp(0.0, 1.0);
+    if scale <= 0.01 {
+        return; // fully dismissed, skip render
     }
+    let w_full = needed_w.min(bounds.width);
+    let h_full = (notes.len() as u16 + 6).min(bounds.height);
+    let w = ((w_full as f32 * scale).round() as u16).max(4);
+    let h = ((h_full as f32 * scale).round() as u16).max(3);
     let x = bounds.x + bounds.width.saturating_sub(w) / 2;
     let y = bounds.y + bounds.height.saturating_sub(h) / 2;
     let area = Rect {
@@ -349,7 +353,15 @@ pub(in crate::tui) fn paint_version_popup(
 /// Returns None if the popup would be too small to render. Mirrors the
 /// geometry inside `paint_version_popup` (kept in sync by sharing the same
 /// width calculation).
-pub(in crate::tui) fn version_popup_url_rect(notes_len: usize, bounds: Rect) -> Option<Rect> {
+pub(in crate::tui) fn version_popup_url_rect(
+    notes_len: usize,
+    bounds: Rect,
+    scale: f32,
+) -> Option<Rect> {
+    let scale = scale.clamp(0.0, 1.0);
+    if scale < 0.99 {
+        return None; // URL not clickable until popup is fully shown
+    }
     let needed_w = 2 + URL_PREFIX.len() as u16 + VERSION_POPUP_URL.len() as u16 + 2;
     let w = needed_w.min(bounds.width);
     let h = (notes_len as u16 + 6).min(bounds.height);
@@ -432,7 +444,7 @@ mod hud_tests {
 
     #[test]
     fn url_rect_fits_inside_normal_popup() {
-        let rect = version_popup_url_rect(4, full_bounds(200, 60)).expect("should fit");
+        let rect = version_popup_url_rect(4, full_bounds(200, 60), 1.0).expect("should fit");
         assert_eq!(rect.width, VERSION_POPUP_URL.len() as u16);
         assert_eq!(rect.height, 1);
     }
@@ -444,7 +456,7 @@ mod hud_tests {
     #[test]
     fn url_rect_does_not_extend_past_clipped_popup_right_edge() {
         let bounds = full_bounds(50, 30);
-        if let Some(rect) = version_popup_url_rect(4, bounds) {
+        if let Some(rect) = version_popup_url_rect(4, bounds, 1.0) {
             let needed_w = 2 + URL_PREFIX.len() as u16 + VERSION_POPUP_URL.len() as u16 + 2;
             let w = needed_w.min(bounds.width);
             let popup_x = bounds.width.saturating_sub(w) / 2;
@@ -468,7 +480,7 @@ mod hud_tests {
         // notes_len=4 → needed h=10. With bounds.height=8 the popup clips
         // to h=8, leaving room for at most ~3 notes — the URL row at offset
         // (notes_len + 3) = 7 lands on the bottom border.
-        let rect = version_popup_url_rect(4, full_bounds(200, 8));
+        let rect = version_popup_url_rect(4, full_bounds(200, 8), 1.0);
         assert!(
             rect.is_none(),
             "expected None when URL row falls on the clipped popup's bottom border: got {rect:?}"

--- a/crates/pixtuoid/tests/test_helpers.rs
+++ b/crates/pixtuoid/tests/test_helpers.rs
@@ -51,7 +51,7 @@ macro_rules! make_draw_ctx {
             coffee_holders: &std::collections::HashSet::new(),
             coffee_fetched_at: &std::collections::HashMap::new(),
             new_coffee_carriers: Vec::new(),
-            version_popup: false,
+            popup_scale: 0.0,
         };
     };
 

--- a/crates/pixtuoid/tests/tui_renderer.rs
+++ b/crates/pixtuoid/tests/tui_renderer.rs
@@ -275,6 +275,43 @@ fn version_popup_animation_starts_small_then_grows() {
     );
 }
 
+/// Regression guard for Fix #5: dismissing mid-entrance must not snap the
+/// popup back to full scale before fading. Before the fix, `set_version_popup`
+/// overwrote `version_popup_started_at = Some(now)` without saving the current
+/// scale, so the dismissal formula evaluated to `1.0 - 0 ≈ 1.0` on the next
+/// frame — a visible flash to full size before fading.
+#[test]
+fn dismiss_mid_entrance_does_not_snap_to_full() {
+    let backend = TestBackend::new(96, 36);
+    let terminal = Terminal::new(backend).expect("terminal");
+    let mut renderer = TuiRenderer::new(
+        terminal,
+        &pixtuoid::tui::theme::NORMAL,
+        pixtuoid::tui::pet::PetKind::ALL.to_vec(),
+    );
+    let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+
+    // Enter mid-entrance at 100ms (EaseOutCubic(0.5) ≈ 0.875)
+    renderer.set_version_popup(true, t0);
+    let mid_entrance = t0 + Duration::from_millis(100);
+    let scale_at_mid = renderer.version_popup_scale(mid_entrance);
+    assert!(
+        scale_at_mid > 0.7 && scale_at_mid < 1.0,
+        "expected mid-entrance scale 0.7..1.0; got {scale_at_mid}"
+    );
+
+    // Dismiss at the same moment
+    renderer.set_version_popup(false, mid_entrance);
+
+    // Immediately after the dismiss edge, scale should be ~scale_at_mid (no snap)
+    let just_after = mid_entrance + Duration::from_millis(1);
+    let scale_after = renderer.version_popup_scale(just_after);
+    assert!(
+        scale_after < scale_at_mid + 0.05,
+        "scale should NOT snap up after dismiss; got {scale_after} (was {scale_at_mid})"
+    );
+}
+
 /// Regression: a resize mid-slide previously left `current_floor` at
 /// `from_floor`, silently reverting a user-initiated navigation with no UI
 /// signal. `cancel_transition` must now land the user on `to_floor`.

--- a/crates/pixtuoid/tests/tui_renderer.rs
+++ b/crates/pixtuoid/tests/tui_renderer.rs
@@ -180,6 +180,52 @@ fn tui_renderer_transition_paints_pets_and_coffee() {
     );
 }
 
+#[test]
+fn set_version_popup_records_timestamp_on_edge() {
+    use std::time::{Duration, SystemTime};
+
+    let backend = TestBackend::new(96, 36);
+    let terminal = Terminal::new(backend).expect("terminal");
+    let mut renderer = TuiRenderer::new(
+        terminal,
+        &pixtuoid::tui::theme::NORMAL,
+        pixtuoid::tui::pet::PetKind::ALL.to_vec(),
+    );
+
+    let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+    let t1 = t0 + Duration::from_millis(50);
+
+    assert_eq!(renderer.version_popup_started_at(), None);
+
+    renderer.set_version_popup(false, t0);
+    assert_eq!(
+        renderer.version_popup_started_at(),
+        None,
+        "no edge from false → false"
+    );
+
+    renderer.set_version_popup(true, t0);
+    assert_eq!(
+        renderer.version_popup_started_at(),
+        Some(t0),
+        "false → true edge records timestamp"
+    );
+
+    renderer.set_version_popup(true, t1);
+    assert_eq!(
+        renderer.version_popup_started_at(),
+        Some(t0),
+        "true → true is not an edge; timestamp unchanged"
+    );
+
+    renderer.set_version_popup(false, t1);
+    assert_eq!(
+        renderer.version_popup_started_at(),
+        Some(t1),
+        "true → false edge records new timestamp"
+    );
+}
+
 /// Regression: a resize mid-slide previously left `current_floor` at
 /// `from_floor`, silently reverting a user-initiated navigation with no UI
 /// signal. `cancel_transition` must now land the user on `to_floor`.

--- a/crates/pixtuoid/tests/tui_renderer.rs
+++ b/crates/pixtuoid/tests/tui_renderer.rs
@@ -226,6 +226,55 @@ fn set_version_popup_records_timestamp_on_edge() {
     );
 }
 
+#[test]
+fn version_popup_animation_starts_small_then_grows() {
+    use std::time::{Duration, SystemTime};
+
+    let backend = TestBackend::new(96, 36);
+    let terminal = Terminal::new(backend).expect("terminal");
+    let mut renderer = TuiRenderer::new(
+        terminal,
+        &pixtuoid::tui::theme::NORMAL,
+        pixtuoid::tui::pet::PetKind::ALL.to_vec(),
+    );
+
+    let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+    renderer.set_version_popup(true, t0);
+
+    let scale_start = renderer.version_popup_scale(t0);
+    assert!(
+        scale_start < 0.1,
+        "expected entrance start scale < 0.1; got {scale_start}"
+    );
+
+    let scale_mid = renderer.version_popup_scale(t0 + Duration::from_millis(100));
+    assert!(
+        scale_mid > 0.8,
+        "expected scale > 0.8 at mid-entrance; got {scale_mid}"
+    );
+
+    let scale_end = renderer.version_popup_scale(t0 + Duration::from_millis(200));
+    assert!(
+        (scale_end - 1.0).abs() < 1e-3,
+        "expected scale 1.0 at end of entrance; got {scale_end}"
+    );
+
+    let t1 = t0 + Duration::from_millis(200);
+    renderer.set_version_popup(false, t1);
+
+    let scale_dismiss_mid = renderer.version_popup_scale(t1 + Duration::from_millis(60));
+    assert!(
+        scale_dismiss_mid > 0.0 && scale_dismiss_mid < 1.0,
+        "expected mid-dismissal scale between 0 and 1; got {scale_dismiss_mid}"
+    );
+
+    let scale_dismiss_end = renderer.version_popup_scale(t1 + Duration::from_millis(120));
+    assert!(
+        scale_dismiss_end < 0.01,
+        "expected dismissal end scale ~0; got {scale_dismiss_end}"
+    );
+}
+
 /// Regression: a resize mid-slide previously left `current_floor` at
 /// `from_floor`, silently reverting a user-initiated navigation with no UI
 /// signal. `cancel_transition` must now land the user on `to_floor`.


### PR DESCRIPTION
## Summary

Adds a tiny `tui/anim.rs` module (one enum, one free function) and re-eases three high-visibility animations across the pixel-art office. No new content; same scene, smoother feel.

## What's eased

| Animation | Before | After |
|---|---|---|
| Floor slide transition | linear ease-out-quadratic | `EaseInOutCubic` (smooth S-curve) |
| Version popup entrance | instant | `EaseOutCubic` 200ms scale + fade-in |
| Version popup dismissal | instant | `EaseInQuad` 120ms scale + fade-out |

## What was reverted before merge

- **A\* walk path-tail ease** — added in `6b85f75`, reverted in `47ae204`. The `EaseOutCubic` on global walk progress decelerated position near the path tail, but the leg-swap cadence stayed wall-clock-driven (220 ms per swap, 2-frame walk cycle), so legs kept marching while the body barely moved — a visible "sliding" / moonwalk artifact. A distance-locked frame override was prototyped to keep the smooth stop, but the underlying trade-off (snap-to-stop vs. moonwalk vs. asset work for more walk frames) wasn't worth carrying. Walks are linear again, same as before this PR.

## What was deliberately cut after architecture review

- **Tooltip fade** — ratatui has no native alpha; color-lerp workarounds read as hacky across terminals. Instant tooltips are fine.
- **Theme cross-fade** — `set_theme` flushes the per-floor `FrameCache`; cross-fading would strobe characters for ~15 frames during the blend. Hard cut stays.
- **Camera breathe** — global pixel offset would shift static geometry (wall clock, neon panel) and invalidate the cached layout's hit-test every frame. Character-level breath already exists via `with_breath` in `anchors.rs`.

## Architecture

`tui/anim.rs` exposes:

```rust
pub enum Easing { Linear, EaseOutCubic, EaseInOutCubic, EaseInQuad }

impl Easing { pub fn apply(self, t: f32) -> f32 }

pub fn eased_progress(
    started_at: SystemTime,
    duration_ms: u32,
    easing: Easing,
    now: SystemTime,
) -> f32
```

Free function over a stateful struct because `FloorTransition` and `TuiRenderer` already carry their own `started_at` + duration fields; matches the stateless helper pattern in `pixel_painter/anchors.rs`.

`SystemTime` (not `Instant`) matches existing animation state for v2 daemon-split compatibility. See CLAUDE.md "Known sharp edges".

Popup tween state lives on `TuiRenderer` as `version_popup_started_at: Option<SystemTime>`, edge-tracked by `set_version_popup`. `paint_version_popup` and `version_popup_url_rect` take a `scale: f32` parameter; the URL hit-test gate (`scale >= 0.7`) prevents phantom clicks during the entrance animation.

## Test plan

- [x] `scripts/preflight.sh` — fmt + machete + deny + clippy (-D warnings) + workspace tests (all pass)
- [x] Unit tests for `Easing` curves and `eased_progress` boundaries
- [x] Edge-detection test for `set_version_popup` timestamp (None → false-noop → true-edge → true-noop → false-edge)
- [x] Animation envelope test: entrance start <0.1, mid >0.8, end ≈1.0; dismissal mid in (0,1), end <0.01
- [ ] Manual: PageUp/PageDown on a multi-floor scene — slide should feel smoother
- [ ] Manual: edit `~/.config/pixtuoid/config.toml`'s `last-seen-version` to an older version, relaunch — popup should scale in over 200ms; press Enter and it should scale out over 120ms

## Invariants kept

- `pixtuoid-core` untouched (easing is display-layer only)
- No new dependencies in `Cargo.toml`
- Theme system unchanged
- Hook protocol unchanged
- Public API surface unchanged for downstream users

🤖 Generated with [Claude Code](https://claude.com/claude-code)