### PR TITLE
test: raise coverage 92→95% (raw) + apply whole-codebase CR findings

### DIFF
--- a/crates/pixtuoid-core/src/layout/approach.rs
+++ b/crates/pixtuoid-core/src/layout/approach.rs
@@ -61,8 +61,20 @@ fn half_extents(kind: WaypointKind, pantry_counter_size: Size) -> Option<(u16, u
     // NOT the mask footprint — which is now a shallow south strip for occlusion,
     // so deriving the stand distance from it would pull the user INSIDE the
     // sprite. Pantry is runtime-sized (visual (0,0)), so its counter size IS the
-    // clearance. Assumes CENTER-anchored placement (pos = sprite center, so
-    // visual/2 reaches the edges) — true for every obstacle kind today.
+    // clearance.
+    //
+    // INVARIANT: this `visual/2` clearance assumes `Anchor::Center` placement
+    // (pos = sprite center, so visual/2 reaches the edges) — true for every
+    // obstacle WAYPOINT today (Pantry/PhoneBooth/StandingDesk/VendingMachine/
+    // Printer all stamp `Anchor::Center` in `mask.rs`). The anchor is a
+    // per-placement-site property (see `placement::Anchor` — Whiteboard is Center
+    // as pod decor but TopLeft as wall decor), and `stand_point`/`approach_point`
+    // receive no `Anchor`: if a future obstacle waypoint were placed `TopLeft`,
+    // this would compute the stand cell off a wrong center. The one TopLeft piece
+    // that reaches the approach machinery (the home Desk) sidesteps this by being
+    // `occupies_pos` (seat branch, no half-extent) and by `desk_walk_anchor`
+    // scanning from the CHAIR, not the desk's TopLeft origin. New TopLeft obstacle
+    // waypoints must pass a center, not the raw origin.
     let Size { w, h } = if matches!(kind, WaypointKind::Pantry) {
         pantry_counter_size
     } else {
@@ -449,6 +461,33 @@ mod tests {
         assert!(
             north.y <= south.y,
             "north-desk stand {north:?} should be no lower than south-desk stand {south:?}"
+        );
+    }
+
+    #[test]
+    fn stand_point_breaks_on_negative_coords_near_the_origin_corner() {
+        // An obstacle pressed into the top-left corner: scanning N or W from a
+        // `pos` this close to (0,0) drives the probe cell below 0 BEFORE any
+        // walkable cell is found, so the `cx < 0 || cy < 0` break ends those
+        // sides. E/S stay positive and one of them wins. Covers the negative-
+        // coordinate break in stand_point's outward scan.
+        let pos = Point { x: 2, y: 2 };
+        let counter = Size { w: 4, h: 4 };
+        let m = mask_with_obstacle(100, 100, pos, counter.w, counter.h);
+        // Origin to the NW (off-buffer-ish corner) so the nearest sides (N/W) are
+        // preferred — but they break on negative coords, forcing an E/S result.
+        let s = stand_point(
+            WaypointKind::Pantry,
+            pos,
+            counter,
+            &m,
+            Point { x: 0, y: 0 },
+            Facing::South,
+        );
+        assert!(m.is_walkable(s.x, s.y), "stand cell must be walkable");
+        assert!(
+            s.x > pos.x || s.y > pos.y,
+            "N/W scans go negative and break → an E or S cell wins, got {s:?}"
         );
     }
 

--- a/crates/pixtuoid-core/src/layout/compute.rs
+++ b/crates/pixtuoid-core/src/layout/compute.rs
@@ -107,15 +107,21 @@ pub(super) fn compute_with_seed(
     let mid_y_split = top_margin + usable_h / 2;
 
     let meeting_room = if has_meeting {
+        // A meeting always shares the left column with either the pantry or a
+        // second meeting room (variant table: meeting-bearing variants 0/3 set
+        // has_pantry, and variant 2 degrades to has_pantry when not dual) — so
+        // the room takes the top HALF unconditionally. The else-arm (full
+        // usable_h) was dead; assert the invariant so a future variant-table
+        // edit fails loud instead of silently picking a full-height room.
+        debug_assert!(
+            has_pantry || has_dual_meeting,
+            "meeting implies pantry-or-dual per the variant table"
+        );
         Some(Bounds {
             x: 0,
             y: top_margin,
             width: mid_x,
-            height: if has_pantry || has_dual_meeting {
-                usable_h / 2
-            } else {
-                usable_h
-            },
+            height: usable_h / 2,
         })
     } else {
         None
@@ -802,13 +808,19 @@ pub(super) fn compute_room_walls(
     // meeting+pantry). Open-plan/lounge pantry-only floors skip it
     // — the counter is the visual boundary.
     if has_vertical_wall {
+        // has_vertical_wall == has_meeting (compute_with_seed), and a meeting
+        // always shares the left column with the pantry or a second meeting room
+        // per the variant table — so the vertical wall always stops at the
+        // mid-height split. The else-arm (full usable_h) was dead; assert the
+        // invariant (mirrors the meeting_room height assert) so a future
+        // variant-table edit fails loud instead of silently picking a full wall.
+        debug_assert!(
+            has_pantry || has_dual_meeting,
+            "meeting implies pantry-or-dual per the variant table"
+        );
         let v_x = mid_x;
         let v_top = top_margin;
-        let v_bot = if has_pantry || has_dual_meeting {
-            mid_y_split
-        } else {
-            top_margin + usable_h
-        };
+        let v_bot = mid_y_split;
         let v_door_center = top_margin + (v_bot - v_top) / 2;
         let v_door_top = v_door_center.saturating_sub(DOOR_GAP_V / 2);
         let v_door_bot = (v_door_center + DOOR_GAP_V / 2).min(v_bot);

--- a/crates/pixtuoid-core/src/layout/decor.rs
+++ b/crates/pixtuoid-core/src/layout/decor.rs
@@ -32,8 +32,8 @@ pub enum WaypointKind {
     MeetingStand,
 }
 
-/// Per-spot idle dwell window. range_ms == 0 is the DECOR sentinel (not a wander
-/// destination); use is_decor() rather than comparing the raw tuple.
+/// Per-spot idle dwell window. `range_ms == 0` is the DECOR sentinel (not a
+/// wander destination).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DwellWindow {
     pub base_ms: u64,
@@ -44,9 +44,6 @@ impl DwellWindow {
         base_ms: 0,
         range_ms: 0,
     };
-    pub fn is_decor(self) -> bool {
-        self.range_ms == 0
-    }
 }
 
 /// Plant GROUND footprint — the one geometry VALUE shared by the ficus + tall
@@ -168,9 +165,9 @@ pub struct FurnitureDef {
     /// CENTER, approached from a side. True set: {Couch, MeetingSofa,
     /// MeetingStand}. (Desks are NOT rows here — home workstation is separate.)
     pub occupies_pos: bool,
-    /// Per-spot idle dwell window. `range_ms == 0` (the `DECOR` rows, via
-    /// [`DwellWindow::is_decor`]) marks a kind that is NOT a wander destination
-    /// and is never fed to `pose::dwell_ms`; `range_ms > 0` marks a destination.
+    /// Per-spot idle dwell window. `range_ms == 0` (the `DECOR` rows) marks a
+    /// kind that is NOT a wander destination and is never fed to
+    /// `pose::dwell_ms`; `range_ms > 0` marks a destination.
     /// `dwell_ms` guards with `% range_ms.max(1)`, so a zero range is safe — it
     /// IS the decor sentinel, not a bug. Do not "fix" a decor row to a non-zero
     /// range (that silently turns it into a wander destination).

--- a/crates/pixtuoid-core/src/layout/reach.rs
+++ b/crates/pixtuoid-core/src/layout/reach.rs
@@ -194,4 +194,68 @@ mod tests {
             "a blocked seed must snap into SOME component, not vanish"
         );
     }
+
+    #[test]
+    fn seed_in_fully_blocked_pocket_snaps_to_nothing() {
+        // Seed buried in a region with NO walkable coarse cell within the
+        // SEED_SNAP_CELLS=3 ring radius → snap_seed returns None and the BFS
+        // never runs, yielding an all-unreachable set (covers the None return
+        // and the skipped `if let Some(start)` BFS guard). The blocked pocket
+        // must extend ≥ (3 rings + 1) coarse cells (≈ 4*4 = 16px) past the seed
+        // cell in every direction so all three snap rings land on blocked cells.
+        let mut m = WalkableMask::new_open(64, 64);
+        // Block a generous square around the seed cell at (8,8)px → cell (2,2);
+        // 3 rings out reaches cell (5,5), spanning px [20,24). Block [0,40) so
+        // every cell the snap scan probes (incl. its ring-interior skips) is
+        // blocked.
+        m.mark_blocked(0, 0, 40, 40, 0);
+        let r = ReachSet::from_mask(&m, Point { x: 8, y: 8 });
+        // Nothing is reachable — the seed could not snap into any component.
+        assert!(!r.reaches(Point { x: 8, y: 8 }), "seed cell is blocked");
+        assert!(!r.reaches(Point { x: 50, y: 50 }), "open area never seeded");
+        assert!(
+            r.reachable.iter().all(|&b| !b),
+            "no-snap seed must yield an all-unreachable set"
+        );
+    }
+
+    #[test]
+    fn corner_seed_ring_scan_handles_negative_coords() {
+        // Seed at the top-left corner cell (0,0) sitting on a blocked patch: the
+        // snap ring scan walks to negative cell coords (covered by the
+        // nx<0||ny<0 guard) and skips ring-INTERIOR cells (the `dx!=r && dy!=r`
+        // continue) before finding a walkable cell a couple rings out. Snap must
+        // still pull it into the open component.
+        let mut m = WalkableMask::new_open(64, 64);
+        // Block the top-left 8×8px patch so cells (0,0) and (1,1) are blocked;
+        // the rest of the field is open, so a walkable cell sits within range.
+        m.mark_blocked(0, 0, 8, 8, 0);
+        let r = ReachSet::from_mask(&m, Point { x: 1, y: 1 }); // → cell (0,0)
+        assert!(
+            r.reaches(Point { x: 40, y: 40 }),
+            "a corner-blocked seed must snap into the open field"
+        );
+    }
+
+    #[test]
+    fn sub_cell_mask_yields_empty_reachset() {
+        // A mask narrower than REACH_CELL_SIZE (4) gives cell_w = 3/4 = 0, so
+        // from_mask hits the degenerate early-return (an all-unreachable set with
+        // an empty reachable grid) instead of indexing into a 0-width grid.
+        let r = ReachSet::from_mask(&WalkableMask::new_open(3, 64), Point { x: 0, y: 0 });
+        assert!(!r.reaches(Point { x: 0, y: 0 }));
+        assert_eq!(r.cell_w, 0, "width < cell size collapses cell_w to 0");
+        assert!(r.reachable.is_empty(), "degenerate mask has no cells");
+    }
+
+    #[test]
+    fn reaches_is_false_out_of_bounds() {
+        // Querying a point whose coarse cell is past the grid hits the OOB guard.
+        let m = WalkableMask::new_open(64, 64);
+        let r = ReachSet::from_mask(&m, Point { x: 4, y: 4 });
+        assert!(
+            !r.reaches(Point { x: 9999, y: 9999 }),
+            "OOB cell → unreachable"
+        );
+    }
 }

--- a/crates/pixtuoid-core/src/layout/tests.rs
+++ b/crates/pixtuoid-core/src/layout/tests.rs
@@ -1,8 +1,113 @@
 use super::*;
 
 #[test]
+fn partial_bottom_row_caps_mid_fill_when_agents_run_out() {
+    // Covers the partial-BOTTOM-ROW capacity break in `compute_pod_desks`
+    // (compute.rs `'partial_y` loop): a layout whose fill needs the partial
+    // bottom row to reach `cap`, fed `num_agents` that runs out PART-WAY through
+    // that row. The break must fire after the first partial-row desk, leaving
+    // `home_desks.len() == num_agents` (NOT the full row). The earlier full-pod
+    // `break 'outer` (small num_agents) caps before this phase, so it never
+    // exercises these lines — `num_agents` must be tuned to the grid (here
+    // `cap - 1`, one short of filling the 2-desk partial row).
+    //
+    // Sizes chosen empirically (each has a 2-desk partial bottom row whose first
+    // desk appears at num_agents = cap-1 and second at cap, so cap-1 breaks the
+    // 'partial_y loop mid-row). Driven through the public compute path (the
+    // private PodGrid has no constructor — see the cov verdict).
+    for (w, h, cap) in [(90u16, 110u16, 4usize), (100, 200, 10), (120, 150, 8)] {
+        // Total capacity at this size is exactly `cap`.
+        let full = SceneLayout::compute_with_seed(w, h, MAX_VISIBLE_DESKS, 0).expect("fits");
+        assert_eq!(
+            full.home_desks.len(),
+            cap,
+            "{w}x{h}: expected total desk capacity {cap}"
+        );
+        let max_y = full.home_desks.iter().map(|d| d.y).max().unwrap();
+        let band_at = |n: usize| {
+            SceneLayout::compute_with_seed(w, h, n, 0)
+                .expect("fits")
+                .home_desks
+                .iter()
+                .filter(|d| d.y == max_y)
+                .count()
+        };
+        // Exact truncation: asking for n agents (n ≤ cap) yields exactly n desks,
+        // so the cap break fires in whichever phase the count lands in.
+        for n in 1..=cap {
+            assert_eq!(
+                SceneLayout::compute_with_seed(w, h, n, 0)
+                    .expect("fits")
+                    .home_desks
+                    .len(),
+                n,
+                "{w}x{h}: num_agents {n} must truncate to exactly {n} desks"
+            );
+        }
+        // The partial bottom row fills incrementally: empty at cap-2, one desk at
+        // cap-1 (the 'partial_y push ran, then the break fired), full at cap. This
+        // is the proof the break executed INSIDE the partial-row loop.
+        assert_eq!(
+            band_at(cap),
+            2,
+            "{w}x{h}: partial bottom row seats 2 at cap"
+        );
+        assert_eq!(
+            band_at(cap - 1),
+            1,
+            "{w}x{h}: cap-1 leaves the partial row half-filled (break mid-row)"
+        );
+    }
+}
+
+#[test]
 fn compute_returns_none_when_buf_too_small() {
     assert!(SceneLayout::compute(20, 20, 4).is_none());
+}
+
+#[test]
+fn every_role_enum_variant_maps_to_a_furniture_row() {
+    // Each role enum (WallDecor, PlantKind) maps onto exactly one Furniture
+    // geometry row via `.furniture()`. The golden seeds never place
+    // WallDecor::BulletinBoard or PlantKind::Ficus, so their `.furniture()` arms
+    // are otherwise uncovered; this exhaustive sweep (mirrors the
+    // `sprite_name()` registry test) maps every variant and confirms each
+    // resolves a real Furniture row, doubling as a guard that a new variant
+    // can't ship without a mapping.
+    for wd in [
+        WallDecor::Bookshelf,
+        WallDecor::Whiteboard,
+        WallDecor::BulletinBoard,
+        WallDecor::ExitSign,
+        WallDecor::MeetingScreen,
+    ] {
+        let f = wd.furniture();
+        // The mapped row must exist in the unified table (visual non-degenerate).
+        assert!(
+            furniture_def(f).visual.w > 0 && furniture_def(f).visual.h > 0,
+            "{wd:?} → {f:?} must resolve a sized Furniture row"
+        );
+    }
+    for pk in [
+        PlantKind::Ficus,
+        PlantKind::Tall,
+        PlantKind::Flower,
+        PlantKind::Succulent,
+    ] {
+        let f = pk.furniture();
+        // Every plant resolves a Furniture row with a (shallow, overhung)
+        // ground footprint and a sized canopy visual. Ficus/Tall share the
+        // PLANT_FOOTPRINT; Flower/Succulent are de-shared (smaller pot strips).
+        let def = furniture_def(f);
+        assert!(
+            def.footprint.is_some(),
+            "{pk:?} → {f:?} must have a ground footprint"
+        );
+        assert!(
+            def.visual.w > 0 && def.visual.h > 0,
+            "{pk:?} → {f:?} must have a sized visual"
+        );
+    }
 }
 
 // Regression: the percentage math (`buf_h * 30`, `buf_w * 35`, …) used bare

--- a/crates/pixtuoid-core/src/physics.rs
+++ b/crates/pixtuoid-core/src/physics.rs
@@ -435,6 +435,36 @@ mod tests {
     }
 
     #[test]
+    fn progress_in_triangular_decel_arm() {
+        // The triangular DECEL arm (s = L - 0.5·a·dt²) fires only when
+        // L < L_crit AND elapsed > t_half. Existing triangular tests probe
+        // t=0, t=t_half (claimed by the `t <= t_half` accel branch) or
+        // t>=duration (early return), so this arm is otherwise uncovered.
+        // SnapBack / short wander legs hit it live.
+        let v_min = V_CRUISE_COMMUTE * SPEED_MULT_MIN;
+        let l_crit_min = l_crit(v_min);
+        let l = (l_crit_min / 4.0) as u32; // guaranteed triangular for all agents
+        let profile = walk_profile(l, WalkIntent::Entry, id(0));
+
+        // Sample at ~0.75·T: well past t_half (= T/2) → in the decel arm.
+        let t75 = profile.duration_ms * 3 / 4;
+        let p75 = walk_progress(&profile, t75);
+        // s(0.75T) = L - 0.125·L = 0.875·L → p ≈ 875, strictly in (500, 1000).
+        assert!(
+            (500..1000).contains(&p75),
+            "triangular decel p(0.75T) should be in (500,1000), got {p75}"
+        );
+
+        // Decel is still advancing: p(0.75T) > p(0.6T) (both in the decel arm).
+        let t60 = profile.duration_ms * 3 / 5;
+        let p60 = walk_progress(&profile, t60);
+        assert!(
+            p75 > p60,
+            "decel must keep advancing: p(0.75T)={p75} should exceed p(0.6T)={p60}"
+        );
+    }
+
+    #[test]
     fn progress_at_half_duration_trapezoidal() {
         // In the trapezoidal regime, T/2 falls somewhere in the cruise band
         // (for long paths). p should be > 400 and < 600 (symmetry; doesn't

--- a/crates/pixtuoid-core/src/pose/tests.rs
+++ b/crates/pixtuoid-core/src/pose/tests.rs
@@ -378,6 +378,68 @@ fn derive_returns_none_when_desk_index_out_of_range() {
 }
 
 #[test]
+fn exit_override_walks_desk_to_door_within_window() {
+    // exiting_at set < ENTRY_ANIMATION_MS ago → Walking from the desk anchor
+    // to the door threshold (the inverse of the entry walk).
+    let (mut s, now) = slot(ActivityState::Idle, 0);
+    s.exiting_at = Some(now - Duration::from_secs(1));
+    let l = layout();
+    let desk = l.home_desks[s.desk_index];
+    match derive(&s, now, &l).expect("pose") {
+        Pose::Walking { from, to, .. } => {
+            assert_eq!(
+                from,
+                desk_walk_anchor(desk),
+                "exit walk starts at desk anchor"
+            );
+            assert_eq!(
+                Some(to),
+                l.door_threshold,
+                "exit walk targets the door threshold"
+            );
+        }
+        other => panic!("expected exit Walking, got {other:?}"),
+    }
+}
+
+#[test]
+fn exit_override_returns_none_past_window() {
+    // exiting_at older than ENTRY_ANIMATION_MS → nothing to render (slot GC'd).
+    let (mut s, now) = slot(ActivityState::Idle, 0);
+    s.exiting_at = Some(now - Duration::from_millis(ENTRY_ANIMATION_MS + 1000));
+    assert!(derive(&s, now, &layout()).is_none());
+}
+
+#[test]
+fn waypoint_index_is_zero_when_no_waypoints() {
+    let id = AgentId::from_transcript_path("/p/wp.jsonl");
+    assert_eq!(waypoint_index_for_cycle(id, 3, 0), 0);
+}
+
+#[test]
+fn entry_window_fall_through_uses_state_driven_pose() {
+    // door_threshold is Some but since_spawn >= ENTRY_ANIMATION_MS, so the
+    // entry override's inner `if` is false and derive falls through to
+    // state_driven_pose. A Waiting slot must yield StandingAtDesk (not Walking).
+    let (mut s, now) = slot(
+        ActivityState::Waiting {
+            reason: "perm".into(),
+        },
+        ENTRY_ANIMATION_MS + 5_000,
+    );
+    // created_at is 60s before `started`, and probe is well past the entry
+    // window, so the entry override does not fire.
+    let l = layout();
+    assert!(
+        l.door_threshold.is_some(),
+        "layout must populate door_threshold"
+    );
+    // Push created_at far enough back to be unambiguously past the window.
+    s.created_at = now - Duration::from_millis(ENTRY_ANIMATION_MS + 10_000);
+    assert_eq!(derive(&s, now, &l), Some(Pose::StandingAtDesk));
+}
+
+#[test]
 fn cycle_ms_for_varies_across_agents() {
     // Sanity: a handful of different agent ids should not all map to the
     // same cycle length.

--- a/crates/pixtuoid-core/src/source/antigravity.rs
+++ b/crates/pixtuoid-core/src/source/antigravity.rs
@@ -51,11 +51,15 @@ pub fn decode_ag_line(transcript_path: &str, source: &str, v: Value) -> Result<V
         return Ok(vec![]);
     };
 
-    if !obj.contains_key("step_index") {
+    // A present-but-non-integer `step_index` (format drift / a renamed field)
+    // must fail SAFE-AND-VISIBLE: skip the line rather than coerce to 0, which
+    // would silently corrupt the `ag-{step}-{i}` tool_use_id pairing — the
+    // `> 0` guard below would then drop the prev-step ActivityEnd, leaving the
+    // slot stuck Active until the reducer's debounce/stale-sweep. (The
+    // `contains_key` guard only checks presence, not type.)
+    let Some(step_index) = obj.get("step_index").and_then(|v| v.as_i64()) else {
         return Ok(vec![]);
-    }
-
-    let step_index = obj.get("step_index").and_then(|v| v.as_i64()).unwrap_or(0);
+    };
     let step_type = obj.get("type").and_then(|s| s.as_str()).unwrap_or("");
 
     let mut out = Vec::new();
@@ -174,5 +178,12 @@ mod tests {
             derive_ag_label(Path::new("/x"), SOURCE_NAME, Path::new("/")),
             "ag"
         );
+    }
+
+    #[test]
+    fn ag_session_ended_is_always_false() {
+        // Antigravity writes no end marker — defer to mtime + stale-sweep.
+        assert!(!ag_session_ended(b"x"));
+        assert!(!ag_session_ended(b""));
     }
 }

--- a/crates/pixtuoid-core/src/source/claude_code.rs
+++ b/crates/pixtuoid-core/src/source/claude_code.rs
@@ -313,4 +313,42 @@ mod tests {
             "cc"
         );
     }
+
+    // The socket-path and default-paths env precedence. All three socket
+    // branches are checked in ONE test because the env vars are process-global —
+    // splitting across tests would race under the default multi-thread runner.
+    #[test]
+    fn default_socket_path_env_precedence_and_default_paths() {
+        // PIXTUOID_SOCKET takes precedence (checked first).
+        std::env::set_var("PIXTUOID_SOCKET", "/tmp/explicit.sock");
+        std::env::set_var("XDG_RUNTIME_DIR", "/run/user/1000");
+        assert_eq!(
+            ClaudeCodeSource::default_socket_path(),
+            PathBuf::from("/tmp/explicit.sock")
+        );
+
+        // Without PIXTUOID_SOCKET, XDG_RUNTIME_DIR drives the path.
+        std::env::remove_var("PIXTUOID_SOCKET");
+        assert_eq!(
+            ClaudeCodeSource::default_socket_path(),
+            PathBuf::from("/run/user/1000/pixtuoid.sock")
+        );
+
+        // With neither set, fall back to the uid-suffixed /tmp socket.
+        std::env::remove_var("XDG_RUNTIME_DIR");
+        // SAFETY: getuid() is a trivial argless syscall.
+        let uid = unsafe { libc::getuid() };
+        assert_eq!(
+            ClaudeCodeSource::default_socket_path(),
+            PathBuf::from(format!("/tmp/pixtuoid-{uid}.sock"))
+        );
+
+        // default_paths derives projects_root from HOME.
+        let paths = ClaudeCodeSource::default_paths();
+        assert!(
+            paths.projects_root.ends_with(".claude/projects"),
+            "projects_root must end with .claude/projects, got {:?}",
+            paths.projects_root
+        );
+    }
 }

--- a/crates/pixtuoid-core/src/source/claude_code.rs
+++ b/crates/pixtuoid-core/src/source/claude_code.rs
@@ -319,6 +319,9 @@ mod tests {
     // splitting across tests would race under the default multi-thread runner.
     #[test]
     fn default_socket_path_env_precedence_and_default_paths() {
+        let saved_socket = std::env::var_os("PIXTUOID_SOCKET");
+        let saved_xdg = std::env::var_os("XDG_RUNTIME_DIR");
+
         // PIXTUOID_SOCKET takes precedence (checked first).
         std::env::set_var("PIXTUOID_SOCKET", "/tmp/explicit.sock");
         std::env::set_var("XDG_RUNTIME_DIR", "/run/user/1000");
@@ -350,5 +353,16 @@ mod tests {
             "projects_root must end with .claude/projects, got {:?}",
             paths.projects_root
         );
+
+        // Restore prior env so a later env-reading test in this binary isn't
+        // poisoned by the cleared state.
+        match saved_socket {
+            Some(v) => std::env::set_var("PIXTUOID_SOCKET", v),
+            None => std::env::remove_var("PIXTUOID_SOCKET"),
+        }
+        match saved_xdg {
+            Some(v) => std::env::set_var("XDG_RUNTIME_DIR", v),
+            None => std::env::remove_var("XDG_RUNTIME_DIR"),
+        }
     }
 }

--- a/crates/pixtuoid-core/src/source/codex.rs
+++ b/crates/pixtuoid-core/src/source/codex.rs
@@ -340,4 +340,36 @@ mod tests {
         let p = Path::new("/tmp/rollout-日本語のとてもながいファイルめい.jsonl");
         let _ = codex_id_from_path(p);
     }
+
+    #[test]
+    fn non_object_line_emits_nothing() {
+        // A bare string / number / array transcript line is not an object →
+        // decode early-returns empty (the `v.as_object()` else-guard).
+        assert!(ev(json!("just a string")).is_empty());
+        assert!(ev(json!(42)).is_empty());
+        assert!(ev(json!([1, 2, 3])).is_empty());
+    }
+
+    #[test]
+    fn function_call_without_arguments_starts_work_not_waiting() {
+        // No `arguments` field → `function_call_needs_approval` hits its
+        // None-arm (false) → falls to codex_tool_start → ActivityStart, never
+        // Waiting (the absence of escalation args is not a permission gate).
+        let out = ev(json!({
+            "type": "response_item",
+            "payload": { "type": "function_call", "name": "x" }
+        }));
+        assert!(
+            matches!(out.as_slice(), [AgentEvent::ActivityStart { .. }]),
+            "{out:?}"
+        );
+    }
+
+    #[test]
+    fn codex_session_ended_is_always_false() {
+        // Codex writes no end marker — the checker always defers to the
+        // mtime window + stale-sweep.
+        assert!(!codex_session_ended(b"anything"));
+        assert!(!codex_session_ended(b""));
+    }
 }

--- a/crates/pixtuoid-core/src/source/decoder.rs
+++ b/crates/pixtuoid-core/src/source/decoder.rs
@@ -1,4 +1,4 @@
-//! Shared decoder utilities used by per-source decoders (CC, Antigravity).
+//! Shared decoder utilities used by per-source decoders (CC, Codex, Antigravity).
 //! Hook payload decoding lives here because the hook socket is shared.
 
 use std::path::Path;

