### PR TITLE
chore: add PR + issue templates for external contributors

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,82 @@
+name: 🐛 Bug report
+description: Something rendered wrong, crashed, or didn't behave as expected.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report! pixtuoid is a terminal renderer, so a **screenshot or GIF**
+        is worth a thousand words — please attach one if the bug is visual.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you see, and what did you expect instead?
+      placeholder: The sprite walked through the wall when the office had only one desk…
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: The exact command(s) you ran, and what you did in the TUI.
+      placeholder: |
+        1. pixtuoid run --theme dracula --max-desks 4
+        2. Started two Claude Code sessions
+        3. …
+    validations:
+      required: true
+  - type: textarea
+    id: visual
+    attributes:
+      label: Screenshot / GIF
+      description: Drag-and-drop an image here if the bug is visual. A cropped snapshot (`scripts/crop-snapshot.py`) is ideal.
+    validations:
+      required: false
+  - type: input
+    id: version
+    attributes:
+      label: pixtuoid version
+      description: Output of `pixtuoid --version` (or the release tag / commit you built from).
+      placeholder: 0.x.y
+    validations:
+      required: true
+  - type: dropdown
+    id: agent-cli
+    attributes:
+      label: Which agent CLI were you visualizing?
+      multiple: true
+      options:
+        - Claude Code
+        - Codex CLI
+        - Antigravity CLI
+        - Other (note it below)
+        - Not applicable
+    validations:
+      required: true
+  - type: dropdown
+    id: install
+    attributes:
+      label: How did you install it?
+      options:
+        - Pre-built binary (release)
+        - Cargo (crates.io)
+        - From source (cargo build --release)
+    validations:
+      required: true
+  - type: input
+    id: env
+    attributes:
+      label: OS + terminal
+      description: e.g. "macOS 15.6, iTerm2" / "Ubuntu 24.04, kitty / tmux". Terminal & multiplexer matter for rendering bugs.
+      placeholder: macOS 15.6, Ghostty
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Anything printed to stderr, or output from `pixtuoid run --headless`. Will be formatted as code.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Questions & ideas
+    url: https://github.com/IvanWng97/pixtuoid/discussions
+    about: Ask a question, share a theme, or float an idea before opening an issue.
+  - name: ☕ Support the project
+    url: https://buymeacoffee.com/IvanWng97
+    about: If you enjoy pixtuoid, consider buying me a coffee.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,51 @@
+name: ✨ Feature request
+description: Suggest a new theme, sprite pack, agent-CLI source, or capability.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        New **themes** and **`Source` adapters** (Copilot, Cursor, OpenCode, …) are
+        especially welcome — see the "Adding a new agent CLI" note in the README.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's the problem or use case?
+      description: What are you trying to do that pixtuoid doesn't support today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like to see? Sketch the behavior, the UI, or the config it'd add.
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - New theme
+        - New sprite pack / character
+        - New agent-CLI source (Copilot / Cursor / OpenCode / …)
+        - Office layout / decoration
+        - Motion / animation
+        - Configuration
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about, or how you work around it today.
+    validations:
+      required: false
+  - type: checkboxes
+    id: contribute
+    attributes:
+      label: Contribution
+      options:
+        - label: I'd be willing to open a PR for this.
+          required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,59 @@
+<!--
+Thanks for contributing to pixtuoid! Before you open this PR:
+- Read CLAUDE.md (root) — architecture invariants & conventions are load-bearing.
+- Run scripts/preflight.sh locally (it mirrors CI: fmt + machete + deny + clippy -D warnings + tests).
+Delete sections that don't apply. Keep it short — the diff speaks for itself.
+-->
+
+## Summary
+
+<!-- What does this change and why? One or two sentences. -->
+
+## Related issue
+
+<!-- e.g. "Closes #123" / "Part of #123" — or "n/a". -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] New theme / sprite pack
+- [ ] New `Source` adapter (another agent CLI)
+- [ ] Docs only
+- [ ] Refactor / chore
+
+## How I tested it
+
+<!--
+- `cargo test --workspace --features pixtuoid-core/test-renderer`
+- ./scripts/preflight.sh (full CI mirror)
+- Live: ./target/release/pixtuoid run --headless --projects-root ~/.claude/projects
+-->
+
+## Visual verification (required for sprite / rendering changes)
+
+<!--
+Skip this block for non-visual changes. For any .sprite edit or change to the
+pixel painter, attach a cropped snapshot and self-critique:
+  cargo build --release --example snapshot
+  ./target/release/examples/snapshot --cols 192 --rows 80 /tmp/snap.png
+  .venv/bin/python3 scripts/crop-snapshot.py /tmp/snap.png --scale 3
+-->
+
+- [ ] Not a visual change, or — screenshot/GIF attached below and it reads at half-block scale.
+
+## Checklist
+
+- [ ] I read the relevant `CLAUDE.md` (root + the nested one for the crate I touched).
+- [ ] New behavior has a test (this repo is TDD-first).
+- [ ] No `unwrap()` in non-test code; errors propagate via `anyhow`/`thiserror`.
+- [ ] No new `println!`/`eprintln!` on a production path (use `tracing`).
+- [ ] Docs updated in the same commit if I changed module structure, architecture, or public API (`CLAUDE.md` / `README.md`).
+- [ ] `scripts/preflight.sh` passes locally.
+
+## AI assistance
+
+<!-- If this PR was authored or heavily assisted by an AI agent, say so — a maintainer
+     will visually verify before merge (see the `needs-human-verify` label). -->
+
+- [ ] This PR was written/heavily-assisted by an AI agent.


### PR DESCRIPTION
## Summary

Adds GitHub-native templates to onboard outside contributors and bake the repo's load-bearing conventions into the contribution flow.

- **`.github/PULL_REQUEST_TEMPLATE.md`** — summary / related issue / type, how-tested (preflight mirror), a **required** visual-verification block for sprite/render changes, a conventions checklist (TDD test, no `unwrap`, no `println`, docs-in-same-commit), and an AI-assistance disclosure tied to the `needs-human-verify` label.
- **`.github/ISSUE_TEMPLATE/bug_report.yml`** — issue form nudging a screenshot/GIF, version, agent CLI (Claude Code / Codex / Antigravity), install method, OS + terminal, and logs.
- **`.github/ISSUE_TEMPLATE/feature_request.yml`** — issue form steering toward new themes and `Source` adapters.
- **`.github/ISSUE_TEMPLATE/config.yml`** — disables blank issues; links Discussions (enabled on this repo) + support.

## Verification

- All three issue-form YAMLs parse (validated locally).
- No code changes — docs/config only; no preflight surface.
- Discussions tab confirmed enabled, so the `config.yml` contact link renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)