### PR TITLE
refactor(paths): pin shim↔daemon socket-path parity + explicit ts narrowing (#93, #98)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ The `test-renderer` feature is needed for the `e2e.rs` integration test; **`just
 ### Test organization (three tiers)
 
 - **Unit tests** — `#[cfg(test)] mod tests` next to the code. For large modules this is a *sibling file* declared `#[cfg(test)] mod tests;` (e.g. `motion/tests.rs`, `pose/tests.rs`, `layout/tests.rs`, `pixel_painter/tests.rs`) so production stays readable; it keeps `use super::*` and full crate-internal access (no API widening).
-- **Integration / public-contract** — `crates/<crate>/tests/*.rs` (separate crate, only `pub` API): `reducer.rs`, `e2e.rs`, `hook_socket.rs`, `jsonl_watcher.rs`.
+- **Integration / public-contract** — `crates/<crate>/tests/*.rs` (separate crate, only `pub` API): `reducer.rs`, `e2e.rs`, `hook_socket.rs`, `jsonl_watcher.rs`. One deliberate exception: `socket_path_parity.rs` `#[path]`-includes the hook shim's `paths.rs` (source inclusion, not a dep) to pin shim↔daemon socket-path equality across crates without violating the no-core-dep-in-shim invariant; it's `exclude`d from the published tarball (the included file can't exist there).
 - **Headless render harness** — `tui_renderer/harness.rs` (`#[cfg(test)] mod harness;`). Drives the *real* `TuiRenderer` through `render()` / `navigate_floor()` via ratatui `TestBackend` (no terminal). Output-first assertions: `buf()` (RgbBuffer pixels) + the `#[cfg(test)] frame_buffer()` ratatui-cell inspector; white-box seams (`floor_motion`, `floor_buf`, `inject_coffee`) only where an invariant isn't observable from output. NOT coverable headlessly (excluded in `codecov.yml`): the crossterm event loop (`tui/mod.rs`, reads the real TTY) and `main.rs`.
 
 Coverage: `just coverage` (writes lcov.info + JUnit XML — the exact command CI runs).

--- a/crates/pixtuoid-core/Cargo.toml
+++ b/crates/pixtuoid-core/Cargo.toml
@@ -10,6 +10,11 @@ authors.workspace      = true
 homepage.workspace     = true
 keywords.workspace     = true
 categories.workspace   = true
+# The parity test #[path]-includes ../../pixtuoid-hook/src/paths.rs, which
+# can't exist inside the published tarball — shipping the test would make
+# `cargo test` fail on the .crate (publish itself is unaffected: its verify
+# step builds, not tests). Workspace-only test, workspace-only file.
+exclude                = ["tests/socket_path_parity.rs"]
 
 [features]
 default       = []

--- a/crates/pixtuoid-core/tests/socket_path_parity.rs
+++ b/crates/pixtuoid-core/tests/socket_path_parity.rs
@@ -1,0 +1,63 @@
+//! Pins the hook shim's socket path EQUAL to the daemon's, branch by branch.
+//!
+//! The shim (producer) and `ClaudeCodeSource` (consumer) each compute the
+//! default socket path independently — they MUST agree or hook events
+//! silently never arrive. Each crate already unit-tests its own three
+//! branches against the same literals, but two parallel literal pins only
+//! hold if a reviewer notices the sibling when one side changes; this test
+//! compares the two implementations DIRECTLY, so a one-sided change fails
+//! regardless of which crate's unit test got updated (#93).
+//!
+//! The shim source is included via `#[path]` — compile-time source inclusion,
+//! NOT a cargo dependency — because the hook crate must stay free of
+//! pixtuoid-core (workspace invariant #5: nothing may slow or bloat the shim).
+
+#[path = "../../pixtuoid-hook/src/paths.rs"]
+mod hook_paths;
+
+use std::path::PathBuf;
+
+use pixtuoid_core::source::claude_code::ClaudeCodeSource;
+
+fn both() -> (PathBuf, PathBuf) {
+    (
+        PathBuf::from(hook_paths::default_socket_path()),
+        ClaudeCodeSource::default_socket_path(),
+    )
+}
+
+// All three branches in ONE test: env vars are process-global, and this is the
+// only test in this integration binary, so there is nothing to race (same
+// pattern as the per-crate branch tests).
+#[test]
+fn shim_and_daemon_resolve_identical_socket_paths_in_all_three_branches() {
+    let saved_socket = std::env::var_os("PIXTUOID_SOCKET");
+    let saved_xdg = std::env::var_os("XDG_RUNTIME_DIR");
+
+    // Branch 1: PIXTUOID_SOCKET wins on both sides.
+    std::env::set_var("PIXTUOID_SOCKET", "/explicit/parity.sock");
+    std::env::set_var("XDG_RUNTIME_DIR", "/run/user/7");
+    let (shim, daemon) = both();
+    assert_eq!(shim, daemon, "PIXTUOID_SOCKET branch diverged");
+    assert_eq!(shim, PathBuf::from("/explicit/parity.sock"));
+
+    // Branch 2: XDG_RUNTIME_DIR drives the path on both sides.
+    std::env::remove_var("PIXTUOID_SOCKET");
+    let (shim, daemon) = both();
+    assert_eq!(shim, daemon, "XDG_RUNTIME_DIR branch diverged");
+    assert_eq!(shim, PathBuf::from("/run/user/7/pixtuoid.sock"));
+
+    // Branch 3: uid-suffixed /tmp fallback on both sides.
+    std::env::remove_var("XDG_RUNTIME_DIR");
+    let (shim, daemon) = both();
+    assert_eq!(shim, daemon, "/tmp-uid fallback branch diverged");
+
+    match saved_socket {
+        Some(v) => std::env::set_var("PIXTUOID_SOCKET", v),
+        None => std::env::remove_var("PIXTUOID_SOCKET"),
+    }
+    match saved_xdg {
+        Some(v) => std::env::set_var("XDG_RUNTIME_DIR", v),
+        None => std::env::remove_var("XDG_RUNTIME_DIR"),
+    }
+}

--- a/crates/pixtuoid-hook/src/main.rs
+++ b/crates/pixtuoid-hook/src/main.rs
@@ -5,18 +5,19 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use anyhow::Result;
 use serde_json::Value;
 
+mod paths;
+use paths::default_socket_path;
+
 const WRITE_TIMEOUT: Duration = Duration::from_millis(200);
 
-fn default_socket_path() -> String {
-    if let Ok(p) = std::env::var("PIXTUOID_SOCKET") {
-        return p;
-    }
-    if let Ok(dir) = std::env::var("XDG_RUNTIME_DIR") {
-        return format!("{dir}/pixtuoid.sock");
-    }
-    // Safety: getuid is always safe on Unix.
-    let uid = unsafe { libc::getuid() };
-    format!("/tmp/pixtuoid-{uid}.sock")
+/// Explicit `u128 → u64` narrowing (`try_from`, not a truncating `as` cast):
+/// ms-since-epoch fits u64 for ~580M years, so the `unwrap_or(u64::MAX)` arm
+/// is unreachable in practice — it exists to make the narrowing visible and
+/// the fn total. A pre-epoch clock maps to 0 (same as before).
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
 }
 
 fn main() -> Result<()> {
@@ -37,11 +38,7 @@ fn main() -> Result<()> {
     };
 
     if let Value::Object(map) = &mut payload {
-        let ts = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_millis())
-            .unwrap_or(0) as u64;
-        enrich_payload(map, std::env::var("PIXTUOID_SOURCE").ok(), ts);
+        enrich_payload(map, std::env::var("PIXTUOID_SOURCE").ok(), now_ms());
     }
 
     // Best-effort send with a hard write timeout so a stuck daemon can never
@@ -84,6 +81,12 @@ fn enrich_payload(
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn now_ms_keeps_real_magnitude() {
+        // 2024-01-01 in ms — a truncating-narrowing bug would land far below.
+        assert!(now_ms() > 1_704_067_200_000);
+    }
 
     #[test]
     fn stamps_cli_source_under_private_key_and_leaves_public_source_untouched() {

--- a/crates/pixtuoid-hook/src/paths.rs
+++ b/crates/pixtuoid-hook/src/paths.rs
@@ -1,0 +1,20 @@
+//! The shim's socket-path resolution, in its own TEST-FREE file on purpose:
+//! `pixtuoid-core/tests/socket_path_parity.rs` includes this file via
+//! `#[path]` (source inclusion, NOT a cargo dependency — the shim must stay
+//! free of pixtuoid-core and vice versa) and asserts it resolves identically
+//! to the daemon's `ClaudeCodeSource::default_socket_path` in all three
+//! branches. Producer and consumer MUST agree or hook events silently never
+//! arrive. If you move or rename this file, that test breaks loudly — fix the
+//! `#[path]` there, don't drop the parity pin.
+
+pub fn default_socket_path() -> String {
+    if let Ok(p) = std::env::var("PIXTUOID_SOCKET") {
+        return p;
+    }
+    if let Ok(dir) = std::env::var("XDG_RUNTIME_DIR") {
+        return format!("{dir}/pixtuoid.sock");
+    }
+    // Safety: getuid is always safe on Unix.
+    let uid = unsafe { libc::getuid() };
+    format!("/tmp/pixtuoid-{uid}.sock")
+}


### PR DESCRIPTION
Closes #93. Closes #98.

## Problem
The Unix socket path is computed byte-for-byte identically in the hook shim (producer) and `ClaudeCodeSource` (consumer). They MUST agree or hook events silently never arrive. Since the #101 coverage sweep each crate unit-tests its own three branches against the same literals — but two *parallel* literal pins only hold if a reviewer notices the sibling when one side changes. Nothing compared the two implementations directly.

## Fix (#93, option B from the issue)
- `pixtuoid-hook/src/paths.rs` — `default_socket_path` moved verbatim into a **test-free** file.
- `pixtuoid-core/tests/socket_path_parity.rs` — includes that file via `#[path]` (**compile-time source inclusion, no cargo dep edge** — invariant #5 holds both ways) and asserts shim == daemon across all three branches (`PIXTUOID_SOCKET` / `XDG_RUNTIME_DIR` / `/tmp`-uid). A one-sided change now fails regardless of which crate's unit test got updated; a file move breaks the include loudly (the module doc says how to re-pin).
- Option A (a `pixtuoid-paths` leaf crate) stays rejected: a new *publishable* crate for 6 duplicated lines is structural churn — with the parity test there is no remaining drift risk.

## Ride-along (#98, meeting its own "only if touching this file anyway" bar)
Shim ts narrowing is now an explicit `now_ms()` using `u64::try_from` (`unwrap_or(u64::MAX)` documents the ~580M-year-unreachable arm) instead of a truncating `as` cast; magnitude regression test added.

## Tests
- `socket_path_parity` 1/1, `pixtuoid-hook` 8/8 (was 7; +`now_ms_keeps_real_magnitude`) — all branch coverage from the existing per-crate tests retained untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)