### PR TITLE
refactor(reducer): extract suppress_subagent_leak + track_active_tasks pre-passes (#90)

### DIFF
--- a/crates/pixtuoid-core/src/state/reducer.rs
+++ b/crates/pixtuoid-core/src/state/reducer.rs
@@ -439,13 +439,14 @@ impl Reducer {
         id: AgentId,
         now: SystemTime,
     ) -> bool {
-        let in_task = self.active_tasks.get(&id).is_some_and(|s| !s.is_empty());
+        let tasks = self.active_tasks.get(&id);
+        let in_task = tasks.is_some_and(|s| !s.is_empty());
         let suppress = match event {
             AgentEvent::ActivityStart { .. } => in_task,
             AgentEvent::ActivityEnd { tool_use_id, .. } => {
                 let is_task_self_end = tool_use_id
                     .as_ref()
-                    .is_some_and(|t| self.active_tasks.get(&id).is_some_and(|s| s.contains(t)));
+                    .is_some_and(|t| tasks.is_some_and(|s| s.contains(t)));
                 in_task && !is_task_self_end
             }
             _ => false,
@@ -463,13 +464,11 @@ impl Reducer {
             // work, so the gate resolved: restore Active(Delegating) instead
             // of leaving a stale "permission?" Waiting until the 60-min
             // stale-sweep. Then drop the spurious display update.
-            let task_tuid = self
-                .active_tasks
-                .get(&id)
-                .and_then(|s| s.iter().next())
-                .map(|t| Arc::<str>::from(t.as_str()));
             if let Some(slot) = scene.agents.get_mut(&id) {
                 if matches!(slot.state, ActivityState::Waiting { .. }) {
+                    let task_tuid = tasks
+                        .and_then(|s| s.iter().next())
+                        .map(|t| Arc::<str>::from(t.as_str()));
                     fsm::enter_delegating(slot, task_tuid, now);
                     self.gated_before_waiting.remove(&id);
                 }

--- a/crates/pixtuoid-core/src/state/reducer.rs
+++ b/crates/pixtuoid-core/src/state/reducer.rs
@@ -127,6 +127,19 @@ fn source_label_prefix(source: &str) -> &str {
         .unwrap_or(source)
 }
 
+/// Outcome flags from [`Reducer::track_active_tasks`], consumed by `apply`'s
+/// main event match.
+struct TaskTracking {
+    /// An `ActivityEnd` drained a tracked Task: the general ActivityEnd arm
+    /// must be skipped — otherwise it would redundantly re-arm
+    /// `pending_idle_at` or arm it while tasks are still in flight.
+    handled_by_task_tracking: bool,
+    /// An `ActivityStart` dispatched a Task (already applied as
+    /// Active(Delegating) by the pre-pass): the general ActivityStart arm
+    /// must be skipped.
+    handled_by_task_start: bool,
+}
+
 #[derive(Debug, Default)]
 pub struct Reducer {
     /// Track recent hook-derived events so JSONL duplicates can be dropped.
@@ -207,50 +220,19 @@ impl Reducer {
             scope::refresh_lineage(scene, id, now);
         }
 
-        // Subagent-leak suppression: if this AgentId currently has any Task
-        // tool in flight, hook ActivityStart/End events for it are almost
-        // certainly subagent work misattributed to the parent. Drop them and
-        // defer to JSONL, which targets the subagent's own AgentId. The
-        // Task's own PostToolUse is exempt — its tool_use_id matches one we
-        // are tracking, so it passes through and clears the slot.
-        if from == Transport::Hook {
-            let in_task = self.active_tasks.get(&id).is_some_and(|s| !s.is_empty());
-            let suppress = match &event {
-                AgentEvent::ActivityStart { .. } => in_task,
-                AgentEvent::ActivityEnd { tool_use_id, .. } => {
-                    let is_task_self_end = tool_use_id
-                        .as_ref()
-                        .is_some_and(|t| self.active_tasks.get(&id).is_some_and(|s| s.contains(t)));
-                    in_task && !is_task_self_end
-                }
-                _ => false,
-            };
-            if suppress {
-                // The misattributed subagent event already refreshed the
-                // parent's lineage above (liveness flows up), keeping the
-                // delegating parent from being wrongly stale-swept.
-                //
-                // One state change still belongs to the parent: if it is
-                // `Waiting` while delegating, that Waiting is the SUBAGENT's
-                // permission gate (the `Notification` was misattributed to the
-                // parent) — a parent blocked on a Task isn't running its own
-                // tools. A suppressed child event means the subagent resumed
-                // work, so the gate resolved: restore Active(Delegating) instead
-                // of leaving a stale "permission?" Waiting until the 60-min
-                // stale-sweep. Then drop the spurious display update.
-                let task_tuid = self
-                    .active_tasks
-                    .get(&id)
-                    .and_then(|s| s.iter().next())
-                    .map(|t| Arc::<str>::from(t.as_str()));
-                if let Some(slot) = scene.agents.get_mut(&id) {
-                    if matches!(slot.state, ActivityState::Waiting { .. }) {
-                        fsm::enter_delegating(slot, task_tuid, now);
-                        self.gated_before_waiting.remove(&id);
-                    }
-                }
-                return;
-            }
+        // PRE-PASS ORDER IS LOAD-BEARING: suppression → hook-wins dedup →
+        // task tracking.
+        // (1) Suppress before the dedup RECORD: a suppressed hook event must
+        //     not record its tool_use_id, or it would dedup-drop its own JSONL
+        //     copy — the only transport left to track that Task (e.g. a
+        //     parallel second dispatch suppressed as a leak; pinned by
+        //     `suppressed_parallel_task_dispatch_jsonl_copy_survives_dedup_and_tracks`).
+        // (2) Dedup before task tracking: a JSONL duplicate must be dropped
+        //     before it can drain `active_tasks` and fire `cascade_exit`
+        //     mid-delegation (pinned by
+        //     `jsonl_duplicate_task_end_inside_dedup_window_does_not_fire_cascade`).
+        if from == Transport::Hook && self.suppress_subagent_leak(scene, &event, id, now) {
+            return;
         }
 
         // Dedup: drop JSONL events that match a recent Hook event by tool_use_id.
@@ -272,81 +254,10 @@ impl Reducer {
             }
         }
 
-        // Track active Task tool_use_ids from either transport. HashSet is
-        // idempotent so duplicate inserts from both hook+jsonl are harmless.
-        //
-        // Side effect: when the parent gains a Task, also mark it as
-        // Active("Delegating") so it doesn't look idle/asleep while its
-        // subagents do the visible work. When the last Task drains, the
-        // next normal hook/JSONL event will reset its state.
-        //
-        // `handled_by_task_tracking`: when an ActivityEnd drains
-        // active_tasks, the general ActivityEnd arm below must be
-        // skipped — otherwise it would redundantly re-arm
-        // pending_idle_at or arm it while tasks are still in flight.
-        let mut handled_by_task_tracking = false;
-        let mut handled_by_task_start = false;
-        // b1 subagent-completion inference (CC writes no completion marker): set
-        // when the parent's LAST Task drains on this event, so the delegated
-        // subtree can be marked exiting below.
-        let mut completed_subtree_root: Option<AgentId> = None;
-        match &event {
-            AgentEvent::ActivityStart {
-                agent_id,
-                tool_use_id: Some(tuid),
-                detail: Some(d),
-                ..
-            } if d.is_task() => {
-                handled_by_task_start = true;
-                self.active_tasks
-                    .entry(*agent_id)
-                    .or_default()
-                    .insert(tuid.clone());
-                if let Some(slot) = scene.agents.get_mut(agent_id) {
-                    fsm::enter_delegating(slot, Some(Arc::<str>::from(tuid.as_str())), now);
-                }
-            }
-            AgentEvent::ActivityEnd {
-                agent_id,
-                tool_use_id: Some(tuid),
-            } => {
-                if let Some(set) = self.active_tasks.get_mut(agent_id) {
-                    if set.remove(tuid) {
-                        handled_by_task_tracking = true;
-                        if let Some(slot) = scene.agents.get_mut(agent_id) {
-                            slot.last_event_at = now;
-                            // Debounce: stay visually Active for
-                            // ACTIVE_GRACE_WINDOW; expire_pending_idles flips to
-                            // Idle if no new tool starts inside the window. Only
-                            // arm when actually Active — if the parent is Waiting
-                            // (its own permission prompt fired during delegation)
-                            // a Task drain must NOT arm the idle-resolve, or the
-                            // expiry would false-clear a still-pending permission.
-                            if set.is_empty() {
-                                // Parent's last Task returned → the delegated
-                                // subtree is done; mark it exiting after this
-                                // match (b1).
-                                completed_subtree_root = Some(*agent_id);
-                                if matches!(slot.state, ActivityState::Active { .. }) {
-                                    fsm::arm_pending_idle(slot, now);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            _ => {}
-        }
-
-        // b1: a drained parent Task means the delegated subtree returned —
-        // cascade EXIT to the parent's descendants (not the parent, which keeps
-        // running) so completed subagents leave promptly instead of lingering to
-        // the 30-min idle stale-sweep. CC infers completion from the Task drain
-        // here; a source with a clean "subagent finished" signal (e.g. Codex)
-        // would drive the same cascade through its own decoder.
-        if let Some(parent) = completed_subtree_root {
-            scope::cascade_exit(scene, parent, now);
-        }
+        let TaskTracking {
+            handled_by_task_tracking,
+            handled_by_task_start,
+        } = self.track_active_tasks(scene, &event, now);
 
         match event {
             AgentEvent::SessionStart {
@@ -506,6 +417,145 @@ impl Reducer {
                 }
                 scope::cascade_exit(scene, agent_id, now);
             }
+        }
+    }
+
+    /// Pre-pass 1 of [`Reducer::apply`] — subagent-leak suppression (hook
+    /// transport only): if this AgentId currently has any Task tool in
+    /// flight, hook ActivityStart/End events for it are almost certainly
+    /// subagent work misattributed to the parent. Drop them (returns `true`)
+    /// and defer to JSONL, which targets the subagent's own AgentId. The
+    /// Task's own PostToolUse is exempt — its tool_use_id matches one we are
+    /// tracking, so it passes through and clears the slot.
+    fn suppress_subagent_leak(
+        &mut self,
+        scene: &mut SceneState,
+        event: &AgentEvent,
+        id: AgentId,
+        now: SystemTime,
+    ) -> bool {
+        let in_task = self.active_tasks.get(&id).is_some_and(|s| !s.is_empty());
+        let suppress = match event {
+            AgentEvent::ActivityStart { .. } => in_task,
+            AgentEvent::ActivityEnd { tool_use_id, .. } => {
+                let is_task_self_end = tool_use_id
+                    .as_ref()
+                    .is_some_and(|t| self.active_tasks.get(&id).is_some_and(|s| s.contains(t)));
+                in_task && !is_task_self_end
+            }
+            _ => false,
+        };
+        if suppress {
+            // The misattributed subagent event already refreshed the
+            // parent's lineage in `apply` (liveness flows up), keeping the
+            // delegating parent from being wrongly stale-swept.
+            //
+            // One state change still belongs to the parent: if it is
+            // `Waiting` while delegating, that Waiting is the SUBAGENT's
+            // permission gate (the `Notification` was misattributed to the
+            // parent) — a parent blocked on a Task isn't running its own
+            // tools. A suppressed child event means the subagent resumed
+            // work, so the gate resolved: restore Active(Delegating) instead
+            // of leaving a stale "permission?" Waiting until the 60-min
+            // stale-sweep. Then drop the spurious display update.
+            let task_tuid = self
+                .active_tasks
+                .get(&id)
+                .and_then(|s| s.iter().next())
+                .map(|t| Arc::<str>::from(t.as_str()));
+            if let Some(slot) = scene.agents.get_mut(&id) {
+                if matches!(slot.state, ActivityState::Waiting { .. }) {
+                    fsm::enter_delegating(slot, task_tuid, now);
+                    self.gated_before_waiting.remove(&id);
+                }
+            }
+        }
+        suppress
+    }
+
+    /// Last pre-pass of [`Reducer::apply`] (after the inline hook-wins
+    /// dedup) — track active Task tool_use_ids from either transport.
+    /// HashSet is idempotent so duplicate inserts from both hook+jsonl are
+    /// harmless.
+    ///
+    /// Side effect: when the parent gains a Task, also mark it as
+    /// Active("Delegating") so it doesn't look idle/asleep while its
+    /// subagents do the visible work. When the last Task drains, the next
+    /// normal hook/JSONL event will reset its state.
+    ///
+    /// b1 subagent-completion inference (CC writes no completion marker): a
+    /// drained parent Task means the delegated subtree returned — cascade
+    /// EXIT to the parent's descendants (not the parent, which keeps running)
+    /// so completed subagents leave promptly instead of lingering to the
+    /// 30-min idle stale-sweep. CC infers completion from the Task drain
+    /// here; a source with a clean "subagent finished" signal (e.g. Codex)
+    /// would drive the same cascade through its own decoder.
+    fn track_active_tasks(
+        &mut self,
+        scene: &mut SceneState,
+        event: &AgentEvent,
+        now: SystemTime,
+    ) -> TaskTracking {
+        let mut handled_by_task_tracking = false;
+        let mut handled_by_task_start = false;
+        // Set when the parent's LAST Task drains on this event, so the
+        // delegated subtree can be marked exiting below (b1).
+        let mut completed_subtree_root: Option<AgentId> = None;
+        match event {
+            AgentEvent::ActivityStart {
+                agent_id,
+                tool_use_id: Some(tuid),
+                detail: Some(d),
+                ..
+            } if d.is_task() => {
+                handled_by_task_start = true;
+                self.active_tasks
+                    .entry(*agent_id)
+                    .or_default()
+                    .insert(tuid.clone());
+                if let Some(slot) = scene.agents.get_mut(agent_id) {
+                    fsm::enter_delegating(slot, Some(Arc::<str>::from(tuid.as_str())), now);
+                }
+            }
+            AgentEvent::ActivityEnd {
+                agent_id,
+                tool_use_id: Some(tuid),
+            } => {
+                if let Some(set) = self.active_tasks.get_mut(agent_id) {
+                    if set.remove(tuid) {
+                        handled_by_task_tracking = true;
+                        if let Some(slot) = scene.agents.get_mut(agent_id) {
+                            slot.last_event_at = now;
+                            // Debounce: stay visually Active for
+                            // ACTIVE_GRACE_WINDOW; expire_pending_idles flips to
+                            // Idle if no new tool starts inside the window. Only
+                            // arm when actually Active — if the parent is Waiting
+                            // (its own permission prompt fired during delegation)
+                            // a Task drain must NOT arm the idle-resolve, or the
+                            // expiry would false-clear a still-pending permission.
+                            if set.is_empty() {
+                                // Parent's last Task returned → the delegated
+                                // subtree is done; mark it exiting after this
+                                // match (b1).
+                                completed_subtree_root = Some(*agent_id);
+                                if matches!(slot.state, ActivityState::Active { .. }) {
+                                    fsm::arm_pending_idle(slot, now);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+
+        if let Some(parent) = completed_subtree_root {
+            scope::cascade_exit(scene, parent, now);
+        }
+
+        TaskTracking {
+            handled_by_task_tracking,
+            handled_by_task_start,
         }
     }
 

--- a/crates/pixtuoid-core/src/state/reducer.rs
+++ b/crates/pixtuoid-core/src/state/reducer.rs
@@ -134,9 +134,10 @@ struct TaskTracking {
     /// must be skipped — otherwise it would redundantly re-arm
     /// `pending_idle_at` or arm it while tasks are still in flight.
     handled_by_task_tracking: bool,
-    /// An `ActivityStart` dispatched a Task (already applied as
-    /// Active(Delegating) by the pre-pass): the general ActivityStart arm
-    /// must be skipped.
+    /// An `ActivityStart` dispatched a Task (applied as Active(Delegating)
+    /// by the pre-pass when the slot exists; in the Task-before-SessionStart
+    /// race nothing is applied — the skipped general arm would no-op too):
+    /// the general ActivityStart arm must be skipped.
     handled_by_task_start: bool,
 }
 
@@ -231,6 +232,10 @@ impl Reducer {
         //     before it can drain `active_tasks` and fire `cascade_exit`
         //     mid-delegation (pinned by
         //     `jsonl_duplicate_task_end_inside_dedup_window_does_not_fire_cascade`).
+        //     Caveat: that guarded window is synthetic-narrow — a real CC
+        //     JSONL Task END only exists once the Task returned — so the pin
+        //     freezes this refactor's ordering, not the kind-blind dedup
+        //     keying (revisited in #150).
         if from == Transport::Hook && self.suppress_subagent_leak(scene, &event, id, now) {
             return;
         }

--- a/crates/pixtuoid-core/tests/reducer.rs
+++ b/crates/pixtuoid-core/tests/reducer.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
 
 use pixtuoid_core::source::{Activity, AgentEvent, Transport};
-use pixtuoid_core::state::reducer::Reducer;
+use pixtuoid_core::state::reducer::{Reducer, HOOK_WINS_WINDOW};
 use pixtuoid_core::state::{ActivityState, SceneState};
 use pixtuoid_core::AgentId;
 
@@ -19,6 +19,56 @@ fn start(reducer: &mut Reducer, scene: &mut SceneState, id: AgentId) {
         SystemTime::now(),
         Transport::Hook,
     );
+}
+
+/// Delegation scaffold shared by the pre-pass ordering pins: parent created
+/// via Hook at `t0`, child created via Jsonl at `t0 + 100ms` with the parent
+/// link (the same two-transport shape the sibling lifecycle tests hand-roll).
+fn delegating_pair(
+    r: &mut Reducer,
+    scene: &mut SceneState,
+    slug: &str,
+    t0: SystemTime,
+) -> (AgentId, AgentId) {
+    let parent = AgentId::from_transcript_path(&format!("/p/{slug}.jsonl"));
+    let child = AgentId::from_parts("claude-code", &format!("/p/{slug}/subagents/agent-1.jsonl"));
+    r.apply(
+        scene,
+        AgentEvent::SessionStart {
+            agent_id: parent,
+            source: "claude-code".into(),
+            session_id: "p".into(),
+            cwd: PathBuf::from("/repo"),
+            parent_id: None,
+        },
+        t0,
+        Transport::Hook,
+    );
+    r.apply(
+        scene,
+        AgentEvent::SessionStart {
+            agent_id: child,
+            source: "claude-code".into(),
+            session_id: "c".into(),
+            cwd: PathBuf::from("/repo"),
+            parent_id: Some(parent),
+        },
+        t0 + Duration::from_millis(100),
+        Transport::Jsonl,
+    );
+    (parent, child)
+}
+
+/// Assert the slot renders Active("Delegating") — `ToolDetail::Task`'s
+/// display, set by `fsm::enter_delegating`.
+#[track_caller]
+fn assert_delegating(scene: &SceneState, id: AgentId, msg: &str) {
+    match &scene.agents.get(&id).unwrap().state {
+        ActivityState::Active { detail, .. } => {
+            assert_eq!(detail.as_deref(), Some("Delegating"), "{msg}");
+        }
+        other => panic!("expected Active(Delegating), got {other:?} — {msg}"),
+    }
 }
 
 #[test]
@@ -2138,37 +2188,14 @@ fn jsonl_duplicate_task_end_inside_dedup_window_does_not_fire_cascade() {
     // BEFORE task tracking. The hook ActivityStart records the Task's
     // tool_use_id in the dedup map; a JSONL duplicate carrying that id inside
     // HOOK_WINS_WINDOW must be dropped BEFORE it can drain active_tasks and
-    // cascade-exit a still-working subtree (b1 above fires on real drains only).
+    // cascade-exit a still-working subtree (b1 above fires on real drains
+    // only). Offsets derive from HOOK_WINS_WINDOW so the pin survives any
+    // retuning of the window.
     let mut scene = SceneState::uniform(8);
     let mut r = Reducer::new();
-    let parent = AgentId::from_transcript_path("/p/orch-dup.jsonl");
-    let child = AgentId::from_parts("claude-code", "/p/orch-dup/subagents/agent-1.jsonl");
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+    let (parent, child) = delegating_pair(&mut r, &mut scene, "orch-dup", t0);
 
-    r.apply(
-        &mut scene,
-        AgentEvent::SessionStart {
-            agent_id: parent,
-            source: "claude-code".into(),
-            session_id: "p".into(),
-            cwd: PathBuf::from("/repo"),
-            parent_id: None,
-        },
-        t0,
-        Transport::Hook,
-    );
-    r.apply(
-        &mut scene,
-        AgentEvent::SessionStart {
-            agent_id: child,
-            source: "claude-code".into(),
-            session_id: "c".into(),
-            cwd: PathBuf::from("/repo"),
-            parent_id: Some(parent),
-        },
-        t0 + Duration::from_millis(100),
-        Transport::Jsonl,
-    );
     // Hook Task start → records "task-T" in the dedup map AND active_tasks.
     r.apply(
         &mut scene,
@@ -2190,7 +2217,7 @@ fn jsonl_duplicate_task_end_inside_dedup_window_does_not_fire_cascade() {
             agent_id: parent,
             tool_use_id: Some("task-T".into()),
         },
-        t0 + Duration::from_secs(1) + Duration::from_millis(100),
+        t0 + Duration::from_secs(1) + HOOK_WINS_WINDOW / 5,
         Transport::Jsonl,
     );
 
@@ -2198,18 +2225,15 @@ fn jsonl_duplicate_task_end_inside_dedup_window_does_not_fire_cascade() {
         scene.agents.get(&child).unwrap().exiting_at.is_none(),
         "a JSONL duplicate of the in-flight Task must be dropped by dedup before it can drain active_tasks and cascade-exit the still-working subtree"
     );
-    match &scene.agents.get(&parent).unwrap().state {
-        ActivityState::Active { detail, .. } => {
-            assert_eq!(
-                detail.as_deref(),
-                Some("Delegating"),
-                "parent must stay Delegating across the duplicate"
-            );
-        }
-        other => panic!("expected Active(Delegating), got {other:?}"),
-    }
-    // Strongest proof active_tasks survived the duplicate: a later
-    // misattributed hook event is still suppressed.
+    assert_delegating(
+        &scene,
+        parent,
+        "parent must stay Delegating across the duplicate",
+    );
+    // Defense-in-depth: if a future change decouples the Task drain from the
+    // b1 cascade, the exiting_at assert above goes vacuous — this probe still
+    // catches the ordering mutant, because a later misattributed hook event
+    // is only suppressed while active_tasks is non-empty.
     r.apply(
         &mut scene,
         AgentEvent::ActivityStart {
@@ -2221,16 +2245,11 @@ fn jsonl_duplicate_task_end_inside_dedup_window_does_not_fire_cascade() {
         t0 + Duration::from_secs(2),
         Transport::Hook,
     );
-    match &scene.agents.get(&parent).unwrap().state {
-        ActivityState::Active { detail, .. } => {
-            assert_eq!(
-                detail.as_deref(),
-                Some("Delegating"),
-                "active_tasks must survive the duplicate — later misattributed hooks stay suppressed"
-            );
-        }
-        other => panic!("expected Active(Delegating), got {other:?}"),
-    }
+    assert_delegating(
+        &scene,
+        parent,
+        "active_tasks must survive the duplicate — later misattributed hooks stay suppressed",
+    );
 }
 
 #[test]
@@ -2243,37 +2262,13 @@ fn suppressed_parallel_task_dispatch_jsonl_copy_survives_dedup_and_tracks() {
     // (same parent AgentId + tool_use_id — the dispatch lives in the
     // parent's own transcript), leaving the second Task untracked: the
     // first Task's drain would then empty active_tasks and cascade-exit the
-    // still-working subtree one Task early.
+    // still-working subtree one Task early. Offsets derive from
+    // HOOK_WINS_WINDOW so the pin survives any retuning of the window.
     let mut scene = SceneState::uniform(8);
     let mut r = Reducer::new();
-    let parent = AgentId::from_transcript_path("/p/orch-par.jsonl");
-    let child = AgentId::from_parts("claude-code", "/p/orch-par/subagents/agent-1.jsonl");
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+    let (parent, child) = delegating_pair(&mut r, &mut scene, "orch-par", t0);
 
-    r.apply(
-        &mut scene,
-        AgentEvent::SessionStart {
-            agent_id: parent,
-            source: "claude-code".into(),
-            session_id: "p".into(),
-            cwd: PathBuf::from("/repo"),
-            parent_id: None,
-        },
-        t0,
-        Transport::Hook,
-    );
-    r.apply(
-        &mut scene,
-        AgentEvent::SessionStart {
-            agent_id: child,
-            source: "claude-code".into(),
-            session_id: "c".into(),
-            cwd: PathBuf::from("/repo"),
-            parent_id: Some(parent),
-        },
-        t0 + Duration::from_millis(100),
-        Transport::Jsonl,
-    );
     // First Task dispatch — applies normally, active_tasks = {task-1}.
     r.apply(
         &mut scene,
@@ -2296,12 +2291,13 @@ fn suppressed_parallel_task_dispatch_jsonl_copy_survives_dedup_and_tracks() {
             tool_use_id: Some("task-2".into()),
             detail: Some("Task".into()),
         },
-        t0 + Duration::from_secs(1) + Duration::from_millis(50),
+        t0 + Duration::from_secs(1) + HOOK_WINS_WINDOW / 10,
         Transport::Hook,
     );
     // The JSONL copy of the second dispatch, inside HOOK_WINS_WINDOW of the
-    // suppressed hook copy. It must survive dedup — it is the only transport
-    // left to track task-2.
+    // suppressed hook copy (so a wrongly-recorded "task-2" would dedup-drop
+    // it). It must survive dedup — it is the only transport left to track
+    // task-2.
     r.apply(
         &mut scene,
         AgentEvent::ActivityStart {
@@ -2310,7 +2306,7 @@ fn suppressed_parallel_task_dispatch_jsonl_copy_survives_dedup_and_tracks() {
             tool_use_id: Some("task-2".into()),
             detail: Some("Task".into()),
         },
-        t0 + Duration::from_secs(1) + Duration::from_millis(110),
+        t0 + Duration::from_secs(1) + HOOK_WINS_WINDOW / 10 + HOOK_WINS_WINDOW / 5,
         Transport::Jsonl,
     );
     // First Task's own PostToolUse drains task-1. task-2 must still be in
@@ -2321,7 +2317,7 @@ fn suppressed_parallel_task_dispatch_jsonl_copy_survives_dedup_and_tracks() {
             agent_id: parent,
             tool_use_id: Some("task-1".into()),
         },
-        t0 + Duration::from_secs(1) + Duration::from_millis(200),
+        t0 + Duration::from_secs(1) + HOOK_WINS_WINDOW * 2 / 5,
         Transport::Hook,
     );
 
@@ -2329,16 +2325,11 @@ fn suppressed_parallel_task_dispatch_jsonl_copy_survives_dedup_and_tracks() {
         scene.agents.get(&child).unwrap().exiting_at.is_none(),
         "first Task's drain must not cascade-exit the subtree while the suppressed-then-JSONL-tracked second Task is still in flight"
     );
-    match &scene.agents.get(&parent).unwrap().state {
-        ActivityState::Active { detail, .. } => {
-            assert_eq!(
-                detail.as_deref(),
-                Some("Delegating"),
-                "parent must stay Delegating on the second Task"
-            );
-        }
-        other => panic!("expected Active(Delegating), got {other:?}"),
-    }
+    assert_delegating(
+        &scene,
+        parent,
+        "parent must stay Delegating on the second Task",
+    );
 
     // Teeth: draining the SECOND Task must fire the cascade — proves the
     // child is wired to the parent and the earlier no-cascade assertion

--- a/crates/pixtuoid-core/tests/reducer.rs
+++ b/crates/pixtuoid-core/tests/reducer.rs
@@ -2133,6 +2133,232 @@ fn subagent_is_removed_promptly_when_its_parent_task_completes() {
 }
 
 #[test]
+fn jsonl_duplicate_task_end_inside_dedup_window_does_not_fire_cascade() {
+    // Ordering pin for `apply()`'s pre-passes (#90): hook-wins dedup MUST run
+    // BEFORE task tracking. The hook ActivityStart records the Task's
+    // tool_use_id in the dedup map; a JSONL duplicate carrying that id inside
+    // HOOK_WINS_WINDOW must be dropped BEFORE it can drain active_tasks and
+    // cascade-exit a still-working subtree (b1 above fires on real drains only).
+    let mut scene = SceneState::uniform(8);
+    let mut r = Reducer::new();
+    let parent = AgentId::from_transcript_path("/p/orch-dup.jsonl");
+    let child = AgentId::from_parts("claude-code", "/p/orch-dup/subagents/agent-1.jsonl");
+    let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+
+    r.apply(
+        &mut scene,
+        AgentEvent::SessionStart {
+            agent_id: parent,
+            source: "claude-code".into(),
+            session_id: "p".into(),
+            cwd: PathBuf::from("/repo"),
+            parent_id: None,
+        },
+        t0,
+        Transport::Hook,
+    );
+    r.apply(
+        &mut scene,
+        AgentEvent::SessionStart {
+            agent_id: child,
+            source: "claude-code".into(),
+            session_id: "c".into(),
+            cwd: PathBuf::from("/repo"),
+            parent_id: Some(parent),
+        },
+        t0 + Duration::from_millis(100),
+        Transport::Jsonl,
+    );
+    // Hook Task start → records "task-T" in the dedup map AND active_tasks.
+    r.apply(
+        &mut scene,
+        AgentEvent::ActivityStart {
+            agent_id: parent,
+            activity: Activity::Typing,
+            tool_use_id: Some("task-T".into()),
+            detail: Some("Task".into()),
+        },
+        t0 + Duration::from_secs(1),
+        Transport::Hook,
+    );
+    // JSONL duplicate END for the same tool_use_id, inside HOOK_WINS_WINDOW.
+    // If task tracking ran before dedup, this would drain active_tasks and
+    // cascade-exit the child mid-delegation.
+    r.apply(
+        &mut scene,
+        AgentEvent::ActivityEnd {
+            agent_id: parent,
+            tool_use_id: Some("task-T".into()),
+        },
+        t0 + Duration::from_secs(1) + Duration::from_millis(100),
+        Transport::Jsonl,
+    );
+
+    assert!(
+        scene.agents.get(&child).unwrap().exiting_at.is_none(),
+        "a JSONL duplicate of the in-flight Task must be dropped by dedup before it can drain active_tasks and cascade-exit the still-working subtree"
+    );
+    match &scene.agents.get(&parent).unwrap().state {
+        ActivityState::Active { detail, .. } => {
+            assert_eq!(
+                detail.as_deref(),
+                Some("Delegating"),
+                "parent must stay Delegating across the duplicate"
+            );
+        }
+        other => panic!("expected Active(Delegating), got {other:?}"),
+    }
+    // Strongest proof active_tasks survived the duplicate: a later
+    // misattributed hook event is still suppressed.
+    r.apply(
+        &mut scene,
+        AgentEvent::ActivityStart {
+            agent_id: parent,
+            activity: Activity::Typing,
+            tool_use_id: Some("subagent-R".into()),
+            detail: Some("Read: /foo".into()),
+        },
+        t0 + Duration::from_secs(2),
+        Transport::Hook,
+    );
+    match &scene.agents.get(&parent).unwrap().state {
+        ActivityState::Active { detail, .. } => {
+            assert_eq!(
+                detail.as_deref(),
+                Some("Delegating"),
+                "active_tasks must survive the duplicate — later misattributed hooks stay suppressed"
+            );
+        }
+        other => panic!("expected Active(Delegating), got {other:?}"),
+    }
+}
+
+#[test]
+fn suppressed_parallel_task_dispatch_jsonl_copy_survives_dedup_and_tracks() {
+    // Ordering pin for `apply()`'s pre-passes (#90), leg (1): suppression
+    // MUST run before the hook dedup RECORD. A parallel SECOND Task dispatch
+    // arrives as a hook ActivityStart while the first Task is in flight, so
+    // the leak-suppression drops it — and must drop it BEFORE its
+    // tool_use_id is recorded, or the dedup would also kill the JSONL copy
+    // (same parent AgentId + tool_use_id — the dispatch lives in the
+    // parent's own transcript), leaving the second Task untracked: the
+    // first Task's drain would then empty active_tasks and cascade-exit the
+    // still-working subtree one Task early.
+    let mut scene = SceneState::uniform(8);
+    let mut r = Reducer::new();
+    let parent = AgentId::from_transcript_path("/p/orch-par.jsonl");
+    let child = AgentId::from_parts("claude-code", "/p/orch-par/subagents/agent-1.jsonl");
+    let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+
+    r.apply(
+        &mut scene,
+        AgentEvent::SessionStart {
+            agent_id: parent,
+            source: "claude-code".into(),
+            session_id: "p".into(),
+            cwd: PathBuf::from("/repo"),
+            parent_id: None,
+        },
+        t0,
+        Transport::Hook,
+    );
+    r.apply(
+        &mut scene,
+        AgentEvent::SessionStart {
+            agent_id: child,
+            source: "claude-code".into(),
+            session_id: "c".into(),
+            cwd: PathBuf::from("/repo"),
+            parent_id: Some(parent),
+        },
+        t0 + Duration::from_millis(100),
+        Transport::Jsonl,
+    );
+    // First Task dispatch — applies normally, active_tasks = {task-1}.
+    r.apply(
+        &mut scene,
+        AgentEvent::ActivityStart {
+            agent_id: parent,
+            activity: Activity::Typing,
+            tool_use_id: Some("task-1".into()),
+            detail: Some("Task".into()),
+        },
+        t0 + Duration::from_secs(1),
+        Transport::Hook,
+    );
+    // Parallel SECOND Task dispatch via hook while task-1 is in flight —
+    // suppressed as a leak (and must NOT record "task-2" in the dedup map).
+    r.apply(
+        &mut scene,
+        AgentEvent::ActivityStart {
+            agent_id: parent,
+            activity: Activity::Typing,
+            tool_use_id: Some("task-2".into()),
+            detail: Some("Task".into()),
+        },
+        t0 + Duration::from_secs(1) + Duration::from_millis(50),
+        Transport::Hook,
+    );
+    // The JSONL copy of the second dispatch, inside HOOK_WINS_WINDOW of the
+    // suppressed hook copy. It must survive dedup — it is the only transport
+    // left to track task-2.
+    r.apply(
+        &mut scene,
+        AgentEvent::ActivityStart {
+            agent_id: parent,
+            activity: Activity::Typing,
+            tool_use_id: Some("task-2".into()),
+            detail: Some("Task".into()),
+        },
+        t0 + Duration::from_secs(1) + Duration::from_millis(110),
+        Transport::Jsonl,
+    );
+    // First Task's own PostToolUse drains task-1. task-2 must still be in
+    // flight, so the subtree must NOT cascade-exit yet.
+    r.apply(
+        &mut scene,
+        AgentEvent::ActivityEnd {
+            agent_id: parent,
+            tool_use_id: Some("task-1".into()),
+        },
+        t0 + Duration::from_secs(1) + Duration::from_millis(200),
+        Transport::Hook,
+    );
+
+    assert!(
+        scene.agents.get(&child).unwrap().exiting_at.is_none(),
+        "first Task's drain must not cascade-exit the subtree while the suppressed-then-JSONL-tracked second Task is still in flight"
+    );
+    match &scene.agents.get(&parent).unwrap().state {
+        ActivityState::Active { detail, .. } => {
+            assert_eq!(
+                detail.as_deref(),
+                Some("Delegating"),
+                "parent must stay Delegating on the second Task"
+            );
+        }
+        other => panic!("expected Active(Delegating), got {other:?}"),
+    }
+
+    // Teeth: draining the SECOND Task must fire the cascade — proves the
+    // child is wired to the parent and the earlier no-cascade assertion
+    // wasn't vacuous.
+    r.apply(
+        &mut scene,
+        AgentEvent::ActivityEnd {
+            agent_id: parent,
+            tool_use_id: Some("task-2".into()),
+        },
+        t0 + Duration::from_secs(2),
+        Transport::Jsonl,
+    );
+    assert!(
+        scene.agents.get(&child).unwrap().exiting_at.is_some(),
+        "last Task's drain must cascade-exit the completed subtree"
+    );
+}
+
+#[test]
 fn parent_waiting_on_subagent_permission_resolves_when_the_subagent_resumes() {
     // During delegation a subagent's permission Notification is misattributed to
     // the parent → the parent goes Waiting. When the subagent resumes work (a


### PR DESCRIPTION
Closes #90.

## What

Decomposes `apply()`'s two cohesive cross-slot pre-passes into named private methods on `Reducer` — `suppress_subagent_leak` + `track_active_tasks` — leaving the hook-wins dedup **inline between the two call sites**, exactly as the issue's ordering constraint demands. The handled flags travel via a private `TaskTracking` struct (destructured at the call site, per the PR #89 named-bundle idiom). Cross-slot correlation maps stay in `reducer.rs` per the Layer-A/Layer-B invariant; `fsm.rs`/`scope.rs` untouched.

## The ordering pins (the issue's whole premise)

The pre-pass order is now documented at the one reorderable call site and pinned by **two forcing-function tests**, each validated by mutation (red under its broken ordering, green on both old and new code):

| Leg | Invariant | Pinning test | Mutation that turns it red |
|---|---|---|---|
| (1) | suppress before the dedup **record** | `suppressed_parallel_task_dispatch_jsonl_copy_survives_dedup_and_tracks` | hoist `recent_hook_tool_uses.insert` above the suppress call |
| (2) | dedup before task tracking | `jsonl_duplicate_task_end_inside_dedup_window_does_not_fire_cascade` | move `track_active_tasks` above the JSONL dedup-drop |

Leg (2) is the issue's stated hazard (a JSONL duplicate draining `active_tasks` → premature `cascade_exit`). Leg (1) was surfaced by review: a parallel **second** Task dispatch arrives as a hook `ActivityStart` while the first is in flight → suppressed as a leak; if it recorded its `tool_use_id` first, dedup would also drop its own JSONL copy (same parent `AgentId` + tuid) — the only transport left to track it — and the first Task's drain would cascade-exit the still-working subtree one Task early. Before this PR, that reorder passed all 1015 tests silently.

## Review

Multi-agent review (3 lenses — mechanical equivalence, correctness, architecture — findings adversarially verified, majority-vote for major+):

- **Equivalence: PROVEN** — token-level diff of old vs new; the only deltas: `match &event` → `match event` on the `&AgentEvent` param (identical binding modes), the early `return` → returned bool with the `Transport::Hook` gate short-circuiting at the call site, b1 `cascade_exit` relocated inside `track_active_tasks` at the same flow position, comments reworded.
- **Correctness:** no behavioral regression (statement-level comparison + mutation testing); both legs of the new ordering comment verified true against the actual code paths.
- **Architecture:** layering invariant respected; no doc-currency impact (internal shape only, no public surface). 1 minor (leg-1 unpinned) + 1 nit (pre-pass ordinal wording) — **both fixed in this PR**; 1 finding refuted.

## Verification

- Baseline 377/377 → after 379/379 (`pixtuoid-core`), green-to-green
- `just preflight` (lint → clippy → hack → test): **1016/1016**, exit 0
- Both pinning tests mutation-validated red→green

🤖 Generated with [Claude Code](https://claude.com/claude-code)