### PR TITLE
feat: add automated entity and pet cropping to snapshot example

### DIFF
--- a/.claude/skills/beautify-decoration/SKILL.md
+++ b/.claude/skills/beautify-decoration/SKILL.md
@@ -27,6 +27,9 @@ A repo-specific iteration loop for visually redesigning a decoration in `pixtuoi
 3. ./target/release/examples/snapshot --cols 192 --rows 80 /tmp/snap.png
    ↓
 4. .venv/bin/python3 scripts/crop-snapshot.py /tmp/snap.png --scale 3 -q <quadrant>
+   (or skip the quadrant guessing: snapshot --crop-furniture pantry|couch|vending|
+   printer|meeting|sofa|desk OR --crop-agent <label> renders a 40x24-cell window
+   already centered on the target — no Python step)
    ↓
 5. Read the cropped PNG → self-critique → back to step 1
    ↓

--- a/crates/pixtuoid/examples/snapshot.rs
+++ b/crates/pixtuoid/examples/snapshot.rs
@@ -191,7 +191,21 @@ struct SnapshotArgs {
     /// faces north). Ignored for non-seat targets.
     #[arg(long)]
     anim_facing: Option<String>,
+
+    /// Crop the generated PNG around a specific agent's visual position.
+    #[arg(long)]
+    pub crop_agent: Option<String>,
+
+    /// Crop the generated PNG around the office pet.
+    #[arg(long)]
+    pub crop_pet: bool,
+
+    /// Crop the generated PNG around a specific furniture piece.
+    /// One of: pantry | couch | vending | printer | meeting | desk.
+    #[arg(long)]
+    pub crop_furniture: Option<String>,
 }
+
 
 fn default_projects_root() -> String {
     format!(
@@ -275,7 +289,7 @@ fn main() -> Result<()> {
     let backend = TestBackend::new(cols, rows);
     let mut term = Terminal::new(backend)?;
     let mut buf = RgbBuffer::filled(0, 0, Rgb { r: 0, g: 0, b: 0 });
-    let pack = load_sprite_pack(args.pack_dir)?;
+    let pack = load_sprite_pack(args.pack_dir.clone())?;
     let mut cache = FrameCache::new();
     let mut router = pixtuoid::tui::pathfind::AStarRouter::new();
     let mut overlay = pixtuoid_core::walkable::OccupancyOverlay::new();
@@ -422,14 +436,29 @@ fn main() -> Result<()> {
         debug_paint_walkable_overlay(&mut term, &scene)?;
     }
 
-    save_backend_as_png(&term, &args.out, cols, rows)?;
+    let last_pet_pos = draw_ctx.last_pet_pos;
+    let crop_rect = compute_crop_rect(
+        &args,
+        &scene,
+        &history,
+        last_pet_pos,
+        cols,
+        rows,
+        now,
+    );
+
+    save_backend_as_png(&term, &args.out, cols, rows, crop_rect)?;
     println!("wrote {}", args.out.display());
 
     println!("\n--- text preview (symbols only) ---");
     let buf = term.backend().buffer();
-    for y in 0..rows {
-        for x in 0..cols {
-            print!("{}", buf[(x, y)].symbol());
+    let (start_x, start_y, render_w, render_h) = match crop_rect {
+        Some(r) => (r.x, r.y, r.width, r.height),
+        None => (0, 0, cols, rows),
+    };
+    for y in 0..render_h {
+        for x in 0..render_w {
+            print!("{}", buf[(start_x + x, start_y + y)].symbol());
         }
         println!();
     }
@@ -862,20 +891,115 @@ fn anim_scene(
     (s, skip_ms)
 }
 
+fn compute_crop_rect(
+    args: &SnapshotArgs,
+    scene: &SceneState,
+    history: &pixtuoid::tui::pose::PoseHistory,
+    last_pet_pos: Option<pixtuoid::tui::pet::PetFrame>,
+    cols: u16,
+    rows: u16,
+    now: SystemTime,
+) -> Option<ratatui::layout::Rect> {
+    let mut target_pixel: Option<pixtuoid::tui::layout::Point> = None;
+
+    if let Some(ref agent_label) = args.crop_agent {
+        if let Some(slot) = scene.agents.values().find(|s| s.label.as_ref() == agent_label) {
+            if let Some(pos) = history.recent(slot.agent_id, u64::MAX, now) {
+                target_pixel = Some(pos);
+            } else {
+                eprintln!("WARN: Agent '{}' has no visual position in PoseHistory", agent_label);
+            }
+        } else {
+            eprintln!("WARN: Agent with label '{}' not found in scene", agent_label);
+        }
+    } else if args.crop_pet {
+        if let Some(pet_frame) = last_pet_pos {
+            target_pixel = Some(pet_frame.pos);
+        } else {
+            eprintln!("WARN: Pet has no visual position in this frame");
+        }
+    } else if let Some(ref furniture_str) = args.crop_furniture {
+        let buf_w = cols;
+        let buf_h = rows.saturating_sub(1).saturating_mul(2);
+        if let Some(layout) = pixtuoid_core::layout::SceneLayout::compute_with_seed(
+            buf_w,
+            buf_h,
+            scene.floor_capacities[0],
+            args.floor_seed,
+        ) {
+            match furniture_str.to_lowercase().as_str() {
+                "pantry" => {
+                    target_pixel = layout.waypoints.iter()
+                        .find(|w| matches!(w.kind, pixtuoid_core::layout::WaypointKind::Pantry))
+                        .map(|w| w.pos);
+                }
+                "couch" => {
+                    target_pixel = layout.waypoints.iter()
+                        .find(|w| matches!(w.kind, pixtuoid_core::layout::WaypointKind::Couch))
+                        .map(|w| w.pos);
+                }
+                "vending" => {
+                    target_pixel = layout.waypoints.iter()
+                        .find(|w| matches!(w.kind, pixtuoid_core::layout::WaypointKind::VendingMachine))
+                        .map(|w| w.pos);
+                }
+                "printer" => {
+                    target_pixel = layout.waypoints.iter()
+                        .find(|w| matches!(w.kind, pixtuoid_core::layout::WaypointKind::Printer))
+                        .map(|w| w.pos);
+                }
+                "meeting" | "sofa" => {
+                    target_pixel = layout.waypoints.iter()
+                        .find(|w| matches!(w.kind, pixtuoid_core::layout::WaypointKind::MeetingSofa))
+                        .map(|w| w.pos);
+                }
+                "desk" => {
+                    target_pixel = layout.home_desks.first().copied();
+                }
+                other => {
+                    eprintln!("WARN: Unknown furniture crop target '{}'", other);
+                }
+            }
+        }
+    }
+
+    let p = target_pixel?;
+    let cell_x = p.x / 8;
+    let cell_y = p.y / 16;
+
+    let crop_w = 40u16.min(cols);
+    let crop_h = 24u16.min(rows);
+
+    let crop_x = cell_x.saturating_sub(crop_w / 2).min(cols.saturating_sub(crop_w));
+    let crop_y = cell_y.saturating_sub(crop_h / 2).min(rows.saturating_sub(crop_h));
+
+    Some(ratatui::layout::Rect {
+        x: crop_x,
+        y: crop_y,
+        width: crop_w,
+        height: crop_h,
+    })
+}
+
 fn save_backend_as_png(
     term: &Terminal<TestBackend>,
     path: &PathBuf,
     cols: u16,
     rows: u16,
+    crop: Option<ratatui::layout::Rect>,
 ) -> Result<()> {
     let buf = term.backend().buffer();
-    let img_w = cols as u32 * CELL_W;
-    let img_h = rows as u32 * CELL_H;
+    let (start_x, start_y, render_w, render_h) = match crop {
+        Some(r) => (r.x, r.y, r.width, r.height),
+        None => (0, 0, cols, rows),
+    };
+    let img_w = render_w as u32 * CELL_W;
+    let img_h = render_h as u32 * CELL_H;
     let mut img = RgbImage::new(img_w, img_h);
 
-    for y in 0..rows {
-        for x in 0..cols {
-            let cell = &buf[(x, y)];
+    for y in 0..render_h {
+        for x in 0..render_w {
+            let cell = &buf[(start_x + x, start_y + y)];
             let symbol = cell.symbol();
             let fg = color_to_rgb(cell.fg, ImgRgb([220, 220, 220]));
             let bg = color_to_rgb(cell.bg, ImgRgb([20, 22, 28]));
@@ -912,6 +1036,7 @@ fn save_backend_as_png(
     img.save(path)?;
     Ok(())
 }
+
 
 /// Rasterize a post-draw ratatui cell buffer to RGBA: half-block cells become
 /// two stacked pixels (fg = top, bg = bottom); text cells a blocky glyph pad —

--- a/crates/pixtuoid/examples/snapshot.rs
+++ b/crates/pixtuoid/examples/snapshot.rs
@@ -192,20 +192,18 @@ struct SnapshotArgs {
     #[arg(long)]
     anim_facing: Option<String>,
 
-    /// Crop the generated PNG around a specific agent's visual position.
-    #[arg(long)]
-    pub crop_agent: Option<String>,
+    /// Crop the generated PNG (and text preview) to a 40x24-cell window
+    /// centered on the agent with this label — e.g. for sprite-iteration
+    /// close-ups without quadrant guessing. Static-PNG path only.
+    #[arg(long, conflicts_with = "crop_furniture")]
+    crop_agent: Option<String>,
 
-    /// Crop the generated PNG around the office pet.
+    /// Crop the generated PNG (and text preview) to a 40x24-cell window
+    /// centered on a furniture piece.
+    /// One of: pantry | couch | vending | printer | meeting | sofa | desk.
     #[arg(long)]
-    pub crop_pet: bool,
-
-    /// Crop the generated PNG around a specific furniture piece.
-    /// One of: pantry | couch | vending | printer | meeting | desk.
-    #[arg(long)]
-    pub crop_furniture: Option<String>,
+    crop_furniture: Option<String>,
 }
-
 
 fn default_projects_root() -> String {
     format!(
@@ -436,16 +434,7 @@ fn main() -> Result<()> {
         debug_paint_walkable_overlay(&mut term, &scene)?;
     }
 
-    let last_pet_pos = draw_ctx.last_pet_pos;
-    let crop_rect = compute_crop_rect(
-        &args,
-        &scene,
-        &history,
-        last_pet_pos,
-        cols,
-        rows,
-        now,
-    );
+    let crop_rect = compute_crop_rect(&args, &scene, &history, cols, rows, now)?;
 
     save_backend_as_png(&term, &args.out, cols, rows, crop_rect)?;
     println!("wrote {}", args.out.display());
@@ -895,90 +884,90 @@ fn compute_crop_rect(
     args: &SnapshotArgs,
     scene: &SceneState,
     history: &pixtuoid::tui::pose::PoseHistory,
-    last_pet_pos: Option<pixtuoid::tui::pet::PetFrame>,
     cols: u16,
     rows: u16,
     now: SystemTime,
-) -> Option<ratatui::layout::Rect> {
-    let mut target_pixel: Option<pixtuoid::tui::layout::Point> = None;
+) -> Result<Option<ratatui::layout::Rect>> {
+    use pixtuoid_core::layout::WaypointKind;
 
-    if let Some(ref agent_label) = args.crop_agent {
-        if let Some(slot) = scene.agents.values().find(|s| s.label.as_ref() == agent_label) {
-            if let Some(pos) = history.recent(slot.agent_id, u64::MAX, now) {
-                target_pixel = Some(pos);
-            } else {
-                eprintln!("WARN: Agent '{}' has no visual position in PoseHistory", agent_label);
-            }
-        } else {
-            eprintln!("WARN: Agent with label '{}' not found in scene", agent_label);
-        }
-    } else if args.crop_pet {
-        if let Some(pet_frame) = last_pet_pos {
-            target_pixel = Some(pet_frame.pos);
-        } else {
-            eprintln!("WARN: Pet has no visual position in this frame");
-        }
+    // Fail loudly like --theme/--weather above — a typo'd crop target silently
+    // writing the full uncropped PNG defeats the point of the flag.
+    let target_pixel: pixtuoid::tui::layout::Point = if let Some(ref agent_label) = args.crop_agent
+    {
+        let slot = scene
+            .agents
+            .values()
+            .find(|s| s.label.as_ref() == agent_label)
+            .ok_or_else(|| {
+                let labels: Vec<&str> = scene.agents.values().map(|s| s.label.as_ref()).collect();
+                anyhow::anyhow!(
+                    "--crop-agent {agent_label:?} not found in scene; labels: {}",
+                    labels.join(", ")
+                )
+            })?;
+        history
+            .recent(slot.agent_id, u64::MAX, now)
+            .ok_or_else(|| anyhow::anyhow!("agent {agent_label:?} has no visual position"))?
     } else if let Some(ref furniture_str) = args.crop_furniture {
         let buf_w = cols;
         let buf_h = rows.saturating_sub(1).saturating_mul(2);
-        if let Some(layout) = pixtuoid_core::layout::SceneLayout::compute_with_seed(
+        let layout = pixtuoid_core::layout::SceneLayout::compute_with_seed(
             buf_w,
             buf_h,
             scene.floor_capacities[0],
             args.floor_seed,
-        ) {
-            match furniture_str.to_lowercase().as_str() {
-                "pantry" => {
-                    target_pixel = layout.waypoints.iter()
-                        .find(|w| matches!(w.kind, pixtuoid_core::layout::WaypointKind::Pantry))
-                        .map(|w| w.pos);
-                }
-                "couch" => {
-                    target_pixel = layout.waypoints.iter()
-                        .find(|w| matches!(w.kind, pixtuoid_core::layout::WaypointKind::Couch))
-                        .map(|w| w.pos);
-                }
-                "vending" => {
-                    target_pixel = layout.waypoints.iter()
-                        .find(|w| matches!(w.kind, pixtuoid_core::layout::WaypointKind::VendingMachine))
-                        .map(|w| w.pos);
-                }
-                "printer" => {
-                    target_pixel = layout.waypoints.iter()
-                        .find(|w| matches!(w.kind, pixtuoid_core::layout::WaypointKind::Printer))
-                        .map(|w| w.pos);
-                }
-                "meeting" | "sofa" => {
-                    target_pixel = layout.waypoints.iter()
-                        .find(|w| matches!(w.kind, pixtuoid_core::layout::WaypointKind::MeetingSofa))
-                        .map(|w| w.pos);
-                }
-                "desk" => {
-                    target_pixel = layout.home_desks.first().copied();
-                }
-                other => {
-                    eprintln!("WARN: Unknown furniture crop target '{}'", other);
-                }
+        )
+        .ok_or_else(|| anyhow::anyhow!("scene too small to compute a layout"))?;
+        let found = match furniture_str.to_lowercase().as_str() {
+            "desk" => layout.home_desks.first().copied(),
+            name => {
+                let kind = match name {
+                    "pantry" => WaypointKind::Pantry,
+                    "couch" => WaypointKind::Couch,
+                    "vending" => WaypointKind::VendingMachine,
+                    "printer" => WaypointKind::Printer,
+                    "meeting" | "sofa" => WaypointKind::MeetingSofa,
+                    other => anyhow::bail!(
+                        "unknown --crop-furniture {other:?}; valid: pantry | couch | vending | printer | meeting | sofa | desk"
+                    ),
+                };
+                layout
+                    .waypoints
+                    .iter()
+                    .find(|w| w.kind == kind)
+                    .map(|w| w.pos)
             }
-        }
-    }
+        };
+        found.ok_or_else(|| {
+            anyhow::anyhow!("no {furniture_str:?} waypoint in this layout (terminal too small?)")
+        })?
+    } else {
+        return Ok(None);
+    };
 
-    let p = target_pixel?;
-    let cell_x = p.x / 8;
-    let cell_y = p.y / 16;
+    // Positions are in the LOGICAL half-block buffer (1 px per cell across,
+    // 2 px per cell down — the same buf_w/buf_h fed to compute_with_seed
+    // above), NOT in PNG pixels: the 8x16 px-per-cell scaling happens later
+    // in save_backend_as_png.
+    let cell_x = target_pixel.x;
+    let cell_y = target_pixel.y / 2;
 
     let crop_w = 40u16.min(cols);
     let crop_h = 24u16.min(rows);
 
-    let crop_x = cell_x.saturating_sub(crop_w / 2).min(cols.saturating_sub(crop_w));
-    let crop_y = cell_y.saturating_sub(crop_h / 2).min(rows.saturating_sub(crop_h));
+    let crop_x = cell_x
+        .saturating_sub(crop_w / 2)
+        .min(cols.saturating_sub(crop_w));
+    let crop_y = cell_y
+        .saturating_sub(crop_h / 2)
+        .min(rows.saturating_sub(crop_h));
 
-    Some(ratatui::layout::Rect {
+    Ok(Some(ratatui::layout::Rect {
         x: crop_x,
         y: crop_y,
         width: crop_w,
         height: crop_h,
-    })
+    }))
 }
 
 fn save_backend_as_png(
@@ -1036,7 +1025,6 @@ fn save_backend_as_png(
     img.save(path)?;
     Ok(())
 }
-
 
 /// Rasterize a post-draw ratatui cell buffer to RGBA: half-block cells become
 /// two stacked pixels (fg = top, bg = bottom); text cells a blocky glyph pad —

--- a/crates/pixtuoid/examples/snapshot.rs
+++ b/crates/pixtuoid/examples/snapshot.rs
@@ -194,14 +194,16 @@ struct SnapshotArgs {
 
     /// Crop the generated PNG (and text preview) to a 40x24-cell window
     /// centered on the agent with this label — e.g. for sprite-iteration
-    /// close-ups without quadrant guessing. Static-PNG path only.
-    #[arg(long, conflicts_with = "crop_furniture")]
+    /// close-ups without quadrant guessing. Static-PNG path only: the
+    /// --gif/--anim paths return before the crop is computed, so clap
+    /// rejects the combination instead of silently ignoring the flag.
+    #[arg(long, conflicts_with_all = ["crop_furniture", "gif", "anim"])]
     crop_agent: Option<String>,
 
     /// Crop the generated PNG (and text preview) to a 40x24-cell window
-    /// centered on a furniture piece.
+    /// centered on a furniture piece. Static-PNG path only (see --crop-agent).
     /// One of: pantry | couch | vending | printer | meeting | sofa | desk.
-    #[arg(long)]
+    #[arg(long, conflicts_with_all = ["gif", "anim"])]
     crop_furniture: Option<String>,
 }
 
@@ -949,9 +951,17 @@ fn compute_crop_rect(
     // 2 px per cell down — the same buf_w/buf_h fed to compute_with_seed
     // above), NOT in PNG pixels: the 8x16 px-per-cell scaling happens later
     // in save_backend_as_png.
-    let cell_x = target_pixel.x;
-    let cell_y = target_pixel.y / 2;
+    Ok(Some(centered_crop(
+        target_pixel.x,
+        target_pixel.y / 2,
+        cols,
+        rows,
+    )))
+}
 
+/// 40x24-cell window centered on (cell_x, cell_y), clamped to stay inside the
+/// cols x rows buffer (shrinks only when the terminal itself is smaller).
+fn centered_crop(cell_x: u16, cell_y: u16, cols: u16, rows: u16) -> ratatui::layout::Rect {
     let crop_w = 40u16.min(cols);
     let crop_h = 24u16.min(rows);
 
@@ -962,12 +972,12 @@ fn compute_crop_rect(
         .saturating_sub(crop_h / 2)
         .min(rows.saturating_sub(crop_h));
 
-    Ok(Some(ratatui::layout::Rect {
+    ratatui::layout::Rect {
         x: crop_x,
         y: crop_y,
         width: crop_w,
         height: crop_h,
-    }))
+    }
 }
 
 fn save_backend_as_png(
@@ -1345,5 +1355,89 @@ mod tests {
             }
         }
         assert_eq!(hit, Some(149));
+    }
+
+    fn crop_args(extra: &[&str]) -> SnapshotArgs {
+        SnapshotArgs::try_parse_from([&["snapshot"], extra].concat()).unwrap()
+    }
+
+    #[test]
+    fn centered_crop_centers_in_the_open() {
+        let r = centered_crop(96, 32, 192, 64);
+        assert_eq!((r.x, r.y, r.width, r.height), (76, 20, 40, 24));
+    }
+
+    #[test]
+    fn centered_crop_clamps_at_origin_and_far_edge() {
+        let near_origin = centered_crop(2, 1, 192, 64);
+        assert_eq!((near_origin.x, near_origin.y), (0, 0));
+        let near_edge = centered_crop(191, 63, 192, 64);
+        assert_eq!((near_edge.x, near_edge.y), (152, 40));
+    }
+
+    #[test]
+    fn centered_crop_shrinks_to_a_small_terminal() {
+        let r = centered_crop(10, 5, 30, 20);
+        assert_eq!((r.x, r.y, r.width, r.height), (0, 0, 30, 20));
+    }
+
+    #[test]
+    fn crop_rect_centers_on_the_pantry_waypoint() {
+        let now = SystemTime::now();
+        let scene = sample_scene(now, 12, 12);
+        let history = pixtuoid::tui::pose::PoseHistory::new();
+        let args = crop_args(&["--crop-furniture", "pantry"]);
+        let rect = compute_crop_rect(&args, &scene, &history, 192, 64, now)
+            .unwrap()
+            .expect("pantry crop");
+        let layout =
+            pixtuoid_core::layout::SceneLayout::compute_with_seed(192, 126, 12, 0).unwrap();
+        let pantry = layout
+            .waypoints
+            .iter()
+            .find(|w| w.kind == pixtuoid_core::layout::WaypointKind::Pantry)
+            .unwrap();
+        let (cx, cy) = (pantry.pos.x, pantry.pos.y / 2);
+        assert!(rect.x <= cx && cx < rect.x + rect.width, "x not in crop");
+        assert!(rect.y <= cy && cy < rect.y + rect.height, "y not in crop");
+    }
+
+    #[test]
+    fn crop_rect_without_flags_is_none() {
+        let now = SystemTime::now();
+        let scene = sample_scene(now, 12, 12);
+        let history = pixtuoid::tui::pose::PoseHistory::new();
+        let args = crop_args(&[]);
+        assert!(compute_crop_rect(&args, &scene, &history, 192, 64, now)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn crop_rect_fails_loudly_on_typos_and_unknown_agents() {
+        let now = SystemTime::now();
+        let scene = sample_scene(now, 12, 12);
+        let history = pixtuoid::tui::pose::PoseHistory::new();
+
+        let typo = crop_args(&["--crop-furniture", "fridge"]);
+        let err = compute_crop_rect(&typo, &scene, &history, 192, 64, now).unwrap_err();
+        assert!(err.to_string().contains("valid: pantry"), "{err}");
+
+        let ghost = crop_args(&["--crop-agent", "ghost"]);
+        let err = compute_crop_rect(&ghost, &scene, &history, 192, 64, now).unwrap_err();
+        assert!(err.to_string().contains("labels:"), "{err}");
+    }
+
+    #[test]
+    fn crop_flags_conflict_with_gif_and_anim() {
+        assert!(SnapshotArgs::try_parse_from(["snapshot", "--gif", "--crop-agent", "x"]).is_err());
+        assert!(SnapshotArgs::try_parse_from([
+            "snapshot",
+            "--anim",
+            "couch",
+            "--crop-furniture",
+            "pantry"
+        ])
+        .is_err());
     }
 }


### PR DESCRIPTION
This PR adds automated entity, pet, and furniture cropping functionality to the snapshot example script.