### PR TITLE
refactor(pet): remove the dead PetKind::config_name (#99)

### DIFF
--- a/crates/pixtuoid/src/tui/pet.rs
+++ b/crates/pixtuoid/src/tui/pet.rs
@@ -48,13 +48,6 @@ pub enum PetKind {
 impl PetKind {
     pub const ALL: &'static [PetKind] = &[PetKind::Cat, PetKind::Dog];
 
-    pub fn config_name(self) -> &'static str {
-        match self {
-            PetKind::Cat => "cat",
-            PetKind::Dog => "dog",
-        }
-    }
-
     pub fn from_config_name(s: &str) -> Option<Self> {
         match s {
             "cat" => Some(PetKind::Cat),
@@ -159,9 +152,17 @@ mod tests {
     }
 
     #[test]
-    fn config_name_roundtrip() {
+    fn every_pet_kind_is_reachable_from_config() {
         for &kind in PetKind::ALL {
-            assert_eq!(PetKind::from_config_name(kind.config_name()), Some(kind));
+            // Exhaustive match — adding a PetKind without a config string
+            // breaks compile HERE instead of warn-skipping at config load.
+            // (This forcing function used to live in the deleted
+            // config_name's own exhaustive match.)
+            let name = match kind {
+                PetKind::Cat => "cat",
+                PetKind::Dog => "dog",
+            };
+            assert_eq!(PetKind::from_config_name(name), Some(kind));
         }
     }
 


### PR DESCRIPTION
Closes #99.

## Problem
`PetKind::config_name` (enum→str) had **no production caller** — the config layer only ever goes string→enum via `from_config_name` (`config.rs:176`). Only the roundtrip test fed it.

## Fix
Delete `config_name` (YAGNI). A future config-write path (e.g. a TUI pet picker persisting a kind) can reintroduce it on need. The `config_name_roundtrip` test is replaced by `from_config_name_maps_known_kinds`, which directly asserts the production string→enum mapping for every kind (`cat`/`dog`) — so the actually-used direction stays guarded.

`just preflight` green (pre-push hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)