--- a/crates/pixtuoid-core/src/source/jsonl.rs
+++ b/crates/pixtuoid-core/src/source/jsonl.rs
@@ -318,40 +318,42 @@ async fn walk_jsonl(path: &Path, decoders: SourceDecoders, ctx: &WatchCtx<'_>) {
     let new_bytes = &new_chunk[..safe_end_relative];
     let transcript_path_str = path.to_string_lossy().into_owned();
 
-    {
-        let mut seen = seen.lock().await;
-        if seen.insert(path.to_path_buf(), true).is_none() {
-            let id = AgentId::from_parts(source, &id_derive(path));
-            let session_id = path
-                .file_stem()
-                .map(|s| s.to_string_lossy().into_owned())
-                .unwrap_or_default();
-            let cwd = extract_cwd(new_bytes).unwrap_or_default();
-            let parent_id = detect_parent_id(path, source);
-            let _ = tx
-                .send((
-                    Transport::Jsonl,
-                    AgentEvent::SessionStart {
-                        agent_id: id,
-                        source: source.to_string(),
-                        session_id: session_id.clone(),
-                        cwd: cwd.clone(),
-                        parent_id,
-                    },
-                ))
-                .await;
+    // Take the `seen` lock ONLY to claim first-sight, then drop it before the
+    // awaited sends — holding it across `tx.send` would block on a slow consumer
+    // for no reason (the flag flip is the entire critical section). Mirrors the
+    // narrow `cursors` locking above.
+    let is_first = seen.lock().await.insert(path.to_path_buf(), true).is_none();
+    if is_first {
+        let id = AgentId::from_parts(source, &id_derive(path));
+        let session_id = path
+            .file_stem()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        let cwd = extract_cwd(new_bytes).unwrap_or_default();
+        let parent_id = detect_parent_id(path, source);
+        let _ = tx
+            .send((
+                Transport::Jsonl,
+                AgentEvent::SessionStart {
+                    agent_id: id,
+                    source: source.to_string(),
+                    session_id: session_id.clone(),
+                    cwd: cwd.clone(),
+                    parent_id,
+                },
+            ))
+            .await;
 
-            let label = derive_label(path, source, &cwd);
-            let _ = tx
-                .send((
-                    Transport::Jsonl,
-                    AgentEvent::Rename {
-                        agent_id: id,
-                        label,
-                    },
-                ))
-                .await;
-        }
+        let label = derive_label(path, source, &cwd);
+        let _ = tx
+            .send((
+                Transport::Jsonl,
+                AgentEvent::Rename {
+                    agent_id: id,
+                    label,
+                },
+            ))
+            .await;
     }
 
     for line in new_bytes.split(|b| *b == b'\n') {

--- a/crates/pixtuoid-core/src/source/mod.rs
+++ b/crates/pixtuoid-core/src/source/mod.rs
@@ -85,12 +85,6 @@ impl From<&str> for ToolDetail {
     }
 }
 
-impl From<String> for ToolDetail {
-    fn from(s: String) -> Self {
-        Self::from(s.as_str())
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AgentEvent {
     SessionStart {

--- a/crates/pixtuoid-core/src/sprite/format.rs
+++ b/crates/pixtuoid-core/src/sprite/format.rs
@@ -228,13 +228,13 @@ pub fn load_pack_from_strings(pack_toml: &str, frames: &[(&str, &str)]) -> Resul
 fn build_palette(map: &HashMap<String, String>) -> Result<Palette> {
     let mut palette = Palette::new();
     for (k, v) in map {
-        if k.chars().count() != 1 {
+        let mut it = k.chars();
+        let key = it.next();
+        // Validate-and-extract in one fallible step so the single-char invariant
+        // and the bail can't drift apart in a refactor (no positional expect).
+        let (Some(key), None) = (key, it.next()) else {
             bail!("palette key {k:?} must be exactly one character");
-        }
-        let key = k
-            .chars()
-            .next()
-            .expect("palette key validated as single char");
+        };
         let pixel = parse_palette_value(v).with_context(|| format!("palette key '{k}'"))?;
         palette.insert(key, pixel);
     }

--- a/crates/pixtuoid-core/src/state/reducer.rs
+++ b/crates/pixtuoid-core/src/state/reducer.rs
@@ -160,6 +160,12 @@ impl Reducer {
         // cascaded out) while a subagent is still working — even if the parent's
         // own hooks dropped or a subagent's hook was misattributed to it. The
         // mirror of `cascade_exit` (which pushes EXIT down): liveness flows UP.
+        // refresh_lineage stamps `last_event_at = now` on the ACTOR too (it walks
+        // from `id` upward, not just the ancestors). The per-arm `last_event_at =
+        // now` writes in enter_active/enter_waiting and the ActivityEnd arms below
+        // therefore re-stamp the same `now` for these three events — harmless. They
+        // are load-bearing only for the event paths NOT matched here (Rename and the
+        // SessionStart-enrich path don't call refresh_lineage), so don't drop them.
         if matches!(
             &event,
             AgentEvent::ActivityStart { .. }
@@ -537,6 +543,11 @@ impl Reducer {
         // same sweep already marked (keeps the log + `exiting_at` write-once).
         for (id, age, threshold) in stale {
             {
+                // Defensive: `id` was just collected from `scene.agents` in pass 1
+                // and nothing removes a slot between the passes (a prior cascade only
+                // SETS `exiting_at`), so this `continue` is unreachable today —
+                // single-threaded `&mut SceneState`. Kept to harden against a future
+                // refactor that mutates membership mid-sweep.
                 let Some(slot) = scene.agents.get_mut(&id) else {
                     continue;
                 };
@@ -559,6 +570,14 @@ impl Reducer {
     /// Remove agents whose exit animation has finished. Called at the top
     /// of every event apply, so any subsequent event naturally triggers
     /// the cleanup of expired slots.
+    ///
+    /// Removing a parent does NOT null any surviving child's `parent_id` — that
+    /// pointer is left dangling intentionally. The scope walks tolerate it (the
+    /// `None => break` guards in `scope::{refresh_lineage, has_waiting_ancestor}`),
+    /// so it never crashes; in practice `cascade_exit` reaps the subtree alongside
+    /// the parent, so a lingering dangle is only observable for a true orphan
+    /// (JSONL-first child of a never-created parent). Scanning every child on each
+    /// parent removal to null the pointer would add cost with no behavioral benefit.
     fn sweep_exited(&mut self, scene: &mut SceneState, now: SystemTime) {
         let expired: Vec<AgentId> = scene
             .agents

--- a/crates/pixtuoid-core/src/state/scope.rs
+++ b/crates/pixtuoid-core/src/state/scope.rs
@@ -34,6 +34,16 @@ use crate::AgentId;
 /// leaves together), while subagent-completion does NOT (the parent keeps
 /// running; only its subtree leaves). Idempotent: slots already exiting are
 /// filtered out, so a leaf or a partly-exiting subtree is a safe no-op.
+///
+/// FOOTGUN: whether `root` itself exits is encoded IMPLICITLY by whether the
+/// caller set `root.exiting_at` *before* calling — there is no assertion here to
+/// catch a caller that forgets. A future caller that means "the whole tree
+/// leaves" but neglects to stamp `root` first would silently leave the root
+/// running while exiting its entire subtree. All three current callers are
+/// correct (SessionEnd + sweep_stale stamp root first; subagent-completion
+/// deliberately does not); if a fourth is added, make the per-call-site intent
+/// explicit (e.g. a typed `StampRoot::{Yes,No}` param) rather than relying on
+/// this convention.
 pub(crate) fn cascade_exit(scene: &mut SceneState, root: AgentId, now: SystemTime) {
     let mut visited: HashSet<AgentId> = HashSet::new();
     visited.insert(root);
@@ -61,7 +71,11 @@ pub(crate) fn cascade_exit(scene: &mut SceneState, root: AgentId, now: SystemTim
 /// emitting events — even if the parent's own hooks dropped or a subagent's hook
 /// was misattributed to it. The mirror of [`cascade_exit`]. Cycle-guarded;
 /// `last_event_at` only gates the stale-sweep, so this never alters an ancestor's
-/// visible state/pose.
+/// visible state/pose. The `None => break` arm tolerates a DANGLING `parent_id`
+/// (a JSONL-first orphan whose parent slot was never created, or a parent already
+/// swept from `scene.agents` — `sweep_exited` removes a parent without nulling its
+/// children's `parent_id`, by design): the walk stops at the missing link, a safe
+/// no-op rather than a crash. Intentional, not a bug.
 pub(crate) fn refresh_lineage(scene: &mut SceneState, id: AgentId, now: SystemTime) {
     let mut visited: HashSet<AgentId> = HashSet::new();
     let mut cur = Some(id);
@@ -103,4 +117,131 @@ pub(crate) fn has_waiting_ancestor(agents: &BTreeMap<AgentId, AgentSlot>, id: Ag
         }
     }
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    fn slot(id: AgentId, parent_id: Option<AgentId>, state: ActivityState) -> AgentSlot {
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+        AgentSlot {
+            agent_id: id,
+            source: Arc::from("cc"),
+            session_id: Arc::from("s"),
+            cwd: Arc::from(std::path::Path::new("/repo")),
+            label: Arc::from("cc·repo"),
+            state,
+            state_started_at: now,
+            last_event_at: now,
+            created_at: now,
+            exiting_at: None,
+            pending_idle_at: None,
+            desk_index: 0,
+            floor_idx: 0,
+            tool_call_count: 0,
+            active_ms: 0,
+            unknown_cwd: false,
+            parent_id,
+        }
+    }
+
+    fn waiting() -> ActivityState {
+        ActivityState::Waiting {
+            reason: Arc::from("perm"),
+        }
+    }
+
+    // --- Dangling-parent guard: a child whose `parent_id` points to a slot that
+    // does not exist in `scene.agents` (the `None => break` arms). -------------
+
+    #[test]
+    fn refresh_lineage_tolerates_dangling_parent_id() {
+        let child = AgentId::from_transcript_path("/p/child.jsonl");
+        let missing = AgentId::from_transcript_path("/p/never-created.jsonl");
+        let mut scene = SceneState::uniform(4);
+        scene
+            .agents
+            .insert(child, slot(child, Some(missing), ActivityState::Idle));
+
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(2_000_000);
+        // Must not panic walking into the missing parent; stamps only the child.
+        refresh_lineage(&mut scene, child, now);
+
+        assert_eq!(scene.agents.get(&child).unwrap().last_event_at, now);
+        assert!(
+            !scene.agents.contains_key(&missing),
+            "the dangling parent is never materialized by the walk"
+        );
+    }
+
+    #[test]
+    fn has_waiting_ancestor_false_when_parent_id_dangling() {
+        let child = AgentId::from_transcript_path("/p/child.jsonl");
+        let missing = AgentId::from_transcript_path("/p/never-created.jsonl");
+        let mut scene = SceneState::uniform(4);
+        scene
+            .agents
+            .insert(child, slot(child, Some(missing), ActivityState::Idle));
+
+        assert!(
+            !has_waiting_ancestor(&scene.agents, child),
+            "a dangling parent_id is not a Waiting ancestor — the walk breaks safely"
+        );
+    }
+
+    // --- Cycle guard: a `parent_id` cycle A->B->A (two SessionStarts each naming
+    // the other) must terminate via `visited` (the `!visited.insert(_) { break }`
+    // arms), not hang. ----------------------------------------------------------
+
+    fn cycle_scene(
+        a_state: ActivityState,
+        b_state: ActivityState,
+    ) -> (SceneState, AgentId, AgentId) {
+        let a = AgentId::from_transcript_path("/p/a.jsonl");
+        let b = AgentId::from_transcript_path("/p/b.jsonl");
+        let mut scene = SceneState::uniform(4);
+        scene.agents.insert(a, slot(a, Some(b), a_state));
+        scene.agents.insert(b, slot(b, Some(a), b_state));
+        (scene, a, b)
+    }
+
+    #[test]
+    fn refresh_lineage_terminates_on_parent_id_cycle() {
+        let (mut scene, a, b) = cycle_scene(ActivityState::Idle, ActivityState::Idle);
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(2_000_000);
+
+        // Walks a -> b -> a; the revisit of `a` hits `!visited.insert` -> break.
+        // Reaching this assertion at all proves no infinite loop.
+        refresh_lineage(&mut scene, a, now);
+
+        assert_eq!(scene.agents.get(&a).unwrap().last_event_at, now);
+        assert_eq!(
+            scene.agents.get(&b).unwrap().last_event_at,
+            now,
+            "the cycle's other node is stamped exactly once before the break"
+        );
+    }
+
+    #[test]
+    fn has_waiting_ancestor_breaks_on_cycle_with_no_waiting_node() {
+        // Neither node Waiting: the walk a -> b -> (a revisited) hits the cycle
+        // break and returns false instead of looping forever.
+        let (scene, a, _b) = cycle_scene(ActivityState::Idle, ActivityState::Idle);
+        assert!(
+            !has_waiting_ancestor(&scene.agents, a),
+            "a cycle with no Waiting node must terminate and return false"
+        );
+    }
+
+    #[test]
+    fn has_waiting_ancestor_true_via_cyclic_ancestor() {
+        // B is Waiting and is A's parent: the very first hop short-circuits true,
+        // before the cycle break — confirms the cycle setup doesn't mask a real
+        // Waiting ancestor.
+        let (scene, a, _b) = cycle_scene(ActivityState::Idle, waiting());
+        assert!(has_waiting_ancestor(&scene.agents, a));
+    }
 }

--- a/crates/pixtuoid-core/src/walkable.rs
+++ b/crates/pixtuoid-core/src/walkable.rs
@@ -177,10 +177,15 @@ mod tests {
     #[test]
     fn overlay_blocks_inside_rects() {
         let mut o = OccupancyOverlay::new();
+        assert_eq!(o.len(), 0);
         o.add(10, 10, 5, 5);
+        o.add(20, 20, 3, 3);
+        assert_eq!(o.len(), 2);
         assert!(o.blocks(12, 12));
         assert!(!o.blocks(9, 10));
         assert!(!o.blocks(15, 10));
+        o.clear();
+        assert_eq!(o.len(), 0);
     }
 
     #[test]

--- a/crates/pixtuoid-core/tests/decoder.rs
+++ b/crates/pixtuoid-core/tests/decoder.rs
@@ -735,6 +735,158 @@ fn decode_hook_payload_missing_transcript_path_falls_back_to_session_id() {
     );
 }
 
+// `describe_tool_target` truncates a tool target longer than 40 chars and
+// appends an ellipsis. The existing multibyte test uses a 39-char command, so
+// the `> 40` branch was never exercised.
+#[test]
+fn decode_pre_tool_use_long_command_is_ellipsis_truncated() {
+    let long_cmd = "echo ".to_string() + &"a".repeat(60); // > 40 chars
+    let payload = serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "session_id": "ses-trunc",
+        "transcript_path": "/tmp/t.jsonl",
+        "cwd": "/repo",
+        "tool_name": "Bash",
+        "tool_input": { "command": long_cmd }
+    });
+    match decode_hook_payload(payload).unwrap() {
+        AgentEvent::ActivityStart { detail, .. } => {
+            let d = detail.expect("detail set");
+            assert!(
+                d.display().ends_with('…'),
+                "a >40-char Bash command must be ellipsis-truncated, got {}",
+                d.display()
+            );
+        }
+        other => panic!("expected ActivityStart, got {other:?}"),
+    }
+}
+
+// `describe_tool_target` early-returns an empty string when the keyed input
+// field is absent. A Bash tool with an empty `tool_input` (no `command`) yields
+// a display of just the tool name — no `": <target>"` suffix.
+#[test]
+fn decode_pre_tool_use_missing_target_field_has_no_suffix() {
+    let payload = serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "session_id": "ses-nocmd",
+        "transcript_path": "/tmp/t.jsonl",
+        "cwd": "/repo",
+        "tool_name": "Bash",
+        "tool_input": {}
+    });
+    match decode_hook_payload(payload).unwrap() {
+        AgentEvent::ActivityStart { detail, .. } => {
+            let d = detail.expect("detail set");
+            assert_eq!(
+                d.display(),
+                "Bash",
+                "absent target field must produce no `: <target>` suffix"
+            );
+        }
+        other => panic!("expected ActivityStart, got {other:?}"),
+    }
+}
+
+// `decode_ag_line` early edge branches: a non-object line and an object with no
+// `step_index` both decode to zero events.
+#[test]
+fn ag_non_object_and_missing_step_index_emit_nothing() {
+    let transcript = "/Users/me/.gemini/antigravity-cli/brain/sess/transcript.jsonl";
+    // Non-object value (bare string).
+    assert!(
+        antigravity::decode_ag_line(transcript, "antigravity", json!("x"))
+            .unwrap()
+            .is_empty()
+    );
+    // Object without `step_index`.
+    assert!(
+        antigravity::decode_ag_line(transcript, "antigravity", json!({ "foo": 1 }))
+            .unwrap()
+            .is_empty()
+    );
+}
+
+// A non-integer `step_index` must fail safe-and-visible: skip the line rather
+// than coerce to 0 (which would corrupt the ag-{step}-{i} tool_use_id pairing).
+#[test]
+fn ag_non_integer_step_index_is_skipped() {
+    let transcript = "/Users/me/.gemini/antigravity-cli/brain/sess/transcript.jsonl";
+    let v = json!({
+        "step_index": "not-a-number",
+        "type": "PLANNER_RESPONSE",
+        "tool_calls": [ { "name": "run_command", "args": { "CommandLine": "ls" } } ]
+    });
+    assert!(
+        antigravity::decode_ag_line(transcript, "antigravity", v)
+            .unwrap()
+            .is_empty(),
+        "a present-but-non-integer step_index must be skipped, not coerced to 0"
+    );
+}
+
+// A `tool_calls` entry that isn't an object is skipped (`continue`), and the
+// run_command/grep_search normalize key-arms are exercised. The display text
+// itself reflects only the tool name (describe_tool_target has no antigravity
+// arm), so assert on the event shape + the load-bearing tool_use_id instead.
+#[test]
+fn ag_skips_non_object_tool_call_and_keys_run_command() {
+    let transcript = "/Users/me/.gemini/antigravity-cli/brain/sess/transcript.jsonl";
+    let v = json!({
+        "step_index": 3,
+        "type": "PLANNER_RESPONSE",
+        "tool_calls": [
+            42,
+            { "name": "run_command", "args": { "CommandLine": "\"git status\"" } }
+        ]
+    });
+    let events = antigravity::decode_ag_line(transcript, "antigravity", v).unwrap();
+    // The integer entry (index 0) is skipped; only the run_command start emits,
+    // and it carries the index-1 id (not index-0 — the skip does not renumber).
+    assert_eq!(
+        events.len(),
+        1,
+        "non-object tool_call must be skipped: {events:?}"
+    );
+    match &events[0] {
+        AgentEvent::ActivityStart { tool_use_id, .. } => {
+            assert_eq!(tool_use_id.as_deref(), Some("ag-3-1"));
+        }
+        other => panic!("expected ActivityStart, got {other:?}"),
+    }
+}
+
+// A PLANNER_RESPONSE with no `tool_calls` key (the `if let Some(Value::Array)`
+// fails to match) decodes to zero events — distinct from an empty array.
+#[test]
+fn ag_planner_response_without_tool_calls_emits_nothing() {
+    let transcript = "/Users/me/.gemini/antigravity-cli/brain/sess/transcript.jsonl";
+    let v = json!({ "step_index": 2, "type": "PLANNER_RESPONSE" });
+    assert!(antigravity::decode_ag_line(transcript, "antigravity", v)
+        .unwrap()
+        .is_empty());
+}
+
+#[test]
+fn ag_grep_search_decodes_to_activity_start() {
+    let transcript = "/Users/me/.gemini/antigravity-cli/brain/sess/transcript.jsonl";
+    let v = json!({
+        "step_index": 4,
+        "type": "PLANNER_RESPONSE",
+        "tool_calls": [
+            { "name": "grep_search", "args": { "SearchPath": "/repo", "query": "TODO" } }
+        ]
+    });
+    let events = antigravity::decode_ag_line(transcript, "antigravity", v).unwrap();
+    assert_eq!(events.len(), 1);
+    match &events[0] {
+        AgentEvent::ActivityStart { tool_use_id, .. } => {
+            assert_eq!(tool_use_id.as_deref(), Some("ag-4-0"));
+        }
+        other => panic!("expected ActivityStart, got {other:?}"),
+    }
+}
+
 #[test]
 fn decode_hook_payload_missing_tool_name_still_succeeds() {
     let payload = serde_json::json!({

--- a/crates/pixtuoid-core/tests/e2e.rs
+++ b/crates/pixtuoid-core/tests/e2e.rs
@@ -4,7 +4,9 @@ use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
 
 use pixtuoid_core::render::test_renderer::TestRenderer;
+use pixtuoid_core::render::Renderer;
 use pixtuoid_core::source::Activity;
+use pixtuoid_core::sprite::format::load_pack_from_strings;
 use pixtuoid_core::state::ActivityState;
 use pixtuoid_core::{AgentEvent, AgentId, Reducer, SceneState, Transport};
 
@@ -118,4 +120,25 @@ fn scripted_timeline_drives_scene_through_states() {
         exit_slot.exiting_at.is_some(),
         "SessionEnd should mark exiting_at, not drop immediately"
     );
+}
+
+/// Exercise the `Renderer` trait impl + the `count()` convenience wrapper
+/// directly — the scripted timeline above records via the inherent `record()`
+/// helper, so the trait-signature path and `count()` are otherwise uncovered.
+#[test]
+fn test_renderer_trait_render_increments_count() {
+    let mut r = TestRenderer::new();
+    let scene = SceneState::uniform(4);
+    // The trait impl ignores the pack, so any in-memory pack satisfies it.
+    let pack = load_pack_from_strings(
+        "[pack]\nname=\"x\"\nversion=\"1\"\n\
+         [palette]\n\"A\"=\"#010203\"\n\
+         [animations.idle]\nframes=[\"i.sprite\"]\nframe_ms=100\n",
+        &[("i.sprite", "@frame 0\nA")],
+    )
+    .unwrap();
+
+    assert_eq!(r.count(), 0);
+    <TestRenderer as Renderer>::render(&mut r, &scene, &pack, SystemTime::now()).unwrap();
+    assert_eq!(r.count(), 1, "trait render must record one snapshot");
 }

--- a/crates/pixtuoid-core/tests/hook_socket.rs
+++ b/crates/pixtuoid-core/tests/hook_socket.rs
@@ -111,6 +111,56 @@ async fn listener_drops_slow_connection_via_timeout() {
 }
 
 #[tokio::test]
+async fn listener_path_accessor_returns_bound_path() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("pixtuoid.sock");
+    let listener = HookSocketListener::bind(path.clone()).await.unwrap();
+    assert_eq!(listener.path(), path.as_path());
+}
+
+// The read-error arm in handle_conn: tokio's Lines::next_line() returns an
+// io::Error (InvalidData) on invalid UTF-8, which the listener warns-and-returns
+// for that connection WITHOUT killing the accept loop. A second valid connection
+// must still produce its event. (The existing malformed-line test sends valid
+// UTF-8 that's just bad JSON, hitting the serde warn instead.)
+#[tokio::test]
+async fn listener_survives_non_utf8_read_error() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("pixtuoid.sock");
+    let (tx, mut rx) = mpsc::channel::<(Transport, AgentEvent)>(16);
+    let listener = HookSocketListener::bind(path.clone()).await.unwrap();
+    let handle = tokio::spawn(async move { listener.run(tx).await });
+    sleep(Duration::from_millis(20)).await;
+
+    // First connection: invalid UTF-8 bytes → next_line() Err arm fires.
+    let mut bad = UnixStream::connect(&path).await.unwrap();
+    bad.write_all(&[0xFF, 0xFE, b'\n']).await.unwrap();
+    bad.shutdown().await.unwrap();
+
+    // Second connection: a valid payload must still be delivered, proving the
+    // accept loop survived the read error.
+    let mut s = UnixStream::connect(&path).await.unwrap();
+    let payload = serde_json::json!({
+        "hook_event_name": "SessionStart",
+        "session_id": "after-bad-read",
+        "transcript_path": "/p/c.jsonl",
+        "cwd": "/repo"
+    });
+    let mut line = serde_json::to_vec(&payload).unwrap();
+    line.push(b'\n');
+    s.write_all(&line).await.unwrap();
+    s.shutdown().await.unwrap();
+
+    let (transport, ev) = tokio::time::timeout(Duration::from_millis(500), rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(transport, Transport::Hook);
+    assert!(matches!(ev, AgentEvent::SessionStart { .. }));
+    handle.abort();
+}
+
+#[tokio::test]
 async fn listener_handles_concurrent_connections() {
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("pixtuoid.sock");

--- a/crates/pixtuoid-core/tests/jsonl_watcher.rs
+++ b/crates/pixtuoid-core/tests/jsonl_watcher.rs
@@ -5,9 +5,14 @@ use tempfile::TempDir;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::mpsc;
 
-use pixtuoid_core::source::claude_code::{cc_derive_label, cc_session_ended, decode_cc_line};
+use pixtuoid_core::source::antigravity::AntigravitySource;
+use pixtuoid_core::source::claude_code::{
+    cc_derive_label, cc_session_ended, decode_cc_line, ClaudeCodeSource,
+};
+use pixtuoid_core::source::codex::CodexSource;
 use pixtuoid_core::source::jsonl::JsonlWatcher;
 use pixtuoid_core::source::AgentEvent;
+use pixtuoid_core::source::Source;
 use pixtuoid_core::source::Transport;
 use pixtuoid_core::AgentId;
 
@@ -651,5 +656,461 @@ async fn default_id_deriver_stays_path_keyed() {
         }
     }
     assert!(ok, "expected a path-keyed SessionStart");
+    handle.abort();
+}
+
+// CodexSource::run is just `JsonlWatcher::new(...).run(tx)` — drive the real
+// Source impl against a TempDir sessions_root so its run()-glue is exercised
+// (not only the watcher internals). A rollout file with a task_started line must
+// surface an ActivityStart through the source.
+#[tokio::test]
+async fn codex_source_run_emits_events_from_rollout() {
+    let dir = TempDir::new().unwrap();
+    let sessions_root = dir.path().to_path_buf();
+    let uuid = "019e7762-9ded-7e33-be41-946ecf105bf4";
+    let transcript = sessions_root.join(format!("rollout-2026-05-29T22-36-52-{uuid}.jsonl"));
+
+    let (tx, mut rx) = mpsc::channel::<(Transport, AgentEvent)>(32);
+    let src = CodexSource { sessions_root };
+    let handle = tokio::spawn(async move { Box::new(src).run(tx).await });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let meta = serde_json::json!({
+        "type": "session_meta",
+        "payload": { "id": uuid, "cwd": "/repo" }
+    });
+    let task_started = serde_json::json!({
+        "type": "event_msg",
+        "payload": { "type": "task_started", "turn_id": "t" }
+    });
+    let mut f = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&transcript)
+        .await
+        .unwrap();
+    f.write_all(format!("{meta}\n{task_started}\n").as_bytes())
+        .await
+        .unwrap();
+    f.flush().await.unwrap();
+    drop(f);
+
+    let mut got_activity = false;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    while tokio::time::Instant::now() < deadline {
+        if let Ok(Some((_, AgentEvent::ActivityStart { .. }))) =
+            tokio::time::timeout(Duration::from_millis(200), rx.recv()).await
+        {
+            got_activity = true;
+            break;
+        }
+    }
+    assert!(
+        got_activity,
+        "CodexSource::run should surface ActivityStart"
+    );
+    handle.abort();
+}
+
+// AntigravitySource::run mirrors CodexSource::run — drive the real Source impl
+// against a TempDir brain_root.
+#[tokio::test]
+async fn antigravity_source_run_emits_events_from_transcript() {
+    let dir = TempDir::new().unwrap();
+    let brain_root = dir.path().to_path_buf();
+    let project_dir = brain_root.join("sess");
+    tokio::fs::create_dir_all(&project_dir).await.unwrap();
+    let transcript = project_dir.join("transcript.jsonl");
+
+    let (tx, mut rx) = mpsc::channel::<(Transport, AgentEvent)>(32);
+    let src = AntigravitySource { brain_root };
+    let handle = tokio::spawn(async move { Box::new(src).run(tx).await });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let planner = serde_json::json!({
+        "step_index": 1,
+        "cwd": "/repo",
+        "type": "PLANNER_RESPONSE",
+        "tool_calls": [ { "name": "list_dir", "args": { "DirectoryPath": "\"/repo/src\"" } } ]
+    });
+    let mut f = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&transcript)
+        .await
+        .unwrap();
+    f.write_all(format!("{planner}\n").as_bytes())
+        .await
+        .unwrap();
+    f.flush().await.unwrap();
+    drop(f);
+
+    let mut got_activity = false;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    while tokio::time::Instant::now() < deadline {
+        if let Ok(Some((_, AgentEvent::ActivityStart { .. }))) =
+            tokio::time::timeout(Duration::from_millis(200), rx.recv()).await
+        {
+            got_activity = true;
+            break;
+        }
+    }
+    assert!(
+        got_activity,
+        "AntigravitySource::run should surface ActivityStart"
+    );
+    handle.abort();
+}
+
+// ClaudeCodeSource::run binds the hook socket, spawns the watcher, and enters
+// the select! — drive the real Source impl so the bind + spawn + select-entry
+// glue is exercised (only the select abort/warn arms stay structurally
+// unreachable: both inner tasks loop forever). A CC transcript written under
+// the projects_root must surface a SessionStart through the JSONL leg.
+#[tokio::test]
+async fn claude_code_source_run_binds_socket_and_emits_events() {
+    let dir = TempDir::new().unwrap();
+    let socket_path = dir.path().join("pixtuoid-test.sock");
+    let projects_root = dir.path().join("projects");
+    let project_dir = projects_root.join("proj-cc");
+    tokio::fs::create_dir_all(&project_dir).await.unwrap();
+    let transcript = project_dir.join("ses-cc.jsonl");
+
+    let (tx, mut rx) = mpsc::channel::<(Transport, AgentEvent)>(32);
+    let src = ClaudeCodeSource {
+        socket_path,
+        projects_root,
+    };
+    let handle = tokio::spawn(async move { Box::new(src).run(tx).await });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let line = serde_json::json!({
+        "type": "assistant",
+        "sessionId": "ses-cc",
+        "cwd": "/repo",
+        "message": {
+            "role": "assistant",
+            "content": [
+                { "type": "tool_use", "id": "tu_1", "name": "Bash", "input": { "command": "ls" } }
+            ]
+        }
+    });
+    let mut f = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&transcript)
+        .await
+        .unwrap();
+    f.write_all(format!("{line}\n").as_bytes()).await.unwrap();
+    f.flush().await.unwrap();
+    drop(f);
+
+    let mut got_start = false;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    while tokio::time::Instant::now() < deadline {
+        if let Ok(Some((_, AgentEvent::SessionStart { .. }))) =
+            tokio::time::timeout(Duration::from_millis(200), rx.recv()).await
+        {
+            got_start = true;
+            break;
+        }
+    }
+    assert!(
+        got_start,
+        "ClaudeCodeSource::run should surface SessionStart from the JSONL leg"
+    );
+    handle.abort();
+}
+
+// Cursor-safety guard: a transcript truncated below the watcher's stored cursor
+// must reset the cursor (not stay stuck) so newly-appended content re-decodes.
+#[tokio::test]
+async fn watcher_resets_cursor_on_truncation_below_cursor() {
+    let dir = TempDir::new().unwrap();
+    let projects_root = dir.path().to_path_buf();
+    let project_dir = projects_root.join("proj-trunc");
+    tokio::fs::create_dir_all(&project_dir).await.unwrap();
+    let transcript = project_dir.join("trunc.jsonl");
+
+    let (tx, mut rx) = mpsc::channel::<(Transport, AgentEvent)>(64);
+    let watcher = cc_watcher(projects_root.clone());
+    let handle = tokio::spawn(async move { watcher.run(tx).await });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let tool_line = |id: &str| {
+        serde_json::json!({
+            "type": "assistant",
+            "sessionId": "trunc",
+            "cwd": "/repo",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    { "type": "tool_use", "id": id, "name": "Bash", "input": { "command": "ls" } }
+                ]
+            }
+        })
+        .to_string()
+    };
+
+    // Write a long first line so the cursor advances well past a later short one.
+    let long = tool_line("tu_long") + &" ".repeat(400);
+    tokio::fs::write(&transcript, format!("{long}\n"))
+        .await
+        .unwrap();
+
+    // Let the watcher advance its cursor to EOF.
+    let mut saw_long = false;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    while tokio::time::Instant::now() < deadline {
+        if let Ok(Some((_, AgentEvent::ActivityStart { tool_use_id, .. }))) =
+            tokio::time::timeout(Duration::from_millis(200), rx.recv()).await
+        {
+            if tool_use_id.as_deref() == Some("tu_long") {
+                saw_long = true;
+                break;
+            }
+        }
+    }
+    assert!(saw_long, "expected the first long line to decode");
+
+    // Truncate the file far below the stored cursor, then append a fresh line.
+    let fresh = tool_line("tu_fresh");
+    tokio::fs::write(&transcript, format!("{fresh}\n"))
+        .await
+        .unwrap();
+
+    // The cursor (set past the long line) now exceeds file_len → reset to 0 →
+    // the fresh line re-decodes on the next scan.
+    let mut saw_fresh = false;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    while tokio::time::Instant::now() < deadline {
+        if let Ok(Some((_, AgentEvent::ActivityStart { tool_use_id, .. }))) =
+            tokio::time::timeout(Duration::from_millis(200), rx.recv()).await
+        {
+            if tool_use_id.as_deref() == Some("tu_fresh") {
+                saw_fresh = true;
+                break;
+            }
+        }
+    }
+    assert!(
+        saw_fresh,
+        "after truncation the cursor must reset so the fresh line decodes"
+    );
+    handle.abort();
+}
+
+// Cursor-safety guard: a > 1 MiB pending tail with no newline must be skipped to
+// EOF (not buffered), and a later newline-terminated valid line still decodes.
+#[tokio::test]
+async fn watcher_skips_oversized_pending_tail() {
+    let dir = TempDir::new().unwrap();
+    let projects_root = dir.path().to_path_buf();
+    let project_dir = projects_root.join("proj-big");
+    tokio::fs::create_dir_all(&project_dir).await.unwrap();
+    let transcript = project_dir.join("big.jsonl");
+
+    let (tx, mut rx) = mpsc::channel::<(Transport, AgentEvent)>(64);
+    let watcher = cc_watcher(projects_root.clone());
+    let handle = tokio::spawn(async move { watcher.run(tx).await });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Write > 1 MiB of junk with NO newline — file_len - cursor exceeds
+    // MAX_PENDING_BYTES, so the watcher seeks the cursor to EOF and skips it.
+    let junk = vec![b'x'; (1 << 20) + 1024];
+    let mut f = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&transcript)
+        .await
+        .unwrap();
+    f.write_all(&junk).await.unwrap();
+    f.flush().await.unwrap();
+    drop(f);
+
+    // Give the watcher a scan to skip the junk.
+    tokio::time::sleep(Duration::from_millis(400)).await;
+    while tokio::time::timeout(Duration::from_millis(20), rx.recv())
+        .await
+        .is_ok()
+    {}
+
+    // Append a newline (closing the junk line) plus a valid line. The junk line
+    // is past the EOF-seeked cursor, so only the valid line decodes.
+    let valid = serde_json::json!({
+        "type": "assistant",
+        "sessionId": "big",
+        "cwd": "/repo",
+        "message": {
+            "role": "assistant",
+            "content": [
+                { "type": "tool_use", "id": "tu_after_junk", "name": "Bash", "input": { "command": "ls" } }
+            ]
+        }
+    });
+    let mut f = tokio::fs::OpenOptions::new()
+        .append(true)
+        .open(&transcript)
+        .await
+        .unwrap();
+    f.write_all(format!("\n{valid}\n").as_bytes())
+        .await
+        .unwrap();
+    f.flush().await.unwrap();
+    drop(f);
+
+    let mut got_after = false;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    while tokio::time::Instant::now() < deadline {
+        if let Ok(Some((_, AgentEvent::ActivityStart { tool_use_id, .. }))) =
+            tokio::time::timeout(Duration::from_millis(200), rx.recv()).await
+        {
+            if tool_use_id.as_deref() == Some("tu_after_junk") {
+                got_after = true;
+                break;
+            }
+        }
+    }
+    assert!(
+        got_after,
+        "the post-skip valid line must decode after the oversized tail is skipped"
+    );
+    handle.abort();
+}
+
+// The per-line non-UTF8 guard in walk_jsonl: a raw invalid-UTF8 byte line is
+// warn-and-skipped, and a following valid JSON line still decodes (the bad line
+// is not fatal to the rest of the read).
+#[tokio::test]
+async fn watcher_skips_non_utf8_line_and_keeps_going() {
+    let dir = TempDir::new().unwrap();
+    let projects_root = dir.path().to_path_buf();
+    let project_dir = projects_root.join("proj-nonutf8");
+    tokio::fs::create_dir_all(&project_dir).await.unwrap();
+    let transcript = project_dir.join("nonutf8.jsonl");
+
+    let (tx, mut rx) = mpsc::channel::<(Transport, AgentEvent)>(32);
+    let watcher = cc_watcher(projects_root.clone());
+    let handle = tokio::spawn(async move { watcher.run(tx).await });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let valid = serde_json::json!({
+        "type": "assistant",
+        "sessionId": "nonutf8",
+        "cwd": "/repo",
+        "message": {
+            "role": "assistant",
+            "content": [
+                { "type": "tool_use", "id": "tu_valid", "name": "Bash", "input": { "command": "ls" } }
+            ]
+        }
+    });
+    // Invalid-UTF8 bytes + newline, then a valid JSON line + newline. The bytes
+    // can't go through serde_json (JSON is UTF-8) — write them raw.
+    let mut bytes: Vec<u8> = vec![0xff, 0xfe, b'\n'];
+    bytes.extend_from_slice(format!("{valid}\n").as_bytes());
+    let mut f = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&transcript)
+        .await
+        .unwrap();
+    f.write_all(&bytes).await.unwrap();
+    f.flush().await.unwrap();
+    drop(f);
+
+    let mut got_valid = false;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    while tokio::time::Instant::now() < deadline {
+        if let Ok(Some((_, AgentEvent::ActivityStart { tool_use_id, .. }))) =
+            tokio::time::timeout(Duration::from_millis(200), rx.recv()).await
+        {
+            if tool_use_id.as_deref() == Some("tu_valid") {
+                got_valid = true;
+                break;
+            }
+        }
+    }
+    assert!(
+        got_valid,
+        "a non-UTF8 line must be skipped, not block the following valid line"
+    );
+    handle.abort();
+}
+
+// Drives detect_parent_id through the REAL watcher recursion: a subagent
+// transcript at <root>/proj/parent/subagents/agent-1.jsonl must emit a
+// SessionStart whose parent_id derives the parent from the grandparent dir.
+#[tokio::test]
+async fn watcher_derives_parent_id_for_subagent_path() {
+    let dir = TempDir::new().unwrap();
+    let projects_root = dir.path().to_path_buf();
+    let subagent_dir = projects_root.join("proj").join("parent").join("subagents");
+    tokio::fs::create_dir_all(&subagent_dir).await.unwrap();
+    let transcript = subagent_dir.join("agent-1.jsonl");
+
+    let (tx, mut rx) = mpsc::channel::<(Transport, AgentEvent)>(32);
+    let watcher = cc_watcher(projects_root.clone());
+    let handle = tokio::spawn(async move { watcher.run(tx).await });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let line = serde_json::json!({
+        "type": "assistant",
+        "sessionId": "agent-1",
+        "cwd": "/repo",
+        "attributionAgent": "feature-dev:code-explorer",
+        "message": {
+            "role": "assistant",
+            "content": [
+                { "type": "tool_use", "id": "tu_1", "name": "Read", "input": { "file_path": "/x" } }
+            ]
+        }
+    });
+    let mut f = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&transcript)
+        .await
+        .unwrap();
+    f.write_all(format!("{line}\n").as_bytes()).await.unwrap();
+    f.flush().await.unwrap();
+    drop(f);
+
+    // The watcher reports either the raw or canonicalized root (macOS /var →
+    // /private/var), so accept either parent key.
+    let parent_path = projects_root.join("proj").join("parent.jsonl");
+    let raw = AgentId::from_parts("claude-code", &parent_path.to_string_lossy());
+    let canon_root = std::fs::canonicalize(&projects_root).unwrap_or(projects_root.clone());
+    let canon = AgentId::from_parts(
+        "claude-code",
+        &canon_root
+            .join("proj")
+            .join("parent.jsonl")
+            .to_string_lossy(),
+    );
+
+    let mut found_parent = None;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    while tokio::time::Instant::now() < deadline {
+        if let Ok(Some((
+            _,
+            AgentEvent::SessionStart {
+                parent_id: Some(pid),
+                ..
+            },
+        ))) = tokio::time::timeout(Duration::from_millis(200), rx.recv()).await
+        {
+            found_parent = Some(pid);
+            break;
+        }
+    }
+    let found = found_parent.expect("expected a SessionStart carrying parent_id");
+    assert!(
+        found == raw || found == canon,
+        "parent_id must derive the parent transcript from the grandparent dir; got {found:?}"
+    );
     handle.abort();
 }

--- a/crates/pixtuoid-core/tests/reducer.rs
+++ b/crates/pixtuoid-core/tests/reducer.rs
@@ -1482,6 +1482,65 @@ fn stale_sweep_cascades_to_children() {
     );
 }
 
+// When BOTH parent and child are independently stale, both enter sweep_stale's
+// pass-1 `stale` vec. The parent's pass-2 cascade marks the child exiting; the
+// child's own pass-2 iteration then hits the `exiting_at.is_some() -> continue`
+// write-once guard (reducer.rs) instead of re-stamping / re-logging it. The
+// existing cascade tests heartbeat the descendant so it is NEVER in `stale`, so
+// they don't exercise this branch — this test drops the heartbeat.
+#[test]
+fn stale_sweep_already_cascaded_child_is_skipped_in_pass_two() {
+    use pixtuoid_core::state::reducer::STALE_IDLE_TIMEOUT;
+    let mut scene = SceneState::uniform(8);
+    let mut r = Reducer::new();
+    let parent = AgentId::from_transcript_path("/p/double-stale.jsonl");
+    let child = AgentId::from_parts("claude-code", "/p/double-stale/subagents/agent-1.jsonl");
+    let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+
+    r.apply(
+        &mut scene,
+        AgentEvent::SessionStart {
+            agent_id: parent,
+            source: "claude-code".into(),
+            session_id: "parent".into(),
+            cwd: PathBuf::from("/repo"),
+            parent_id: None,
+        },
+        t0,
+        Transport::Hook,
+    );
+    r.apply(
+        &mut scene,
+        AgentEvent::SessionStart {
+            agent_id: child,
+            source: "claude-code".into(),
+            session_id: "child".into(),
+            cwd: PathBuf::from("/repo"),
+            parent_id: Some(parent),
+        },
+        t0 + Duration::from_millis(100),
+        Transport::Jsonl,
+    );
+
+    // No heartbeat for either: both cross STALE_IDLE_TIMEOUT, so both enter the
+    // pass-1 `stale` vec. The id is set once, on whichever pass-2 iteration runs
+    // first; the other iteration must hit the write-once skip.
+    let now = t0 + STALE_IDLE_TIMEOUT + Duration::from_secs(1);
+    r.tick(&mut scene, now);
+
+    let parent_exit = scene.agents.get(&parent).unwrap().exiting_at;
+    let child_exit = scene.agents.get(&child).unwrap().exiting_at;
+    assert!(parent_exit.is_some(), "stale parent marked exiting");
+    assert!(
+        child_exit.is_some(),
+        "independently-stale child also marked exiting (write-once, no double-stamp)"
+    );
+    // Both stamped at the same sweep `now`: the pass-2 skip preserved the first
+    // write rather than overwriting it on the second iteration.
+    assert_eq!(parent_exit, Some(now));
+    assert_eq!(child_exit, Some(now));
+}
+
 #[test]
 fn stale_sweep_cascades_to_grandchildren() {
     use pixtuoid_core::state::reducer::STALE_IDLE_TIMEOUT;

--- a/crates/pixtuoid-core/tests/source_manager.rs
+++ b/crates/pixtuoid-core/tests/source_manager.rs
@@ -25,6 +25,64 @@ impl Source for StaticSource {
     }
 }
 
+/// A source whose `run` returns Err immediately — exercises the manager's
+/// log-and-isolate Err arm.
+struct FailingSource;
+
+#[async_trait]
+impl Source for FailingSource {
+    fn name(&self) -> &str {
+        "failing"
+    }
+    async fn run(self: Box<Self>, _tx: TaggedSender) -> anyhow::Result<()> {
+        anyhow::bail!("boom")
+    }
+}
+
+// A source returning Err must be logged and isolated — it must NOT abort its
+// siblings. Register a FailingSource beside a good one and assert the good
+// source's event still arrives.
+#[tokio::test]
+async fn manager_isolates_a_failing_source_from_siblings() {
+    let good_id = AgentId::from_parts("good", "1");
+    let good = StaticSource {
+        name: "good",
+        events: vec![(
+            Transport::Hook,
+            AgentEvent::SessionStart {
+                agent_id: good_id,
+                source: "good".into(),
+                session_id: "1".into(),
+                cwd: PathBuf::from("/g"),
+                parent_id: None,
+            },
+        )],
+    };
+
+    let (tx, mut rx) = mpsc::channel::<(Transport, AgentEvent)>(8);
+    let mgr = SourceManager::new()
+        .with_source(Box::new(FailingSource))
+        .with_source(Box::new(good));
+    mgr.spawn(tx);
+
+    let mut got_good = false;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    while tokio::time::Instant::now() < deadline {
+        if let Ok(Some((_, AgentEvent::SessionStart { agent_id, .. }))) =
+            tokio::time::timeout(Duration::from_millis(50), rx.recv()).await
+        {
+            if agent_id == good_id {
+                got_good = true;
+                break;
+            }
+        }
+    }
+    assert!(
+        got_good,
+        "a failing sibling must be logged-and-isolated, not abort the good source"
+    );
+}
+
 #[tokio::test]
 async fn manager_runs_multiple_sources_concurrently() {
     let id_a = AgentId::from_parts("src-a", "1");

--- a/crates/pixtuoid-core/tests/sprite_blit.rs
+++ b/crates/pixtuoid-core/tests/sprite_blit.rs
@@ -288,6 +288,39 @@ fn dotted_hline_alternates() {
 }
 
 #[test]
+fn dotted_hline_breaks_when_dash_overruns_x1() {
+    // dash=3, gap=1 → period 4. Span [0,9] is NOT a multiple of the period,
+    // so the final dash (starting at x=8) wants to paint 8,9,10 but 10 > x1=9
+    // fires the line-94 break. Painted set: [0,1,2, 4,5,6, 8,9].
+    let mut buf = RgbBuffer::filled(12, 1, Rgb { r: 0, g: 0, b: 0 });
+    let red = Rgb { r: 255, g: 0, b: 0 };
+    draw_dotted_hline(&mut buf, 0, 0, 9, red, 3, 1);
+    // x1 itself is painted (the dash reaches it before the break).
+    assert_eq!(buf.get(9, 0), red, "x1 should be painted");
+    // x1+1 is NOT painted — the break stopped the overrunning dash.
+    assert_eq!(
+        buf.get(10, 0),
+        Rgb { r: 0, g: 0, b: 0 },
+        "x1+1 must be unpainted"
+    );
+    // No panic; sanity-check the rest of the expected pattern.
+    for x in [0, 1, 2, 4, 5, 6, 8] {
+        assert_eq!(buf.get(x, 0), red, "x={x} should be painted");
+    }
+    assert_eq!(buf.get(3, 0), Rgb { r: 0, g: 0, b: 0 }, "x=3 is a gap");
+    assert_eq!(buf.get(7, 0), Rgb { r: 0, g: 0, b: 0 }, "x=7 is a gap");
+}
+
+#[test]
+fn half_block_cells_on_empty_buffers_returns_empty_grid() {
+    let rgb = Rgb { r: 1, g: 2, b: 3 };
+    // w == 0 arm of the degenerate guard.
+    assert!(half_block_cells(&RgbBuffer::filled(0, 4, rgb)).is_empty());
+    // h == 0 arm.
+    assert!(half_block_cells(&RgbBuffer::filled(4, 0, rgb)).is_empty());
+}
+
+#[test]
 fn half_block_cells_pads_odd_height_with_repeated_row() {
     let buf = RgbBuffer {
         width: 1,

--- a/crates/pixtuoid-core/tests/sprite_format.rs
+++ b/crates/pixtuoid-core/tests/sprite_format.rs
@@ -1,6 +1,8 @@
 use std::path::Path;
 
-use pixtuoid_core::sprite::format::{load_pack, parse_sprite_file, validate_pack_animations};
+use pixtuoid_core::sprite::format::{
+    load_pack, load_pack_from_strings, parse_sprite_file, validate_pack_animations,
+};
 use pixtuoid_core::sprite::{Palette, Rgb};
 
 fn palette() -> Palette {
@@ -42,6 +44,82 @@ fn rejects_inconsistent_row_widths() {
     let src = "@frame 0\nA . B .\nA . B";
     let err = parse_sprite_file(src, &palette).unwrap_err();
     assert!(err.to_string().contains("row width"), "got: {err}");
+}
+
+// ---- malformed-input error bails (the guards the parser exists to enforce) --
+
+#[test]
+fn rejects_empty_source_with_no_frames() {
+    let err = parse_sprite_file("", &palette()).unwrap_err();
+    assert!(
+        err.to_string().contains("contains no frames"),
+        "empty source must bail with 'contains no frames'; got: {err}"
+    );
+}
+
+#[test]
+fn rejects_multi_char_pixel_token() {
+    // "AB" is two characters in one whitespace-delimited token.
+    let err = parse_sprite_file("@frame 0\nAB . .", &palette()).unwrap_err();
+    assert!(
+        err.to_string().contains("single character"),
+        "a multi-char pixel token must bail; got: {err}"
+    );
+}
+
+#[test]
+fn rejects_frame_block_with_no_rows() {
+    // Back-to-back @frame headers: the first block has zero rows, so the
+    // header-handling `rows_to_frame(vec![])` path bails with 'no rows'.
+    let err = parse_sprite_file("@frame 0\n@frame 1\nA", &palette()).unwrap_err();
+    assert!(
+        err.to_string().contains("no rows"),
+        "an empty frame block must bail with 'frame has no rows'; got: {err}"
+    );
+}
+
+#[test]
+fn rejects_palette_key_longer_than_one_char() {
+    // build_palette is reached via load_pack_from_strings; key "AB" is 2 chars.
+    let pack_toml = "[pack]\nname=\"x\"\nversion=\"1\"\n\
+         [palette]\n\"AB\"=\"#010203\"\n\
+         [animations.idle]\nframes=[\"i.sprite\"]\nframe_ms=100\n";
+    let err = load_pack_from_strings(pack_toml, &[("i.sprite", "@frame 0\nA")]).unwrap_err();
+    assert!(
+        format!("{err:#}").contains("exactly one character"),
+        "a >1-char palette key must bail; got: {err:#}"
+    );
+}
+
+#[test]
+fn rejects_palette_value_not_six_hex_digits() {
+    let pack_toml = "[pack]\nname=\"x\"\nversion=\"1\"\n\
+         [palette]\n\"A\"=\"#12345\"\n\
+         [animations.idle]\nframes=[\"i.sprite\"]\nframe_ms=100\n";
+    let err = load_pack_from_strings(pack_toml, &[("i.sprite", "@frame 0\nA")]).unwrap_err();
+    assert!(
+        format!("{err:#}").contains("6 hex digits"),
+        "a non-6-hex-digit color must bail; got: {err:#}"
+    );
+}
+
+#[test]
+fn validate_reports_insufficient_frames_for_single_frame_typing() {
+    // `typing` requires >= 2 frames (MULTI_FRAME_REQUIREMENTS). A 1-frame
+    // typing animation must populate insufficient_frames and set has_errors().
+    let pack_toml = "[pack]\nname=\"x\"\nversion=\"1\"\n\
+         [palette]\n\"A\"=\"#010203\"\n\
+         [animations.typing]\nframes=[\"t.sprite\"]\nframe_ms=100\n";
+    let pack = load_pack_from_strings(pack_toml, &[("t.sprite", "@frame 0\nA")]).unwrap();
+    let report = validate_pack_animations(&pack);
+    assert!(
+        report
+            .insufficient_frames
+            .contains(&("typing".to_string(), 2, 1)),
+        "single-frame typing must report (typing, 2, 1); got: {:?}",
+        report.insufficient_frames
+    );
+    assert!(report.has_errors());
 }
 
 #[test]

--- a/crates/pixtuoid-hook/src/main.rs
+++ b/crates/pixtuoid-hook/src/main.rs
@@ -111,4 +111,40 @@ mod tests {
         enrich_payload(map, Some(String::new()), 1);
         assert!(map.get("_pixtuoid_source").is_none());
     }
+
+    // Env vars are process-global. This is the ONLY env-touching test in this
+    // crate (the integration suite in tests/shim.rs runs in a separate binary
+    // and sets PIXTUOID_SOCKET in the spawned child, not in-process), so it can
+    // save/restore both vars and drive all three branches without serial_test.
+    #[test]
+    fn default_socket_path_branches() {
+        let prior_socket = std::env::var("PIXTUOID_SOCKET").ok();
+        let prior_xdg = std::env::var("XDG_RUNTIME_DIR").ok();
+
+        // Arm 1: PIXTUOID_SOCKET set -> returned verbatim, wins over XDG.
+        std::env::set_var("PIXTUOID_SOCKET", "/explicit/path.sock");
+        std::env::set_var("XDG_RUNTIME_DIR", "/run/user/0");
+        assert_eq!(default_socket_path(), "/explicit/path.sock");
+
+        // Arm 2: no PIXTUOID_SOCKET, XDG_RUNTIME_DIR set -> "{dir}/pixtuoid.sock".
+        std::env::remove_var("PIXTUOID_SOCKET");
+        std::env::set_var("XDG_RUNTIME_DIR", "/run/user/1000");
+        assert_eq!(default_socket_path(), "/run/user/1000/pixtuoid.sock");
+
+        // Arm 3: neither set -> "/tmp/pixtuoid-{uid}.sock".
+        std::env::remove_var("PIXTUOID_SOCKET");
+        std::env::remove_var("XDG_RUNTIME_DIR");
+        // Safety: getuid is always safe on Unix.
+        let uid = unsafe { libc::getuid() };
+        assert_eq!(default_socket_path(), format!("/tmp/pixtuoid-{uid}.sock"));
+
+        match prior_socket {
+            Some(v) => std::env::set_var("PIXTUOID_SOCKET", v),
+            None => std::env::remove_var("PIXTUOID_SOCKET"),
+        }
+        match prior_xdg {
+            Some(v) => std::env::set_var("XDG_RUNTIME_DIR", v),
+            None => std::env::remove_var("XDG_RUNTIME_DIR"),
+        }
+    }
 }

--- a/crates/pixtuoid/src/cli.rs
+++ b/crates/pixtuoid/src/cli.rs
@@ -116,6 +116,13 @@ mod tests {
     use super::*;
 
     #[test]
+    fn target_name_as_str_covers_all_arms() {
+        assert_eq!(TargetName::Claude.as_str(), "claude");
+        assert_eq!(TargetName::Codex.as_str(), "codex");
+        assert_eq!(TargetName::All.as_str(), "all");
+    }
+
+    #[test]
     fn cmd_or_default_returns_run_when_no_subcommand() {
         let cli = Cli {
             cmd: None,

--- a/crates/pixtuoid/src/config.rs
+++ b/crates/pixtuoid/src/config.rs
@@ -208,10 +208,14 @@ mod tests {
     }
 
     // config_path reads process-global env, so save+restore both vars and drive
-    // the three branches in one test (avoids cross-test env races; the repo has
-    // no serial_test dep and CI runs tests process-isolated via nextest).
+    // the three branches in one test. The TEST_ENV_LOCK serializes against the
+    // other env-mutating test in this binary (embedded_pack's XDG test) so they
+    // can't race under plain `cargo test`.
     #[test]
     fn config_path_xdg_home_and_relative_branches() {
+        let _env = crate::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let saved_xdg = std::env::var_os("XDG_CONFIG_HOME");
         let saved_home = std::env::var_os("HOME");
 

--- a/crates/pixtuoid/src/config.rs
+++ b/crates/pixtuoid/src/config.rs
@@ -207,6 +207,54 @@ mod tests {
         assert!(cfg.theme.is_none());
     }
 
+    // config_path reads process-global env, so save+restore both vars and drive
+    // the three branches in one test (avoids cross-test env races; the repo has
+    // no serial_test dep and CI runs tests process-isolated via nextest).
+    #[test]
+    fn config_path_xdg_home_and_relative_branches() {
+        let saved_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        let saved_home = std::env::var_os("HOME");
+
+        // XDG_CONFIG_HOME wins when set.
+        std::env::set_var("XDG_CONFIG_HOME", "/xdg/base");
+        std::env::set_var("HOME", "/home/u");
+        assert_eq!(
+            config_path(),
+            PathBuf::from("/xdg/base/pixtuoid/config.toml")
+        );
+
+        // No XDG → fall back to $HOME/.config.
+        std::env::remove_var("XDG_CONFIG_HOME");
+        assert_eq!(
+            config_path(),
+            PathBuf::from("/home/u/.config/pixtuoid/config.toml")
+        );
+
+        // Neither → relative fallback.
+        std::env::remove_var("HOME");
+        assert_eq!(config_path(), PathBuf::from(".config/pixtuoid/config.toml"));
+
+        // Restore.
+        match saved_xdg {
+            Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+            None => std::env::remove_var("XDG_CONFIG_HOME"),
+        }
+        match saved_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    // load()'s non-NotFound read-error arm: pointing at a DIRECTORY makes
+    // read_to_string error (IsADirectory) → warn + return defaults (never crash).
+    #[test]
+    fn load_unreadable_path_returns_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        // The directory itself is an existing, non-NotFound, unreadable "file".
+        let cfg = load(dir.path());
+        assert!(cfg.theme.is_none());
+    }
+
     #[test]
     fn expand_tilde_only_expands_leading_current_user_home() {
         let home = Some("/Users/x");

--- a/crates/pixtuoid/src/init_pack.rs
+++ b/crates/pixtuoid/src/init_pack.rs
@@ -25,12 +25,12 @@ pub fn init_pack(dest: &Path, force: bool) -> Result<()> {
         ),
     ];
 
+    // No per-file exists-skip here: with force=false a dest already containing
+    // pack.toml/placeholder.sprite would have tripped the non-empty guard above,
+    // and force=true overwrites by design — so the only reachable behavior is a
+    // plain write. (A per-file skip would be dead code; see init_pack tests.)
     for (name, content) in files {
         let path = dest.join(name);
-        if path.exists() && !force {
-            println!("skip: {name} (exists)");
-            continue;
-        }
         std::fs::write(&path, content)?;
         println!("wrote: {name}");
     }

--- a/crates/pixtuoid/src/install/claude.rs
+++ b/crates/pixtuoid/src/install/claude.rs
@@ -273,6 +273,38 @@ mod tests {
         assert_eq!(hooks["PostToolUse"], json!(42));
     }
 
+    // Defensive coercion (install side): a non-object `hooks` value is replaced
+    // with a fresh object, then all events are populated.
+    #[test]
+    fn install_coerces_non_object_hooks_to_object() {
+        let doc = json_merge_install(json!({ "hooks": "garbage-string" }), "/x");
+        let hooks = doc.get("hooks").and_then(|v| v.as_object()).unwrap();
+        for ev in EVENTS {
+            assert_eq!(
+                hooks.get(*ev).and_then(|v| v.as_array()).unwrap().len(),
+                1,
+                "event {ev} populated after coercion"
+            );
+        }
+    }
+
+    // Defensive coercion (install side): a non-array event value becomes a
+    // 1-element array carrying the managed sentinel.
+    #[test]
+    fn install_coerces_non_array_event_to_array() {
+        let doc = json_merge_install(json!({ "hooks": { "PreToolUse": 42 } }), "/x");
+        let arr = doc["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert!(arr[0][SENTINEL_KEY].as_bool().unwrap());
+    }
+
+    // Uninstall early-return: a top-level non-object document is returned as-is.
+    #[test]
+    fn uninstall_non_object_doc_returns_unchanged() {
+        let input = json!([1, 2, 3]);
+        assert_eq!(json_merge_uninstall(input.clone()), input);
+    }
+
     #[test]
     fn merge_install_on_empty_string_produces_valid_populated_config() {
         let out = merge_install("", "pixtuoid-hook").unwrap();

--- a/crates/pixtuoid/src/install/codex.rs
+++ b/crates/pixtuoid/src/install/codex.rs
@@ -359,6 +359,47 @@ command = "/old/pixtuoid-hook"
         );
     }
 
+    // Defensive coercion (install side): a non-table `hooks` value is replaced
+    // with a fresh table, then re-emits a valid hooks table for all events.
+    #[test]
+    fn install_coerces_non_table_hooks_to_table() {
+        let out = merge_install("hooks = 5", "/x/pixtuoid-hook").unwrap();
+        let v = parse(&out.content);
+        let hooks = v["hooks"].as_table().unwrap();
+        for ev in CODEX_EVENTS {
+            assert_eq!(
+                hooks.get(*ev).and_then(|e| e.as_array()).unwrap().len(),
+                1,
+                "event {ev} populated after coercion"
+            );
+        }
+    }
+
+    // Defensive coercion (install side): a non-array event value becomes a
+    // 1-element array carrying the managed group.
+    #[test]
+    fn install_coerces_non_array_event_to_array() {
+        let out = merge_install("[hooks]\nPreToolUse = 5", "/x/pixtuoid-hook").unwrap();
+        let v = parse(&out.content);
+        let arr = v["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert!(arr[0]["hooks"][0]["_pixtuoid"].as_bool().unwrap());
+    }
+
+    // Uninstall early-return: a top-level non-table document is returned as-is.
+    #[test]
+    fn uninstall_non_table_doc_returns_unchanged() {
+        let input = toml::Value::Integer(3);
+        assert_eq!(toml_merge_uninstall(input.clone()), input);
+    }
+
+    // Uninstall early-return: a document with no [hooks] table is unchanged.
+    #[test]
+    fn uninstall_doc_without_hooks_returns_unchanged() {
+        let out = merge_uninstall("model = \"o1\"\n").unwrap();
+        assert!(!out.changed, "no [hooks] → nothing to remove");
+    }
+
     // Internal-consistency guard: every hook event we REGISTER with Codex must
     // have a decoder arm — otherwise it arrives at the shared socket and
     // `decode_hook_payload` bails ("unsupported hook_event_name"), silently

--- a/crates/pixtuoid/src/install/io.rs
+++ b/crates/pixtuoid/src/install/io.rs
@@ -18,7 +18,9 @@ pub fn default_hook_binary() -> Result<PathBuf> {
     if let Ok(p) = which::which("pixtuoid-hook") {
         return Ok(p);
     }
-    let exe = std::env::current_exe().context("current_exe")?;
+    let exe = std::env::current_exe().context(
+        "could not determine the running executable's path while locating pixtuoid-hook",
+    )?;
     let dir = exe.parent().ok_or_else(|| anyhow!("exe has no parent"))?;
     let candidate = dir.join("pixtuoid-hook");
     if candidate.exists() {
@@ -195,6 +197,22 @@ mod tests {
             std::fs::canonicalize(&resolved).unwrap(),
             std::fs::canonicalize(&target).unwrap()
         );
+    }
+
+    #[test]
+    fn resolve_symlink_cycle_terminates_after_budget() {
+        // A 2-node cycle a→b→a: symlink_metadata (lstat) + read_link (readlink)
+        // both succeed on every hop without following, so the 32-hop budget is
+        // exhausted and the loop falls through to `cur` (line 131) instead of
+        // looping forever. The assertion is simply that it TERMINATES (and
+        // returns one of the two cycle nodes).
+        let dir = TempDir::new().unwrap();
+        let a = dir.path().join("a.link");
+        let b = dir.path().join("b.link");
+        std::os::unix::fs::symlink(&b, &a).unwrap();
+        std::os::unix::fs::symlink(&a, &b).unwrap();
+        let resolved = resolve_symlink(&a);
+        assert!(resolved == a || resolved == b, "got {resolved:?}");
     }
 
     #[test]

--- a/crates/pixtuoid/src/install/mod.rs
+++ b/crates/pixtuoid/src/install/mod.rs
@@ -93,15 +93,26 @@ fn parse_confirm(answer: &str) -> bool {
     a.is_empty() || a == "y" || a == "yes"
 }
 
+/// Interpret a `read_line` result on the destructive confirm prompt.
+/// `read` is `Ok(bytes)` from `read_line` or `Err(())` for a read error.
+/// EOF (`Ok(0)`, e.g. Ctrl-D) and a read error both CANCEL (false) — only a
+/// genuinely-entered line (`Ok(n>0)`, including a bare Enter) takes
+/// `parse_confirm`'s default-yes. Pure so the EOF→cancel rule is unit-testable
+/// without injecting stdin.
+fn interpret_confirm_read(read: Result<usize, ()>, line: &str) -> bool {
+    match read {
+        Ok(0) | Err(()) => false,
+        Ok(_) => parse_confirm(line),
+    }
+}
+
 fn confirm(prompt: &str) -> bool {
     use std::io::Write;
     print!("{prompt} [Y/n] ");
     let _ = std::io::stdout().flush();
     let mut line = String::new();
-    if std::io::stdin().read_line(&mut line).is_err() {
-        return false;
-    }
-    parse_confirm(&line)
+    let read = std::io::stdin().read_line(&mut line).map_err(|_| ());
+    interpret_confirm_read(read, &line)
 }
 
 fn detection() -> Vec<(&'static Target, bool)> {
@@ -434,6 +445,70 @@ mod tests {
         post_install_note: None,
     };
 
+    // A fixed config path under the system temp dir, used by FAKE2/FAKE_DIR so
+    // their fn-pointer `default_config_path` can point at a test-controlled file
+    // (the fn signature `fn() -> PathBuf` can't capture a TempDir).
+    fn fake2_config_path() -> std::path::PathBuf {
+        std::env::temp_dir().join("pixtuoid-test-fake2-config.toml")
+    }
+
+    fn fake_dir_config_path() -> std::path::PathBuf {
+        std::env::temp_dir().join("pixtuoid-test-fake-dir-config")
+    }
+
+    // FAKE2: default_config_path points at a test-writable file, and its
+    // merge_uninstall reports `changed` iff the content is non-empty — so
+    // has_hooks can be driven through both the changed (true) and unchanged
+    // (false) arms by controlling the on-disk content.
+    static FAKE2: Target = Target {
+        name: "fake2",
+        display_name: "Fake2",
+        restart_noun: "Fake2",
+        default_config_path: fake2_config_path,
+        hook_command: |_| Ok("x".into()),
+        merge_install: |c, _| {
+            Ok(MergeOutcome {
+                content: c.to_string(),
+                changed: false,
+            })
+        },
+        merge_uninstall: |c| {
+            Ok(MergeOutcome {
+                content: c.to_string(),
+                changed: !c.trim().is_empty(),
+            })
+        },
+        needs_path_warning: false,
+        needs_resolved_binary: false,
+        post_install_note: None,
+    };
+
+    // FAKE_DIR: default_config_path points at a path the test creates as a
+    // DIRECTORY, so read_config's File::open(dir).read_to_string errors → the
+    // has_hooks Err(_) => true arm.
+    static FAKE_DIR: Target = Target {
+        name: "fakedir",
+        display_name: "FakeDir",
+        restart_noun: "FakeDir",
+        default_config_path: fake_dir_config_path,
+        hook_command: |_| Ok("x".into()),
+        merge_install: |c, _| {
+            Ok(MergeOutcome {
+                content: c.to_string(),
+                changed: false,
+            })
+        },
+        merge_uninstall: |c| {
+            Ok(MergeOutcome {
+                content: c.to_string(),
+                changed: false,
+            })
+        },
+        needs_path_warning: false,
+        needs_resolved_binary: false,
+        post_install_note: None,
+    };
+
     fn present(claude: bool, fake: bool) -> Vec<(&'static Target, bool)> {
         vec![(&CLAUDE, claude), (&FAKE, fake)]
     }
@@ -532,5 +607,236 @@ mod tests {
             false,
             true
         ));
+    }
+
+    // --- confirm EOF/cancel (CR: Ctrl-D must abort the destructive uninstall) --
+
+    #[test]
+    fn confirm_read_eof_and_error_cancel_but_entered_line_decides() {
+        // EOF (Ctrl-D → Ok(0)) and a read error (Err) must CANCEL, even though
+        // the buffered line is empty (which parse_confirm would treat as yes).
+        assert!(!interpret_confirm_read(Ok(0), ""));
+        assert!(!interpret_confirm_read(Err(()), ""));
+        // A genuinely-entered empty line (bare Enter, Ok(1) for the newline)
+        // still takes the default-yes; an entered "n" is a no.
+        assert!(interpret_confirm_read(Ok(1), "\n"));
+        assert!(interpret_confirm_read(Ok(2), "y\n"));
+        assert!(!interpret_confirm_read(Ok(2), "n\n"));
+    }
+
+    // --- plan_targets branch coverage -----------------------------------------
+
+    #[test]
+    fn all_with_nothing_present_is_nothing_detected() {
+        let p = plan_targets(Some("all"), false, &present(false, false), false);
+        assert!(matches!(p, Plan::NothingDetected));
+    }
+
+    #[test]
+    fn all_with_both_present_returns_both() {
+        let p = plan_targets(Some("all"), false, &present(true, true), false);
+        assert!(matches!(p, Plan::Targets(ref t) if t.len() == 2));
+    }
+
+    #[test]
+    fn unknown_explicit_target_is_conflict() {
+        let p = plan_targets(Some("bogus"), false, &present(true, true), false);
+        assert!(matches!(p, Plan::Conflict(_)));
+    }
+
+    // --- resolve_plan ----------------------------------------------------------
+
+    // `Target` isn't Debug, so unwrap/unwrap_err on Result<Vec<&Target>> won't
+    // compile — match explicitly instead.
+    #[test]
+    fn resolve_plan_targets_passes_through() {
+        match resolve_plan(Plan::Targets(vec![&CLAUDE])) {
+            Ok(got) => {
+                assert_eq!(got.len(), 1);
+                assert_eq!(got[0].name, "claude");
+            }
+            Err(e) => panic!("expected Ok, got {e}"),
+        }
+    }
+
+    #[test]
+    fn resolve_plan_nothing_detected_is_ok_empty() {
+        match resolve_plan(Plan::NothingDetected) {
+            Ok(got) => assert!(got.is_empty()),
+            Err(e) => panic!("expected Ok(empty), got {e}"),
+        }
+    }
+
+    #[test]
+    fn resolve_plan_conflict_is_err() {
+        match resolve_plan(Plan::Conflict("boom".into())) {
+            Ok(_) => panic!("expected a Conflict to be an Err"),
+            Err(e) => assert!(e.to_string().contains("boom")),
+        }
+    }
+
+    // --- run_each --------------------------------------------------------------
+
+    #[test]
+    fn run_each_all_ok_returns_ok() {
+        let n = std::cell::Cell::new(0);
+        run_each(&[&FAKE, &FAKE2], "install", |_| {
+            n.set(n.get() + 1);
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(n.get(), 2, "op ran for each target");
+    }
+
+    #[test]
+    fn run_each_reports_failed_count_and_bails() {
+        let err = run_each(&[&FAKE, &FAKE2], "install", |_| anyhow::bail!("kaboom")).unwrap_err();
+        assert!(
+            err.to_string().contains("2 of 2 target(s) failed"),
+            "got: {err}"
+        );
+    }
+
+    // --- needs_confirm / confirm_targets format -------------------------------
+
+    #[test]
+    fn needs_confirm_only_multi_target_interactive_no_yes() {
+        assert!(needs_confirm(2, false, true));
+        assert!(!needs_confirm(1, false, true)); // single target
+        assert!(!needs_confirm(2, true, true)); // --yes
+        assert!(!needs_confirm(2, false, false)); // non-tty
+    }
+
+    // --- has_hooks arms --------------------------------------------------------
+
+    #[test]
+    fn has_hooks_empty_config_is_false() {
+        // FAKE's default_config_path is /nonexistent/fake → read_config returns
+        // Ok("") (the missing-file early return), hitting the empty arm → false.
+        assert!(!has_hooks(&FAKE));
+    }
+
+    #[test]
+    fn has_hooks_unreadable_config_is_true() {
+        // FAKE_DIR points at a path we create as a DIRECTORY: it exists, so
+        // read_config tries File::open + read_to_string which errors → Err arm.
+        let dir = fake_dir_config_path();
+        let _ = std::fs::remove_file(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        assert!(has_hooks(&FAKE_DIR));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn has_hooks_changed_vs_unchanged_arms() {
+        let path = fake2_config_path();
+        // Non-empty content → FAKE2.merge_uninstall reports changed=true → true.
+        std::fs::write(&path, "model = \"x\"\n").unwrap();
+        assert!(has_hooks(&FAKE2));
+        // Whitespace-only content → read_config returns it, but it trims to empty
+        // → the `c.trim().is_empty()` empty arm → false (changed arm not reached).
+        std::fs::write(&path, "   \n").unwrap();
+        assert!(!has_hooks(&FAKE2));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    // --- run_interactive 0/1-candidate arms (no TTY needed) -------------------
+
+    #[test]
+    fn run_interactive_zero_candidates_prints_and_skips_op() {
+        let ran = std::cell::Cell::new(false);
+        run_interactive(vec![], "nothing here", "prompt", "install", |_| {
+            ran.set(true);
+            Ok(())
+        })
+        .unwrap();
+        assert!(!ran.get(), "op must NOT run when there are no candidates");
+    }
+
+    #[test]
+    fn run_interactive_single_candidate_runs_op_once() {
+        let count = std::cell::Cell::new(0);
+        run_interactive(vec![&FAKE], "nothing here", "prompt", "install", |_| {
+            count.set(count.get() + 1);
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(
+            count.get(),
+            1,
+            "single candidate acts directly, no checklist"
+        );
+    }
+
+    // --- run_install: FAKE up-to-date + CLAUDE sentinel write + backup --------
+
+    #[test]
+    fn run_install_fake_target_is_up_to_date_noop() {
+        // FAKE.merge_install reports changed=false → the up-to-date branch (no
+        // write, no backup). needs_path_warning=false avoids any PATH coupling.
+        run_install(&FAKE, Some(PathBuf::from("/nonexistent/fake")), None).unwrap();
+    }
+
+    #[test]
+    fn run_install_claude_writes_sentinel_and_backs_up() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let cfg = tmp.path().join("settings.json");
+        std::fs::write(&cfg, "{}\n").unwrap(); // existing content → triggers a backup
+
+        // Explicit hook_path short-circuits resolution (no host PATH dependency).
+        run_install(
+            &CLAUDE,
+            Some(cfg.clone()),
+            Some(PathBuf::from("/fake/pixtuoid-hook")),
+        )
+        .unwrap();
+
+        let v: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&cfg).unwrap()).unwrap();
+        assert!(v["hooks"]["PreToolUse"][0]["_pixtuoid"].as_bool().unwrap());
+        assert!(
+            tmp.path().join("settings.json.pixtuoid.bak").exists(),
+            "a backup of the prior content was written"
+        );
+
+        // Second install is a semantic no-op → already-up-to-date branch.
+        run_install(
+            &CLAUDE,
+            Some(cfg.clone()),
+            Some(PathBuf::from("/fake/pixtuoid-hook")),
+        )
+        .unwrap();
+    }
+
+    // --- run_uninstall: FAKE2 changed-path write + remove-backup --------------
+
+    #[test]
+    fn run_uninstall_fake2_changed_writes_and_removes_backup() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let cfg = tmp.path().join("config.toml");
+        std::fs::write(&cfg, "model = \"x\"\n").unwrap(); // non-empty → changed=true
+        let bak = tmp.path().join("config.toml.pixtuoid.bak");
+        std::fs::write(&bak, "backup").unwrap();
+
+        run_uninstall(&FAKE2, Some(cfg.clone())).unwrap();
+
+        assert!(
+            !bak.exists(),
+            "the backup is removed on a changing uninstall"
+        );
+    }
+
+    #[test]
+    fn run_uninstall_fake_unchanged_is_noop() {
+        // FAKE.merge_uninstall reports changed=false → the semantic no-op branch.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let cfg = tmp.path().join("config.toml");
+        std::fs::write(&cfg, "anything\n").unwrap();
+        let bak = tmp.path().join("config.toml.pixtuoid.bak");
+        std::fs::write(&bak, "backup").unwrap();
+
+        run_uninstall(&FAKE, Some(cfg.clone())).unwrap();
+
+        assert!(bak.exists(), "a no-op uninstall must NOT delete the backup");
     }
 }

--- a/crates/pixtuoid/src/install/mod.rs
+++ b/crates/pixtuoid/src/install/mod.rs
@@ -445,15 +445,17 @@ mod tests {
         post_install_note: None,
     };
 
-    // A fixed config path under the system temp dir, used by FAKE2/FAKE_DIR so
-    // their fn-pointer `default_config_path` can point at a test-controlled file
-    // (the fn signature `fn() -> PathBuf` can't capture a TempDir).
+    // A per-process config path under the system temp dir, used by FAKE2/FAKE_DIR
+    // so their fn-pointer `default_config_path` can point at a test-controlled
+    // file (the `fn() -> PathBuf` signature can't capture a TempDir). The PID
+    // suffix keeps two concurrent `cargo test` invocations of this binary from
+    // racing on the same fixed path.
     fn fake2_config_path() -> std::path::PathBuf {
-        std::env::temp_dir().join("pixtuoid-test-fake2-config.toml")
+        std::env::temp_dir().join(format!("pixtuoid-test-fake2-{}.toml", std::process::id()))
     }
 
     fn fake_dir_config_path() -> std::path::PathBuf {
-        std::env::temp_dir().join("pixtuoid-test-fake-dir-config")
+        std::env::temp_dir().join(format!("pixtuoid-test-fake-dir-{}", std::process::id()))
     }
 
     // FAKE2: default_config_path points at a test-writable file, and its

--- a/crates/pixtuoid/src/lib.rs
+++ b/crates/pixtuoid/src/lib.rs
@@ -10,3 +10,11 @@ pub mod runtime;
 pub mod tui;
 pub mod validate;
 pub mod version;
+
+/// Test-only mutex serializing tests that mutate process-global environment
+/// variables (`HOME` / `XDG_CONFIG_HOME` / …). The crate's unit tests share one
+/// test binary, so two env-mutating tests can otherwise race under plain
+/// `cargo test` (nextest isolates per-process, but the `justfile` falls back to
+/// `cargo test` when nextest is absent). Lock it for the whole test.
+#[cfg(test)]
+pub(crate) static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());

--- a/crates/pixtuoid/src/runtime.rs
+++ b/crates/pixtuoid/src/runtime.rs
@@ -351,6 +351,89 @@ mod tests {
     // fetch_max only, so an over-seed (the old `[cap; MAX_FLOORS]` path) strands
     // agents on non-existent desks on small terminals until the terminal grows.
     #[test]
+    fn summarize_reports_each_activity_state() {
+        use pixtuoid_core::source::{Activity, AgentEvent};
+        use pixtuoid_core::AgentId;
+
+        let mut scene = SceneState::new([8; MAX_FLOORS]);
+        let mut reducer = Reducer::new();
+        let now = SystemTime::now();
+
+        let seat = |reducer: &mut Reducer, scene: &mut SceneState, id: AgentId| {
+            reducer.apply(
+                scene,
+                AgentEvent::SessionStart {
+                    agent_id: id,
+                    source: "claude-code".into(),
+                    session_id: "s".into(),
+                    cwd: std::path::PathBuf::from("/repo"),
+                    parent_id: None,
+                },
+                now,
+                Transport::Hook,
+            );
+        };
+
+        // Agent A: active with a detail.
+        let a = AgentId::from_transcript_path("/p/a.jsonl");
+        seat(&mut reducer, &mut scene, a);
+        reducer.apply(
+            &mut scene,
+            AgentEvent::ActivityStart {
+                agent_id: a,
+                activity: Activity::Typing,
+                tool_use_id: Some("t1".into()),
+                detail: Some("Edit: foo.rs".into()),
+            },
+            now,
+            Transport::Hook,
+        );
+
+        // Agent B: waiting on a permission prompt.
+        let b = AgentId::from_transcript_path("/p/b.jsonl");
+        seat(&mut reducer, &mut scene, b);
+        reducer.apply(
+            &mut scene,
+            AgentEvent::Waiting {
+                agent_id: b,
+                reason: "permission".into(),
+            },
+            now,
+            Transport::Hook,
+        );
+
+        // Agent C: bare SessionStart → idle.
+        let c = AgentId::from_transcript_path("/p/c.jsonl");
+        seat(&mut reducer, &mut scene, c);
+
+        let summary = summarize(&scene);
+        assert!(summary.starts_with("agents=["), "got: {summary}");
+        assert!(summary.contains("active(Edit: foo.rs)"), "got: {summary}");
+        assert!(summary.contains("waiting(permission)"), "got: {summary}");
+        assert!(summary.contains(":idle"), "got: {summary}");
+        // The "@desk_index" format is present for each agent.
+        assert!(summary.contains('@'), "got: {summary}");
+    }
+
+    #[test]
+    fn run_with_unknown_theme_errors_before_runtime() {
+        // The theme is resolved synchronously before any tokio runtime / socket is
+        // built, so an unknown name returns Err without touching async machinery.
+        let cfg = RunConfig {
+            socket: None,
+            projects_root: None,
+            codex_sessions_root: None,
+            pack_dir: None,
+            desk_cap: None,
+            headless: true,
+            config_path: std::path::PathBuf::from("/tmp/pixtuoid-test-config.toml"),
+            pets: vec![],
+        };
+        let err = run(cfg, "definitely-not-a-theme".into()).unwrap_err();
+        assert!(err.to_string().contains("unknown theme"), "got: {err}");
+    }
+
+    #[test]
     fn explicit_cap_clamps_to_layout_capacity_not_above() {
         let base = boot_capacities_for(192, 48);
         let layout_max = *base.iter().max().unwrap();

--- a/crates/pixtuoid/src/tui/anim.rs
+++ b/crates/pixtuoid/src/tui/anim.rs
@@ -157,6 +157,21 @@ mod tests {
     }
 
     #[test]
+    fn eased_progress_zero_duration_is_complete() {
+        // A zero-length animation reads as instantly complete (raw = 1.0),
+        // never divides by zero — covers the `duration_ms == 0` guard.
+        let start = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+        assert!(approx_eq(
+            eased_progress(start, 0, Easing::Linear, start),
+            1.0
+        ));
+        assert!(approx_eq(
+            eased_progress(start, 0, Easing::EaseOutCubic, start),
+            1.0
+        ));
+    }
+
+    #[test]
     fn eased_progress_applies_curve() {
         let start = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
         let now = start + Duration::from_millis(100);

--- a/crates/pixtuoid/src/tui/chitchat.rs
+++ b/crates/pixtuoid/src/tui/chitchat.rs
@@ -363,6 +363,15 @@ mod tests {
     }
 
     #[test]
+    fn empty_participants_yields_no_bubble() {
+        // The participants.is_empty() short-circuit in current_bubble: a venue
+        // with no attendees never speaks even at turn 0.
+        let start = base_time();
+        let chat = ActiveChitchat::new(vk(0), vec![], start);
+        assert!(chat.current_bubble(start).is_none());
+    }
+
+    #[test]
     fn no_bubble_after_four_turns() {
         let start = base_time();
         let chat = ActiveChitchat::new(vk(0), vec![aid("/a"), aid("/b")], start);

--- a/crates/pixtuoid/src/tui/embedded_pack.rs
+++ b/crates/pixtuoid/src/tui/embedded_pack.rs
@@ -215,11 +215,15 @@ mod tests {
         );
     }
 
-    // The XDG path mutates a process-global env var, so all of its assertions
-    // run inside ONE test (sequential) — no other test in the crate touches
-    // XDG_CONFIG_HOME, so this is race-free without serial_test.
+    // The XDG path mutates a process-global env var. The TEST_ENV_LOCK
+    // serializes this against the crate's other env-mutating test
+    // (config::config_path_xdg_home_and_relative_branches, which also sets
+    // XDG_CONFIG_HOME) so the two can't race under plain `cargo test`.
     #[test]
     fn load_sprite_pack_resolves_then_falls_back_via_xdg() {
+        let _env = crate::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let saved = std::env::var_os("XDG_CONFIG_HOME");
 
         // (a) Valid XDG pack at $XDG/pixtuoid/sprites/ → loaded.

--- a/crates/pixtuoid/src/tui/embedded_pack.rs
+++ b/crates/pixtuoid/src/tui/embedded_pack.rs
@@ -169,6 +169,91 @@ fn load_embedded_pack() -> Result<Pack> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use std::path::Path;
+
+    /// Copy the skeleton pack (a valid, loadable character pack) into `dst`.
+    fn copy_skeleton_pack(dst: &Path) {
+        fs::create_dir_all(dst).expect("mkdir pack dir");
+        let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("sprites/skeleton");
+        for entry in fs::read_dir(&src).expect("read skeleton dir") {
+            let entry = entry.expect("dir entry");
+            let path = entry.path();
+            if path.is_file() {
+                let name = path.file_name().expect("file name");
+                fs::copy(&path, dst.join(name)).expect("copy pack file");
+            }
+        }
+    }
+
+    #[test]
+    fn load_sprite_pack_from_custom_dir_merges_with_embedded() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let pack_dir = tmp.path().join("custom");
+        copy_skeleton_pack(&pack_dir);
+
+        let pack = load_sprite_pack(Some(pack_dir)).expect("custom pack loads");
+        // The custom pack supplies character poses; furniture is merged from the
+        // embedded default, so both must be present.
+        assert!(
+            pack.animation("seated").is_some(),
+            "custom pack must carry the seated character pose"
+        );
+        assert!(
+            pack.animation("desk").is_some(),
+            "furniture merged from the embedded default"
+        );
+    }
+
+    #[test]
+    fn load_sprite_pack_from_missing_custom_dir_errors() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let missing = tmp.path().join("does-not-exist");
+        assert!(
+            load_sprite_pack(Some(missing)).is_err(),
+            "a nonexistent --pack-dir must surface a load error"
+        );
+    }
+
+    // The XDG path mutates a process-global env var, so all of its assertions
+    // run inside ONE test (sequential) — no other test in the crate touches
+    // XDG_CONFIG_HOME, so this is race-free without serial_test.
+    #[test]
+    fn load_sprite_pack_resolves_then_falls_back_via_xdg() {
+        let saved = std::env::var_os("XDG_CONFIG_HOME");
+
+        // (a) Valid XDG pack at $XDG/pixtuoid/sprites/ → loaded.
+        let good = tempfile::TempDir::new().expect("tempdir");
+        let good_sprites = good.path().join("pixtuoid").join("sprites");
+        copy_skeleton_pack(&good_sprites);
+        std::env::set_var("XDG_CONFIG_HOME", good.path());
+        let pack = load_sprite_pack(None).expect("xdg pack loads");
+        assert!(
+            pack.animation("seated").is_some(),
+            "the valid XDG pack must be loaded (xdg Ok arm)"
+        );
+
+        // (b) Malformed pack.toml at the XDG path → warn + fall back to embedded.
+        let bad = tempfile::TempDir::new().expect("tempdir");
+        let bad_sprites = bad.path().join("pixtuoid").join("sprites");
+        fs::create_dir_all(&bad_sprites).expect("mkdir bad sprites");
+        fs::write(bad_sprites.join("pack.toml"), b"this is not valid toml {{{")
+            .expect("write malformed pack.toml");
+        std::env::set_var("XDG_CONFIG_HOME", bad.path());
+        // The malformed pack triggers the Err arm → falls back to embedded (Ok),
+        // which still carries the embedded character poses.
+        let fallback = load_sprite_pack(None).expect("malformed pack falls back, never errors");
+        assert!(
+            fallback.animation("seated").is_some(),
+            "fallback to the embedded default after a malformed user pack"
+        );
+
+        // Restore env for the rest of the suite.
+        match saved {
+            Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+            None => std::env::remove_var("XDG_CONFIG_HOME"),
+        }
+    }
 
     // The recolor invariant applies to EVERY palette key, not just the 4
     // recolor targets: recolor_frame matches by RGB equality, so two keys

--- a/crates/pixtuoid/src/tui/floor.rs
+++ b/crates/pixtuoid/src/tui/floor.rs
@@ -335,6 +335,36 @@ mod tests {
         );
     }
 
+    #[test]
+    fn floor_ctx_default_equals_new() {
+        // Both Default impls delegate to new(); pin the equivalence so a future
+        // field addition can't make `default()` diverge silently.
+        let d = FloorCtx::default();
+        assert_eq!(
+            d.door_anim_max_ms, 0,
+            "FloorCtx::default() must match new() (door_anim_max_ms == 0)"
+        );
+        assert!(
+            d.motion.is_empty(),
+            "default FloorCtx has no in-flight motion"
+        );
+    }
+
+    #[test]
+    fn lighting_state_default_equals_new() {
+        // LightingState::default() delegates to new() — both start fully lit.
+        assert_eq!(
+            LightingState::default().level(),
+            LightingState::new().level(),
+            "LightingState::default() must equal new()"
+        );
+        assert_eq!(
+            LightingState::default().level(),
+            1.0,
+            "a fresh LightingState is fully lit"
+        );
+    }
+
     fn make_scene(n: usize, max_desks: usize) -> SceneState {
         let mut s = SceneState::uniform(max_desks);
         let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);

--- a/crates/pixtuoid/src/tui/frame_cache.rs
+++ b/crates/pixtuoid/src/tui/frame_cache.rs
@@ -53,3 +53,46 @@ impl FrameCache {
         self.entries.is_empty()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dummy_frame() -> Frame {
+        Frame {
+            width: 1,
+            height: 1,
+            pixels: vec![None],
+        }
+    }
+
+    fn key() -> FrameKey {
+        FrameKey {
+            agent_id: AgentId::from_transcript_path("/fc/a.jsonl"),
+            anim_name: "standing",
+            frame_idx: 0,
+            flip_x: false,
+            glow_tint: None,
+        }
+    }
+
+    #[test]
+    fn new_cache_is_empty_then_populated_after_get_or_make() {
+        let mut cache = FrameCache::new();
+        assert!(cache.is_empty(), "fresh cache must be empty");
+        assert_eq!(cache.len(), 0);
+
+        let _ = cache.get_or_make(key(), dummy_frame);
+        assert!(!cache.is_empty(), "cache must be non-empty after a make");
+        assert_eq!(cache.len(), 1);
+
+        // A second get_or_make for the SAME key must reuse, not grow the cache.
+        let mut computed_again = false;
+        let _ = cache.get_or_make(key(), || {
+            computed_again = true;
+            dummy_frame()
+        });
+        assert!(!computed_again, "cached key must not recompute");
+        assert_eq!(cache.len(), 1);
+    }
+}

--- a/crates/pixtuoid/src/tui/hit_test.rs
+++ b/crates/pixtuoid/src/tui/hit_test.rs
@@ -158,9 +158,12 @@ pub fn hit_test_furniture(layout: &Layout, mx: u16, my: u16) -> Option<&'static 
                 WaypointKind::StandingDesk => "Standing Desk",
                 WaypointKind::VendingMachine => "Vending Machine",
                 WaypointKind::Printer => "Printer",
-                // Unreachable: couch + meeting slots `continue` above.
+                // Proven unreachable today (couch + meeting slots `continue`
+                // above), but this is a per-frame mouse path: skip an unexpected
+                // kind rather than panic the whole TUI if a future refactor adds
+                // a WaypointKind or drops one of those earlier `continue`s.
                 WaypointKind::Couch | WaypointKind::MeetingSofa | WaypointKind::MeetingStand => {
-                    unreachable!()
+                    continue
                 }
             });
         }
@@ -454,6 +457,101 @@ mod tests {
         let pos = Point { x: 50, y: 80 };
         // Way outside the 6x6 sprite.
         assert!(!hit_test_pet(PetKind::Cat, pos, "cat_sit", 10, 10));
+    }
+
+    // --- hit_test_from_tui (click-to-pin, home-desk-only) -----------------
+
+    fn scene_with_agent_at_desk(desk_index: usize) -> (SceneState, AgentId) {
+        use pixtuoid_core::state::{ActivityState, AgentSlot};
+        use std::path::Path;
+        use std::sync::Arc;
+        let id = AgentId::from_transcript_path("/pin/0.jsonl");
+        let slot = AgentSlot {
+            agent_id: id,
+            source: Arc::from("cc"),
+            session_id: Arc::from("s"),
+            cwd: Arc::from(Path::new("/repo")),
+            label: Arc::from("a"),
+            state: ActivityState::Idle,
+            state_started_at: SystemTime::UNIX_EPOCH,
+            created_at: SystemTime::UNIX_EPOCH,
+            last_event_at: SystemTime::UNIX_EPOCH,
+            exiting_at: None,
+            pending_idle_at: None,
+            desk_index,
+            floor_idx: 0,
+            tool_call_count: 0,
+            active_ms: 0,
+            unknown_cwd: false,
+            parent_id: None,
+        };
+        let mut scene = SceneState::uniform(16);
+        scene.agents.insert(id, slot);
+        (scene, id)
+    }
+
+    #[test]
+    fn from_tui_hits_agent_at_its_desk_anchor() {
+        let layout = Layout::compute(160, 200, 4).expect("layout");
+        let (scene, id) = scene_with_agent_at_desk(0);
+        let d = layout.home_desks[0];
+        // Mirror hit_test_from_tui's own anchor geometry.
+        let cx = d.x + 1;
+        let cy = d.y.saturating_sub(4) / 2;
+        assert_eq!(hit_test_from_tui(&scene, &layout, cx, cy), Some(id));
+    }
+
+    #[test]
+    fn from_tui_misses_empty_space() {
+        let layout = Layout::compute(160, 200, 4).expect("layout");
+        let (scene, _id) = scene_with_agent_at_desk(0);
+        assert_eq!(hit_test_from_tui(&scene, &layout, 0, 0), None);
+    }
+
+    #[test]
+    fn from_tui_skips_agent_with_out_of_range_desk() {
+        let layout = Layout::compute(160, 200, 4).expect("layout");
+        // desk_index past the layout's home-desk count ⇒ `continue` arm.
+        let (scene, _id) = scene_with_agent_at_desk(layout.home_desks.len() + 100);
+        // No agent occupies any cell — scan a few and confirm None everywhere.
+        for &(mx, my) in &[(0u16, 0u16), (40, 20), (80, 40)] {
+            assert_eq!(hit_test_from_tui(&scene, &layout, mx, my), None);
+        }
+    }
+
+    // --- hit_test_furniture: kinds the compute path never emits -------------
+    // compute_with_seed never produces PlantKind::Ficus or WallDecor::Bulletin
+    // Board, so the harness real-layout loop can't reach those two return arms.
+    // Push them into the pub Vecs of a computed layout and hit their centers.
+
+    #[test]
+    fn furniture_hit_test_ficus_via_synthetic_plant() {
+        use crate::tui::layout::Point;
+        let mut layout = Layout::compute(160, 200, 4).expect("layout");
+        let pos = Point { x: 40, y: 40 };
+        layout.plants.push(crate::tui::layout::PlantItem {
+            kind: crate::tui::layout::PlantKind::Ficus,
+            pos,
+        });
+        // Plants are center-anchored on `pos`; hover the center cell.
+        assert_eq!(hit_test_furniture(&layout, pos.x, pos.y / 2), Some("Ficus"));
+    }
+
+    #[test]
+    fn furniture_hit_test_bulletin_board_via_synthetic_wall_decor() {
+        use crate::tui::layout::Point;
+        let mut layout = Layout::compute(160, 200, 4).expect("layout");
+        // Wall decor is TOP-LEFT anchored at `pos` (not centered). Place it in
+        // open space so no earlier furniture arm shadows it.
+        let pos = Point { x: 60, y: 30 };
+        layout.wall_decor.push(crate::tui::layout::WallDecorItem {
+            kind: crate::tui::layout::WallDecor::BulletinBoard,
+            pos,
+        });
+        assert_eq!(
+            hit_test_furniture(&layout, pos.x, pos.y / 2),
+            Some("Bulletin Board")
+        );
     }
 
     #[test]

--- a/crates/pixtuoid/src/tui/layout.rs
+++ b/crates/pixtuoid/src/tui/layout.rs
@@ -13,14 +13,3 @@ pub use pixtuoid_core::layout::{
 
 /// Backwards-compat alias — existing call sites construct `Layout::compute()`.
 pub type Layout = SceneLayout;
-
-/// Convert a core `Bounds` to a ratatui `Rect` for widget rendering. Same
-/// shape, just a different type to keep the core crate free of ratatui.
-pub fn bounds_to_rect(b: Bounds) -> ratatui::layout::Rect {
-    ratatui::layout::Rect {
-        x: b.x,
-        y: b.y,
-        width: b.width,
-        height: b.height,
-    }
-}

--- a/crates/pixtuoid/src/tui/motion/mod.rs
+++ b/crates/pixtuoid/src/tui/motion/mod.rs
@@ -447,8 +447,6 @@ fn pick_wander_dest(
             origin,
             &layout.reachable,
         );
-        // Seat foot cell `S`: the walk SETTLES from `dest` onto it (the sprite
-        // renders here). `None` for obstacles — the agent stands AT `dest`.
         // NO approach-side fallback: when no allowed+reachable side exists,
         // approach_point returns the blocked `wp.pos` sentinel (a seat boxed in to
         // only its backrest, or an obstacle with no open reachable side). Never
@@ -465,8 +463,6 @@ fn pick_wander_dest(
     }
 }
 
-/// Sum of octile distances along a routed polyline.
-///
 /// Snapshot the WanderBack `WalkProfile`: route `wander_dest → desk approach
 /// cell`, add the seat-rise (`settle_len(wander_dest, wander_seat)`) and the
 /// chair-glide settle, then freeze a `WanderBack` profile over that full

--- a/crates/pixtuoid/src/tui/motion/tests.rs
+++ b/crates/pixtuoid/src/tui/motion/tests.rs
@@ -951,3 +951,184 @@ fn wander_dest_for_pantry_is_the_home_desk_stand_point() {
         "motion dest must equal the home-desk approach_point (core↔tui mirror)"
     );
 }
+
+// -----------------------------------------------------------------------
+// Missing-profile recover: a WalkingOut / WalkingBack phase with a
+// `wander_profile == None` is "shouldn't happen", but the convention is to
+// warn + recover (never freeze silently). Drive that arm directly by
+// pre-inserting a corrupt MotionState and asserting advance_wander returns
+// `(phase, 0)` without panicking.
+// -----------------------------------------------------------------------
+
+/// Insert a MotionState already in `phase` with NO walk profile, anchored so
+/// the bootstrap/stale-resume re-seed does NOT fire (phase clock at `now`,
+/// last_advanced just before `now`, slot Idle well before that).
+fn corrupt_walking_state(
+    motion: &mut HashMap<AgentId, MotionState>,
+    id: AgentId,
+    now: SystemTime,
+    phase: WanderPhase,
+) {
+    let mut ms = MotionState::new(id);
+    ms.wander_phase = phase;
+    ms.wander_profile = None;
+    ms.wander_phase_started_at = now;
+    ms.last_advanced_at = now - Duration::from_millis(33);
+    motion.insert(id, ms);
+}
+
+#[test]
+fn walking_out_missing_profile_recovers_without_panic() {
+    let now = t0();
+    let slot = idle_slot("/p/recover_out.jsonl", now - Duration::from_secs(90));
+    let l = layout();
+    let overlay = OccupancyOverlay::new();
+    let mut router = Straight;
+    let mut motion: HashMap<AgentId, MotionState> = HashMap::new();
+    corrupt_walking_state(&mut motion, slot.agent_id, now, WanderPhase::WalkingOut);
+
+    let (phase, t) = advance_wander(&slot, now, &l, &mut router, &overlay, &mut motion);
+
+    assert_eq!(
+        phase,
+        WanderPhase::WalkingOut,
+        "must recover, staying WalkingOut"
+    );
+    assert_eq!(t, 0, "missing-profile recover returns t_x1000 == 0");
+}
+
+#[test]
+fn walking_back_missing_profile_recovers_without_panic() {
+    let now = t0();
+    let slot = idle_slot("/p/recover_back.jsonl", now - Duration::from_secs(90));
+    let l = layout();
+    let overlay = OccupancyOverlay::new();
+    let mut router = Straight;
+    let mut motion: HashMap<AgentId, MotionState> = HashMap::new();
+    corrupt_walking_state(&mut motion, slot.agent_id, now, WanderPhase::WalkingBack);
+
+    let (phase, t) = advance_wander(&slot, now, &l, &mut router, &overlay, &mut motion);
+
+    assert_eq!(
+        phase,
+        WanderPhase::WalkingBack,
+        "must recover, staying WalkingBack"
+    );
+    assert_eq!(t, 0, "missing-profile recover returns t_x1000 == 0");
+}
+
+// -----------------------------------------------------------------------
+// AtWaypoint re-snapshot fallback: the back profile is normally snapshotted
+// at WalkingOut arrival, but if it goes missing during the dwell the
+// AtWaypoint→WalkingBack transition re-snapshots it. Drive an agent to
+// AtWaypoint normally, NULL its profile, then advance past the dwell and
+// assert it transitions to WalkingBack with a fresh profile.
+// -----------------------------------------------------------------------
+#[test]
+fn at_waypoint_resnapshots_back_profile_when_missing() {
+    let trip_id = trip_agent("resnap");
+    let now = t0();
+    let slot = AgentSlot {
+        agent_id: trip_id,
+        ..idle_slot("/dummy", now)
+    };
+
+    let short_len: u32 = 200;
+    let l = layout();
+    let overlay = OccupancyOverlay::new();
+    let mut router = FixedLen {
+        octile_len: short_len,
+    };
+    let mut motion: HashMap<AgentId, MotionState> = HashMap::new();
+
+    advance_wander(&slot, now, &l, &mut router, &overlay, &mut motion);
+    let t1 = advance_until_leaves(
+        &slot,
+        &l,
+        &mut router,
+        &overlay,
+        &mut motion,
+        now,
+        WanderPhase::Seated,
+        60_000,
+    );
+    let t2 = advance_until_leaves(
+        &slot,
+        &l,
+        &mut router,
+        &overlay,
+        &mut motion,
+        t1,
+        WanderPhase::WalkingOut,
+        20_000,
+    );
+    assert!(matches!(
+        motion.get(&trip_id).unwrap().wander_phase,
+        WanderPhase::AtWaypoint
+    ));
+
+    // Simulate the back profile going missing during the dwell.
+    motion.get_mut(&trip_id).unwrap().wander_profile = None;
+
+    // Cross the per-spot dwell — the AtWaypoint arm must re-snapshot the back
+    // profile rather than freeze.
+    advance_until_leaves(
+        &slot,
+        &l,
+        &mut router,
+        &overlay,
+        &mut motion,
+        t2,
+        WanderPhase::AtWaypoint,
+        60_000,
+    );
+
+    let ms = motion.get(&trip_id).expect("state");
+    assert_eq!(
+        ms.wander_phase,
+        WanderPhase::WalkingBack,
+        "must transition to WalkingBack after the dwell"
+    );
+    assert!(
+        ms.wander_profile.is_some(),
+        "the back profile must be freshly re-snapshotted, not left None"
+    );
+}
+
+// -----------------------------------------------------------------------
+// pick_wander_dest aimless fallback: when approach_point returns the blocked
+// `wp.pos` "no valid approach" sentinel (no allowed+reachable side), the
+// directed-waypoint branch falls back to an aimless dest (kind None). Recipe:
+// take a real layout, block the ENTIRE walkable mask so NO approach side is
+// reachable for any waypoint, rebuild `reachable`, and drive a NON-aimless
+// cycle. `pick_wander_dest` (private; sibling has access) must return kind None.
+// -----------------------------------------------------------------------
+#[test]
+fn pick_wander_dest_falls_back_to_aimless_when_boxed_in() {
+    use pixtuoid_core::layout::ReachSet;
+
+    let mut l = layout();
+    assert!(!l.waypoints.is_empty(), "layout must have waypoints");
+    // Box EVERY waypoint in: block the whole mask so approach_point finds no
+    // allowed+reachable side for any waypoint and returns the `pos` sentinel.
+    l.walkable
+        .mark_blocked(0, 0, l.walkable.width, l.walkable.height, 0);
+    l.reachable = ReachSet::from_mask(&l.walkable, Point { x: 0, y: 0 });
+
+    // Find an agent whose cycle 0 is a directed (non-aimless) trip so we reach
+    // the `else` branch where approach_point is consulted.
+    let id = (0u64..2000)
+        .map(|i| AgentId::from_transcript_path(&format!("/p/boxed_{i}.jsonl")))
+        .find(|id| takes_trip(*id, 0) && !is_aimless_cycle(*id, 0))
+        .expect("should find a directed-trip agent");
+
+    let origin = l.home_desks[0];
+    let (_dest, kind, wp_idx, seat) = pick_wander_dest(id, 0, &l, origin);
+
+    assert_eq!(
+        kind, None,
+        "a boxed-in waypoint (no reachable approach side) must amble aimlessly"
+    );
+    assert_eq!(wp_idx, None, "aimless fallback carries no waypoint index");
+    assert_eq!(seat, None, "aimless fallback carries no seat cell");
+}

--- a/crates/pixtuoid/src/tui/pathfind.rs
+++ b/crates/pixtuoid/src/tui/pathfind.rs
@@ -891,4 +891,138 @@ mod tests {
             "open-floor snap walkable"
         );
     }
+
+    // ── Router accessor / trait-default coverage ───────────────────────────
+
+    /// A Router that does NOT override `set_preferred_zone`, so calling it hits
+    /// the trait DEFAULT no-op body (pathfind.rs:63-65).
+    struct NoZoneRouter;
+    impl Router for NoZoneRouter {
+        fn route(
+            &mut self,
+            _: &WalkableMask,
+            _: &OccupancyOverlay,
+            from: Point,
+            to: Point,
+        ) -> Vec<Point> {
+            vec![from, to]
+        }
+        fn invalidate(&mut self) {}
+        // set_preferred_zone intentionally NOT overridden.
+    }
+
+    #[test]
+    fn router_default_set_preferred_zone_is_a_noop() {
+        let mut r = NoZoneRouter;
+        // The default impl just drops the argument — calling it must not panic
+        // and must leave routing unchanged.
+        r.set_preferred_zone(Some(Bounds {
+            x: 0,
+            y: 0,
+            width: 8,
+            height: 8,
+        }));
+        r.set_preferred_zone(None);
+        assert_eq!(
+            r.route(
+                &WalkableMask::new_open(40, 40),
+                &OccupancyOverlay::new(),
+                Point { x: 0, y: 0 },
+                Point { x: 10, y: 0 },
+            ),
+            vec![Point { x: 0, y: 0 }, Point { x: 10, y: 0 }]
+        );
+    }
+
+    #[test]
+    fn astar_is_empty_then_invalidate_clears_cache() {
+        let mask = WalkableMask::new_open(80, 80);
+        let overlay = OccupancyOverlay::new();
+        let mut router = AStarRouter::new();
+        // Fresh router has an empty cache.
+        assert!(router.is_empty(), "fresh router cache must be empty");
+        assert_eq!(router.len(), 0);
+
+        // One route populates the cache.
+        let _ = router.route(
+            &mask,
+            &overlay,
+            Point { x: 4, y: 4 },
+            Point { x: 60, y: 60 },
+        );
+        assert!(!router.is_empty(), "cache must be non-empty after a route");
+        assert_ne!(router.len(), 0);
+
+        // invalidate() drops every cached path.
+        router.invalidate();
+        assert!(router.is_empty(), "invalidate must clear the cache");
+        assert_eq!(router.len(), 0);
+    }
+
+    // ── Degenerate sub-CELL_SIZE grid ──────────────────────────────────────
+
+    #[test]
+    fn degenerate_grid_returns_fallbacks() {
+        // A 3×3 mask: 3 / CELL_SIZE(4) == 0 on both axes ⇒ grid_dims None.
+        let mask = WalkableMask::new_open(3, 3);
+        let overlay = OccupancyOverlay::new();
+        let a = Point { x: 0, y: 0 };
+        let b = Point { x: 2, y: 2 };
+        // find_path hits the grid_dims-None early return ⇒ straight [a,b].
+        assert_eq!(
+            find_path(&mask, &overlay, None, a, b),
+            Some(vec![a, b]),
+            "degenerate grid must fall back to the straight [from,to]"
+        );
+        // point_in_walkable_cell hits its grid_dims-None branch ⇒ false.
+        assert!(
+            !point_in_walkable_cell(&mask, a),
+            "degenerate grid: no point is in a walkable cell"
+        );
+    }
+
+    #[test]
+    fn snap_to_walkable_skips_out_of_bounds_corner_neighbours() {
+        // Block the bottom-right CORNER cell so the expanding ring at r>=1 pokes
+        // PAST the grid's far edge (nx>=cell_w / ny>=cell_h), forcing the
+        // out-of-range `continue` (pathfind.rs:274) before it lands on an
+        // interior walkable cell. Must still return Some.
+        let mut mask = WalkableMask::new_open(40, 40); // 10×10 cells
+        let overlay = OccupancyOverlay::new();
+        let (cell_w, cell_h) = grid_dims(&mask).expect("non-degenerate");
+        // Block the corner cell (cell_w-1, cell_h-1) at the pixel level.
+        let corner_px = ((cell_w - 1) * CELL_SIZE, (cell_h - 1) * CELL_SIZE);
+        mask.mark_blocked(corner_px.0, corner_px.1, CELL_SIZE, CELL_SIZE, 0);
+
+        let result = snap_to_walkable(&mask, &overlay, (cell_w - 1, cell_h - 1), cell_w, cell_h);
+        assert!(
+            result.is_some(),
+            "snap from the corner must still find an interior walkable cell"
+        );
+    }
+
+    #[test]
+    fn find_path_none_when_two_regions_split_by_a_full_wall() {
+        // Two open regions split by a full-height blocked strip with NO door gap.
+        // `from`/`to` are each in open cells (snap succeeds) but the search
+        // exhausts the open set without reaching the goal ⇒ None AFTER the loop
+        // (pathfind.rs:356) — distinct from the goal-snap-fails None at 302.
+        let mut mask = WalkableMask::new_open(80, 40);
+        let overlay = OccupancyOverlay::new();
+        // Block x ∈ [36, 44) across the full height: 2 fully-blocked cell
+        // columns (cells 9,10) — impassable to the coarse diagonal stepper.
+        mask.mark_blocked(36, 0, 8, 40, 0);
+
+        let from = Point { x: 10, y: 20 }; // left region
+        let to = Point { x: 70, y: 20 }; // right region
+                                         // Sanity: both endpoints are in walkable cells, so snapping succeeds and
+                                         // the A* loop actually runs (start != goal).
+        assert!(point_in_walkable_cell(&mask, from));
+        assert!(point_in_walkable_cell(&mask, to));
+
+        assert!(
+            find_path(&mask, &overlay, None, from, to).is_none(),
+            "a wall with no gap must leave the two regions unconnected (loop exhausts → None)"
+        );
+    }
 }

--- a/crates/pixtuoid/src/tui/pixel_painter/ambient.rs
+++ b/crates/pixtuoid/src/tui/pixel_painter/ambient.rs
@@ -173,6 +173,11 @@ fn collect_ceiling_halos(
         let Some(desk) = ctx.layout.home_desks.get(agent.desk_index) else {
             continue;
         };
+        // `tool_glow_tint` only returns None for a non-Active state, but the
+        // `Active { detail: Some(_) }` guard above has already filtered to
+        // Active-with-detail agents — so this else arm is unreachable here
+        // (the `_ => glow.default` fallback always yields Some). Kept as a
+        // total binding; not a missing-coverage target.
         let Some(color) =
             crate::tui::pixel_painter::palette::tool_glow_tint(agent, &ctx.theme.tool_glow)
         else {
@@ -477,5 +482,149 @@ mod tests {
             "snow still throws a faint spot ({snow} vs {base})"
         );
         assert_eq!(rain, base, "rain has no direct beam → no sun spot");
+    }
+
+    // At the exact sun-up boundary (~05:30 / ~19:30 local) `sun_on_wall` returns
+    // an East/West spot whose `boundary_fade` is 0, so `spot.intensity == 0` and
+    // `effective_intensity` collapses to 0 even with a positive beam — the
+    // `effective_intensity <= 0.0` early-return must fire (NOT the earlier beam
+    // gate). Search days for a beam-bearing weather at that 10-min bucket, same
+    // pattern as the beam-strength test above.
+    #[test]
+    fn sun_spot_zero_intensity_at_hour_edge_leaves_buffer_untouched() {
+        use crate::tui::pixel_painter::background::Weather;
+        use chrono::TimeZone;
+        let theme = &crate::tui::theme::NORMAL;
+        let layout = crate::tui::layout::Layout::compute(192, 80, 4).expect("layout fits");
+        // 19:30 local → West-wall spot at the upper boundary (boundary_fade=0).
+        let dusk_edge = |day: u32| -> SystemTime {
+            chrono::Local
+                .with_ymd_and_hms(2026, 1, day, 19, 30, 0)
+                .single()
+                .unwrap()
+                .into()
+        };
+        // A beam-bearing weather (Clear/Windy/Snow/Smog/Fog) so the earlier
+        // `beam <= 0.0` gate is NOT what returns — it must be the intensity gate.
+        let beam_bearing = |w: Weather| {
+            matches!(
+                w,
+                Weather::Clear | Weather::Windy | Weather::Snow | Weather::Smog | Weather::Fog
+            )
+        };
+        let now = (1..=120u32)
+            .map(dusk_edge)
+            .find(|t| beam_bearing(weather_state(*t)))
+            .expect("a beam-bearing dusk-edge bucket exists");
+        // Precondition: the spot exists and its intensity is zero at this edge.
+        let spot = sun_on_wall(now).expect("sun is up at the boundary");
+        assert!(
+            !matches!(spot.wall, WallSide::South),
+            "19:30 must be a West-wall spot, not the South window"
+        );
+        assert_eq!(spot.intensity, 0.0, "boundary_fade=0 → zero intensity");
+
+        let fill = Rgb {
+            r: 20,
+            g: 20,
+            b: 24,
+        };
+        let mut buf = RgbBuffer::filled(192, 80, fill);
+        paint_sun_spot(&mut buf, theme, &layout, now);
+        for y in 0..buf.height {
+            for x in 0..buf.width {
+                assert_eq!(
+                    buf.get(x, y),
+                    fill,
+                    "zero-intensity sun spot must paint nothing"
+                );
+            }
+        }
+    }
+
+    // Dust motes and ceiling halos clamp per-pixel writes against the buffer
+    // bounds. A mote/halo positioned at the far edge of a tight buffer must hit
+    // the `>= buf.width || >= buf.height` continue without panicking (RgbBuffer
+    // has no internal bounds guard).
+    #[test]
+    fn ceiling_halo_near_edge_does_not_panic() {
+        let mut buf = RgbBuffer::filled(6, 4, Rgb { r: 0, g: 0, b: 0 });
+        let theme = &crate::tui::theme::CYBERPUNK; // Dark theme so halos paint.
+                                                   // Halo centred at the bottom-right corner: the 5×2 stamp runs off both
+                                                   // edges, exercising the clamp.
+        let halos = vec![CeilingHalo {
+            x: 5,
+            y: 0,
+            color: Rgb {
+                r: 0,
+                g: 200,
+                b: 255,
+            },
+            intensity: 0.8,
+        }];
+        paint_ceiling_halos(&mut buf, theme, &halos);
+    }
+
+    // Dust motes anchored to the layout's spill columns can land outside a
+    // buffer narrower/shorter than the layout, exercising the bounds `continue`.
+    // Render into a 1×1 buffer with a daytime beam-bearing `now` so the mote
+    // loop runs but every put is clamped.
+    #[test]
+    fn dust_motes_clamp_to_a_tiny_buffer() {
+        use chrono::TimeZone;
+        let theme = &crate::tui::theme::NORMAL;
+        let layout = crate::tui::layout::Layout::compute(192, 80, 4).expect("layout fits");
+        // 07:00 Clear morning → sun up + full beam.
+        let now = (1..=60u32)
+            .map(|day| -> SystemTime {
+                chrono::Local
+                    .with_ymd_and_hms(2026, 1, day, 7, 0, 0)
+                    .single()
+                    .unwrap()
+                    .into()
+            })
+            .find(|t| weather_state(*t) == crate::tui::pixel_painter::background::Weather::Clear)
+            .expect("a clear morning");
+        // Buffer far smaller than the layout's spill columns → every mote put is
+        // out of bounds and clamped. The assertion is simply "no panic".
+        let fill = Rgb { r: 0, g: 0, b: 0 };
+        let mut buf = RgbBuffer::filled(1, 1, fill);
+        paint_dust_motes(&mut buf, theme, &layout, 7, now);
+    }
+
+    // wall_band_h == 0 (a degenerate tiny top margin) makes paint_sun_spot
+    // early-return before any wall projection — must not panic / paint.
+    #[test]
+    fn sun_spot_zero_wall_band_returns_early() {
+        use chrono::TimeZone;
+        let theme = &crate::tui::theme::NORMAL;
+        // top_margin == WALL_BAND_TO_TOP_MARGIN → wall_band_h saturating_sub to 0.
+        let mut layout = crate::tui::layout::Layout::compute(192, 80, 4).expect("layout fits");
+        layout.top_margin = pixtuoid_core::layout::WALL_BAND_TO_TOP_MARGIN;
+        // 07:00 → East wall spot with a real beam under Clear, so execution
+        // reaches the wall_band_h==0 guard rather than an earlier return.
+        let clear_morning = (1..=60u32)
+            .map(|day| -> SystemTime {
+                chrono::Local
+                    .with_ymd_and_hms(2026, 1, day, 7, 0, 0)
+                    .single()
+                    .unwrap()
+                    .into()
+            })
+            .find(|t| weather_state(*t) == crate::tui::pixel_painter::background::Weather::Clear)
+            .expect("a clear morning");
+        let fill = Rgb {
+            r: 20,
+            g: 20,
+            b: 24,
+        };
+        let mut buf = RgbBuffer::filled(layout.buf_w, layout.buf_h, fill);
+        paint_sun_spot(&mut buf, theme, &layout, clear_morning);
+        // wall_band_h == 0 → nothing painted.
+        for y in 0..buf.height {
+            for x in 0..buf.width {
+                assert_eq!(buf.get(x, y), fill, "zero wall band → no sun spot");
+            }
+        }
     }
 }

--- a/crates/pixtuoid/src/tui/pixel_painter/background/lighting.rs
+++ b/crates/pixtuoid/src/tui/pixel_painter/background/lighting.rs
@@ -266,3 +266,99 @@ pub(in crate::tui::pixel_painter) fn paint_shadow(
 ) {
     paint_ellipse_blend(buf, ellipse, strength, theme.office.shadow);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A degenerate ellipse (half_w == 0) or zero strength must early-return and
+    // leave the buffer untouched — the guard at the top of paint_ellipse_blend.
+    #[test]
+    fn ellipse_blend_degenerate_is_a_noop() {
+        let theme = &crate::tui::theme::NORMAL;
+        let fill = Rgb {
+            r: 30,
+            g: 30,
+            b: 30,
+        };
+        // half_w == 0.
+        let mut buf = RgbBuffer::filled(20, 20, fill);
+        paint_ellipse_blend(
+            &mut buf,
+            Ellipse {
+                cx: 10,
+                cy: 10,
+                half_w: 0,
+                half_h: 5,
+            },
+            0.8,
+            theme.lighting.ceiling_pool,
+        );
+        for y in 0..buf.height {
+            for x in 0..buf.width {
+                assert_eq!(buf.get(x, y), fill, "half_w==0 must paint nothing");
+            }
+        }
+        // strength <= 0.
+        let mut buf = RgbBuffer::filled(20, 20, fill);
+        paint_ellipse_blend(
+            &mut buf,
+            Ellipse {
+                cx: 10,
+                cy: 10,
+                half_w: 5,
+                half_h: 5,
+            },
+            0.0,
+            theme.lighting.ceiling_pool,
+        );
+        for y in 0..buf.height {
+            for x in 0..buf.width {
+                assert_eq!(buf.get(x, y), fill, "strength<=0 must paint nothing");
+            }
+        }
+    }
+
+    // A non-degenerate ellipse fully inside the buffer DOES paint, so the
+    // degenerate test above isn't passing vacuously.
+    #[test]
+    fn ellipse_blend_paints_when_valid() {
+        let theme = &crate::tui::theme::NORMAL;
+        let fill = Rgb {
+            r: 30,
+            g: 30,
+            b: 30,
+        };
+        let mut buf = RgbBuffer::filled(20, 20, fill);
+        paint_ellipse_blend(
+            &mut buf,
+            Ellipse {
+                cx: 10,
+                cy: 10,
+                half_w: 5,
+                half_h: 5,
+            },
+            0.9,
+            theme.lighting.ceiling_pool,
+        );
+        assert_ne!(buf.get(10, 10), fill, "the ellipse centre must be tinted");
+    }
+
+    // paint_neon_panel clamps per-pixel writes against the buffer edge — a panel
+    // positioned so its width runs off the right edge must hit the `continue`
+    // without panicking (RgbBuffer::put has no internal bounds guard).
+    #[test]
+    fn neon_panel_off_edge_does_not_panic() {
+        let theme = &crate::tui::theme::NORMAL;
+        let now = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(5);
+        let mut buf = RgbBuffer::filled(10, 10, Rgb { r: 0, g: 0, b: 0 });
+        // x=8, w=6 → px reaches 13 (>= width 10); y=8, h=5 → py reaches 12.
+        paint_neon_panel(&mut buf, 8, 8, 6, 5, now, theme);
+        // In-bounds border pixel still painted (panel frame at the origin corner).
+        assert_ne!(
+            buf.get(8, 8),
+            Rgb { r: 0, g: 0, b: 0 },
+            "in-bounds frame paints"
+        );
+    }
+}

--- a/crates/pixtuoid/src/tui/pixel_painter/background/mod.rs
+++ b/crates/pixtuoid/src/tui/pixel_painter/background/mod.rs
@@ -600,14 +600,21 @@ fn paint_floor_to_ceiling_window(
                     let py = glass_y0 + ((phase as u16 + dy) % gh);
                     if px < buf.width && py < buf.height {
                         let alpha = 0.6 - (dy as f32 / len as f32) * 0.3;
+                        let cur = buf.get(px, py);
+                        // Storm streak keeps its distinct cool-blue target (b:245)
+                        // vs Rain's b:240; one buf.get, same idiom as the Rain arm.
                         buf.put(
                             px,
                             py,
-                            Rgb {
-                                r: blend(buf.get(px, py).r, 210, alpha),
-                                g: blend(buf.get(px, py).g, 220, alpha),
-                                b: blend(buf.get(px, py).b, 245, alpha),
-                            },
+                            blend_rgb(
+                                cur,
+                                Rgb {
+                                    r: 210,
+                                    g: 220,
+                                    b: 245,
+                                },
+                                alpha,
+                            ),
                         );
                     }
                 }
@@ -968,5 +975,104 @@ mod tests {
         assert!(offsets
             .iter()
             .all(|&o| o < LIGHTNING_PERIOD_MS - LIGHTNING_FLASH_MS));
+    }
+
+    // The Storm window arm paints rain streaks plus a bright on-glass bolt that
+    // fires only inside the ~90 ms lightning flash. Drive the painter directly
+    // with Weather::Storm at a `now` inside a low-offset strike window (same
+    // technique as lightning_flash_storm_only) and assert the glass interior is
+    // markedly brighter than the same window painted one second later (no flash).
+    #[test]
+    fn storm_window_bolt_brightens_glass_during_the_flash() {
+        use std::time::{Duration, UNIX_EPOCH};
+        let bucket = (0u64..)
+            .find(|&b| strike_offset(b) < 500)
+            .expect("a low-offset bucket exists");
+        let off = strike_offset(bucket);
+        let at = |ms: u64| UNIX_EPOCH + Duration::from_millis(bucket * LIGHTNING_PERIOD_MS + ms);
+        // Sanity: the chosen instant has a positive flash level, the next-second
+        // probe does not — so the only difference between the two renders is the
+        // bolt block.
+        assert!(
+            lightning_flash_level(at(off)) > 0.0,
+            "flash at strike offset"
+        );
+        assert_eq!(
+            lightning_flash_level(at(off + 1000)),
+            0.0,
+            "quiet 1 s later"
+        );
+
+        let theme = crate::tui::theme::theme_by_name("normal").expect("theme");
+        let render_lum = |now: SystemTime| -> u64 {
+            let look = time_of_day_look(now, theme);
+            let mut buf = RgbBuffer::filled(40, 40, Rgb { r: 8, g: 8, b: 10 });
+            paint_floor_to_ceiling_window(
+                &mut buf,
+                0,
+                0,
+                WINDOW_W,
+                30,
+                theme.surface.window_frame,
+                &look,
+                0,
+                now,
+                theme,
+                Weather::Storm,
+                0.0,
+            );
+            // Sum luminance over the glass interior (inside the 1px frame).
+            let mut sum = 0u64;
+            for y in 1..29u16 {
+                for x in 1..(WINDOW_W - 1) {
+                    let p = buf.get(x, y);
+                    sum += p.r as u64 + p.g as u64 + p.b as u64;
+                }
+            }
+            sum
+        };
+        let flashing = render_lum(at(off));
+        let quiet = render_lum(at(off + 1000));
+        assert!(
+            flashing > quiet,
+            "the on-glass bolt must brighten the storm glass during the flash \
+             (flash={flashing}, quiet={quiet})"
+        );
+    }
+
+    // The spill/window bounds clamps: a buffer barely taller than the wall band
+    // forces the window-light spill trapezoid AND the floor-to-ceiling window to
+    // run off the bottom edge, exercising the `break` / `continue` guards. The
+    // render must not panic and the in-bounds rows must still paint.
+    #[test]
+    fn short_buffer_clamps_spill_and_window_without_panic() {
+        let theme = crate::tui::theme::theme_by_name("normal").expect("theme");
+        let top_wall_h = 18u16;
+        // buf_h sits just above top_wall_h so the spill (SPILL_DEPTH rows below
+        // the wall band) and the window glass both straddle the bottom edge.
+        let buf_h = top_wall_h + 2;
+        let buf_w = 60u16;
+        let now = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(12 * 3600);
+        // Construct the look directly with a positive spill so the spill path
+        // runs regardless of the local clock.
+        let look = TimeOfDayLook {
+            glass_a: theme.office.building_light,
+            glass_b: theme.office.building_dark,
+            spill_strength: 0.8,
+            spill_slant: 0.0,
+            darkness: 0.2,
+            twilight: 0.0,
+        };
+        let mut buf = RgbBuffer::filled(buf_w, buf_h, Rgb { r: 5, g: 5, b: 5 });
+        paint_floor_and_walls(
+            &mut buf, buf_w, buf_h, now, &look, top_wall_h, None, theme, 0.0,
+        );
+        // No panic reaching here is the primary assertion (RgbBuffer::put has no
+        // bounds guard). The wall band's in-bounds rows must still be painted.
+        assert_ne!(
+            buf.get(0, 0),
+            Rgb { r: 5, g: 5, b: 5 },
+            "the wall band should still paint in the in-bounds rows"
+        );
     }
 }

--- a/crates/pixtuoid/src/tui/pixel_painter/debug_overlay.rs
+++ b/crates/pixtuoid/src/tui/pixel_painter/debug_overlay.rs
@@ -340,4 +340,84 @@ mod tests {
             "at least one allowed, reachable desk approach cell must be tinted green"
         );
     }
+
+    fn slot(id: AgentId) -> pixtuoid_core::AgentSlot {
+        use pixtuoid_core::state::ActivityState;
+        use std::path::PathBuf;
+        use std::sync::Arc;
+        use std::time::SystemTime;
+        let now = SystemTime::UNIX_EPOCH;
+        pixtuoid_core::AgentSlot {
+            agent_id: id,
+            source: Arc::from("claude-code"),
+            session_id: Arc::from("s"),
+            cwd: Arc::from(PathBuf::from("/x").as_path()),
+            label: Arc::from("x"),
+            state: ActivityState::Idle,
+            state_started_at: now,
+            created_at: now,
+            last_event_at: now,
+            exiting_at: None,
+            pending_idle_at: None,
+            desk_index: 0,
+            floor_idx: 0,
+            tool_call_count: 0,
+            active_ms: 0,
+            unknown_cwd: false,
+            parent_id: None,
+        }
+    }
+
+    // paint_routes skips an agent absent from the motion map (187) and one whose
+    // MotionState has no frozen walk_path (190); it draws the route polyline for
+    // an agent with a frozen walk_path. A path endpoint at/past the buffer edge
+    // also exercises tint's out-of-bounds guard (63).
+    #[test]
+    fn paint_routes_draws_frozen_paths_and_skips_the_rest() {
+        use crate::tui::motion::{MotionState, WalkPathSnapshot};
+        use std::collections::HashMap;
+
+        let mut scene = SceneState::uniform(8);
+        let id_path = AgentId::from_transcript_path("/with_path.jsonl");
+        let id_nopath = AgentId::from_transcript_path("/no_path.jsonl");
+        let id_absent = AgentId::from_transcript_path("/absent.jsonl");
+        for id in [id_path, id_nopath, id_absent] {
+            scene.agents.insert(id, slot(id));
+        }
+        let mut motion: HashMap<AgentId, MotionState> = HashMap::new();
+        let mut ms_path = MotionState::new(id_path);
+        ms_path.walk_path = Some(WalkPathSnapshot {
+            from: Point { x: 5, y: 5 },
+            to: Point { x: 80, y: 80 },
+            path: vec![Point { x: 5, y: 5 }, Point { x: 80, y: 80 }],
+        });
+        motion.insert(id_path, ms_path);
+        motion.insert(id_nopath, MotionState::new(id_nopath)); // walk_path: None
+                                                               // id_absent intentionally NOT inserted into the motion map.
+
+        let bg = Rgb { r: 0, g: 0, b: 0 };
+        let mut buf = RgbBuffer::filled(50, 50, bg);
+        paint_routes(&mut buf, &scene, &motion);
+        let painted = (0..50u16)
+            .flat_map(|y| (0..50u16).map(move |x| (x, y)))
+            .any(|(x, y)| buf.get(x, y) != bg);
+        assert!(painted, "the frozen walk_path must draw a route polyline");
+    }
+
+    // first_reachable_on_side breaks the moment the scan steps to a negative
+    // coordinate (cx < 0 || cy < 0), returning None — the line-101 break.
+    #[test]
+    fn first_reachable_on_side_breaks_on_negative_coords() {
+        let l = SceneLayout::compute_with_seed(200, 130, 8, 0).unwrap();
+        assert_eq!(
+            first_reachable_on_side(&l, Point { x: 0, y: 0 }, -1, 0),
+            None,
+            "scanning into negative x must break and return None"
+        );
+        assert_eq!(
+            first_reachable_on_side(&l, Point { x: 0, y: 0 }, 0, -1),
+            None,
+            "scanning into negative y must break and return None"
+        );
+    }
 }

--- a/crates/pixtuoid/src/tui/pixel_painter/drawable.rs
+++ b/crates/pixtuoid/src/tui/pixel_painter/drawable.rs
@@ -822,4 +822,243 @@ mod tests {
         let pts = [p(5, 5), p(5, 5), p(15, 5)];
         assert_eq!(sample_polyline(&pts, 0.5, p(0, 0)), p(10, 5));
     }
+
+    #[test]
+    fn sample_polyline_target_on_zero_length_segment_uses_local_t_zero() {
+        // The CHOSEN segment (not merely a leading one) has zero length: target=0
+        // selects i=0 whose seg is the duplicate (0,0)->(0,0), slen<1e-3, so the
+        // `local_t = 0.0` branch fires and returns the segment start.
+        let pts = [p(0, 0), p(0, 0), p(10, 0)];
+        assert_eq!(sample_polyline(&pts, 0.0, p(9, 9)), p(0, 0));
+    }
+
+    fn test_pack() -> Pack {
+        crate::tui::embedded_pack::load_sprite_pack(None).expect("embedded pack")
+    }
+
+    #[test]
+    fn pet_rest_picks_sleep_anim_when_all_idle() {
+        // frac >= 0.35 (rest phase) AND all_idle => the sleep anim is selected
+        // regardless of whether the rest spot is an idle desk.
+        let layout = crate::tui::layout::Layout::compute(160, 200, 4).expect("layout fits");
+        let pack = test_pack();
+        // elapsed % 40_000 == 20_000 → frac = 0.5 (rest phase).
+        let now = SystemTime::UNIX_EPOCH + std::time::Duration::from_millis(20_000);
+        let (_, _, anim, frame) =
+            pet_position(PetKind::Cat, &layout, &pack, now, &[], true, 0).expect("a pet position");
+        assert_eq!(anim, PetKind::Cat.sleep_anim(), "all_idle → sleep anim");
+        assert_eq!(frame, 0, "rest pose uses frame 0");
+    }
+
+    #[test]
+    fn pet_no_route_falls_back_to_straight_lerp() {
+        // Build a Layout whose walkable mask is split into two disconnected
+        // pockets by a solid vertical wall. With one spot in each pocket, the
+        // pet's walk leg routes between them, find_path returns None, and the
+        // straight-lerp fallback (the cited 297-300) is taken.
+        use pixtuoid_core::layout::{Bounds, ReachSet};
+        use pixtuoid_core::walkable::WalkableMask;
+        let (w, h) = (200u16, 120u16);
+        let mut mask = WalkableMask::new_open(w, h);
+        // Solid wall band x∈[80,120) for the full height → left (x<80) and right
+        // (x>=120) pockets are unreachable from each other on the coarse grid.
+        mask.mark_blocked(80, 0, 40, h, 0);
+        let reachable = ReachSet::from_mask(&mask, Point { x: 20, y: 20 });
+        let mut layout = crate::tui::layout::Layout::compute(w, h, 4).expect("layout fits");
+        // Override geometry: exactly two spots, one per pocket. The desk spot
+        // resolves to (desk.x+DESK_W+1, desk.y+DESK_H+2) on the LEFT; the
+        // corridor centre on the RIGHT.
+        layout.home_desks = vec![Point { x: 20, y: 30 }];
+        layout.waypoints.clear();
+        layout.meeting_sofas.clear();
+        layout.corridor = Some(Bounds {
+            x: 150,
+            y: 40,
+            width: 20,
+            height: 20,
+        });
+        layout.walkable = mask;
+        layout.reachable = reachable;
+        let pack = test_pack();
+
+        // Walk phase (frac < 0.35): pick a pet_seed where consecutive picks land
+        // in different pockets so the leg actually crosses the wall (None route).
+        let now = SystemTime::UNIX_EPOCH + std::time::Duration::from_millis(5_000); // frac=0.125
+        let seed = (0u64..256)
+            .find(|&s| {
+                let r = pet_position(PetKind::Cat, &layout, &pack, now, &[], false, s);
+                // Walk phase always returns the walk anim; we only need it not to panic.
+                r.is_some()
+            })
+            .expect("a pet position exists");
+        let (pos, _, anim, _) =
+            pet_position(PetKind::Cat, &layout, &pack, now, &[], false, seed).expect("pos");
+        assert_eq!(anim, PetKind::Cat.walk_anim(), "walk phase");
+        // The lerp result must lie within the buffer bounds (no panic, no wrap).
+        assert!(pos.x < w && pos.y < h, "lerped pos in bounds: {pos:?}");
+    }
+
+    fn theme() -> &'static crate::tui::theme::Theme {
+        crate::tui::theme::theme_by_name("normal").expect("theme")
+    }
+
+    #[test]
+    fn desk_cubicle_with_cabinet_blits_cabinet_and_trash_bin() {
+        // A DeskCubicle with has_cabinet=true paints the filing cabinet (west of
+        // the desk) and the trash bin (at the desk's east edge) when both fit in
+        // the buffer (covers the cabinet blit + the side-bin blit).
+        let pack = test_pack();
+        let mut cache = FrameCache::new();
+        let now = SystemTime::UNIX_EPOCH;
+        let desk = Point { x: 40, y: 30 };
+        let cab = pack
+            .animation("filing_cabinet")
+            .and_then(|a| a.frames.first())
+            .expect("filing_cabinet anim");
+        let bin = pack
+            .animation("trash_bin")
+            .and_then(|a| a.frames.first())
+            .expect("trash_bin anim");
+        let bg = Rgb { r: 1, g: 2, b: 3 };
+        let mut buf = RgbBuffer::filled(120, 80, bg);
+        let d = Drawable {
+            anchor_y: desk.y + 8,
+            kind: DrawableKind::DeskCubicle {
+                desk,
+                is_last_col: true,
+                has_cabinet: true,
+                screen_glow: None,
+                session_age_secs: 0,
+                has_coffee: false,
+                coffee_steam: false,
+            },
+        };
+        paint_drawable(&d, &mut buf, &pack, &mut cache, now, theme());
+        // Cabinet lands at desk.x - cab.width - 1 .. ; sample a pixel inside it.
+        let cab_x = desk.x.saturating_sub(cab.width + 1);
+        let mut cab_painted = false;
+        for dy in 0..cab.height {
+            for dx in 0..cab.width {
+                if buf.get(cab_x + dx, desk.y + dy) != bg {
+                    cab_painted = true;
+                }
+            }
+        }
+        assert!(cab_painted, "filing cabinet should paint west of the desk");
+        // Trash bin lands at desk.x + DESK_W.
+        let bin_x = desk.x + DESK_W;
+        let mut bin_painted = false;
+        for dy in 0..bin.height {
+            for dx in 0..bin.width {
+                if buf.get(bin_x + dx, desk.y + 4 + dy) != bg {
+                    bin_painted = true;
+                }
+            }
+        }
+        assert!(bin_painted, "trash bin should paint at the desk east edge");
+    }
+
+    #[test]
+    fn meeting_sofa_mirrored_flips_vertically() {
+        // A mirrored MeetingSofa paints the vertically-flipped sprite — assert it
+        // differs from the unmirrored render (the `mirrored=true` arm).
+        let pack = test_pack();
+        let mut cache = FrameCache::new();
+        let now = SystemTime::UNIX_EPOCH;
+        let pos = Point { x: 30, y: 30 };
+        let mut render = |mirrored: bool| {
+            let mut buf = RgbBuffer::filled(80, 80, Rgb { r: 0, g: 0, b: 0 });
+            let d = Drawable {
+                anchor_y: pos.y,
+                kind: DrawableKind::MeetingSofa { pos, mirrored },
+            };
+            paint_drawable(&d, &mut buf, &pack, &mut cache, now, theme());
+            buf
+        };
+        let plain = render(false);
+        let flipped = render(true);
+        let mut differs = false;
+        for y in 0..80u16 {
+            for x in 0..80u16 {
+                if plain.get(x, y) != flipped.get(x, y) {
+                    differs = true;
+                }
+            }
+        }
+        assert!(differs, "mirrored sofa must render distinct pixels");
+    }
+
+    #[test]
+    fn pet_drawable_missing_anim_is_a_noop() {
+        // A Pet drawable whose anim_name is absent from the pack early-returns
+        // (the `let Some(anim) = ... else { return }` defensive guard) and paints
+        // nothing.
+        let pack = test_pack();
+        let mut cache = FrameCache::new();
+        let now = SystemTime::UNIX_EPOCH;
+        let bg = Rgb { r: 7, g: 8, b: 9 };
+        let mut buf = RgbBuffer::filled(60, 60, bg);
+        let d = Drawable {
+            anchor_y: 30,
+            kind: DrawableKind::Pet {
+                kind: PetKind::Cat,
+                pos: Point { x: 30, y: 30 },
+                flip: false,
+                anim_name: "nonexistent_anim",
+                frame_idx: 0,
+                pet_elapsed_ms: None,
+            },
+        };
+        paint_drawable(&d, &mut buf, &pack, &mut cache, now, theme());
+        for y in 0..buf.height {
+            for x in 0..buf.width {
+                assert_eq!(buf.get(x, y), bg, "missing pet anim must paint nothing");
+            }
+        }
+    }
+
+    #[test]
+    fn pet_drawable_sleep_anim_paints_sleep_z() {
+        // A Pet drawable with the sleep anim and pet_elapsed_ms=None takes the
+        // sleep-z branch (paints the floating z's glyph near the pet).
+        let pack = test_pack();
+        let mut cache = FrameCache::new();
+        let now = SystemTime::UNIX_EPOCH;
+        let pos = Point { x: 30, y: 40 };
+        let mut render = |anim_name: &'static str| {
+            let mut buf = RgbBuffer::filled(60, 60, Rgb { r: 0, g: 0, b: 0 });
+            let d = Drawable {
+                anchor_y: pos.y,
+                kind: DrawableKind::Pet {
+                    kind: PetKind::Cat,
+                    pos,
+                    flip: false,
+                    anim_name,
+                    frame_idx: 0,
+                    pet_elapsed_ms: None,
+                },
+            };
+            paint_drawable(&d, &mut buf, &pack, &mut cache, now, theme());
+            buf
+        };
+        // Count non-background pixels ABOVE the pet (where the z's float) — the
+        // sleep render should add some vs. the sit render.
+        let count_above = |buf: &RgbBuffer| {
+            let mut n = 0u32;
+            for y in 0..pos.y.saturating_sub(4) {
+                for x in 0..60u16 {
+                    if buf.get(x, y) != (Rgb { r: 0, g: 0, b: 0 }) {
+                        n += 1;
+                    }
+                }
+            }
+            n
+        };
+        let sit = count_above(&render(PetKind::Cat.sit_anim()));
+        let sleep = count_above(&render(PetKind::Cat.sleep_anim()));
+        assert!(
+            sleep > sit,
+            "sleep anim must add floating z's above the pet (sleep={sleep}, sit={sit})"
+        );
+    }
 }

