### PR TITLE
Add Codex hook installation support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ crates/
 │                           drawable.rs (y-sort), effects.rs (glow/z's/dots/steam/dust/bubble),
 │                           palette.rs (tool_glow_tint), anchors.rs (breath, walk position, character_anchor),
 │                           furniture.rs (coffee table, area rug, side table, pantry table/chair)
-└── pixtuoid-hook/      tiny shim CC invokes — stdin JSON → Unix socket, 200ms write timeout
+└── pixtuoid-hook/      tiny shim agent CLIs invoke — stdin JSON → Unix socket, 200ms write timeout
 │   └── sprites/
 │       ├── default/        coworking-lounge pack (embedded via include_str!)
 │       ├── robot/          proof-of-concept robot character pack (loadable via --pack-dir)
@@ -120,8 +120,8 @@ These are load-bearing; don't break them without updating the spec.
 1. **`pixtuoid-core` has no terminal dependencies.** No `ratatui`, no `crossterm`, no `stdout` writes. If you need one, the abstraction belongs behind the `Renderer` trait.
 2. **Events flow through ONE channel** typed `mpsc::Sender<(Transport, AgentEvent)>`. The `Transport` tag is load-bearing — the reducer uses it for hook-wins dedup. Do not hardcode `Transport::Hook` on the consumer side; the producer (each Source impl) tags its own events.
 3. **`Source` trait is the only seam for adding agent CLIs** (Codex / Cursor / Copilot). Don't bypass it. Per-source JSONL format knowledge lives in the source's own decoder fn (injected into `JsonlWatcher` via fn pointers), not in a shared decoder.
-4. **`install-hooks` writes through symlinks.** `resolve_symlink` in `install/io.rs` is critical for stow-managed `~/.claude/settings.json`. Don't replace it with `fs::rename` on the symlink path.
-5. **The hook shim must never block CC.** Always exit 0 silently on any error. The 200ms write timeout is non-negotiable.
+4. **`install-hooks` writes through symlinks.** `resolve_symlink` in `install/io.rs` is critical for stow-managed `~/.claude/settings.json` and `~/.codex/config.toml`. Don't replace it with `fs::rename` on the symlink path.
+5. **The hook shim must never block the invoking agent CLI.** Always exit 0 silently on any error. The 200ms write timeout is non-negotiable.
 6. **Walkable mask = ground footprint only.** This is a top-down view. Visual sprites can be wider/taller than their ground footprint (elevation effects, shadows, wall trim). The walkable mask must only block the ground-level projection — e.g., a 3px-wide wall visual has a 1px walkable mask because the wall's base is 1px. Characters walk right next to walls, not 3px away.
 
 ## Known sharp edges (don't be surprised by these)
@@ -139,7 +139,7 @@ These are load-bearing; don't break them without updating the spec.
 ## Things NOT to do
 
 - Don't add `ratatui` / `crossterm` / terminal anything to `pixtuoid-core`.
-- Don't write to `~/.claude/settings.json` directly. Always go through `install/io.rs::write_settings_atomic` (advisory lock + atomic rename + symlink resolution).
+- Don't write to `~/.claude/settings.json` or `~/.codex/config.toml` directly. Always go through `install/io.rs` atomic writers (advisory lock + atomic rename + symlink resolution).
 - Don't add `println!` / `eprintln!` to any production path other than the headless summary and explicit user-facing CLI output. Use `tracing::{info, warn, error}` instead.
 - Don't relax the hook shim's "always exit 0" contract. Blocking CC = breaking the user's primary workflow.
 - Don't add `--no-verify` / hook-skipping flags to any git operations performed in this repo.
@@ -158,7 +158,7 @@ These are load-bearing; don't break them without updating the spec.
 - "Why don't old idle sessions show on startup?" → `source::jsonl::initial_seed_walk`. Checks `check_session_ended` (tail-scans last 8KB for `session_end`/`SessionEnd` markers) and skips files not modified in 5+ min. mtime > `DEFAULT_INITIAL_WINDOW` (1 hour) → cursor seeded at EOF, no `SessionStart`.
 - "How does the default character pack get into the binary?" → `tui::embedded_pack` does the `include_str!` at compile time; `sprite::format::load_pack_from_strings` parses it.
 - "How do custom sprite packs work?" → `pixtuoid init-pack ./dir` extracts the skeleton template from `sprites/skeleton/` (embedded via `include_str!`). `pixtuoid validate-pack ./dir` loads the pack and checks against `REQUIRED_CHARACTER_ANIMATIONS` / `OPTIONAL_*` registries in `sprite::format`. `--pack-dir` CLI flag or `pack-dir` config key loads a custom pack at runtime. Custom packs only need character sprites — furniture/environment animations are merged from the embedded default via `Pack::merge_from()` (only `OPTIONAL_FURNITURE_ANIMATIONS`, never character poses). The robot pack at `sprites/robot/` is a TV-head character set (10×12 sprites).
-- "How do hooks get installed?" → `install::merge::merge_install` for the JSON merge logic, `install::io::write_settings_atomic` for the safe filesystem write.
+- "How do hooks get installed?" → `install::merge::merge_install` for Claude JSON, `install::merge::merge_codex_install` for Codex TOML, and `install::io` atomic writers for safe filesystem writes. `pixtuoid install-hooks` defaults to Claude for compatibility; use `--target codex` or `--target all` for Codex.
 - "How does the neon wall display work?" → `pixel_painter/background/lighting.rs::paint_neon_panel` paints the dark panel with pulsing cyan border in the pixel buffer; `widgets/hud.rs::paint_wall_display` overlays ratatui text (branding, state dots, scrolling ticker); `widgets/mod.rs::TickerQueue` manages the persistent scrolling message buffer.
 - "How do pets work?" → `tui/pet.rs::PetKind` enum (Cat, Dog) with per-kind static data (sprite names, hitboxes, behavior). One pet per floor selected via `select_pet_for_floor(floor_seed, enabled_pets)`. Config: `enabled-pets = ["cat", "dog"]` (absent = all, empty = none). `pixel_painter/drawable.rs::pet_position` — 40s cycle, picks a destination from all spots (desks, pantry, sofas, couch, corridor), walks there (35%), sits/sleeps (65%). Cat sleeps with z's near idle agents; both pets sleep when all agents are idle. Sprites per kind: `*_walk` (8×6), `*_sit` (6×6), `*_sleep` (6×4). Click to pet → hearts animation via `PetState` on `TuiRenderer`. `hit_test_pet` / `paint_pet_tooltip` parameterized on `PetKind`.
 - "How does desk personalization work?" → `drawable.rs::paint_desk_personalization` — procedural pixel items appear on desks based on `session_age_secs`: coffee cup (event-driven, after pantry visit), plant (30min), photo frame (1hr).

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ pixtuoid
 
 In another terminal, start a Claude Code session. A character walks in from the elevator within a second.
 
+For Codex CLI:
+
+```bash
+pixtuoid install-hooks --target codex
+```
+
 **Keyboard shortcuts:** `q` quit · `p` pause · `t` themes · `↑↓/jk/PgUp/PgDn` floors · click to pin tooltip
 
 <details>
@@ -109,7 +115,7 @@ cargo build --release
 |---|---|---|
 | [**Claude Code**](https://code.claude.com) | ✅ Supported | Hook shim + JSONL watcher |
 | [**Antigravity CLI**](https://github.com/antiGravity-AI/antigravity-cli) | ✅ Supported | JSONL watcher |
-| [**Codex CLI**](https://github.com/openai/codex) | 🔜 Planned | Same hook pattern as CC |
+| [**Codex CLI**](https://github.com/openai/codex) | ✅ Supported | Hook shim |
 | [**Copilot CLI**](https://github.com/github/copilot-cli) | 🔜 Planned | Identical event names |
 | [**OpenCode**](https://github.com/opencode-ai/opencode) | 🔜 Planned | Any LLM (DeepSeek / GPT / Claude / Gemini) |
 | [**Cursor CLI**](https://cursor.com/cli) | 🔜 Planned | NDJSON stream |
@@ -192,7 +198,7 @@ Three Rust crates:
 |---|---|
 | **pixtuoid-core** | Headless library — no terminal deps. Source trait, reducer, pose, layout, sprites. |
 | **pixtuoid** | TUI binary — ratatui + crossterm + tokio. Half-block rendering + theme system. |
-| **pixtuoid-hook** | Tiny shim CC invokes from hooks. 200ms timeout, always exits 0. |
+| **pixtuoid-hook** | Tiny shim agent CLIs invoke from hooks. 200ms timeout, always exits 0. |
 
 </details>
 
@@ -238,7 +244,7 @@ Three Rust crates:
 
 ## Contributing
 
-See [`CLAUDE.md`](CLAUDE.md) for architecture and conventions. PRs welcome — especially new themes and `Source` adapters for other agent CLIs (Codex, Cursor, Gemini).
+See [`CLAUDE.md`](CLAUDE.md) for architecture and conventions. PRs welcome — especially new themes and `Source` adapters for other agent CLIs (Cursor, Gemini).
 
 <details>
 <summary><strong>Adding a new agent CLI</strong></summary>

--- a/crates/pixtuoid-core/src/source/decoder.rs
+++ b/crates/pixtuoid-core/src/source/decoder.rs
@@ -11,10 +11,11 @@ pub fn decode_hook_payload(v: Value) -> Result<AgentEvent> {
     let obj = v
         .as_object()
         .ok_or_else(|| anyhow!("hook payload must be an object"))?;
-    let event = obj
+    let raw_event = obj
         .get("hook_event_name")
         .and_then(|s| s.as_str())
         .ok_or_else(|| anyhow!("missing hook_event_name"))?;
+    let event = normalize_hook_event(raw_event);
 
     let session_id = obj
         .get("session_id")
@@ -22,25 +23,33 @@ pub fn decode_hook_payload(v: Value) -> Result<AgentEvent> {
         .ok_or_else(|| anyhow!("missing session_id"))?
         .to_string();
     let transcript_path = obj
-        .get("transcript_path")
+        .get("agent_transcript_path")
+        .or_else(|| obj.get("transcript_path"))
         .and_then(|s| s.as_str())
         .ok_or_else(|| anyhow!("missing transcript_path"))?;
     let source = obj
         .get("source")
         .and_then(|s| s.as_str())
-        .unwrap_or(crate::source::claude_code::SOURCE_NAME);
+        .unwrap_or_else(|| infer_hook_source(transcript_path, raw_event));
     let agent_id = AgentId::from_parts(source, transcript_path);
 
     match event {
-        "SessionStart" => {
+        "SessionStart" | "SubagentStart" => {
             let cwd = obj.get("cwd").and_then(|s| s.as_str()).unwrap_or("").into();
             let source = source.to_string();
+            let parent_id = if event == "SubagentStart" {
+                obj.get("transcript_path")
+                    .and_then(|s| s.as_str())
+                    .map(|path| AgentId::from_parts(&source, path))
+            } else {
+                None
+            };
             Ok(AgentEvent::SessionStart {
                 agent_id,
                 source,
                 session_id,
                 cwd,
-                parent_id: None,
+                parent_id,
             })
         }
         "PreToolUse" => {
@@ -77,8 +86,40 @@ pub fn decode_hook_payload(v: Value) -> Result<AgentEvent> {
                 reason: msg.into(),
             })
         }
-        "SessionEnd" => Ok(AgentEvent::SessionEnd { agent_id }),
+        "SessionEnd" | "Stop" | "SubagentStop" => Ok(AgentEvent::SessionEnd { agent_id }),
+        "UserPromptSubmit" => Ok(AgentEvent::Waiting {
+            agent_id,
+            reason: "prompt submitted".into(),
+        }),
         other => bail!("unsupported hook_event_name: {other}"),
+    }
+}
+
+fn normalize_hook_event(event: &str) -> &str {
+    match event {
+        "session_start" => "SessionStart",
+        "pre_tool_use" => "PreToolUse",
+        "post_tool_use" => "PostToolUse",
+        "notification" => "Notification",
+        "session_end" => "SessionEnd",
+        "stop" => "Stop",
+        "user_prompt_submit" => "UserPromptSubmit",
+        "subagent_start" => "SubagentStart",
+        "subagent_stop" => "SubagentStop",
+        other => other,
+    }
+}
+
+fn infer_hook_source(transcript_path: &str, event: &str) -> &'static str {
+    if transcript_path.contains("/.codex/")
+        || matches!(
+            normalize_hook_event(event),
+            "Stop" | "UserPromptSubmit" | "SubagentStart" | "SubagentStop"
+        )
+    {
+        "codex"
+    } else {
+        crate::source::claude_code::SOURCE_NAME
     }
 }
 

--- a/crates/pixtuoid-core/tests/decoder.rs
+++ b/crates/pixtuoid-core/tests/decoder.rs
@@ -424,3 +424,69 @@ fn decode_hook_payload_missing_tool_name_still_succeeds() {
         other => panic!("expected ActivityStart, got {other:?}"),
     }
 }
+
+#[test]
+fn decode_codex_hook_infers_source_from_transcript_path() {
+    let transcript = "/Users/me/.codex/sessions/ses-abc.jsonl";
+    let payload = serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "session_id": "ses-abc",
+        "transcript_path": transcript,
+        "tool_name": "Bash",
+        "tool_input": { "command": "cargo test" }
+    });
+    let ev = decode_hook_payload(payload).unwrap();
+    match ev {
+        AgentEvent::ActivityStart {
+            agent_id, detail, ..
+        } => {
+            assert_eq!(agent_id, AgentId::from_parts("codex", transcript));
+            assert_eq!(detail.unwrap().display(), "Bash: cargo test");
+        }
+        other => panic!("expected ActivityStart, got {other:?}"),
+    }
+}
+
+#[test]
+fn decode_codex_stop_ends_session() {
+    let transcript = "/Users/me/.codex/sessions/ses-abc.jsonl";
+    let payload = serde_json::json!({
+        "hook_event_name": "Stop",
+        "session_id": "ses-abc",
+        "transcript_path": transcript
+    });
+    let ev = decode_hook_payload(payload).unwrap();
+    assert_eq!(
+        ev,
+        AgentEvent::SessionEnd {
+            agent_id: AgentId::from_parts("codex", transcript)
+        }
+    );
+}
+
+#[test]
+fn decode_codex_subagent_start_uses_agent_transcript_path() {
+    let parent = "/Users/me/.codex/sessions/parent.jsonl";
+    let child = "/Users/me/.codex/sessions/child.jsonl";
+    let payload = serde_json::json!({
+        "hook_event_name": "SubagentStart",
+        "session_id": "ses-abc",
+        "transcript_path": parent,
+        "agent_transcript_path": child,
+        "cwd": "/repo"
+    });
+    let ev = decode_hook_payload(payload).unwrap();
+    match ev {
+        AgentEvent::SessionStart {
+            agent_id,
+            source,
+            parent_id,
+            ..
+        } => {
+            assert_eq!(source, "codex");
+            assert_eq!(agent_id, AgentId::from_parts("codex", child));
+            assert_eq!(parent_id, Some(AgentId::from_parts("codex", parent)));
+        }
+        other => panic!("expected SessionStart, got {other:?}"),
+    }
+}

--- a/crates/pixtuoid/src/cli.rs
+++ b/crates/pixtuoid/src/cli.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 
 #[derive(Debug, Parser)]
 #[command(
@@ -38,17 +38,25 @@ pub enum Cmd {
         #[arg(long, default_value_t = false)]
         headless: bool,
     },
-    /// Install Claude Code hooks into ~/.claude/settings.json.
+    /// Install agent hooks.
     InstallHooks {
         #[arg(long)]
         hook_path: Option<PathBuf>,
-        #[arg(long)]
+        #[arg(long, alias = "claude-settings")]
         settings: Option<PathBuf>,
+        #[arg(long)]
+        codex_config: Option<PathBuf>,
+        #[arg(long, value_enum, default_value_t = HookTarget::Claude)]
+        target: HookTarget,
     },
-    /// Remove pixtuoid hook entries from settings.json.
+    /// Remove pixtuoid hook entries.
     UninstallHooks {
-        #[arg(long)]
+        #[arg(long, alias = "claude-settings")]
         settings: Option<PathBuf>,
+        #[arg(long)]
+        codex_config: Option<PathBuf>,
+        #[arg(long, value_enum, default_value_t = HookTarget::Claude)]
+        target: HookTarget,
     },
     /// Validate a custom sprite pack directory.
     ValidatePack {
@@ -63,6 +71,13 @@ pub enum Cmd {
         #[arg(long, default_value_t = false)]
         force: bool,
     },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub enum HookTarget {
+    Claude,
+    Codex,
+    All,
 }
 
 impl Cli {
@@ -107,7 +122,11 @@ mod tests {
     #[test]
     fn cmd_or_default_preserves_explicit_subcommand() {
         let cli = Cli {
-            cmd: Some(Cmd::UninstallHooks { settings: None }),
+            cmd: Some(Cmd::UninstallHooks {
+                settings: None,
+                codex_config: None,
+                target: HookTarget::Claude,
+            }),
             log_level: "debug".into(),
             theme: Some("cyberpunk".into()),
         };

--- a/crates/pixtuoid/src/install/io.rs
+++ b/crates/pixtuoid/src/install/io.rs
@@ -11,6 +11,11 @@ pub fn default_settings_path() -> PathBuf {
     PathBuf::from(format!("{home}/.claude/settings.json"))
 }
 
+pub fn default_codex_config_path() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
+    PathBuf::from(format!("{home}/.codex/config.toml"))
+}
+
 pub fn default_hook_binary() -> Result<PathBuf> {
     if let Ok(p) = std::env::var("PIXTUOID_HOOK") {
         return Ok(PathBuf::from(p));
@@ -49,6 +54,34 @@ pub fn read_settings(path: &Path) -> Result<Value> {
 /// of `path` (resolving any symlink), then renames onto the target. This avoids
 /// destroying a stow-managed `~/.claude/settings.json` symlink.
 pub fn write_settings_atomic(path: &Path, doc: &Value) -> Result<()> {
+    let serialized = serde_json::to_string_pretty(doc)?;
+    write_string_atomic(path, &serialized, "json")
+}
+
+pub fn read_toml_config(path: &Path) -> Result<toml::Value> {
+    let target = resolve_symlink(path);
+    if !target.exists() {
+        return Ok(toml::Value::Table(toml::value::Table::new()));
+    }
+    let mut s = String::new();
+    File::open(&target)?.read_to_string(&mut s)?;
+    if s.trim().is_empty() {
+        return Ok(toml::Value::Table(toml::value::Table::new()));
+    }
+    toml::from_str::<toml::Value>(&s).with_context(|| {
+        format!(
+            "{} is not valid TOML — refusing to overwrite",
+            target.display()
+        )
+    })
+}
+
+pub fn write_toml_atomic(path: &Path, doc: &toml::Value) -> Result<()> {
+    let serialized = toml::to_string_pretty(doc)?;
+    write_string_atomic(path, &serialized, "toml")
+}
+
+fn write_string_atomic(path: &Path, contents: &str, extension: &str) -> Result<()> {
     let target = resolve_symlink(path);
     if let Some(parent) = target.parent() {
         std::fs::create_dir_all(parent)?;
@@ -63,15 +96,14 @@ pub fn write_settings_atomic(path: &Path, doc: &Value) -> Result<()> {
     lock.try_lock_exclusive()
         .map_err(|e| anyhow!("could not lock {}: {e}", lock_path.display()))?;
 
-    let tmp = target.with_extension("json.tmp");
+    let tmp = target.with_extension(format!("{extension}.tmp"));
     {
         let mut f = OpenOptions::new()
             .create(true)
             .write(true)
             .truncate(true)
             .open(&tmp)?;
-        let serialized = serde_json::to_string_pretty(doc)?;
-        f.write_all(serialized.as_bytes())?;
+        f.write_all(contents.as_bytes())?;
         f.sync_all()?;
     }
     std::fs::rename(&tmp, &target)?;

--- a/crates/pixtuoid/src/install/merge.rs
+++ b/crates/pixtuoid/src/install/merge.rs
@@ -1,4 +1,6 @@
 use serde_json::{json, Map, Value};
+use std::path::Path;
+use toml::value::Table;
 
 pub const SENTINEL_KEY: &str = "_pixtuoid";
 
@@ -14,6 +16,16 @@ pub const EVENTS: &[&str] = &[
     "PostToolUse",
     "Notification",
     "SessionEnd",
+];
+
+pub const CODEX_EVENTS: &[&str] = &[
+    "SessionStart",
+    "PreToolUse",
+    "PostToolUse",
+    "UserPromptSubmit",
+    "SubagentStart",
+    "SubagentStop",
+    "Stop",
 ];
 
 fn is_managed_entry(entry: &Value) -> bool {
@@ -88,6 +100,144 @@ pub fn merge_uninstall(mut doc: Value) -> Value {
         hooks_obj.remove(&k);
     }
     if hooks_obj.is_empty() {
+        root.remove("hooks");
+    }
+    doc
+}
+
+fn codex_managed_command(command: &str) -> bool {
+    Path::new(command).file_name().and_then(|s| s.to_str()) == Some("pixtuoid-hook")
+}
+
+fn codex_hook_is_managed(hook: &toml::Value) -> bool {
+    hook.get("type").and_then(|v| v.as_str()) == Some("command")
+        && hook
+            .get("command")
+            .and_then(|v| v.as_str())
+            .is_some_and(codex_managed_command)
+}
+
+fn prune_codex_managed_hooks(group: &mut toml::Value) {
+    let Some(hooks) = group
+        .get_mut("hooks")
+        .and_then(|hooks| hooks.as_array_mut())
+    else {
+        return;
+    };
+    hooks.retain(|hook| !codex_hook_is_managed(hook));
+}
+
+fn codex_group_has_no_hooks(group: &toml::Value) -> bool {
+    group
+        .get("hooks")
+        .and_then(|hooks| hooks.as_array())
+        .is_some_and(|hooks| hooks.is_empty())
+}
+
+fn codex_group(event: &str, hook_command: &str) -> toml::Value {
+    let mut hook = Table::new();
+    hook.insert(
+        "type".to_string(),
+        toml::Value::String("command".to_string()),
+    );
+    hook.insert(
+        "command".to_string(),
+        toml::Value::String(hook_command.to_string()),
+    );
+    hook.insert("timeout".to_string(), toml::Value::Integer(1));
+    hook.insert(
+        "statusMessage".to_string(),
+        toml::Value::String("Updating pixtuoid".to_string()),
+    );
+
+    let mut group = Table::new();
+    if matches!(
+        event,
+        "PreToolUse" | "PostToolUse" | "SubagentStart" | "SubagentStop"
+    ) {
+        group.insert("matcher".to_string(), toml::Value::String("*".to_string()));
+    } else if event == "SessionStart" {
+        group.insert(
+            "matcher".to_string(),
+            toml::Value::String("startup|resume|clear|compact".to_string()),
+        );
+    }
+    group.insert(
+        "hooks".to_string(),
+        toml::Value::Array(vec![toml::Value::Table(hook)]),
+    );
+    toml::Value::Table(group)
+}
+
+/// Merge pixtuoid hook entries into a Codex config.toml document.
+/// Idempotent: re-running replaces existing pixtuoid entries.
+pub fn merge_codex_install(doc: toml::Value, hook_command: &str) -> toml::Value {
+    let mut root = doc.as_table().cloned().unwrap_or_default();
+    let features = root
+        .entry("features".to_string())
+        .or_insert_with(|| toml::Value::Table(Table::new()));
+    if !features.is_table() {
+        *features = toml::Value::Table(Table::new());
+    }
+    if let Some(table) = features.as_table_mut() {
+        table.insert("hooks".to_string(), toml::Value::Boolean(true));
+    }
+
+    let hooks = root
+        .entry("hooks".to_string())
+        .or_insert_with(|| toml::Value::Table(Table::new()));
+    if !hooks.is_table() {
+        *hooks = toml::Value::Table(Table::new());
+    }
+    if let Some(hooks) = hooks.as_table_mut() {
+        for ev in CODEX_EVENTS {
+            let entry = hooks
+                .entry((*ev).to_string())
+                .or_insert_with(|| toml::Value::Array(vec![]));
+            if !entry.is_array() {
+                *entry = toml::Value::Array(vec![]);
+            }
+            if let Some(arr) = entry.as_array_mut() {
+                for group in arr.iter_mut() {
+                    prune_codex_managed_hooks(group);
+                }
+                arr.retain(|group| !codex_group_has_no_hooks(group));
+                arr.push(codex_group(ev, hook_command));
+            }
+        }
+    }
+
+    toml::Value::Table(root)
+}
+
+/// Remove pixtuoid hook entries from a Codex config.toml document.
+pub fn merge_codex_uninstall(mut doc: toml::Value) -> toml::Value {
+    let Some(root) = doc.as_table_mut() else {
+        return doc;
+    };
+    let Some(toml::Value::Table(hooks)) = root.get_mut("hooks") else {
+        return doc;
+    };
+
+    for (_ev, list) in hooks.iter_mut() {
+        if let Some(arr) = list.as_array_mut() {
+            for group in arr.iter_mut() {
+                prune_codex_managed_hooks(group);
+            }
+            arr.retain(|group| !codex_group_has_no_hooks(group));
+        }
+    }
+    let empty_events: Vec<String> = hooks
+        .iter()
+        .filter_map(|(k, v)| match v.as_array() {
+            Some(a) if a.is_empty() => Some(k.clone()),
+            _ => None,
+        })
+        .collect();
+    for key in empty_events {
+        hooks.remove(&key);
+    }
+    if hooks.is_empty() {
         root.remove("hooks");
     }
     doc
@@ -236,5 +386,143 @@ mod tests {
             "non-array values should pass through unchanged"
         );
         assert_eq!(hooks["PostToolUse"], json!(42));
+    }
+
+    #[test]
+    fn codex_install_creates_entries_for_all_events() {
+        let doc = merge_codex_install(toml::Value::Table(Table::new()), "/opt/bin/pixtuoid-hook");
+        let hooks = doc.get("hooks").and_then(|v| v.as_table()).unwrap();
+        for ev in CODEX_EVENTS {
+            let arr = hooks.get(*ev).and_then(|v| v.as_array()).unwrap();
+            assert_eq!(arr.len(), 1, "event {ev}");
+            assert_eq!(
+                arr[0]["hooks"][0]["command"].as_str().unwrap(),
+                "/opt/bin/pixtuoid-hook"
+            );
+        }
+        assert_eq!(
+            doc["features"]["hooks"].as_bool(),
+            Some(true),
+            "Codex hook feature must be enabled"
+        );
+    }
+
+    #[test]
+    fn codex_install_registers_user_prompt_submit_without_matcher() {
+        let doc = merge_codex_install(toml::Value::Table(Table::new()), "/opt/bin/pixtuoid-hook");
+        let group = &doc["hooks"]["UserPromptSubmit"][0];
+
+        assert_eq!(
+            group["hooks"][0]["command"].as_str().unwrap(),
+            "/opt/bin/pixtuoid-hook"
+        );
+        assert!(
+            group.get("matcher").is_none(),
+            "UserPromptSubmit should not have a matcher"
+        );
+    }
+
+    #[test]
+    fn codex_install_is_idempotent_and_replaces_old_pixtuoid_command() {
+        let initial = r#"
+[features]
+hooks = true
+
+[[hooks.PreToolUse]]
+matcher = "*"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "pixtuoid-hook"
+"#;
+        let parsed = toml::from_str::<toml::Value>(initial).unwrap();
+        let merged = merge_codex_install(parsed, "/new/pixtuoid-hook");
+        let merged_again = merge_codex_install(merged.clone(), "/new/pixtuoid-hook");
+        assert_eq!(merged, merged_again);
+
+        let pre = merged["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(pre.len(), 1);
+        assert_eq!(
+            pre[0]["hooks"][0]["command"].as_str().unwrap(),
+            "/new/pixtuoid-hook"
+        );
+    }
+
+    #[test]
+    fn codex_install_preserves_sibling_hooks_in_mixed_group() {
+        let initial = r#"
+[[hooks.PreToolUse]]
+matcher = "*"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "/keep"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "/old/pixtuoid-hook"
+"#;
+        let merged = merge_codex_install(
+            toml::from_str::<toml::Value>(initial).unwrap(),
+            "/new/pixtuoid-hook",
+        );
+        let pre = merged["hooks"]["PreToolUse"].as_array().unwrap();
+
+        assert_eq!(
+            pre.len(),
+            2,
+            "mixed group should be kept and new managed group added"
+        );
+        assert_eq!(pre[0]["hooks"].as_array().unwrap().len(), 1);
+        assert_eq!(pre[0]["hooks"][0]["command"].as_str().unwrap(), "/keep");
+        assert_eq!(
+            pre[1]["hooks"][0]["command"].as_str().unwrap(),
+            "/new/pixtuoid-hook"
+        );
+    }
+
+    #[test]
+    fn codex_uninstall_removes_only_pixtuoid_entries() {
+        let initial = r#"
+[[hooks.PreToolUse]]
+matcher = "*"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "/keep"
+
+[[hooks.PreToolUse]]
+matcher = "*"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "/opt/bin/pixtuoid-hook"
+"#;
+        let cleaned = merge_codex_uninstall(toml::from_str::<toml::Value>(initial).unwrap());
+        let pre = cleaned["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(pre.len(), 1);
+        assert_eq!(pre[0]["hooks"][0]["command"].as_str().unwrap(), "/keep");
+    }
+
+    #[test]
+    fn codex_uninstall_preserves_sibling_hooks_in_mixed_group() {
+        let initial = r#"
+[[hooks.PreToolUse]]
+matcher = "*"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "/keep"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "/opt/bin/pixtuoid-hook"
+"#;
+        let cleaned = merge_codex_uninstall(toml::from_str::<toml::Value>(initial).unwrap());
+        let pre = cleaned["hooks"]["PreToolUse"].as_array().unwrap();
+
+        assert_eq!(pre.len(), 1);
+        assert_eq!(pre[0]["hooks"].as_array().unwrap().len(), 1);
+        assert_eq!(pre[0]["hooks"][0]["command"].as_str().unwrap(), "/keep");
     }
 }

--- a/crates/pixtuoid/src/install/mod.rs
+++ b/crates/pixtuoid/src/install/mod.rs
@@ -5,7 +5,27 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 
-pub fn install(hook_path: Option<PathBuf>, settings: Option<PathBuf>) -> Result<()> {
+use crate::cli::HookTarget;
+
+pub fn install(
+    hook_path: Option<PathBuf>,
+    settings: Option<PathBuf>,
+    codex_config: Option<PathBuf>,
+    target: HookTarget,
+) -> Result<()> {
+    let hook = hook_path.map(Ok).unwrap_or_else(io::default_hook_binary)?;
+    match target {
+        HookTarget::Claude => install_claude(Some(hook), settings)?,
+        HookTarget::Codex => install_codex(Some(hook), codex_config)?,
+        HookTarget::All => {
+            install_claude(Some(hook.clone()), settings)?;
+            install_codex(Some(hook), codex_config)?;
+        }
+    }
+    Ok(())
+}
+
+fn install_claude(hook_path: Option<PathBuf>, settings: Option<PathBuf>) -> Result<()> {
     let settings_path = settings.unwrap_or_else(io::default_settings_path);
     // Verify the binary exists, but write just the bare name so settings.json
     // stays portable across machines with different install locations.
@@ -51,7 +71,51 @@ pub fn install(hook_path: Option<PathBuf>, settings: Option<PathBuf>) -> Result<
     Ok(())
 }
 
-pub fn uninstall(settings: Option<PathBuf>) -> Result<()> {
+fn install_codex(hook_path: Option<PathBuf>, codex_config: Option<PathBuf>) -> Result<()> {
+    let config_path = codex_config.unwrap_or_else(io::default_codex_config_path);
+    let hook = hook_path.map(Ok).unwrap_or_else(io::default_hook_binary)?;
+    let hook_str = hook.to_string_lossy().to_string();
+
+    let doc = io::read_toml_config(&config_path)?;
+    let merged = merge::merge_codex_install(doc.clone(), &hook_str);
+    let changed = merged != doc;
+
+    if changed {
+        io::write_toml_atomic(&config_path, &merged)?;
+        println!(
+            "ok: installed pixtuoid hooks into {}",
+            config_path.display()
+        );
+    } else {
+        println!(
+            "already up to date — pixtuoid hooks in {} are current",
+            config_path.display()
+        );
+    }
+
+    if changed {
+        println!("→ start a new Codex session for this to take effect.");
+    }
+    Ok(())
+}
+
+pub fn uninstall(
+    settings: Option<PathBuf>,
+    codex_config: Option<PathBuf>,
+    target: HookTarget,
+) -> Result<()> {
+    match target {
+        HookTarget::Claude => uninstall_claude(settings)?,
+        HookTarget::Codex => uninstall_codex(codex_config)?,
+        HookTarget::All => {
+            uninstall_claude(settings)?;
+            uninstall_codex(codex_config)?;
+        }
+    }
+    Ok(())
+}
+
+fn uninstall_claude(settings: Option<PathBuf>) -> Result<()> {
     let settings_path = settings.unwrap_or_else(io::default_settings_path);
     if !settings_path.exists() {
         println!(
@@ -81,6 +145,32 @@ pub fn uninstall(settings: Option<PathBuf>) -> Result<()> {
         println!(
             "no pixtuoid hooks found in {} — nothing to remove",
             settings_path.display()
+        );
+    }
+    Ok(())
+}
+
+fn uninstall_codex(codex_config: Option<PathBuf>) -> Result<()> {
+    let config_path = codex_config.unwrap_or_else(io::default_codex_config_path);
+    if !config_path.exists() {
+        println!(
+            "no config.toml at {} — nothing to do",
+            config_path.display()
+        );
+        return Ok(());
+    }
+    let doc = io::read_toml_config(&config_path)?;
+    let cleaned = merge::merge_codex_uninstall(doc.clone());
+    let changed = cleaned != doc;
+
+    if changed {
+        io::write_toml_atomic(&config_path, &cleaned)?;
+        println!("ok: removed pixtuoid hooks from {}", config_path.display());
+        println!("→ start a new Codex session for this to take effect.");
+    } else {
+        println!(
+            "no pixtuoid hooks found in {} — nothing to remove",
+            config_path.display()
         );
     }
     Ok(())

--- a/crates/pixtuoid/src/main.rs
+++ b/crates/pixtuoid/src/main.rs
@@ -72,8 +72,14 @@ fn main() -> Result<()> {
         Cmd::InstallHooks {
             hook_path,
             settings,
-        } => install::install(hook_path, settings),
-        Cmd::UninstallHooks { settings } => install::uninstall(settings),
+            codex_config,
+            target,
+        } => install::install(hook_path, settings, codex_config, target),
+        Cmd::UninstallHooks {
+            settings,
+            codex_config,
+            target,
+        } => install::uninstall(settings, codex_config, target),
         Cmd::ValidatePack { pack_dir } => validate::validate_pack(&pack_dir),
         Cmd::InitPack { dest, force } => init_pack::init_pack(&dest, force),
     }

--- a/crates/pixtuoid/tests/install.rs
+++ b/crates/pixtuoid/tests/install.rs
@@ -32,3 +32,55 @@ fn install_then_uninstall_round_trip() {
     let v: serde_json::Value = serde_json::from_str(&contents).unwrap();
     assert!(v.get("hooks").is_none(), "got {v}");
 }
+
+#[test]
+fn codex_install_then_uninstall_round_trip() {
+    let dir = TempDir::new().unwrap();
+    let config = dir.path().join("config.toml");
+
+    let bin = env!("CARGO_BIN_EXE_pixtuoid");
+    let status = std::process::Command::new(bin)
+        .args([
+            "install-hooks",
+            "--target",
+            "codex",
+            "--codex-config",
+            config.to_str().unwrap(),
+            "--hook-path",
+            "/fake/pixtuoid-hook",
+        ])
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    let contents = std::fs::read_to_string(&config).unwrap();
+    let v = toml::from_str::<toml::Value>(&contents).unwrap();
+    assert_eq!(v["features"]["hooks"].as_bool(), Some(true));
+    assert_eq!(
+        v["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+            .as_str()
+            .unwrap(),
+        "/fake/pixtuoid-hook"
+    );
+
+    let status = std::process::Command::new(bin)
+        .args([
+            "uninstall-hooks",
+            "--target",
+            "codex",
+            "--codex-config",
+            config.to_str().unwrap(),
+        ])
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    let contents = std::fs::read_to_string(&config).unwrap();
+    let v = toml::from_str::<toml::Value>(&contents).unwrap();
+    assert!(v.get("hooks").is_none(), "got {v}");
+    assert_eq!(
+        v["features"]["hooks"].as_bool(),
+        Some(true),
+        "uninstall should not rewrite unrelated feature settings"
+    );
+}


### PR DESCRIPTION
## Summary
- add `install-hooks --target codex` / `uninstall-hooks --target codex` support for Codex `config.toml`
- decode Codex hook events including `UserPromptSubmit`, `Stop`, and subagent start/stop events
- preserve sibling commands in mixed Codex hook groups while replacing/removing only pixtuoid hook commands
- update docs and regression coverage for Codex install/uninstall

Written with Codex/Reviewed with Claude -- but not really reviewed by a human sorry.  Seems to work!

## Testing
- `docker run --rm -u 501:20 -v /Users/timh/src-personal/pixtuoid:/workspace -w /workspace rust:latest cargo fmt --all --check`
- `docker run --rm -u 501:20 -v /Users/timh/src-personal/pixtuoid:/workspace -w /workspace rust:latest cargo test --workspace`