### PR TITLE
refactor: eliminate async-trait in favor of native async traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,17 +98,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1422,7 +1411,6 @@ name = "pixtuoid-core"
 version = "0.6.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "filetime",
  "insta",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ serde              = { version = "1", features = ["derive"] }
 serde_json         = "1"
 toml               = "1"
 anyhow             = "1"
-async-trait        = "0.1"
 tracing            = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 notify             = "8"

--- a/crates/pixtuoid-core/CLAUDE.md
+++ b/crates/pixtuoid-core/CLAUDE.md
@@ -12,7 +12,9 @@ and the pure physics/pose math. The binary (`pixtuoid`) and renderer
 ```
 src/
 ├── source/             Source trait, hook+jsonl decoders, listeners, SourceManager
-│                       mod.rs (Source trait, AgentEvent + agent_id(), REGISTERED_SOURCES, AgentId::from_parts),
+│                       mod.rs (Source trait [native async via Send-bounded RPITIT] + its object-safety
+│                       twin DynSource [boxed-future, blanket-impl'd — SourceManager's Box<dyn> currency;
+│                       source authors never name it], AgentEvent + agent_id(), REGISTERED_SOURCES, AgentId::from_parts),
 │                       registry.rs (THE per-source fact table: SourceDescriptor{label_prefix, line_decoder,
 │                       hook{id_key,custom}, caps} — one row per CLI; doc(hidden), not public API),
 │                       decoder.rs (shared utils + decode_hook_payload, a registry-driven dispatcher),

--- a/crates/pixtuoid-core/Cargo.toml
+++ b/crates/pixtuoid-core/Cargo.toml
@@ -26,7 +26,6 @@ serde       = { workspace = true }
 serde_json  = { workspace = true }
 toml        = { workspace = true }
 anyhow      = { workspace = true }
-async-trait = { workspace = true }
 tracing     = { workspace = true }
 notify      = { workspace = true }
 

--- a/crates/pixtuoid-core/src/source/antigravity.rs
+++ b/crates/pixtuoid-core/src/source/antigravity.rs
@@ -1,7 +1,6 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
-use async_trait::async_trait;
 use serde_json::Value;
 
 use crate::source::decoder::{cwd_basename_label, make_tool_detail};
@@ -30,7 +29,6 @@ impl AntigravitySource {
     }
 }
 
-#[async_trait]
 impl Source for AntigravitySource {
     fn name(&self) -> &str {
         SOURCE_NAME

--- a/crates/pixtuoid-core/src/source/claude_code.rs
+++ b/crates/pixtuoid-core/src/source/claude_code.rs
@@ -1,7 +1,6 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
-use async_trait::async_trait;
 use serde_json::Value;
 
 use crate::source::decoder::{cwd_basename_label, make_tool_detail};
@@ -52,7 +51,6 @@ impl ClaudeCodeSource {
     }
 }
 
-#[async_trait]
 impl Source for ClaudeCodeSource {
     fn name(&self) -> &str {
         SOURCE_NAME

--- a/crates/pixtuoid-core/src/source/codex.rs
+++ b/crates/pixtuoid-core/src/source/codex.rs
@@ -12,7 +12,6 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
-use async_trait::async_trait;
 use serde_json::{Map, Value};
 
 use crate::source::decoder::{cwd_basename_label, make_tool_detail};
@@ -229,7 +228,6 @@ impl CodexSource {
     }
 }
 
-#[async_trait]
 impl Source for CodexSource {
     fn name(&self) -> &str {
         SOURCE_NAME

--- a/crates/pixtuoid-core/src/source/manager.rs
+++ b/crates/pixtuoid-core/src/source/manager.rs
@@ -1,7 +1,7 @@
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 
-use crate::source::{Source, TaggedSender};
+use crate::source::{DynSource, TaggedSender};
 
 /// A source's fatal exit, published on the health channel so the binary can
 /// surface it (#157). Plain data — no terminal deps (workspace invariant #1);
@@ -33,7 +33,7 @@ impl SourceDeath {
 /// Adding a second CLI (Codex, Cursor, Gemini, …) is a one-line addition.
 #[derive(Default)]
 pub struct SourceManager {
-    sources: Vec<Box<dyn Source>>,
+    sources: Vec<Box<dyn DynSource>>,
 }
 
 impl SourceManager {
@@ -44,7 +44,7 @@ impl SourceManager {
     /// Register one more `Source`. Builder-style — chain to add several.
     /// Named `with_source` (not `add`) to avoid clippy's
     /// `should_implement_trait` confusing it with `std::ops::Add`.
-    pub fn with_source(mut self, source: Box<dyn Source>) -> Self {
+    pub fn with_source(mut self, source: Box<dyn DynSource>) -> Self {
         self.sources.push(source);
         self
     }
@@ -92,12 +92,10 @@ impl SourceManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::source::{AgentEvent, Transport};
-    use async_trait::async_trait;
+    use crate::source::{AgentEvent, Source, Transport};
 
     struct DyingSource;
 
-    #[async_trait]
     impl Source for DyingSource {
         fn name(&self) -> &str {
             "dying-test-source"
@@ -109,7 +107,6 @@ mod tests {
 
     struct HealthySource;
 
-    #[async_trait]
     impl Source for HealthySource {
         fn name(&self) -> &str {
             "healthy-test-source"

--- a/crates/pixtuoid-core/src/source/mod.rs
+++ b/crates/pixtuoid-core/src/source/mod.rs
@@ -1,6 +1,5 @@
 use std::path::PathBuf;
 
-use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 
@@ -194,10 +193,47 @@ pub type TaggedReceiver = mpsc::Receiver<(Transport, AgentEvent)>;
 ///    than `unwrap`.
 ///
 /// [`AgentId::from_parts`]: crate::AgentId::from_parts
-#[async_trait]
 pub trait Source: Send + 'static {
     fn name(&self) -> &str;
-    async fn run(self: Box<Self>, tx: TaggedSender) -> anyhow::Result<()>;
+    fn run(
+        self: Box<Self>,
+        tx: TaggedSender,
+    ) -> impl std::future::Future<Output = anyhow::Result<()>> + Send;
+}
+
+/// Object-safety twin of [`Source`] — the type `SourceManager` actually
+/// boxes (`Box<dyn DynSource>`). It exists ONLY because [`Source`]'s native
+/// `-> impl Future + Send` return (RPITIT, how the `+ Send` bound is
+/// expressed without `async-trait`) is not dyn-compatible, so `dyn Source`
+/// cannot exist. Don't merge the two traits or make `Source` `dyn` again —
+/// that's the un-simplifiable WHY of the split. Source authors never name
+/// this trait: the blanket impl below + unsize coercion let
+/// `with_source(Box::new(my_source))` work directly; implement [`Source`]
+/// only.
+pub trait DynSource: Send + 'static {
+    fn name(&self) -> &str;
+    fn run(
+        self: Box<Self>,
+        tx: TaggedSender,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send>>;
+}
+
+/// The bridge: every [`Source`] is a [`DynSource`] whose future is boxed at
+/// the erasure boundary — the same one box per `run` that `async-trait` used
+/// to add, now paid only where dynamic dispatch genuinely needs it. The
+/// inner `self.name()`/`self.run(tx)` calls resolve to `<T as Source>` (the
+/// where-clause candidate), not recursively to this impl.
+impl<T: Source> DynSource for T {
+    fn name(&self) -> &str {
+        self.name()
+    }
+
+    fn run(
+        self: Box<Self>,
+        tx: TaggedSender,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send>> {
+        Box::pin(self.run(tx))
+    }
 }
 
 pub mod antigravity;

--- a/crates/pixtuoid-core/tests/source_manager.rs
+++ b/crates/pixtuoid-core/tests/source_manager.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use async_trait::async_trait;
 use tokio::sync::mpsc;
 
 use pixtuoid_core::source::{manager::SourceManager, AgentEvent, Source, TaggedSender, Transport};
@@ -12,7 +11,6 @@ struct StaticSource {
     events: Vec<(Transport, AgentEvent)>,
 }
 
-#[async_trait]
 impl Source for StaticSource {
     fn name(&self) -> &str {
         self.name
@@ -29,7 +27,6 @@ impl Source for StaticSource {
 /// log-and-isolate Err arm.
 struct FailingSource;
 
-#[async_trait]
 impl Source for FailingSource {
     fn name(&self) -> &str {
         "failing"

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -118,15 +118,23 @@ historically-missed one):
    with a `SOURCE_NAME` const, a `LineDecoder` fn (one JSONL line → `Vec<AgentEvent>`),
    a label deriver, and unit tests for every event mapping. Per-source format
    knowledge lives HERE, not in shared code.
-3. **Implement the `Source` trait** (the watcher lifecycle):
+3. **Implement the `Source` trait** (the watcher lifecycle). Your impl is a
+   plain `async fn`:
 
    ```rust
