### PR TITLE
refactor(state): remove the never-used Activity::Thinking variant (#94)

### DIFF
--- a/crates/pixtuoid-core/src/source/mod.rs
+++ b/crates/pixtuoid-core/src/source/mod.rs
@@ -64,7 +64,6 @@ pub enum Transport {
 pub enum Activity {
     Typing,
     Reading,
-    Thinking,
 }
 
 /// Structured tool detail. Replaces the free-form `Option<String>` so the


### PR DESCRIPTION
Closes #94.

## Problem
`Activity::Thinking` was defined but **never constructed or matched** anywhere — genuinely dead (`Typing` is produced 12+ times; `Reading` is used in tests; `Thinking` zero).

## Fix
Delete only the `Thinking` variant. `Reading` stays — it's the deliberate JSONL-vs-hook discriminator for the hook-wins-dedup + event→state value-fidelity tests. The `Serialize`/`Deserialize` derive is for the v2-daemon split, not a variant-count-pinned wire format, so removing `Thinking` breaks no serialization contract.

`just preflight` green (pre-push hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)