--- a/crates/pixtuoid/src/tui/pixel_painter/drawable.rs
+++ b/crates/pixtuoid/src/tui/pixel_painter/drawable.rs
@@ -881,21 +881,58 @@ mod tests {
         layout.reachable = reachable;
         let pack = test_pack();
 
-        // Walk phase (frac < 0.35): pick a pet_seed where consecutive picks land
-        // in different pockets so the leg actually crosses the wall (None route).
-        let now = SystemTime::UNIX_EPOCH + std::time::Duration::from_millis(5_000); // frac=0.125
-        let seed = (0u64..256)
-            .find(|&s| {
-                let r = pet_position(PetKind::Cat, &layout, &pack, now, &[], false, s);
-                // Walk phase always returns the walk anim; we only need it not to panic.
-                r.is_some()
-            })
-            .expect("a pet position exists");
+        // The two spots pet_position gathers, in its order: the home desk
+        // (left pocket) then the corridor centre (right pocket).
+        let spots = [
+            Point {
+                x: 20 + DESK_W + 1,
+                y: 30 + DESK_H + 2,
+            },
+            Point { x: 160, y: 50 },
+        ];
+        // Walk phase: elapsed 5s → frac 0.125 (<0.35); cycle_n == pet_seed
+        // (elapsed/40000 == 0). Replicate pet_position's pick so we KNOW the leg
+        // crosses the wall (prev ≠ dest), guaranteeing find_path → None — the
+        // fallback branch is then the ONLY way a position is produced (a broken
+        // fallback would panic here, not pass silently).
+        let now = SystemTime::UNIX_EPOCH + std::time::Duration::from_millis(5_000);
+        let seed = 0u64;
+        let pick = |n: u64| spots[(n.wrapping_mul(0x9e37_79b9_7f4a_7c15) as usize) % spots.len()];
+        let dest = pick(seed);
+        let prev = pick(seed.wrapping_sub(1));
+        assert_ne!(prev, dest, "seed must make the leg cross the wall");
+
+        // Precondition: the two snapped anchors are genuinely unroutable.
+        let src_anchor = snap_point_to_walkable(&layout.walkable, prev).expect("prev snaps");
+        let dst_anchor = snap_point_to_walkable(&layout.walkable, dest).expect("dest snaps");
+        assert!(
+            find_path(
+                &layout.walkable,
+                &OccupancyOverlay::new(),
+                layout.corridor,
+                prev,
+                dest
+            )
+            .is_none(),
+            "the two pockets must be disconnected so the straight-lerp fallback is the only path"
+        );
+
+        // The fallback is the EXACT straight lerp between the snapped anchors at
+        // t = frac/0.35 — pin the math so a regression in 297-300 fails the test.
+        let t = (0.125_f32 / 0.35).clamp(0.0, 1.0);
+        let lerp = |a: u16, b: u16| (a as f32 + (b as f32 - a as f32) * t) as u16;
+        let expected = Point {
+            x: lerp(src_anchor.x, dst_anchor.x),
+            y: lerp(src_anchor.y, dst_anchor.y),
+        };
+
         let (pos, _, anim, _) =
-            pet_position(PetKind::Cat, &layout, &pack, now, &[], false, seed).expect("pos");
+            pet_position(PetKind::Cat, &layout, &pack, now, &[], false, seed).expect("walk pos");
         assert_eq!(anim, PetKind::Cat.walk_anim(), "walk phase");
-        // The lerp result must lie within the buffer bounds (no panic, no wrap).
-        assert!(pos.x < w && pos.y < h, "lerped pos in bounds: {pos:?}");
+        assert_eq!(
+            pos, expected,
+            "no-route leg must be the straight lerp between snapped anchors"
+        );
     }
 
     fn theme() -> &'static crate::tui::theme::Theme {

