### PR TITLE
ci: skip Claude review workflows on fork PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   review:
     if: >
-      (github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && github.event.pull_request.draft == false) ||
+      (github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/claude-review'))
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   security-review:
-    if: github.actor != 'dependabot[bot]'
+    if: github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:


### PR DESCRIPTION
## Problem

Fork PRs (e.g. #58, an external README change from `chenshaoju:patch-1`) show a spurious red X on the **claude review** check.

GitHub runs fork-triggered `pull_request` workflows in a restricted context: repo **secrets are blanked out** and **`id-token: write` is downgraded to read-only**. So `claude-code-action` can't fetch an OIDC token and `CLAUDE_CODE_OAUTH_TOKEN` is empty — the job can *never* succeed:

```
ANTHROPIC_API_KEY:                          ← empty
Could not fetch an OIDC token...
Unable to get ACTIONS_ID_TOKEN_REQUEST_URL  ← because it's a fork
```

This is an intentional GitHub security measure (stops a malicious PR from exfiltrating secrets), not a workflow bug.

## Fix

Guard both auto-review jobs on `github.event.pull_request.head.repo.full_name == github.repository` so fork PRs skip the doomed review job instead of failing it.

- `claude-review.yml` — added the guard to the `pull_request` branch of the `if`; the `/claude-review` comment path is untouched.
- `claude-security-review.yml` — added the guard to its `if`.

Maintainers can still review a fork PR by commenting `/claude-review` — that's an `issue_comment` event, which runs in the trusted base-repo context where secrets are available.

`claude.yml` needs no change: it only triggers on comments/reviews/issues, which always run in the base-repo context.

## Note

`pull_request` workflows are read from the base branch, so #58 keeps failing until this lands on `main`. After merge, re-running #58's checks will skip the review job cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)