### PR TITLE
feat(install): friendlier install/uninstall flow + backup cleanup

### DIFF
--- a/crates/pixtuoid/src/install/io.rs
+++ b/crates/pixtuoid/src/install/io.rs
@@ -92,6 +92,28 @@ pub fn backup_once(path: &Path) -> Result<Option<PathBuf>> {
     Ok(Some(bak))
 }
 
+/// Delete the pixtuoid-created backup, if present. Returns the removed path so
+/// the caller can report it. Conservative by design: it only removes our own
+/// `.pixtuoid.bak` footprint and never restores from it (the live file may hold
+/// edits the user made after install — uninstall already reverses our hooks
+/// surgically via the sentinel).
+pub fn remove_backup(path: &Path) -> Result<Option<PathBuf>> {
+    let target = resolve_symlink(path);
+    let bak = target.with_extension("json.pixtuoid.bak");
+    if !bak.exists() {
+        return Ok(None);
+    }
+    std::fs::remove_file(&bak)?;
+    Ok(Some(bak))
+}
+
+/// Whether the bare `pixtuoid-hook` name resolves on PATH. settings.json stores
+/// the bare name for portability, and Claude Code spawns hooks via PATH — so if
+/// this is false the installed hooks silently never fire.
+pub fn hook_on_path() -> bool {
+    which::which("pixtuoid-hook").is_ok()
+}
+
 /// Follow symlink chain to the final target, even if that target doesn't exist
 /// yet (stow creates the link before the dotfiles repo is fully set up).
 /// `canonicalize` fails on a dangling symlink, so we walk `read_link` manually.
@@ -239,5 +261,39 @@ mod tests {
         assert!(bak.exists());
         let bak2 = backup_once(&path).unwrap().unwrap();
         assert_eq!(bak, bak2);
+    }
+
+    #[test]
+    fn remove_backup_deletes_existing_bak() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("settings.json");
+        std::fs::write(&path, r#"{"v":1}"#).unwrap();
+        let bak = backup_once(&path).unwrap().unwrap();
+        assert!(bak.exists());
+        let removed = remove_backup(&path).unwrap();
+        assert_eq!(removed, Some(bak.clone()));
+        assert!(!bak.exists());
+    }
+
+    #[test]
+    fn remove_backup_no_bak_returns_none() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("settings.json");
+        std::fs::write(&path, r#"{"v":1}"#).unwrap();
+        assert_eq!(remove_backup(&path).unwrap(), None);
+    }
+
+    #[test]
+    fn remove_backup_resolves_symlink() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("real.json");
+        std::fs::write(&target, r#"{"v":1}"#).unwrap();
+        let link = dir.path().join("link.json");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        let bak = backup_once(&link).unwrap().unwrap();
+        assert!(bak.exists());
+        let removed = remove_backup(&link).unwrap();
+        assert_eq!(removed, Some(bak));
+        assert!(!std::path::Path::new(&target.with_extension("json.pixtuoid.bak")).exists());
     }
 }

--- a/crates/pixtuoid/src/install/mod.rs
+++ b/crates/pixtuoid/src/install/mod.rs
@@ -14,15 +14,35 @@ pub fn install(hook_path: Option<PathBuf>, settings: Option<PathBuf>) -> Result<
 
     let backup = io::backup_once(&settings_path)?;
     let doc = io::read_settings(&settings_path)?;
-    let merged = merge::merge_install(doc, &hook_str);
-    io::write_settings_atomic(&settings_path, &merged)?;
+    let merged = merge::merge_install(doc.clone(), &hook_str);
+    let changed = merged != doc;
 
-    println!(
-        "ok: installed pixtuoid hooks into {}",
-        settings_path.display()
-    );
-    if let Some(b) = backup {
-        println!("backup: {}", b.display());
+    if changed {
+        io::write_settings_atomic(&settings_path, &merged)?;
+        println!(
+            "ok: installed pixtuoid hooks into {}",
+            settings_path.display()
+        );
+        if let Some(b) = backup {
+            println!(
+                "backup: {} (removed automatically on uninstall-hooks)",
+                b.display()
+            );
+        }
+    } else {
+        println!(
+            "already up to date — pixtuoid hooks in {} are current",
+            settings_path.display()
+        );
+    }
+
+    if !io::hook_on_path() {
+        println!("warn: `pixtuoid-hook` is not on your PATH. Claude Code spawns hooks via PATH,");
+        println!("      so they will not fire until the binary is installed on PATH (e.g.");
+        println!("      `cargo install --path crates/pixtuoid-hook`).");
+    }
+    if changed {
+        println!("→ start a new Claude Code session for this to take effect.");
     }
     Ok(())
 }
@@ -37,11 +57,27 @@ pub fn uninstall(settings: Option<PathBuf>) -> Result<()> {
         return Ok(());
     }
     let doc = io::read_settings(&settings_path)?;
-    let cleaned = merge::merge_uninstall(doc);
-    io::write_settings_atomic(&settings_path, &cleaned)?;
-    println!(
-        "ok: removed pixtuoid hooks from {}",
-        settings_path.display()
-    );
+    let cleaned = merge::merge_uninstall(doc.clone());
+    let changed = cleaned != doc;
+
+    if changed {
+        io::write_settings_atomic(&settings_path, &cleaned)?;
+        println!(
+            "ok: removed pixtuoid hooks from {}",
+            settings_path.display()
+        );
+    } else {
+        println!(
+            "no pixtuoid hooks found in {} — nothing to remove",
+            settings_path.display()
+        );
+    }
+
+    if let Some(b) = io::remove_backup(&settings_path)? {
+        println!("removed backup: {}", b.display());
+    }
+    if changed {
+        println!("→ start a new Claude Code session for this to take effect.");
+    }
     Ok(())
 }