--- a/crates/pixtuoid/src/tui/pixel_painter/tests.rs
+++ b/crates/pixtuoid/src/tui/pixel_painter/tests.rs
@@ -1141,3 +1141,297 @@ fn sunset_strength_varies_across_day() {
     assert!(has_zero, "sunset should be ~0 at some hours");
     assert!(has_nonzero, "sunset should be >0 at dawn/dusk hours");
 }
+
+// --- waypoint_rank_offset_x decollision table -------------------------
+
+#[test]
+fn waypoint_rank_offset_x_decollision_table() {
+    use super::anchors::waypoint_rank_offset_x;
+    use crate::tui::layout::WaypointKind;
+    // rank 0 = first arrival, no offset, for every kind.
+    assert_eq!(waypoint_rank_offset_x(WaypointKind::Couch, 0), 0);
+    assert_eq!(waypoint_rank_offset_x(WaypointKind::Pantry, 0), 0);
+    // Couch decollision is ±6 (3 seats on a 20px sofa).
+    assert_eq!(waypoint_rank_offset_x(WaypointKind::Couch, 1), 6);
+    assert_eq!(waypoint_rank_offset_x(WaypointKind::Couch, 2), -6);
+    assert_eq!(
+        waypoint_rank_offset_x(WaypointKind::Couch, 3),
+        0,
+        "rank >2 collapses to 0"
+    );
+    // Generic kinds step aside ±9.
+    assert_eq!(waypoint_rank_offset_x(WaypointKind::Pantry, 1), 9);
+    assert_eq!(waypoint_rank_offset_x(WaypointKind::Pantry, 2), -9);
+    assert_eq!(
+        waypoint_rank_offset_x(WaypointKind::Pantry, 5),
+        0,
+        "rank >2 collapses to 0"
+    );
+}
+
+// --- tool_glow_tint token arms ----------------------------------------
+
+#[test]
+fn tool_glow_tint_maps_delegation_search_and_unknown_tokens() {
+    use pixtuoid_core::source::Activity;
+    let id = pixtuoid_core::AgentId::from_transcript_path("/g.jsonl");
+    let glow = &crate::tui::theme::NORMAL.tool_glow;
+    let active = |detail: &str| {
+        make_slot(
+            id,
+            ActivityState::Active {
+                activity: Activity::Typing,
+                tool_use_id: None,
+                detail: Some(Arc::from(detail)),
+            },
+        )
+    };
+    // Agent / Task → glow.agent.
+    assert_eq!(
+        palette::tool_glow_tint(&active("Agent code-reviewer"), glow),
+        Some(glow.agent)
+    );
+    assert_eq!(
+        palette::tool_glow_tint(&active("Task: do X"), glow),
+        Some(glow.agent)
+    );
+    // Grep / Glob → glow.grep.
+    assert_eq!(
+        palette::tool_glow_tint(&active("Grep pattern"), glow),
+        Some(glow.grep)
+    );
+    assert_eq!(
+        palette::tool_glow_tint(&active("Glob **/*.rs"), glow),
+        Some(glow.grep)
+    );
+    // Unknown token → glow.default.
+    assert_eq!(
+        palette::tool_glow_tint(&active("WebFetch https://x"), glow),
+        Some(glow.default)
+    );
+}
+
+// --- SeatView::of obstacle (upright) arm -------------------------------
+
+#[test]
+fn seat_view_of_obstacle_kinds_is_upright_unflipped() {
+    use crate::tui::layout::{Facing, WaypointKind};
+    // The non-seat obstacle kinds dispatch directly in production and never
+    // reach a seated render through SeatView, but the explicit arm maps them to
+    // the upright default (Side { flip: false }) for totality.
+    for kind in [
+        WaypointKind::Pantry,
+        WaypointKind::PhoneBooth,
+        WaypointKind::StandingDesk,
+        WaypointKind::VendingMachine,
+        WaypointKind::Printer,
+    ] {
+        assert_eq!(
+            SeatView::of(kind, Facing::South),
+            SeatView::Side { flip: false },
+            "{kind:?} must map to the upright default",
+        );
+    }
+}
+
+// --- paint_character_at defensive missing-anim early return -----------
+
+#[test]
+fn paint_character_at_missing_anim_is_a_noop() {
+    let pack = crate::tui::embedded_pack::load_sprite_pack(None).expect("embedded pack");
+    let mut cache = FrameCache::new();
+    let id = pixtuoid_core::AgentId::from_transcript_path("/c.jsonl");
+    let slot = make_slot(id, ActivityState::Idle);
+    let bg = Rgb { r: 4, g: 5, b: 6 };
+    let mut buf = RgbBuffer::filled(40, 40, bg);
+    paint_character_at(
+        &mut buf,
+        "does_not_exist",
+        0,
+        Point { x: 20, y: 20 },
+        &slot,
+        &pack,
+        false,
+        None,
+        &mut cache,
+    );
+    for y in 0..buf.height {
+        for x in 0..buf.width {
+            assert_eq!(
+                buf.get(x, y),
+                bg,
+                "missing character anim must paint nothing"
+            );
+        }
+    }
+}
+
+// --- glass bounds clamps ----------------------------------------------
+
+#[test]
+fn glass_wall_h_clamps_below_buffer_bottom() {
+    // y_top near the buffer bottom → the cap+face row span exceeds the height,
+    // so the per-row `y >= bh continue` fires. Must not panic; in-bounds rows
+    // still paint.
+    let theme = crate::tui::theme::theme_by_name("normal").expect("theme");
+    let bh = 16u16;
+    let mut buf = RgbBuffer::filled(40, bh, Rgb { r: 0, g: 0, b: 0 });
+    paint_glass_wall_h(&mut buf, theme, 0, 39, bh - 1);
+    // The cap rows that ARE in-bounds (above bh) must have painted something.
+    let mut painted = false;
+    for y in 0..bh {
+        for x in 0..40u16 {
+            if buf.get(x, y) != (Rgb { r: 0, g: 0, b: 0 }) {
+                painted = true;
+            }
+        }
+    }
+    assert!(painted, "in-bounds glass rows should still paint");
+}
+
+#[test]
+fn glass_wall_v_clamps_past_right_edge() {
+    // x_left == bw-1 → x_left+dx for dx>=1 exceeds the width, exercising the
+    // `x >= bw continue`. Must not panic.
+    let theme = crate::tui::theme::theme_by_name("normal").expect("theme");
+    let bw = 12u16;
+    let mut buf = RgbBuffer::filled(bw, 40, Rgb { r: 0, g: 0, b: 0 });
+    paint_glass_wall_v(&mut buf, theme, bw - 1, 5, 20);
+    // The dx==0 column (in-bounds) must have painted.
+    let mut painted = false;
+    for y in 5..21u16 {
+        if buf.get(bw - 1, y) != (Rgb { r: 0, g: 0, b: 0 }) {
+            painted = true;
+        }
+    }
+    assert!(painted, "the in-bounds glass column should paint");
+}
+
+// --- effects: thinking dots phase + pet hearts edges ------------------
+
+#[test]
+fn thinking_dots_phase_two_paints_two_dots() {
+    use super::effects::paint_thinking_dots;
+    let theme = crate::tui::theme::theme_by_name("normal").expect("theme");
+    let bg = Rgb { r: 0, g: 0, b: 0 };
+    // phase = (epoch_ms / 800) % 4 == 2 → 1600..2399 ms. Pick 1700ms.
+    let now = SystemTime::UNIX_EPOCH + std::time::Duration::from_millis(1_700);
+    let anchor = Point { x: 10, y: 10 };
+    let mut buf = RgbBuffer::filled(40, 40, bg);
+    paint_thinking_dots(&mut buf, anchor, now, theme);
+    let painted = (0..40u16)
+        .flat_map(|y| (0..40u16).map(move |x| (x, y)))
+        .filter(|&(x, y)| buf.get(x, y) != bg)
+        .count();
+    assert_eq!(
+        painted, 2,
+        "phase 2 must paint exactly 2 dots, got {painted}"
+    );
+}
+
+#[test]
+fn pet_hearts_skip_dead_and_faded_hearts() {
+    use super::effects::paint_pet_hearts;
+    let bg = Rgb { r: 0, g: 0, b: 0 };
+    let cat_pos = Point { x: 20, y: 20 };
+    let painted_count = |elapsed_ms: u64| -> usize {
+        let mut buf = RgbBuffer::filled(40, 40, bg);
+        paint_pet_hearts(&mut buf, cat_pos, elapsed_ms);
+        (0..40u16)
+            .flat_map(|y| (0..40u16).map(move |x| (x, y)))
+            .filter(|&(x, y)| buf.get(x, y) != bg)
+            .count()
+    };
+    // Past HEART_LIFE_MS (1550) for the first heart but the later staggered
+    // hearts are also dead (i=1 starts at 150 → dead by 1700; ... i=3 at 450 →
+    // dead by 2000). At elapsed=2100 all four hearts are past their life → the
+    // `local_ms >= HEART_LIFE_MS continue` (152) fires for each → nothing paints.
+    assert_eq!(
+        painted_count(2_100),
+        0,
+        "all hearts past their life → none paint"
+    );
+    // A fresh frame DOES paint (proves the count isn't vacuously 0).
+    assert!(painted_count(0) > 0, "first heart paints at t=0");
+    // alpha < 0.05 continue (158): for heart i=0, local_ms in [1473,1549] gives
+    // alpha just under 0.05 → that heart is skipped while still within its life.
+    // Compare the heart count at elapsed=1500 (i=0 faded) vs a fresh stagger
+    // where i=0 is bright — fewer hearts at the faded frame proves 158 fired.
+    // (i=1..3 may still be alive at 1500, so just assert no panic + bounded.)
+    let faded = painted_count(1_500);
+    assert!(
+        faded <= painted_count(300),
+        "the faded heart drops out (alpha<0.05)"
+    );
+}
+
+// --- furniture decor guards + bodies + corner clip --------------------
+
+#[test]
+fn furniture_room_decor_too_small_bounds_are_noops() {
+    use super::furniture::{
+        paint_doormat, paint_notice_board, paint_trash_bin, paint_water_cooler,
+    };
+    let theme = crate::tui::theme::theme_by_name("normal").expect("theme");
+    let bg = Rgb { r: 9, g: 9, b: 9 };
+    let small = crate::tui::layout::Bounds {
+        x: 2,
+        y: 2,
+        width: 8,
+        height: 8,
+    };
+    let assert_noop = |f: &dyn Fn(&mut RgbBuffer)| {
+        let mut buf = RgbBuffer::filled(60, 60, bg);
+        f(&mut buf);
+        for y in 0..buf.height {
+            for x in 0..buf.width {
+                assert_eq!(buf.get(x, y), bg, "too-small bounds must paint nothing");
+            }
+        }
+    };
+    assert_noop(&|b| paint_notice_board(b, small, theme));
+    assert_noop(&|b| paint_doormat(b, small, theme));
+    assert_noop(&|b| paint_water_cooler(b, small, theme));
+    assert_noop(&|b| paint_trash_bin(b, small));
+}
+
+#[test]
+fn furniture_room_decor_large_bounds_paint() {
+    use super::furniture::{
+        paint_doormat, paint_notice_board, paint_trash_bin, paint_water_cooler,
+    };
+    let theme = crate::tui::theme::theme_by_name("normal").expect("theme");
+    let bg = Rgb { r: 9, g: 9, b: 9 };
+    // A generous room: width 40, height 40, well above every guard threshold.
+    let big = crate::tui::layout::Bounds {
+        x: 4,
+        y: 4,
+        width: 40,
+        height: 40,
+    };
+    let assert_paints = |f: &dyn Fn(&mut RgbBuffer)| {
+        let mut buf = RgbBuffer::filled(120, 80, bg);
+        f(&mut buf);
+        let painted = (0..80u16)
+            .flat_map(|y| (0..120u16).map(move |x| (x, y)))
+            .any(|(x, y)| buf.get(x, y) != bg);
+        assert!(painted, "large bounds must paint the decor");
+    };
+    assert_paints(&|b| paint_notice_board(b, big, theme));
+    assert_paints(&|b| paint_doormat(b, big, theme));
+    assert_paints(&|b| paint_water_cooler(b, big, theme));
+    assert_paints(&|b| paint_trash_bin(b, big));
+}
+
+#[test]
+fn furniture_corner_clip_does_not_panic() {
+    use super::furniture::{paint_area_rug, paint_pantry_table, paint_side_table};
+    let theme = crate::tui::theme::theme_by_name("normal").expect("theme");
+    // Centre each piece near the (0,0) corner so part of the sprite has a
+    // negative px/py, exercising the `< 0` / out-of-range `continue` clamps.
+    let mut buf = RgbBuffer::filled(40, 40, Rgb { r: 0, g: 0, b: 0 });
+    paint_area_rug(&mut buf, 1, 1, 10, 8, theme);
+    paint_side_table(&mut buf, 1, 1, theme);
+    paint_pantry_table(&mut buf, 1, 1, theme);
+    // No panic reaching here is the assertion (negative coords are clipped).
+}

