### PR TITLE
fix(reducer): make the ghost-label counter contiguous (#95)

### DIFF
--- a/crates/pixtuoid-core/src/state/reducer.rs
+++ b/crates/pixtuoid-core/src/state/reducer.rs
@@ -349,7 +349,6 @@ impl Reducer {
                     return;
                 };
                 let floor_idx = scene.floor_of(desk_index);
-                self.next_label_n += 1;
                 let base = cwd
                     .file_name()
                     .and_then(|n| n.to_str())
@@ -358,7 +357,13 @@ impl Reducer {
                 let prefix = source_label_prefix(&source);
                 let label: Arc<str> = match base {
                     Some(b) => Arc::<str>::from(format!("{prefix}·{b}").as_str()),
-                    None => Arc::<str>::from(format!("{prefix}#{}", self.next_label_n).as_str()),
+                    None => {
+                        // Only an unknown-cwd ghost consumes an ordinal, so labels
+                        // stay contiguous (cc#1, cc#2, …) instead of skipping the
+                        // count of preceding named sessions.
+                        self.next_label_n += 1;
+                        Arc::<str>::from(format!("{prefix}#{}", self.next_label_n).as_str())
+                    }
                 };
                 // Disambiguation for multiple sessions sharing a cwd happens
                 // at render time, not here — we don't want to suffix unique

--- a/crates/pixtuoid-core/tests/reducer.rs
+++ b/crates/pixtuoid-core/tests/reducer.rs
@@ -502,6 +502,42 @@ fn session_start_without_cwd_falls_back_to_cc_label() {
 }
 
 #[test]
+fn ghost_label_counter_is_contiguous_after_named_sessions() {
+    // A named-cwd session must NOT consume a ghost ordinal: the first
+    // unknown-cwd ghost is cc#1 even when named sessions preceded it.
+    let mut scene = SceneState::uniform(4);
+    let mut r = Reducer::new();
+    let named = AgentId::from_transcript_path("/p/named.jsonl");
+    let ghost = AgentId::from_transcript_path("/p/ghost.jsonl");
+    r.apply(
+        &mut scene,
+        AgentEvent::SessionStart {
+            agent_id: named,
+            source: "claude-code".into(),
+            session_id: "named".into(),
+            cwd: PathBuf::from("/Users/me/Desktop/pixtuoid"),
+            parent_id: None,
+        },
+        SystemTime::now(),
+        Transport::Hook,
+    );
+    r.apply(
+        &mut scene,
+        AgentEvent::SessionStart {
+            agent_id: ghost,
+            source: "claude-code".into(),
+            session_id: "ghost".into(),
+            cwd: PathBuf::from(""),
+            parent_id: None,
+        },
+        SystemTime::now(),
+        Transport::Hook,
+    );
+    assert_eq!(&*scene.agents.get(&named).unwrap().label, "cc·pixtuoid");
+    assert_eq!(&*scene.agents.get(&ghost).unwrap().label, "cc#1");
+}
+
+#[test]
 fn session_start_codex_source_gets_cx_label() {
     // Codex arrives via the shared hook socket (no JSONL Rename), so the cx·
     // prefix must come from the reducer at SessionStart.


### PR DESCRIPTION
Closes #95.

## Problem
The unknown-cwd ghost-label disambiguator incremented `next_label_n` on **every** `SessionStart`, so the first ghost after N named sessions was `cc#(N+1)` instead of `cc#1`. Uniqueness held; it was cosmetic.

## Fix
Move `self.next_label_n += 1` into the empty-cwd (`None`) match arm — the counter's only consumer — so ghost ordinals are contiguous (`cc#1, 2, 3…`).

## Test
Added `ghost_label_counter_is_contiguous_after_named_sessions`: a named-cwd session no longer consumes an ordinal, so the first unknown-cwd ghost stays `cc#1`. The existing `session_start_without_cwd_falls_back_to_cc_label` (first ghost → `cc#1`) stays green. Full 53-test reducer suite green; `just preflight` green (pre-push hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)