--- a/crates/pixtuoid/src/install/mod.rs
+++ b/crates/pixtuoid/src/install/mod.rs
@@ -12,12 +12,14 @@ pub fn install(hook_path: Option<PathBuf>, settings: Option<PathBuf>) -> Result<
     let _hook = hook_path.map(Ok).unwrap_or_else(io::default_hook_binary)?;
     let hook_str = "pixtuoid-hook".to_string();
 
-    let backup = io::backup_once(&settings_path)?;
     let doc = io::read_settings(&settings_path)?;
     let merged = merge::merge_install(doc.clone(), &hook_str);
     let changed = merged != doc;
 
     if changed {
+        // Only snapshot when we're about to mutate the file — a backup of an
+        // unchanged file is a silent, pointless side effect.
+        let backup = io::backup_once(&settings_path)?;
         io::write_settings_atomic(&settings_path, &merged)?;
         println!(
             "ok: installed pixtuoid hooks into {}",
@@ -37,9 +39,11 @@ pub fn install(hook_path: Option<PathBuf>, settings: Option<PathBuf>) -> Result<
     }
 
     if !io::hook_on_path() {
-        println!("warn: `pixtuoid-hook` is not on your PATH. Claude Code spawns hooks via PATH,");
-        println!("      so they will not fire until the binary is installed on PATH (e.g.");
-        println!("      `cargo install --path crates/pixtuoid-hook`).");
+        // `which` only sees this shell's PATH, not the (often launchd) PATH
+        // Claude Code spawns hooks under — so this is a heuristic, not a verdict.
+        println!("warn: `pixtuoid-hook` not found on PATH (checked against this shell).");
+        println!("      Claude Code spawns hooks via PATH; if it can't find the binary, hooks");
+        println!("      won't fire. Install it on PATH, e.g. `cargo install --path crates/pixtuoid-hook`.");
     }
     if changed {
         println!("→ start a new Claude Code session for this to take effect.");
@@ -66,18 +70,18 @@ pub fn uninstall(settings: Option<PathBuf>) -> Result<()> {
             "ok: removed pixtuoid hooks from {}",
             settings_path.display()
         );
+        // Only drop the backup once we've actually reversed our own hooks. On a
+        // no-op (nothing matched, or a corrupted sentinel we couldn't match)
+        // the backup is the user's only recovery path — never destroy it.
+        if let Some(b) = io::remove_backup(&settings_path)? {
+            println!("removed backup: {}", b.display());
+        }
+        println!("→ start a new Claude Code session for this to take effect.");
     } else {
         println!(
             "no pixtuoid hooks found in {} — nothing to remove",
             settings_path.display()
         );
-    }
-
-    if let Some(b) = io::remove_backup(&settings_path)? {
-        println!("removed backup: {}", b.display());
-    }
-    if changed {
-        println!("→ start a new Claude Code session for this to take effect.");
     }
     Ok(())
 }


### PR DESCRIPTION
## What

Polishes the `install-hooks` / `uninstall-hooks` UX — the commands previously claimed success even on no-ops, left an orphaned backup file behind, and gave no hint when hooks silently wouldn't fire.

## Changes

- **Backup cleanup on uninstall.** `uninstall-hooks` now removes the pixtuoid-created `settings.json.pixtuoid.bak`. Conservative by design: it deletes only our own footprint and **never restores from it** (the live file may hold edits made after install; uninstall already reverses our hook entries surgically via the `_pixtuoid` sentinel). Closes the install/uninstall asymmetry.
- **Honest no-op messaging.** Compares the doc before/after the merge:
  - re-running install → `already up to date — pixtuoid hooks … are current`
  - uninstall with nothing to remove → `no pixtuoid hooks found … nothing to remove`
- **PATH warning.** `settings.json` stores the bare name `pixtuoid-hook` (for portability); CC spawns hooks via `PATH`. If the binary isn't resolvable, hooks were a *silent* failure (empty office, no clue). Install now `warn:`s with the fix command.
- **Restart hint.** Prints `→ start a new Claude Code session for this to take effect.` after any real change, since hooks only apply to new sessions.

The restart hint and backup line print only when something actually changed; the PATH warning prints whenever the binary isn't resolvable.

## Why no `.bak` restore

`uninstall-hooks` already surgically reverses our edits (sentinel-tagged entries only), so the backup is no longer needed for recovery after a clean uninstall. Restoring from it could clobber unrelated edits the user made after install. Researched the convention (Advanced Installer keeps/makes backups; Husky removes only its own footprint) — "remove our own footprint, never destroy user data" is the throughline.

## Test

- 3 new `remove_backup` tests (delete / no-op / symlink-resolution) + 24 existing install tests green
- fmt + clippy clean (pre-push preflight passed)
- Manual lifecycle verified: install → rerun → uninstall → rerun, with an unrelated `/other` hook + `theme` key provably preserved and `.bak` count `0` after uninstall

🤖 Generated with [Claude Code](https://claude.com/claude-code)