--- a/crates/pixtuoid/src/tui/pose/tests.rs
+++ b/crates/pixtuoid/src/tui/pose/tests.rs
@@ -2587,3 +2587,256 @@ fn multiple_agents_share_overlay_without_teleport() {
         "agents sharing a churning overlay must not teleport (max frame jump {max_step}px)"
     );
 }
+
+// ====================================================================
+// No-door exit-fallback arm: on a layout with NO door_threshold, an
+// exiting agent whose state-driven pose is a Walking (it was mid-wander
+// walk-out when the session ended) routes that walk via route_walking_pose
+// with Settle::None instead of vanishing. Covers mod.rs:194-205.
+// ====================================================================
+#[test]
+fn no_door_exiting_walking_pose_routes_via_settle_none() {
+    let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+    let mut l = layout();
+    l.door_threshold = None;
+
+    // An agent whose cycle-0 is a trip, so idle_pose yields a Walking pose in
+    // the walk-out band. takes_trip(id, 0) drives the directed walk.
+    let trip_id = (0u64..2000)
+        .map(|i| AgentId::from_transcript_path(&format!("/nodoor/{i}.jsonl")))
+        .find(|id| takes_trip(*id, 0))
+        .expect("find a trip agent");
+
+    // Place state_started_at so elapsed lands in the walk-out band:
+    // [seated_dwell, seated_dwell + WANDER_WALK_EST_MS). Idle, was_active=false
+    // (last_event_at == created_at) so derive_state_only routes through idle_pose,
+    // not SeatedThinking.
+    let seated = seated_dwell_ms(trip_id);
+    let into_walk = WANDER_WALK_EST_MS / 2;
+    let created = now - Duration::from_secs(300);
+    let mut slot = entry_slot(created);
+    slot.agent_id = trip_id;
+    slot.last_event_at = created;
+    slot.state_started_at = now - Duration::from_millis(seated + into_walk);
+    slot.exiting_at = Some(now);
+
+    // Sanity: derive_state_only must indeed produce a Walking pose here.
+    assert!(
+        matches!(
+            derive_state_only(&slot, now, &l),
+            Some(Pose::Walking { .. })
+        ),
+        "test setup: the exiting agent must be mid walk-out for the no-door arm"
+    );
+
+    let overlay = pixtuoid_core::walkable::OccupancyOverlay::new();
+    let mut history = PoseHistory::new();
+    let mut router = StubRouter::straight();
+    let mut motion: HashMap<AgentId, MotionState> = HashMap::new();
+
+    let p = derive_with_routing(
+        &slot,
+        now,
+        &l,
+        &mut crate::tui::pose::RouteCtx {
+            router: &mut router,
+            overlay: &overlay,
+            history: &mut history,
+            motion: &mut motion,
+        },
+    );
+    assert!(
+        matches!(p, Some(Pose::Walking { .. })),
+        "no-door exiting Walking pose must route to a Walking pose (not vanish), got {p:?}"
+    );
+    // No exit profile was snapshotted — we took the no-door fallback arm, not the
+    // physics exit branch.
+    assert!(
+        motion
+            .get(&slot.agent_id)
+            .is_none_or(|ms| ms.exit.is_none()),
+        "the no-door arm must not snapshot a physics exit profile"
+    );
+}
+
+// ====================================================================
+// route_walking_pose DIRECT unit tests (it's module-private; the sibling
+// `mod tests` has `use super::*`). These hit branches the orchestration
+// tests can't reach precisely.
+// ====================================================================
+
+fn unit_slot(now: SystemTime) -> AgentSlot {
+    active_slot(now, now - Duration::from_secs(60))
+}
+
+#[test]
+fn route_walking_pose_straight_leg_records_lerp_and_clears_walk_path() {
+    // Settle::None straight 2-point leg at t_x1000=500: the returned Walking
+    // keeps the original (from,to), walk_path is set to None (straight legs are
+    // never frozen), and the lerped midpoint is recorded to history.
+    // Covers mod.rs:796-797 + 805-812.
+    let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+    let l = layout();
+    let slot = unit_slot(now);
+    let from = Point { x: 10, y: 20 };
+    let to = Point { x: 30, y: 20 };
+
+    let overlay = pixtuoid_core::walkable::OccupancyOverlay::new();
+    let mut history = PoseHistory::new();
+    let mut router = StubRouter::straight();
+    let mut motion: HashMap<AgentId, MotionState> = HashMap::new();
+
+    let p = route_walking_pose(
+        &slot,
+        now,
+        &l,
+        &mut crate::tui::pose::RouteCtx {
+            router: &mut router,
+            overlay: &overlay,
+            history: &mut history,
+            motion: &mut motion,
+        },
+        Pose::Walking {
+            from,
+            to,
+            t_x1000: 500,
+            frame: 0,
+            carrying_coffee: false,
+        },
+        Settle::None,
+    );
+
+    match p {
+        Some(Pose::Walking {
+            from: f,
+            to: t,
+            t_x1000,
+            ..
+        }) => {
+            assert_eq!((f, t), (from, to), "straight leg keeps original endpoints");
+            assert_eq!(t_x1000, 500, "straight leg passes t_x1000 through");
+        }
+        other => panic!("expected straight Walking, got {other:?}"),
+    }
+    // A 2-point leg is never frozen.
+    assert!(
+        motion
+            .get(&slot.agent_id)
+            .is_some_and(|ms| ms.walk_path.is_none()),
+        "straight 2-point walk must clear walk_path"
+    );
+    // History records the lerped midpoint of from→to at t=500.
+    let recorded = history.recent(slot.agent_id, 1_000, now).expect("history");
+    assert_eq!(
+        recorded,
+        walking_position(from, to, 500),
+        "straight leg records the lerped position"
+    );
+}
+
+#[test]
+fn route_walking_pose_coincident_path_returns_input_pose() {
+    // A coincident corners path [p,p,p] has total octile length 0; the
+    // `total == 0` guard returns the input pose unchanged. Covers mod.rs:823.
+    let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+    let l = layout();
+    let slot = unit_slot(now);
+    let p = Point { x: 40, y: 40 };
+
+    let overlay = pixtuoid_core::walkable::OccupancyOverlay::new();
+    let mut history = PoseHistory::new();
+    // 3 coincident points → len > 2 (so it isn't the straight branch) but total
+    // segment length is 0.
+    let mut router = StubRouter::corners(vec![p, p, p]);
+    let mut motion: HashMap<AgentId, MotionState> = HashMap::new();
+
+    let input = Pose::Walking {
+        from: p,
+        to: p,
+        t_x1000: 500,
+        frame: 2,
+        carrying_coffee: false,
+    };
+    let out = route_walking_pose(
+        &slot,
+        now,
+        &l,
+        &mut crate::tui::pose::RouteCtx {
+            router: &mut router,
+            overlay: &overlay,
+            history: &mut history,
+            motion: &mut motion,
+        },
+        input,
+        Settle::None,
+    );
+    assert_eq!(
+        out,
+        Some(input),
+        "a zero-length (coincident) polyline returns the input pose unchanged"
+    );
+}
+
+#[test]
+fn route_walking_pose_records_at_waypoint_and_aimless_history() {
+    // The non-Walking arm records the AtWaypoint waypoint pos (mod.rs:731) and
+    // the AimlessAt dest (mod.rs:732) into history (mod.rs:736) so a subsequent
+    // snap-back has a valid "previous position".
+    let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+    let l = layout();
+    assert!(!l.waypoints.is_empty(), "layout must have waypoints");
+    let slot = unit_slot(now);
+
+    let overlay = pixtuoid_core::walkable::OccupancyOverlay::new();
+    let mut history = PoseHistory::new();
+    let mut router = StubRouter::straight();
+    let mut motion: HashMap<AgentId, MotionState> = HashMap::new();
+
+    // AtWaypoint → records layout.waypoints[0].pos.
+    let wp0 = l.waypoints[0];
+    let out = route_walking_pose(
+        &slot,
+        now,
+        &l,
+        &mut crate::tui::pose::RouteCtx {
+            router: &mut router,
+            overlay: &overlay,
+            history: &mut history,
+            motion: &mut motion,
+        },
+        Pose::AtWaypoint {
+            wp: 0,
+            kind: wp0.kind,
+        },
+        Settle::None,
+    );
+    assert!(matches!(out, Some(Pose::AtWaypoint { wp: 0, .. })));
+    assert_eq!(
+        history.recent(slot.agent_id, 1_000, now),
+        Some(wp0.pos),
+        "AtWaypoint must record the waypoint pos to history"
+    );
+
+    // AimlessAt → records its dest.
+    let dest = Point { x: 55, y: 60 };
+    let later = now + Duration::from_millis(10);
+    let out2 = route_walking_pose(
+        &slot,
+        later,
+        &l,
+        &mut crate::tui::pose::RouteCtx {
+            router: &mut router,
+            overlay: &overlay,
+            history: &mut history,
+            motion: &mut motion,
+        },
+        Pose::AimlessAt { dest },
+        Settle::None,
+    );
+    assert!(matches!(out2, Some(Pose::AimlessAt { .. })));
+    assert_eq!(
+        history.recent(slot.agent_id, 1_000, later),
+        Some(dest),
+        "AimlessAt must record its dest to history"
+    );
+}

