### PR TITLE
feat(ci): upstream wire-format drift watch + internal registered-vs-decoded test

### DIFF
--- a/.github/workflows/upstream-drift.yml
+++ b/.github/workflows/upstream-drift.yml
@@ -1,0 +1,58 @@
+name: upstream-drift
+
+# Weekly watch for upstream CC/Codex wire-format renames (hook event names, the
+# subagent-dispatch tool). The Task -> Agent rename shipped undocumented and
+# silently disabled subagent suppression; this surfaces the next one before a
+# user hits it. See scripts/check_upstream_drift.py and the "Keeping the decode
+# mapping current" section in crates/pixtuoid-core/CLAUDE.md.
+
+on:
+  schedule:
+    - cron: "0 9 * * 1" # Mondays 09:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  drift:
+    name: upstream wire-format drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check upstream drift
+        id: check
+        shell: bash
+        run: |
+          set +e
+          python3 scripts/check_upstream_drift.py | tee drift-report.md
+          echo "exit=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Open or update tracking issue
+        if: steps.check.outputs.exit == '1'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh label create upstream-drift --color FBCA04 \
+            --description "Upstream CLI wire-format drift" 2>/dev/null || true
+          num=$(gh issue list --label upstream-drift --state open \
+            --json number --jq '.[0].number // empty')
+          if [ -n "$num" ]; then
+            gh issue comment "$num" --body-file drift-report.md
+          else
+            gh issue create \
+              --title "Upstream CLI wire-format drift detected" \
+              --label upstream-drift \
+              --body-file drift-report.md
+          fi
+
+      - name: Note transient check failure
+        if: steps.check.outputs.exit == '2'
+        run: echo "::warning::upstream-drift could not verify (transient network/HTTP); see report above."
+
+      - name: Fail the run on confirmed drift
+        if: steps.check.outputs.exit == '1'
+        run: exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ Cargo.lock.bak
 docs/superpowers/
 .claude/worktrees/
 docs/superpowers/