-   #[async_trait]
-   pub trait Source: Send + 'static {
-       fn name(&self) -> &str;
-       async fn run(self: Box<Self>, tx: TaggedSender) -> anyhow::Result<()>;
+   impl Source for MyCliSource {
+       fn name(&self) -> &str { "my-cli" }
+       async fn run(self: Box<Self>, tx: TaggedSender) -> anyhow::Result<()> {
+           // watch + decode + tx.send(...) until the session universe ends
+       }
    }
    ```
+
+   (The trait itself declares `run` as `-> impl Future<Output = …> + Send` —
+   the explicit form is what carries the `Send` bound `tokio::spawn` needs,
+   so a non-`Send` future in your impl is a compile error, not a runtime
+   surprise. `SourceManager` boxes sources via the object-safe `DynSource`
+   twin; the blanket impl means you never name it.)
 
    **Hook-only CLI** (no watchable transcript — e.g. one that full-rewrites
    its session file per turn)? Skip the `LineDecoder`, the `Source` trait, and


### PR DESCRIPTION
This PR refactors the `Source` trait to use native Rust async trait syntax (MSRV 1.78) and introduces the object-safe `DynSource` trait wrapper to remove the `async-trait` crate dependency entirely. This simplifies the dependency graph, reduces macro compilation overhead, and improves compile times.