--- a/crates/pixtuoid/src/tui/tui_renderer/harness.rs
+++ b/crates/pixtuoid/src/tui/tui_renderer/harness.rs
@@ -1498,3 +1498,477 @@ fn meeting_glass_partition_connects_at_window_and_corner() {
         "vertical divider should fill the inside corner at the horizontal wall"
     );
 }
+
+// ===================================================================
+// hit_test_furniture — every per-kind label arm, against a REAL layout
+// ===================================================================
+
+// Drive a real production layout (the same `compute_with_seed` the renderer
+// calls) and hover the CENTER of each populated furniture field, asserting
+// hit_test_furniture returns that kind's label. This closes the waypoint loop
+// (Pantry/Phone Booth/Standing Desk/Vending/Printer), meeting sofas, pantry
+// table/chairs, plants, floor lamp, wall+pod decor, lounge couch + side table,
+// and the procedural meeting/pantry items. Ficus + BulletinBoard are covered
+// by synthetic-layout unit tests (compute never emits those two kinds).
+#[test]
+fn furniture_hit_test_covers_every_kind_on_real_layouts() {
+    use crate::tui::hit_test::hit_test_furniture;
+    use crate::tui::layout::{
+        Layout, PlantKind, PodDecor, WallDecor, WaypointKind, MAX_VISIBLE_DESKS,
+    };
+    use std::collections::HashSet;
+
+    // Scan the WHOLE cell grid and collect every label hit_test_furniture
+    // returns anywhere. Per-item shadowing (e.g. a floor lamp under the couch
+    // region, a chair under the pantry table) means a single center-probe is
+    // brittle, but an item's NON-shadowed cells still yield its label — so the
+    // returned-label SET reaches every arm that is geometrically reachable.
+    let labels_on = |layout: &Layout| -> HashSet<&'static str> {
+        let mut set = HashSet::new();
+        for cy in 0..(layout.buf_h / 2) {
+            for cx in 0..layout.buf_w {
+                if let Some(l) = hit_test_furniture(layout, cx, cy) {
+                    set.insert(l);
+                }
+            }
+        }
+        set
+    };
+
+    // Seeds 0 and 3 between them populate every field (seed 3 brings the
+    // PhoneBooth/StandingDesk pod-decor + a coat-rack-only meeting room).
+    let mut covered: HashSet<&'static str> = HashSet::new();
+    for seed in [0u64, 3] {
+        let layout = Layout::compute_with_seed(160, 200, MAX_VISIBLE_DESKS, seed)
+            .unwrap_or_else(|| panic!("layout for seed {seed}"));
+        let labels = labels_on(&layout);
+
+        // For every kind PRESENT in this layout, its label must be reachable.
+        for wp in &layout.waypoints {
+            let want = match wp.kind {
+                WaypointKind::Pantry => Some("Pantry Counter"),
+                WaypointKind::PhoneBooth => Some("Phone Booth"),
+                WaypointKind::StandingDesk => Some("Standing Desk"),
+                WaypointKind::VendingMachine => Some("Vending Machine"),
+                WaypointKind::Printer => Some("Printer"),
+                WaypointKind::Couch | WaypointKind::MeetingSofa | WaypointKind::MeetingStand => {
+                    None
+                }
+            };
+            if let Some(label) = want {
+                assert!(
+                    labels.contains(label),
+                    "seed {seed}: waypoint {:?} → label {label:?} never resolved",
+                    wp.kind
+                );
+            }
+        }
+        if !layout.meeting_sofas.is_empty() {
+            assert!(labels.contains("Meeting Sofa"), "seed {seed}: Meeting Sofa");
+        }
+        if !layout.meeting_tables.is_empty() {
+            assert!(
+                labels.contains("Meeting Table"),
+                "seed {seed}: Meeting Table"
+            );
+        }
+        if layout.pantry_table.is_some() {
+            assert!(labels.contains("Pantry Table"), "seed {seed}: Pantry Table");
+        }
+        if !layout.pantry_chairs.is_empty() {
+            assert!(labels.contains("Chair"), "seed {seed}: Chair");
+        }
+        if layout.floor_lamp.is_some() {
+            assert!(labels.contains("Floor Lamp"), "seed {seed}: Floor Lamp");
+        }
+        if layout.couch_sprite_center.is_some() {
+            assert!(labels.contains("Lounge Sofa"), "seed {seed}: Lounge Sofa");
+        }
+        if layout.lounge_side_table.is_some() {
+            assert!(labels.contains("Side Table"), "seed {seed}: Side Table");
+        }
+        for item in &layout.plants {
+            let label = match item.kind {
+                PlantKind::Ficus => "Ficus",
+                PlantKind::Tall => "Tall Plant",
+                PlantKind::Flower => "Flower Pot",
+                PlantKind::Succulent => "Succulent",
+            };
+            assert!(labels.contains(label), "seed {seed}: plant {:?}", item.kind);
+        }
+        for item in &layout.wall_decor {
+            let label = match item.kind {
+                WallDecor::Whiteboard => "Whiteboard",
+                WallDecor::Bookshelf => "Bookshelf",
+                WallDecor::BulletinBoard => "Bulletin Board",
+                WallDecor::ExitSign => "Exit Sign",
+                WallDecor::MeetingScreen => "Meeting Screen",
+            };
+            assert!(
+                labels.contains(label),
+                "seed {seed}: wall decor {:?}",
+                item.kind
+            );
+        }
+        for item in &layout.pod_decor {
+            let label = match item.kind {
+                PodDecor::PlantTall => "Tall Plant",
+                PodDecor::Whiteboard => "Whiteboard",
+                PodDecor::Tv => "TV Stand",
+                PodDecor::PhoneBooth => "Phone Booth",
+                PodDecor::StandingDesk => "Standing Desk",
+            };
+            assert!(
+                labels.contains(label),
+                "seed {seed}: pod decor {:?}",
+                item.kind
+            );
+        }
+        // Procedural room items (coat rack / doormat / water cooler / trash bin)
+        // are emitted by hit_test_furniture from the room bounds, not a layout
+        // field, so just gather whatever resolved.
+        covered.extend(labels);
+    }
+
+    // The procedural meeting/pantry-room items must surface across the two
+    // seeds (seed 0 has both a meeting room and a pantry room at 160×200).
+    for label in [
+        "Coat Rack",
+        "Doormat",
+        "Water Cooler",
+        "Trash Bin",
+        "Elevator",
+    ] {
+        assert!(
+            covered.contains(label),
+            "procedural/room item {label:?} never resolved across seeds"
+        );
+    }
+}
+
+// ===================================================================
+// hit_test_agent + hover marker
+// ===================================================================
+
+// Hover an idle agent's own sprite cell → the label gains the '▸' hovered
+// marker (exercises hit_test_agent's Some-return + tooltip is_hovered branch).
+#[test]
+fn hovering_an_agent_marks_its_label() {
+    let mut s = idle("/hov/0.jsonl", 0, t0() - Duration::from_secs(300));
+    s.label = Arc::from("HOVERME");
+    let scene = scene_with(vec![s], 16);
+    let mut r = build(140, 48, vec![]);
+    r.render(&scene, &pack(), t0()).unwrap();
+    // A long-idle agent at its home desk; mirror hit_test_from_tui's anchor.
+    let desk = r.cached_layout().expect("layout").home_desks[0];
+    let cell_x = desk.x + 2;
+    let cell_y = desk.y.saturating_sub(4) / 2 + 1;
+    r.set_mouse_pos(Some((cell_x, cell_y)));
+    r.render(&scene, &pack(), t0()).unwrap();
+    let text = frame_text(r.frame_buffer());
+    assert!(
+        text.contains("\u{25b8}HOVERME") || text.contains("\u{25b8}"),
+        "hovering an agent should add the ▸ marker to its label; frame:\n{text}"
+    );
+}
+
+// ===================================================================
+// Tooltip state arms: Active (with detail), Waiting, exiting label,
+// active-% numeric, flip-left, bottom-edge flip-up (CG4/CG5/CG6)
+// ===================================================================
+
+#[test]
+fn pinned_active_agent_tooltip_shows_state_and_detail() {
+    // active() sets last_event_at = started; created >5s ago so active_str is
+    // a numeric percent (not "--%"), and active_ms>0 forces a non-zero %.
+    let mut a = active(
+        "/ttA/0.jsonl",
+        0,
+        "Edit src/lib.rs",
+        t0() - Duration::from_secs(600),
+    );
+    a.active_ms = 120_000; // 120s active over a 600s session ⇒ 20%
+    let id = a.agent_id;
+    let scene = scene_with(vec![a], 16);
+    let mut r = build(120, 44, vec![]);
+    r.set_pinned_agent(Some(id));
+    r.render(&scene, &pack(), t0()).unwrap();
+    let text = frame_text(r.frame_buffer());
+    assert!(text.contains("Active"), "active state arm: {text}");
+    assert!(text.contains("Edit src/lib.rs"), "detail line: {text}");
+    // active_str numeric branch (session ≥5s): a '%' that is not "--%".
+    assert!(
+        text.contains('%') && !text.contains("--%"),
+        "numeric active %: {text}"
+    );
+}
+
+#[test]
+fn pinned_waiting_agent_tooltip_shows_reason() {
+    let mut a = idle("/ttW/0.jsonl", 0, t0() - Duration::from_secs(60));
+    a.state = ActivityState::Waiting {
+        reason: Arc::from("permission to edit"),
+    };
+    let id = a.agent_id;
+    let scene = scene_with(vec![a], 16);
+    let mut r = build(120, 44, vec![]);
+    r.set_pinned_agent(Some(id));
+    r.render(&scene, &pack(), t0()).unwrap();
+    let text = frame_text(r.frame_buffer());
+    assert!(text.contains("Waiting"), "waiting state arm: {text}");
+    assert!(text.contains("permission"), "reason line: {text}");
+}
+
+#[test]
+fn exiting_agent_label_uses_exiting_color() {
+    // The exiting_at branch in paint_label_widgets: render an exiting agent and
+    // confirm its label still paints (the branch runs without panic). Color is
+    // theme-internal; we assert the label survives the exiting code path.
+    let mut a = idle("/ttE/0.jsonl", 0, t0() - Duration::from_secs(10));
+    a.label = Arc::from("LEAVING");
+    a.exiting_at = Some(t0());
+    let scene = scene_with(vec![a], 16);
+    let mut r = build(120, 44, vec![]);
+    r.render(&scene, &pack(), t0() + Duration::from_millis(100))
+        .unwrap();
+    let text = frame_text(r.frame_buffer());
+    assert!(text.contains("LEAVING"), "exiting agent label: {text}");
+}
+
+#[test]
+fn pinned_then_removed_agent_is_a_safe_noop() {
+    // paint_hover_tooltip's early return when the pinned id is gone from scene.
+    let id = AgentId::from_transcript_path("/ttGone/0.jsonl");
+    let scene = scene_with(vec![slot(id, 0, 0, t0())], 16);
+    let mut r = build(120, 44, vec![]);
+    r.render(&scene, &pack(), t0()).unwrap();
+    r.set_pinned_agent(Some(id));
+    // Re-render with the agent removed → tooltip paint hits the get()=None bail.
+    let empty = SceneState::uniform(16);
+    r.render(&empty, &pack(), t0() + Duration::from_millis(33))
+        .expect("render must not panic when the pinned agent vanished");
+}
+
+// ===================================================================
+// Pet tooltip: cooldown (purr/woof per kind) + sleeping arms (CG5)
+// ===================================================================
+
+#[test]
+fn pet_tooltip_shows_cooldown_reaction_for_cat_and_dog() {
+    for (kind, word) in [(PetKind::Cat, "purr"), (PetKind::Dog, "woof")] {
+        let scene = scene_with(vec![active("/ck/0.jsonl", 0, "Edit", t0())], 16);
+        let mut r = build(140, 48, vec![kind]);
+        r.render(&scene, &pack(), t0()).unwrap();
+        let PetFrame { pos, .. } = r.cached_pet_pos().expect("pet placed");
+        // Activate the petting cooldown so the tooltip shows purr/woof.
+        r.set_active_pet(Some(PetState {
+            petted_at: t0(),
+            pet_pos: pos,
+            kind,
+            floor_idx: 0,
+        }));
+        r.set_mouse_pos(Some((pos.x, pos.y / 2)));
+        r.render(&scene, &pack(), t0() + Duration::from_millis(200))
+            .unwrap();
+        let text = frame_text(r.frame_buffer());
+        assert!(
+            text.contains(word),
+            "{kind:?} on cooldown should show '{word}'; got:\n{text}"
+        );
+    }
+}
+
+#[test]
+fn pet_tooltip_shows_sleeping_when_all_idle() {
+    // With every agent idle the cat sleeps (sleeps_near_idle); hovering it shows
+    // the sleeping line. Use a long-idle scene so the pet settles to sleep.
+    let scene = scene_with(
+        vec![idle("/slp/0.jsonl", 0, t0() - Duration::from_secs(300))],
+        16,
+    );
+    let mut r = build(160, 64, vec![PetKind::Cat]);
+    // Scan the pet cycle for a sleeping frame, then hover it.
+    let mut hit = None;
+    for i in 0..40u64 {
+        let now = t0() + Duration::from_secs(i);
+        r.render(&scene, &pack(), now).unwrap();
+        if let Some(PetFrame { pos, anim, .. }) = r.cached_pet_pos() {
+            if anim == PetKind::Cat.sleep_anim() {
+                hit = Some((pos, now));
+                break;
+            }
+        }
+    }
+    let (pos, now) = hit.expect("a long-idle cat must enter its sleep anim within the window");
+    r.set_mouse_pos(Some((pos.x, pos.y / 2)));
+    r.render(&scene, &pack(), now).unwrap();
+    let text = frame_text(r.frame_buffer());
+    assert!(
+        text.contains("sleeping"),
+        "hovering a sleeping cat shows the sleeping line; got:\n{text}"
+    );
+}
+
+// Hover a furniture item near the TOP edge so paint_simple_tooltip flips the
+// box BELOW the cursor (the my < scene_rect.y + tip_h branch).
+#[test]
+fn furniture_tooltip_flips_below_near_top_edge() {
+    let scene = scene_with(vec![idle("/flip/0.jsonl", 0, t0())], 16);
+    let mut r = build(140, 48, vec![]);
+    r.render(&scene, &pack(), t0()).unwrap();
+    let layout = r.cached_layout().expect("layout");
+    // Find a furniture hit at the smallest cell-y (closest to the top edge).
+    let mut top_hit = None;
+    'scan: for my in 0..6u16 {
+        for mx in 0..140u16 {
+            if crate::tui::hit_test::hit_test_furniture(layout, mx, my).is_some() {
+                top_hit = Some((mx, my));
+                break 'scan;
+            }
+        }
+    }
+    let (mx, my) = top_hit.expect("some furniture must hover-test near the top edge");
+    r.set_mouse_pos(Some((mx, my)));
+    r.render(&scene, &pack(), t0())
+        .expect("top-edge furniture hover must flip the tooltip below without panic");
+}
+
+// Hover an AGENT near the BOTTOM edge so paint_hover_tooltip flips the panel UP
+// (the ty overflow branch). Pin it to force the centered/hover panel path.
+#[test]
+fn agent_tooltip_flips_up_near_bottom_edge() {
+    let scene = scene_with(
+        vec![idle("/flup/0.jsonl", 0, t0() - Duration::from_secs(120))],
+        16,
+    );
+    let mut r = build(120, 44, vec![]);
+    r.render(&scene, &pack(), t0()).unwrap();
+    let layout = r.cached_layout().expect("layout").clone();
+    // Pick the home desk nearest the bottom of the scene.
+    let bottom_desk = layout
+        .home_desks
+        .iter()
+        .max_by_key(|d| d.y)
+        .copied()
+        .expect("a home desk");
+    let id = AgentId::from_transcript_path("/flup/0.jsonl");
+    r.set_pinned_agent(Some(id));
+    // Hover near the very bottom rows so the hover-tooltip ty must flip up.
+    let my = (44u16).saturating_sub(2);
+    r.set_mouse_pos(Some((bottom_desk.x, my)));
+    r.render(&scene, &pack(), t0())
+        .expect("bottom-edge hover must not panic");
+    // Reaching here (no panic, tooltip flipped within bounds) is the assertion.
+}
+
+// ===================================================================
+// renderer.rs: Layout::compute None bail (CG7)
+// ===================================================================
+
+// A terminal that PASSES the 20×12 scene-rect gate but is too small for
+// Layout::compute (buf_w < MIN_W) takes draw_scene's compute-None bail → no
+// cached layout, footer-only, no error.
+#[test]
+fn layout_compute_none_bails_to_footer_only() {
+    let scene = scene_with(vec![idle("/lc/0.jsonl", 0, t0())], 16);
+    // scene_rect 28×39: width 28 ≥ 20 (passes gate), buf_w 28 < MIN_W → compute
+    // returns None, hitting the second bail arm.
+    let mut r = build(28, 40, vec![]);
+    r.render(&scene, &pack(), t0())
+        .expect("render must not error on the compute-None bail");
+    assert!(
+        r.cached_layout().is_none(),
+        "a layout that fails compute yields no cached layout"
+    );
+}
+
+// ===================================================================
+// tui_renderer: render_transition too-small bail (CG9) + getters (CG10)
+// ===================================================================
+
+#[test]
+fn transition_on_too_small_terminal_clears_interaction_state() {
+    // Two-floor scene on a sub-20×12 terminal: starting a transition hits the
+    // render_transition too-small bail → cached layout / pet / popup cleared.
+    let scene = two_floor_scene();
+    let mut r = build(18, 10, vec![PetKind::Cat]);
+    let now = t0();
+    r.render(&scene, &pack(), now).unwrap();
+    r.navigate_floor(1, now);
+    r.render(&scene, &pack(), now + Duration::from_millis(100))
+        .expect("transition render on a tiny terminal must not panic");
+    assert!(r.cached_layout().is_none());
+    assert!(r.cached_pet_pos().is_none());
+    assert_eq!(r.last_popup_scale(), 0.0);
+}
+
+#[test]
+fn debug_walkable_getter_reflects_setter() {
+    let mut r = build(100, 40, vec![]);
+    assert!(!r.debug_walkable());
+    r.set_debug_walkable(true);
+    assert!(r.debug_walkable());
+    r.set_debug_walkable(false);
+    assert!(!r.debug_walkable());
+}
+
+#[test]
+fn already_expired_active_pet_clears_on_render() {
+    // set_active_pet with a PetState whose petted_at is far in the past → the
+    // render-time auto-expire drops it.
+    let scene = scene_with(vec![active("/exp/0.jsonl", 0, "Edit", t0())], 16);
+    let mut r = build(100, 40, vec![PetKind::Cat]);
+    r.set_active_pet(Some(PetState {
+        petted_at: t0() - Duration::from_secs(3600), // long expired
+        pet_pos: Point { x: 10, y: 10 },
+        kind: PetKind::Cat,
+        floor_idx: 0,
+    }));
+    r.render(&scene, &pack(), t0()).unwrap();
+    assert!(
+        r.active_pet_ref().is_none(),
+        "an already-expired pet state must be cleared on render"
+    );
+}
+
+#[test]
+fn current_floor_clamps_when_floor_count_drops() {
+    // Land on floor 1, then re-render a scene with only floor 0 ⇒ current_floor
+    // must clamp back into range (the nf-shrink clamp).
+    let cap = 16;
+    let two = two_floor_scene();
+    let mut r = build(100, 40, vec![]);
+    let mut now = t0();
+    r.render(&two, &pack(), now).unwrap();
+    r.navigate_floor(1, now);
+    render_until_settled(&mut r, &two, &pack(), &mut now, 1);
+    assert_eq!(r.current_floor(), 1);
+    // Drop to a single-floor scene.
+    let one = scene_with(vec![idle("/clamp/0.jsonl", 0, t0())], cap);
+    r.render(&one, &pack(), now).unwrap();
+    assert_eq!(
+        r.current_floor(),
+        0,
+        "current_floor clamps when floors shrink"
+    );
+}
+
+#[test]
+fn theme_picker_renders_during_floor_transition() {
+    // Opening the theme picker mid-transition exercises the transition-path
+    // theme_picker paint arm.
+    let scene = two_floor_scene();
+    let mut r = build(140, 48, vec![]);
+    let mut now = t0();
+    r.render(&scene, &pack(), now).unwrap();
+    r.set_theme_picker(Some(0));
+    r.navigate_floor(1, now);
+    now += Duration::from_millis(200);
+    r.render(&scene, &pack(), now).unwrap();
+    assert!(r.transition().is_some(), "still mid-transition");
+    let text = frame_text(r.frame_buffer());
+    assert!(
+        text.contains("cyberpunk") || text.contains("normal"),
+        "theme picker must paint over a floor transition; frame:\n{text}"
+    );
+}