+drift-report.md
+__pycache__/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,8 @@ crates/
 └── pixtuoid-hook/      tiny shim CC invokes — stdin JSON → Unix socket, 200ms write timeout
 scripts/                preflight.sh (CI mirror), crop-snapshot.py (visual verification),
                         replay-fixture.sh (replay a captured source rollout fixture into a
-                        headless run via --codex-sessions-root, for eyeballing lifecycle)
+                        headless run via --codex-sessions-root, for eyeballing lifecycle),
+                        check_upstream_drift.py (weekly CI: CC/Codex wire-format rename watch)
 ```
 
 > Note: the `sprites/` directory (default / robot / skeleton character packs) lives under

--- a/crates/pixtuoid-core/CLAUDE.md
+++ b/crates/pixtuoid-core/CLAUDE.md
@@ -74,13 +74,14 @@ src/
 
 ## Keeping the decode mapping current (upstream drift)
 
-Tool names, hook-event names and transcript types are upstream wire contracts that change **without notice** (the `Task`→`Agent` rename shipped undocumented). Three defenses, in order of reliability:
+Tool names, hook-event names and transcript types are upstream wire contracts that change **without notice** (the `Task`→`Agent` rename shipped undocumented). Four defenses, in order of reliability:
 
 1. **Resilient detection (in code).** Prefer a *semantic* signal over a hardcoded name where one exists — e.g. `make_tool_detail` keys subagent dispatch on the stable `subagent_type` input field, not the tool name. This survives a rename by construction.
 2. **Self-monitoring from the real stream (in code).** The decoders already see ground truth. An unrecognized `hook_event_name` `bail!`s + `warn!`s; a dispatch under an unknown name logs a `debug!` breadcrumb. These surface drift the moment it appears in a user's own usage — no network, no upstream-layout dependency.
-3. **Upstream watch (CI follow-up, not yet built).** Pin + diff the machine-readable sources on a schedule:
-   - **Codex** (open Rust): `codex-rs/protocol/src/protocol.rs` — the `HookEventName` enum (hook names) and `EventMsg`/`RolloutItem` enums (transcript `type`s). Raw: `raw.githubusercontent.com/openai/codex/main/codex-rs/protocol/src/protocol.rs`. Releases are frequent; tags are `rust-vX.Y.Z`.
-   - **CC** (closed binary — no source to grep): diff the docs markdown `code.claude.com/docs/en/hooks.md` (hook names) and `…/tools-reference.md` (authoritative tool-name list), plus `raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md` / `releases.atom`. Tool names like `Agent` are NOT schematized upstream, so defense #2 is the real backstop for CC.
+3. **Internal consistency test.** `every_registered_codex_event_decodes` / `every_registered_cc_event_decodes` (in `install/{codex,claude}.rs`) assert that every hook event we *register* has a decoder arm — catching the *registered-but-not-decoded* class (the original SubagentStop bug) at `cargo test` time.
+4. **Upstream watch (CI).** `scripts/check_upstream_drift.py` + `.github/workflows/upstream-drift.yml` (weekly) read the names we depend on directly from our source and compare to live upstream; on a vanished name or a new unhandled Codex hook it opens a deduped `upstream-drift` issue. Sources:
+   - **Codex** (open Rust): `codex-rs/protocol/src/protocol.rs` `HookEventName` enum (raw on `main`). `PreCompact`/`PostCompact` are intentionally omitted (`CODEX_KNOWN_OMITTED` in the script) — not agent activity.
+   - **CC** (closed binary — no source to grep): the docs markdown `code.claude.com/docs/en/tools-reference.md` (authoritative tool-name list). Tool names like `Agent` are NOT schematized upstream, so defense #2 is the real backstop for CC.
 
 ## When refactoring
 

--- a/crates/pixtuoid/src/install/claude.rs
+++ b/crates/pixtuoid/src/install/claude.rs
@@ -311,4 +311,25 @@ mod tests {
         let out = merge_uninstall(user).unwrap();
         assert!(!out.changed, "no managed entries → semantic no-op");
     }
+
+    // Internal-consistency guard (mirror of the Codex one): every hook event we
+    // REGISTER with Claude Code must have a decoder arm, else it bails at the
+    // shared socket and is silently dropped.
+    #[test]
+    fn every_registered_cc_event_decodes() {
+        use pixtuoid_core::source::decoder::decode_hook_payload;
+        for ev in EVENTS {
+            let payload = serde_json::json!({
+                "hook_event_name": ev,
+                "session_id": "sess",
+                "transcript_path": "/p/sess.jsonl",
+                "cwd": "/repo",
+            });
+            assert!(
+                decode_hook_payload(payload).is_ok(),
+                "registered CC hook {ev:?} has no decoder arm — it would bail as \
+                 unsupported. Add an arm in pixtuoid-core source/decoder.rs."
+            );
+        }
+    }
 }

--- a/crates/pixtuoid/src/install/codex.rs
+++ b/crates/pixtuoid/src/install/codex.rs
@@ -358,4 +358,31 @@ command = "/old/pixtuoid-hook"
             "PIXTUOID_SOURCE=codex '/Users/Jane Doe/bin/pixtuoid-hook'"
         );
     }
+
+    // Internal-consistency guard: every hook event we REGISTER with Codex must
+    // have a decoder arm — otherwise it arrives at the shared socket and
+    // `decode_hook_payload` bails ("unsupported hook_event_name"), silently
+    // dropping it. This is exactly the class the SubagentStop bug fell into
+    // (registered but not decoded). The external drift-watch covers upstream
+    // renames; this covers our own registered-vs-decoded drift.
+    #[test]
+    fn every_registered_codex_event_decodes() {
+        use pixtuoid_core::source::decoder::decode_hook_payload;
+        for ev in CODEX_EVENTS {
+            // A complete-enough payload: `agent_id` satisfies SubagentStart/Stop;
+            // the rest is ignored by events that don't need it.
+            let payload = serde_json::json!({
+                "hook_event_name": ev,
+                "session_id": "sess",
+                "agent_id": "child",
+                "cwd": "/repo",
+                "_pixtuoid_source": "codex",
+            });
+            assert!(
+                decode_hook_payload(payload).is_ok(),
+                "registered Codex hook {ev:?} has no decoder arm — it would bail \
+                 as unsupported. Add an arm in pixtuoid-core source/decoder.rs."
+            );
+        }
+    }
 }

--- a/scripts/check_upstream_drift.py
+++ b/scripts/check_upstream_drift.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import pathlib
 import re
 import sys
+import urllib.error
 import urllib.request
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
@@ -80,56 +81,71 @@ def main() -> int:
     review: list[str] = []
     errors: list[str] = []
 
-    # --- Codex hook events -------------------------------------------------
+    # Read what WE depend on from our OWN source first. A failure here means the
+    # monitor itself is broken (decoder.rs / install/codex.rs refactored away from
+    # what the parsers expect) — that is a LOUD breaking signal, never a transient
+    # one, or drift monitoring would silently stop with zero alarm.
+    codex_ours = None
+    dispatch_names = None
     try:
-        ours = read_codex_events()
-        text = fetch(CODEX_PROTOCOL_URL)
-        upstream = upstream_codex_hooks(text)
-        if upstream is None:
-            breaking.append(
-                "Codex `HookEventName` enum not found at the pinned path "
-                "(codex-rs/protocol/src/protocol.rs) — upstream moved it; "
-                "update CODEX_PROTOCOL_URL / the parser."
-            )
-        else:
-            for ev in sorted(ours):
-                if ev not in upstream:
-                    breaking.append(
-                        f"Codex hook `{ev}` (registered in CODEX_EVENTS) is GONE "
-                        f"from upstream HookEventName — likely renamed; the decoder "
-                        f"will silently drop it."
-                    )
-            for ev in sorted(upstream - ours - CODEX_KNOWN_OMITTED):
-                review.append(
-                    f"new Codex hook `{ev}` upstream — we neither register nor "
-                    f"intentionally omit it (add a decoder arm + CODEX_EVENTS, or "
-                    f"add it to CODEX_KNOWN_OMITTED)."
-                )
-    except urllib.error.URLError as e:
-        errors.append(f"Codex source fetch failed (transient?): {e}")
-    except Exception as e:  # noqa: BLE001 — report any unexpected failure
-        errors.append(f"Codex check error: {e}")
-
-    # --- CC subagent-dispatch tool -----------------------------------------
-    try:
-        dispatch = read_dispatch_names()  # e.g. {"Task", "Agent"}
-        tools = fetch(CC_TOOLS_URL)
-        # The current dispatch tool must still appear in the tools reference.
-        # We don't require legacy names — only that at least one name we'd
-        # detect by-name is still the documented dispatch tool.
-        present = [n for n in dispatch if re.search(rf"`{re.escape(n)}`", tools)]
-        if not present:
-            breaking.append(
-                f"None of our known dispatch tool names {sorted(dispatch)} appear "
-                f"in CC tools-reference — the subagent tool was likely renamed "
-                f"again. Update make_tool_detail's known names. (Semantic "
-                f"subagent_type detection still works, but the breadcrumb/name "
-                f"fallback is stale.)"
-            )
-    except urllib.error.URLError as e:
-        errors.append(f"CC tools-reference fetch failed (transient?): {e}")
+        codex_ours = read_codex_events()
+        dispatch_names = read_dispatch_names()
     except Exception as e:  # noqa: BLE001
-        errors.append(f"CC check error: {e}")
+        breaking.append(
+            f"drift-watch cannot read our own source ({e}) — the parsers in "
+            f"check_upstream_drift.py are stale (decoder.rs / install refactored?). "
+            f"The monitor is blind until the script is fixed."
+        )
+
+    # --- Codex hook events (only the FETCH is transient) -------------------
+    if codex_ours is not None:
+        try:
+            text = fetch(CODEX_PROTOCOL_URL)
+        except urllib.error.URLError as e:
+            errors.append(f"Codex source fetch failed (transient?): {e}")
+            text = None
+        if text is not None:
+            upstream = upstream_codex_hooks(text)
+            if upstream is None:
+                breaking.append(
+                    "Codex `HookEventName` enum not found at the pinned path "
+                    "(codex-rs/protocol/src/protocol.rs) — upstream moved it; "
+                    "update CODEX_PROTOCOL_URL / the parser."
+                )
+            else:
+                for ev in sorted(codex_ours):
+                    if ev not in upstream:
+                        breaking.append(
+                            f"Codex hook `{ev}` (registered in CODEX_EVENTS) is GONE "
+                            f"from upstream HookEventName — likely renamed; the "
+                            f"decoder will silently drop it."
+                        )
+                for ev in sorted(upstream - codex_ours - CODEX_KNOWN_OMITTED):
+                    review.append(
+                        f"new Codex hook `{ev}` upstream — we neither register nor "
+                        f"intentionally omit it (add a decoder arm + CODEX_EVENTS, "
+                        f"or add it to CODEX_KNOWN_OMITTED)."
+                    )
+
+    # --- CC subagent-dispatch tool (only the FETCH is transient) -----------
+    if dispatch_names is not None:
+        try:
+            tools = fetch(CC_TOOLS_URL)
+        except urllib.error.URLError as e:
+            errors.append(f"CC tools-reference fetch failed (transient?): {e}")
+            tools = None
+        if tools is not None:
+            # At least one name we'd detect by-name must still be the documented
+            # dispatch tool. (Losing a legacy name like `Task` is fine.)
+            present = [n for n in dispatch_names if re.search(rf"`{re.escape(n)}`", tools)]
+            if not present:
+                breaking.append(
+                    f"None of our known dispatch tool names {sorted(dispatch_names)} "
+                    f"appear in CC tools-reference — the subagent tool was likely "
+                    f"renamed again. Update make_tool_detail's known names. (Semantic "
+                    f"subagent_type detection still works, but the name fallback is "
+                    f"stale.)"
+                )
 
     # --- report ------------------------------------------------------------
     out = ["# pixtuoid upstream wire-format drift report", ""]

--- a/scripts/check_upstream_drift.py
+++ b/scripts/check_upstream_drift.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Upstream wire-format drift watch.
+
+pixtuoid decodes the CC and Codex CLI wire formats (hook event names, the
+subagent-dispatch tool name). Those names change upstream WITHOUT notice — the
+`Task` -> `Agent` rename shipped undocumented and silently disabled subagent
+suppression. This script verifies that the names we depend on still exist at the
+canonical upstream sources, so CI can flag a break before it reaches a user.
+
+It reads what we depend on directly from our own source (no snapshot file to rot)
+and compares against the live upstream:
+
+  * Codex hook events  -> `CODEX_EVENTS` in crates/pixtuoid/src/install/codex.rs
+                          vs the `HookEventName` enum in openai/codex protocol.rs
+  * CC dispatch tool   -> the known names in `make_tool_detail`
+                          vs the tool list in code.claude.com tools-reference
+
+Exit codes:
+  0  no drift
+  1  actionable drift (a name we depend on vanished, or a new upstream Codex
+     hook we neither register nor intentionally omit) -> open a tracking issue
+  2  could not check (network/HTTP error) -> transient, do NOT alarm
+
+See crates/pixtuoid-core/CLAUDE.md "Keeping the decode mapping current".
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+import urllib.request
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+
+CODEX_PROTOCOL_URL = (
+    "https://raw.githubusercontent.com/openai/codex/main/"
+    "codex-rs/protocol/src/protocol.rs"
+)
+CC_TOOLS_URL = "https://code.claude.com/docs/en/tools-reference.md"
+
+# Codex hook events we DELIBERATELY do not register — they are not agent
+# activity a visualizer cares about. A new upstream hook NOT in this set is
+# surfaced for review (it might be a lifecycle signal worth handling).
+CODEX_KNOWN_OMITTED = {"PreCompact", "PostCompact"}
+
+
+def fetch(url: str) -> str:
+    req = urllib.request.Request(url, headers={"User-Agent": "pixtuoid-drift-watch"})
+    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310 (trusted hosts)
+        return resp.read().decode("utf-8", "replace")
+
+
+def read_codex_events() -> set[str]:
+    src = (REPO / "crates/pixtuoid/src/install/codex.rs").read_text()
+    m = re.search(r"const CODEX_EVENTS[^=]*=\s*&\[(.*?)\];", src, re.S)
+    if not m:
+        raise RuntimeError("could not locate CODEX_EVENTS in install/codex.rs")
+    return set(re.findall(r'"(\w+)"', m.group(1)))
+
+
+def read_dispatch_names() -> set[str]:
+    src = (REPO / "crates/pixtuoid-core/src/source/decoder.rs").read_text()
+    m = re.search(r"known_name\s*=\s*([^;]+);", src)
+    if not m:
+        raise RuntimeError("could not locate the dispatch known_name check in decoder.rs")
+    return set(re.findall(r'"(\w+)"', m.group(1)))
+
+
+def upstream_codex_hooks(text: str) -> set[str] | None:
+    m = re.search(r"enum HookEventName\s*\{(.*?)\}", text, re.S)
+    if not m:
+        return None
+    # variant identifiers (drop comments/attrs by keeping CamelCase words)
+    return set(re.findall(r"\b([A-Z][A-Za-z]+)\b", m.group(1)))
+
+
+def main() -> int:
+    breaking: list[str] = []
+    review: list[str] = []
+    errors: list[str] = []
+
+    # --- Codex hook events -------------------------------------------------
+    try:
+        ours = read_codex_events()
+        text = fetch(CODEX_PROTOCOL_URL)
+        upstream = upstream_codex_hooks(text)
+        if upstream is None:
+            breaking.append(
+                "Codex `HookEventName` enum not found at the pinned path "
+                "(codex-rs/protocol/src/protocol.rs) — upstream moved it; "
+                "update CODEX_PROTOCOL_URL / the parser."
+            )
+        else:
+            for ev in sorted(ours):
+                if ev not in upstream:
+                    breaking.append(
+                        f"Codex hook `{ev}` (registered in CODEX_EVENTS) is GONE "
+                        f"from upstream HookEventName — likely renamed; the decoder "
+                        f"will silently drop it."
+                    )
+            for ev in sorted(upstream - ours - CODEX_KNOWN_OMITTED):
+                review.append(
+                    f"new Codex hook `{ev}` upstream — we neither register nor "
+                    f"intentionally omit it (add a decoder arm + CODEX_EVENTS, or "
+                    f"add it to CODEX_KNOWN_OMITTED)."
+                )
+    except urllib.error.URLError as e:
+        errors.append(f"Codex source fetch failed (transient?): {e}")
+    except Exception as e:  # noqa: BLE001 — report any unexpected failure
+        errors.append(f"Codex check error: {e}")
+
+    # --- CC subagent-dispatch tool -----------------------------------------
+    try:
+        dispatch = read_dispatch_names()  # e.g. {"Task", "Agent"}
+        tools = fetch(CC_TOOLS_URL)
+        # The current dispatch tool must still appear in the tools reference.
+        # We don't require legacy names — only that at least one name we'd
+        # detect by-name is still the documented dispatch tool.
+        present = [n for n in dispatch if re.search(rf"`{re.escape(n)}`", tools)]
+        if not present:
+            breaking.append(
+                f"None of our known dispatch tool names {sorted(dispatch)} appear "
+                f"in CC tools-reference — the subagent tool was likely renamed "
+                f"again. Update make_tool_detail's known names. (Semantic "
+                f"subagent_type detection still works, but the breadcrumb/name "
+                f"fallback is stale.)"
+            )
+    except urllib.error.URLError as e:
+        errors.append(f"CC tools-reference fetch failed (transient?): {e}")
+    except Exception as e:  # noqa: BLE001
+        errors.append(f"CC check error: {e}")
+
+    # --- report ------------------------------------------------------------
+    out = ["# pixtuoid upstream wire-format drift report", ""]
+    if breaking:
+        out.append("## ⛔ Breaking drift — decoder will silently drop events")
+        out += [f"- {b}" for b in breaking]
+        out.append("")
+    if review:
+        out.append("## 🔎 New upstream events to review")
+        out += [f"- {r}" for r in review]
+        out.append("")
+    if errors:
+        out.append("## ⚠️ Could not verify (transient network/HTTP — not drift)")
+        out += [f"- {e}" for e in errors]
+        out.append("")
+    if not (breaking or review or errors):
+        out.append("✅ No drift. Every name we depend on is present upstream.")
+    print("\n".join(out))
+
+    if breaking or review:
+        return 1
+    if errors:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

**Layer 3** of the decode-drift defense, following #79. The `Task`→`Agent` rename shipped **undocumented** and silently disabled subagent suppression for every CC subagent. This adds the missing automated guards so the *next* rename surfaces before a user hits it.

### 1. External drift-watch
- **`scripts/check_upstream_drift.py`** reads the names we depend on **directly from our own source** (no snapshot file to rot): `CODEX_EVENTS` (install/codex.rs) and `make_tool_detail`'s dispatch names (decoder.rs). It fetches the **canonical upstream** — the `HookEventName` enum in `openai/codex` `protocol.rs` and the CC `tools-reference.md` tool list — and reports:
  - **breaking** (exit 1): a name we depend on vanished upstream → decoder would silently drop it
  - **review** (exit 1): a new Codex hook we neither register nor intentionally omit
  - `PreCompact`/`PostCompact` are intentionally omitted (`CODEX_KNOWN_OMITTED`) — not agent activity
  - exit 2 = transient network/HTTP (no false alarm)
- **`.github/workflows/upstream-drift.yml`** — weekly (Mon 09:00 UTC) + `workflow_dispatch`; on confirmed drift opens/updates a deduped `upstream-drift` issue with the report and fails the run.

### 2. Internal consistency test (the other half)
`every_registered_codex_event_decodes` / `every_registered_cc_event_decodes` assert that **every hook event we register has a decoder arm** — catching the *registered-but-not-decoded* class (the original SubagentStop bug) at `cargo test` time, not in production.

### 3. Docs
`CLAUDE.md` "Keeping the decode mapping current" now documents all four defenses (semantic detection · self-monitoring · internal test · upstream watch).

## Verification
- **Baseline audited against live upstream first**: all 8 registered Codex events decode; dispatch tool is `Agent` (confirmed in `tools-reference.md`, `Task` gone); fixtures faithful; `PreCompact`/`PostCompact` the only intentional omissions.
- Script run live → **no drift** (exit 0); parsed sets confirmed real (8 registered ↔ 10 upstream); **planted-drift detection works**; `KNOWN_OMITTED` suppresses the compact-hook false-positive.
- Full preflight green; workflow YAML validated; script `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