--- a/crates/pixtuoid/src/tui/widgets/help.rs
+++ b/crates/pixtuoid/src/tui/widgets/help.rs
@@ -78,7 +78,9 @@ mod tests {
 
     #[test]
     fn help_overlay_renders_without_panic_across_sizes() {
-        for (w, h) in [(200, 60), (40, 20), (24, 30), (10, 4), (4, 3)] {
+        // (2,2): centered_in clamps the area to 2×2, tripping the width<4
+        // early return — must still render Clear-less without panic.
+        for (w, h) in [(200, 60), (40, 20), (24, 30), (10, 4), (4, 3), (2, 2)] {
             render_at(w, h);
         }
     }

--- a/crates/pixtuoid/src/tui/widgets/hud.rs
+++ b/crates/pixtuoid/src/tui/widgets/hud.rs
@@ -678,4 +678,90 @@ mod hud_tests {
             "expected None when URL row falls on the clipped popup's bottom border: got {rect:?}"
         );
     }
+
+    // The URL is not clickable until the popup reaches 70% entrance scale.
+    #[test]
+    fn url_rect_none_below_seventy_percent_scale() {
+        assert!(version_popup_url_rect(4, full_bounds(200, 60), 0.5).is_none());
+        assert!(version_popup_url_rect(4, full_bounds(200, 60), 0.0).is_none());
+    }
+
+    // A popup envelope clamped to a tiny bounds (w<4 || h<3) yields no rect.
+    #[test]
+    fn url_rect_none_when_envelope_too_small() {
+        // 3-col bounds → envelope width clamps to 3 (<4) → None.
+        assert!(version_popup_url_rect(4, full_bounds(3, 60), 1.0).is_none());
+    }
+
+    // paint_version_popup's fully-dismissed early return (scale ≤ 0.01): a
+    // near-zero scale paints nothing, so the buffer stays blank.
+    #[test]
+    fn version_popup_skips_render_when_fully_dismissed() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+        let mut term = Terminal::new(TestBackend::new(80, 30)).unwrap();
+        term.draw(|f| {
+            paint_version_popup(
+                f,
+                "1.2.3",
+                &["note a", "note b"],
+                Rect::new(0, 0, 80, 30),
+                &crate::tui::theme::NORMAL,
+                0.0, // fully dismissed
+                std::time::UNIX_EPOCH,
+            );
+        })
+        .unwrap();
+        // Nothing painted ⇒ every cell is still the default blank space.
+        let buf = term.backend().buffer();
+        let any_glyph = buf.content().iter().any(|c| !c.symbol().trim().is_empty());
+        assert!(!any_glyph, "dismissed popup must paint nothing");
+    }
+
+    // status_segments' tool-token guard: a detail whose first split token is
+    // empty (leading non-alphanumeric) must be SKIPPED, not counted as a tool.
+    #[test]
+    fn status_segments_skips_empty_leading_token() {
+        use pixtuoid_core::source::Activity;
+        use pixtuoid_core::{AgentId, AgentSlot};
+        use std::path::PathBuf;
+        use std::sync::Arc;
+        let slot = AgentSlot {
+            agent_id: AgentId::from_transcript_path("/p/lead.jsonl"),
+            source: Arc::from("cc"),
+            session_id: Arc::from("s"),
+            cwd: Arc::from(PathBuf::from("/p").as_path()),
+            label: Arc::from("lead"),
+            // Leading '/' ⇒ first token after split-on-non-alphanumeric is "".
+            state: ActivityState::Active {
+                activity: Activity::Typing,
+                tool_use_id: Some(Arc::from("t")),
+                detail: Some(Arc::from("/usr/bin/thing")),
+            },
+            state_started_at: SystemTime::UNIX_EPOCH,
+            created_at: SystemTime::UNIX_EPOCH,
+            last_event_at: SystemTime::UNIX_EPOCH,
+            exiting_at: None,
+            pending_idle_at: None,
+            desk_index: 0,
+            floor_idx: 0,
+            tool_call_count: 0,
+            active_ms: 0,
+            unknown_cwd: false,
+            parent_id: None,
+        };
+        let mut scene = SceneState::uniform(16);
+        scene.agents.insert(slot.agent_id, slot);
+        // No '×' tool breakdown token survives — the empty leading token was
+        // skipped, so the active agent contributes no tool count.
+        let line = build_status_summary(&scene, 200, None);
+        assert!(
+            !line.contains('\u{00d7}'),
+            "empty leading token must not produce a tool count: {line}"
+        );
+        assert!(
+            line.contains("1 active"),
+            "active count still shows: {line}"
+        );
+    }
 }

--- a/crates/pixtuoid/src/tui/widgets/mod.rs
+++ b/crates/pixtuoid/src/tui/widgets/mod.rs
@@ -154,6 +154,56 @@ mod tests {
         assert_eq!(out, "a-very-l");
     }
 
+    #[test]
+    fn truncate_label_plain_take_when_suffix_exceeds_budget() {
+        // The disambig suffix ("·abcdefgh") is longer than budget=4, so the
+        // suffix-preserving branch can't fit and it falls through to a plain
+        // budget-char take from the front.
+        let out = truncate_label("x\u{00b7}abcdefgh", 4);
+        assert_eq!(out.chars().count(), 4);
+        assert_eq!(out, "x\u{00b7}ab");
+    }
+
+    // --- TickerQueue -------------------------------------------------------
+
+    #[test]
+    fn ticker_default_is_empty() {
+        let q = TickerQueue::default();
+        assert_eq!(q.visible(40, SystemTime::UNIX_EPOCH), "");
+    }
+
+    #[test]
+    fn ticker_includes_waiting_reason() {
+        let mut q = TickerQueue::new();
+        let s = scene_of(vec![waiting("perm-agent")]);
+        q.update(&s);
+        // The Waiting arm formats "{label}: ?{reason}".
+        let text = q.visible(200, SystemTime::UNIX_EPOCH);
+        assert!(text.contains("perm-agent"), "got: {text}");
+        assert!(text.contains('?'), "waiting marker missing: {text}");
+    }
+
+    #[test]
+    fn ticker_trims_buffer_past_max() {
+        let mut q = TickerQueue::new();
+        // Push many distinct snapshots so the buffer grows past MAX_CHARS=512
+        // and the drain path runs. Each update with a NEW snapshot appends.
+        for i in 0..200 {
+            let label = format!("agent-with-a-fairly-long-name-{i:04}");
+            let s = scene_of(vec![active_with("Edit some/long/path.rs", &label)]);
+            q.update(&s);
+        }
+        // Buffer must have been trimmed: visible() still works and the kept
+        // text stays bounded near MAX_CHARS rather than growing unbounded.
+        let text = q.visible(40, SystemTime::UNIX_EPOCH);
+        assert_eq!(text.chars().count(), 40, "visible window must fill");
+        assert!(
+            q.buffer.chars().count() <= 512,
+            "buffer must be trimmed to MAX_CHARS, got {}",
+            q.buffer.chars().count()
+        );
+    }
+
     // --- build_status_summary ---------------------------------------------
 
     fn slot_with(state: ActivityState, label: &str) -> AgentSlot {

--- a/crates/pixtuoid/src/tui/widgets/tooltip.rs
+++ b/crates/pixtuoid/src/tui/widgets/tooltip.rs
@@ -354,7 +354,11 @@ pub fn paint_chitchat_bubbles(
 ) {
     for bubble in bubbles {
         let text = format!(" {} ", bubble.text);
-        let tip_w = text.len() as u16;
+        // Size by DISPLAY width, not byte length: a wide-glyph quip (the line
+        // pool can grow) would otherwise over-size + mis-center the bubble.
+        // Matches the rest of this file (paint_simple_tooltip uses `.width()`).
+        let line = Line::from(text.clone());
+        let tip_w = line.width() as u16;
         let tip_h = 1u16;
 
         let cell_x = scene_rect.x + bubble.anchor.x;

--- a/crates/pixtuoid/src/validate.rs
+++ b/crates/pixtuoid/src/validate.rs
@@ -9,11 +9,14 @@ pub fn validate_pack(dir: &Path) -> Result<()> {
 
     let report = validate_pack_animations(&pack);
 
+    // ERROR diagnostics and the final tally go to stderr so stdout stays the
+    // parseable channel (the OK line, WARN/INFO advisories) even when a caller
+    // redirects stdout — errors also drive a non-zero exit via the bail! below.
     for name in &report.missing_required {
-        println!("ERROR: missing required animation \"{name}\"");
+        eprintln!("ERROR: missing required animation \"{name}\"");
     }
     for (name, need, got) in &report.insufficient_frames {
-        println!("ERROR: \"{name}\" needs at least {need} frames, has {got}");
+        eprintln!("ERROR: \"{name}\" needs at least {need} frames, has {got}");
     }
     for name in &report.missing_optional {
         println!("WARN:  missing optional animation \"{name}\" (will not render)");
@@ -24,7 +27,7 @@ pub fn validate_pack(dir: &Path) -> Result<()> {
 
     let errors = report.missing_required.len() + report.insufficient_frames.len();
     let warnings = report.missing_optional.len();
-    println!("\n{} error(s), {} warning(s)", errors, warnings);
+    eprintln!("\n{} error(s), {} warning(s)", errors, warnings);
 
     if report.has_errors() {
         bail!("pack validation failed with {errors} error(s)");

--- a/crates/pixtuoid/tests/pack_cli.rs
+++ b/crates/pixtuoid/tests/pack_cli.rs
@@ -1,0 +1,176 @@
+//! Integration coverage for the `init-pack` and `validate-pack` subcommand
+//! cores (`pixtuoid::init_pack::init_pack` / `pixtuoid::validate::validate_pack`).
+//! Both are plain synchronous filesystem code — no TTY, async, or socket — so we
+//! drive them directly through the public crate API rather than spawning the
+//! binary, which exercises more branches deterministically. Tests may unwrap.
+
+use std::fs;
+use std::path::Path;
+
+use pixtuoid::init_pack::init_pack;
+use pixtuoid::validate::validate_pack;
+use tempfile::TempDir;
+
+// --- init_pack ------------------------------------------------------------
+
+#[test]
+fn init_pack_writes_skeleton_into_fresh_dir() {
+    let tmp = TempDir::new().unwrap();
+    let dest = tmp.path().join("newpack");
+
+    init_pack(&dest, false).unwrap();
+
+    let pack_toml = dest.join("pack.toml");
+    let placeholder = dest.join("placeholder.sprite");
+    assert!(pack_toml.exists(), "pack.toml written");
+    assert!(placeholder.exists(), "placeholder.sprite written");
+
+    // Content matches the embedded skeleton assets.
+    assert_eq!(
+        fs::read_to_string(&pack_toml).unwrap(),
+        include_str!("../sprites/skeleton/pack.toml")
+    );
+    assert_eq!(
+        fs::read_to_string(&placeholder).unwrap(),
+        include_str!("../sprites/skeleton/placeholder.sprite")
+    );
+}
+
+#[test]
+fn init_pack_into_populated_dir_without_force_errors() {
+    let tmp = TempDir::new().unwrap();
+    let dest = tmp.path().join("pack");
+    // Populate it with a real extraction first.
+    init_pack(&dest, false).unwrap();
+
+    // A second call without --force must refuse rather than clobber.
+    let err = init_pack(&dest, false).unwrap_err();
+    assert!(
+        err.to_string().contains("non-empty"),
+        "expected a non-empty guard error, got: {err}"
+    );
+}
+
+#[test]
+fn init_pack_with_file_at_dest_errors_not_a_directory() {
+    let tmp = TempDir::new().unwrap();
+    let dest = tmp.path().join("a-file");
+    fs::write(&dest, "i am a file, not a dir").unwrap();
+
+    let err = init_pack(&dest, false).unwrap_err();
+    assert!(
+        err.to_string().contains("not a directory"),
+        "expected a not-a-directory error, got: {err}"
+    );
+}
+
+#[test]
+fn init_pack_force_rewrites_populated_dir() {
+    let tmp = TempDir::new().unwrap();
+    let dest = tmp.path().join("pack");
+    init_pack(&dest, false).unwrap();
+
+    // Mutate the extracted file, then force re-extract restores the original.
+    let pack_toml = dest.join("pack.toml");
+    fs::write(&pack_toml, "# clobbered\n").unwrap();
+
+    init_pack(&dest, true).unwrap();
+
+    assert_eq!(
+        fs::read_to_string(&pack_toml).unwrap(),
+        include_str!("../sprites/skeleton/pack.toml"),
+        "force=true overwrites the user-modified file with the embedded skeleton"
+    );
+}
+
+// --- validate_pack --------------------------------------------------------
+
+#[test]
+fn validate_pack_skeleton_is_ok_and_warns_on_optionals() {
+    let tmp = TempDir::new().unwrap();
+    let dest = tmp.path().join("skeleton");
+    init_pack(&dest, false).unwrap();
+
+    // The skeleton defines exactly the required animations and no optionals, so
+    // validation succeeds (Ok) while exercising the missing-optional WARN loop.
+    validate_pack(&dest).unwrap();
+}
+
+/// Write a deliberately-broken pack: it DROPS the required `seated` animation,
+/// gives `typing` only one frame (needs ≥2 → insufficient_frames), and declares
+/// a bogus `[animations.foo]` (unknown). Exercises the ERROR / INFO loops + bail.
+fn write_broken_pack(dir: &Path) {
+    fs::create_dir_all(dir).unwrap();
+    // Reuse the embedded skeleton sprite as the frame for every animation.
+    fs::write(
+        dir.join("placeholder.sprite"),
+        include_str!("../sprites/skeleton/placeholder.sprite"),
+    )
+    .unwrap();
+
+    // All required animations EXCEPT `seated`, with `typing` at a single frame,
+    // plus an unknown `foo`. Palette mirrors the skeleton's keys.
+    let pack_toml = r##"
+[pack]
+name = "broken"
+version = "0.0.1"
+
+[palette]
+"." = "transparent"
+B = "#4488cc"
+H = "#443322"
+S = "#e8c090"
+P = "#334455"
+W = "#ffffff"
+
+[animations.typing]
+frames = ["placeholder.sprite"]
+frame_ms = 400
+
+[animations.standing]
+frames = ["placeholder.sprite"]
+frame_ms = 500
+
+[animations.walking]
+frames = ["placeholder.sprite", "placeholder.sprite"]
+frame_ms = 200
+
+[animations.walking_back]
+frames = ["placeholder.sprite", "placeholder.sprite"]
+frame_ms = 200
+
+[animations.seated_sleeping]
+frames = ["placeholder.sprite"]
+frame_ms = 500
+
+[animations.seated_sleeping_alt]
+frames = ["placeholder.sprite"]
+frame_ms = 500
+
+[animations.holding_coffee]
+frames = ["placeholder.sprite"]
+frame_ms = 500
+
+[animations.back_couch]
+frames = ["placeholder.sprite"]
+frame_ms = 500
+
+[animations.foo]
+frames = ["placeholder.sprite"]
+frame_ms = 500
+"##;
+    fs::write(dir.join("pack.toml"), pack_toml).unwrap();
+}
+
+#[test]
+fn validate_pack_with_errors_bails() {
+    let tmp = TempDir::new().unwrap();
+    let dest = tmp.path().join("broken");
+    write_broken_pack(&dest);
+
+    let err = validate_pack(&dest).unwrap_err();
+    assert!(
+        err.to_string().contains("validation failed"),
+        "expected a validation-failed bail, got: {err}"
+    );
+}


### PR DESCRIPTION
## What

A **coverage-weighted multi-agent code review** of the whole workspace, then the implementation: write the tests for every genuinely-reachable gap, and apply all the general-CR findings the review surfaced.

`58 files, +4738 / −110`. **+167 tests (824 → 991).** Line coverage **91.8% → 95.3% raw** (~97-98% codecov-adjusted — codecov excludes `main.rs` + `tui/mod.rs`). `just preflight` green (fmt + machete + deny + clippy + 991 tests).

## How the gaps were triaged

Each uncovered region was classified **testable** (write the test) vs **untestable-headless** (real TTY / tokio-runtime / dead-by-construction), then an adversarial-verify pass checked every "untestable" claim against **both** the unit and the harness tiers. That flipped ~30 over-eager "untestable" calls back to testable — e.g. `Source::run()` async loops became `#[tokio::test]`s, and the bulk of the pixel-pass / hit-test / render-bail gaps became `tui_renderer/harness.rs` renders.

**No `codecov.yml` bypass flags were added.** Every gap was handled by *writing the test*, *deleting the dead code*, or *leaving an honest 1-2 line residue* for the cases neither a unit nor a harness test can reach (real-TTY `setup/teardown_terminal`, the tokio runtime/`ctrl_c` glue, the hook-shim subprocess residual, and a few dead-by-construction defensive branches — most of which were instead deleted or downgraded to `debug_assert!`).

## Tests added

init_pack/validate-pack integration (`tests/pack_cli.rs`, new) · runtime `summarize` + theme-error · install orchestration via a fake `Target` · Source `run()` tokio-tests + jsonl watcher cursor/utf8/parent-detect guards · reducer/scope/sprite-format/blit error paths · the full pixel-pass + hit-test + tooltip + render-bail arm matrix (harness) · motion/pose timeline edges · pathfind degenerate grids · hook-shim socket path.

## CR findings applied (28)

**Dead-code deletions** (these *were* the 0%-coverage regions): `bounds_to_rect`, `DwellWindow::is_decor`, `impl From<String> for ToolDetail`, and the dead meeting-room/`v_bot` else-arms → `debug_assert!`.

**Real fixes:** `unreachable!()` → `continue` in the per-frame mouse hit-test path (was a latent TUI-crash vector); **Ctrl-D (EOF) at the destructive uninstall confirm now CANCELS** instead of proceeding; chitchat bubble width uses display columns not bytes; validate-pack ERROR/tally → stderr; antigravity non-integer `step_index` fails safe-and-visible; `build_palette` drops a prod `expect()`; Storm rain-streak uses `blend_rgb`. Plus doc/comment cleanups.

## Note for the reviewer

Labeled `needs-human-verify`. This is overwhelmingly additive (tests + dead-code removal); the handful of behavior touches (Ctrl-D confirm, validate stderr, antigravity step_index, `unreachable!`→`continue`) are small and individually noted above. The golden/pixel-regression suites are unchanged → render output is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
