### PR TITLE
feat: cross-platform pre-work for Windows support (#128)

### DIFF
--- a/crates/pixtuoid-core/CLAUDE.md
+++ b/crates/pixtuoid-core/CLAUDE.md
@@ -55,6 +55,8 @@ src/
 │                       walk_arrived, speed_mult, pause_ms_for; constants: V_CRUISE_COMMUTE=0.36,
 │                       V_CRUISE_SNAPBACK=0.65, V_CRUISE_WANDER=0.25, WALK_ACCEL=6.5e-4,
 │                       WALK_ACCEL_SNAPBACK=2.0e-3, SPEED_MULT_MIN/MAX, PAUSE_MS_MIN/MAX
+├── platform.rs         cross-platform home-dir resolution (user_home(), USERPROFILE-first on
+│                       Windows — HOME is unset there and Git Bash's HOME is POSIX-form)
 ├── pose/               pure state→pose derivation + wander state machine (no terminal deps);
 │                       mod.rs (production) + tests.rs sibling.
 │                       ENTRY_ANIMATION_MS is demoted: not a duration knob, only the spawn-window

--- a/crates/pixtuoid-core/src/lib.rs
+++ b/crates/pixtuoid-core/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod id;
 pub mod layout;
 pub mod physics;
+mod platform;
 pub mod pose;
 pub mod render;
 pub mod source;

--- a/crates/pixtuoid-core/src/platform.rs
+++ b/crates/pixtuoid-core/src/platform.rs
@@ -10,8 +10,6 @@
 //! treated as unset).
 
 /// USERPROFILE-first on Windows, HOME on Unix. See module doc for WHY.
-// consumed by source::*::default_paths in the next commit
-#[allow(dead_code)]
 pub(crate) fn user_home() -> String {
     resolve_home(
         cfg!(windows),

--- a/crates/pixtuoid-core/src/platform.rs
+++ b/crates/pixtuoid-core/src/platform.rs
@@ -1,0 +1,79 @@
+//! Cross-platform home-dir resolution.
+//!
+//! On native Windows, `HOME` is normally unset — today's `env::var("HOME")`
+//! sites silently fall back to `/tmp`, so the watcher would watch
+//! `/tmp/.claude/projects` and never see a session. When Git Bash *does*
+//! export a `HOME`, it's a POSIX-form path (`/c/Users/me`) that native Rust
+//! code must not join onto — so `USERPROFILE` must win on Windows. On Unix,
+//! `HOME` stays authoritative and behavior matches the old per-site
+//! `env::var("HOME")` reads (one deliberate improvement: an empty `HOME` is
+//! treated as unset).
+
+/// USERPROFILE-first on Windows, HOME on Unix. See module doc for WHY.
+// consumed by source::*::default_paths in the next commit
+#[allow(dead_code)]
+pub(crate) fn user_home() -> String {
+    resolve_home(
+        cfg!(windows),
+        std::env::var("USERPROFILE").ok(),
+        std::env::var("HOME").ok(),
+        std::env::temp_dir().to_string_lossy().into_owned(),
+    )
+}
+
+/// Pure resolution core, separated so the Windows branch is unit-testable
+/// on any platform (it's string logic, not OS calls).
+fn resolve_home(
+    windows: bool,
+    userprofile: Option<String>,
+    home: Option<String>,
+    temp_dir: String,
+) -> String {
+    let nonempty = |v: Option<String>| v.filter(|s| !s.is_empty());
+    if windows {
+        if let Some(p) = nonempty(userprofile) {
+            return p;
+        }
+        // USERPROFILE is effectively always set on Windows; a lone HOME here
+        // was set deliberately (MSYS users exporting a real Windows path).
+        return nonempty(home).unwrap_or(temp_dir);
+    }
+    nonempty(home).unwrap_or_else(|| "/tmp".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(v: &str) -> Option<String> {
+        Some(v.to_string())
+    }
+
+    #[test]
+    fn windows_prefers_userprofile_over_home() {
+        // Git Bash exports HOME=/c/Users/me — must lose to USERPROFILE.
+        let got = resolve_home(true, s(r"C:\Users\me"), s("/c/Users/me"), "T".into());
+        assert_eq!(got, r"C:\Users\me");
+    }
+
+    #[test]
+    fn windows_falls_back_to_home_then_tempdir() {
+        assert_eq!(
+            resolve_home(true, None, s("/c/Users/me"), "T".into()),
+            "/c/Users/me"
+        );
+        assert_eq!(resolve_home(true, None, None, "T".into()), "T");
+        // empty strings are treated as unset
+        assert_eq!(resolve_home(true, s(""), s(""), "T".into()), "T");
+    }
+
+    #[test]
+    fn unix_home_stays_authoritative_and_empty_home_is_unset() {
+        assert_eq!(
+            resolve_home(false, s(r"C:\ignored"), s("/Users/me"), "T".into()),
+            "/Users/me"
+        );
+        assert_eq!(resolve_home(false, None, None, "T".into()), "/tmp");
+        assert_eq!(resolve_home(false, None, s(""), "T".into()), "/tmp");
+    }
+}

--- a/crates/pixtuoid-core/src/source/antigravity.rs
+++ b/crates/pixtuoid-core/src/source/antigravity.rs
@@ -20,9 +20,12 @@ pub struct AntigravitySource {
 
 impl AntigravitySource {
     pub fn default_paths() -> Self {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+        let home = crate::platform::user_home();
         Self {
-            brain_root: PathBuf::from(format!("{home}/.gemini/antigravity-cli/brain")),
+            brain_root: PathBuf::from(home)
+                .join(".gemini")
+                .join("antigravity-cli")
+                .join("brain"),
         }
     }
 }

--- a/crates/pixtuoid-core/src/source/claude_code.rs
+++ b/crates/pixtuoid-core/src/source/claude_code.rs
@@ -31,10 +31,10 @@ impl ClaudeCodeSource {
     }
 
     pub fn default_paths() -> Self {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+        let home = crate::platform::user_home();
         Self {
             socket_path: Self::default_socket_path(),
-            projects_root: PathBuf::from(format!("{home}/.claude/projects")),
+            projects_root: PathBuf::from(home).join(".claude").join("projects"),
         }
     }
 }

--- a/crates/pixtuoid-core/src/source/codex.rs
+++ b/crates/pixtuoid-core/src/source/codex.rs
@@ -222,9 +222,9 @@ pub struct CodexSource {
 
 impl CodexSource {
     pub fn default_paths() -> Self {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+        let home = crate::platform::user_home();
         Self {
-            sessions_root: PathBuf::from(format!("{home}/.codex/sessions")),
+            sessions_root: PathBuf::from(home).join(".codex").join("sessions"),
         }
     }
 }

--- a/crates/pixtuoid/examples/snapshot.rs
+++ b/crates/pixtuoid/examples/snapshot.rs
@@ -191,7 +191,7 @@ struct SnapshotArgs {
 fn default_projects_root() -> String {
     format!(
         "{}/.claude/projects",
-        std::env::var("HOME").unwrap_or_else(|_| ".".into())
+        pixtuoid::install::io::user_home().unwrap_or_else(|| ".".into())
     )
 }
 

--- a/crates/pixtuoid/src/config.rs
+++ b/crates/pixtuoid/src/config.rs
@@ -232,6 +232,12 @@ mod tests {
             .unwrap_or_else(|e| e.into_inner());
         let saved_xdg = std::env::var_os("XDG_CONFIG_HOME");
         let saved_home = std::env::var_os("HOME");
+        let saved_userprofile = std::env::var_os("USERPROFILE");
+
+        // Clear USERPROFILE for the whole test: on Windows it outranks HOME
+        // in user_home(), so both the HOME arm and the relative-fallback arm
+        // need it absent to assert their branches.
+        std::env::remove_var("USERPROFILE");
 
         // XDG_CONFIG_HOME wins when set.
         std::env::set_var("XDG_CONFIG_HOME", "/xdg/base");
@@ -260,6 +266,10 @@ mod tests {
         match saved_home {
             Some(v) => std::env::set_var("HOME", v),
             None => std::env::remove_var("HOME"),
+        }
+        match saved_userprofile {
+            Some(v) => std::env::set_var("USERPROFILE", v),
+            None => std::env::remove_var("USERPROFILE"),
         }
     }
 

--- a/crates/pixtuoid/src/config.rs
+++ b/crates/pixtuoid/src/config.rs
@@ -53,7 +53,7 @@ pub fn resolve_pack_dir(config: &AppConfig, cli_pack_dir: Option<PathBuf>) -> Op
         config
             .pack_dir
             .as_ref()
-            .map(|p| PathBuf::from(expand_tilde(p, std::env::var("HOME").ok().as_deref())))
+            .map(|p| PathBuf::from(expand_tilde(p, crate::install::io::user_home().as_deref())))
     })
 }
 
@@ -73,7 +73,7 @@ pub fn config_path() -> PathBuf {
     if let Ok(base) = std::env::var("XDG_CONFIG_HOME") {
         return PathBuf::from(base).join("pixtuoid").join("config.toml");
     }
-    if let Ok(home) = std::env::var("HOME") {
+    if let Some(home) = crate::install::io::user_home() {
         return PathBuf::from(home)
             .join(".config")
             .join("pixtuoid")

--- a/crates/pixtuoid/src/install/io.rs
+++ b/crates/pixtuoid/src/install/io.rs
@@ -47,11 +47,18 @@ pub fn default_hook_binary() -> Result<PathBuf> {
         "could not determine the running executable's path while locating pixtuoid-hook",
     )?;
     let dir = exe.parent().ok_or_else(|| anyhow!("exe has no parent"))?;
-    let candidate = dir.join("pixtuoid-hook");
+    let candidate = dir.join(hook_sibling_name());
     if candidate.exists() {
         return Ok(candidate);
     }
     Err(anyhow!("could not locate pixtuoid-hook; pass --hook-path"))
+}
+
+/// The hook binary's filename next to the running exe — `.exe`-suffixed on
+/// Windows (exec-form spawning needs the real PE name; PATHEXT is a shell
+/// behavior we must not rely on).
+fn hook_sibling_name() -> String {
+    format!("pixtuoid-hook{}", std::env::consts::EXE_SUFFIX)
 }
 
 /// Build a sibling path by APPENDING `.suffix` to the full filename — never
@@ -320,5 +327,13 @@ mod tests {
             resolve_user_home(false, up, Some("/Users/me".into())),
             Some("/Users/me".into())
         );
+    }
+
+    #[test]
+    fn default_hook_binary_sibling_appends_exe_suffix() {
+        // Platform-neutral: EXE_SUFFIX is "" on Unix, ".exe" on Windows —
+        // assert the candidate filename is built with it either way.
+        let expected = format!("pixtuoid-hook{}", std::env::consts::EXE_SUFFIX);
+        assert_eq!(hook_sibling_name(), expected);
     }
 }

--- a/crates/pixtuoid/src/install/io.rs
+++ b/crates/pixtuoid/src/install/io.rs
@@ -5,9 +5,34 @@ use std::path::{Path, PathBuf};
 use anyhow::{anyhow, Context, Result};
 use fs2::FileExt;
 
-/// Resolve a `$HOME`-relative path, falling back to the CWD when `HOME` is unset.
+/// The user's home dir — `USERPROFILE`-first on Windows (HOME is normally
+/// unset there; Git Bash's exported HOME is POSIX-form and unusable), `HOME`
+/// on Unix. `None` when nothing is set: call sites keep their own fallbacks.
+/// An empty value counts as unset.
+pub fn user_home() -> Option<String> {
+    resolve_user_home(
+        cfg!(windows),
+        std::env::var("USERPROFILE").ok(),
+        std::env::var("HOME").ok(),
+    )
+}
+
+fn resolve_user_home(
+    windows: bool,
+    userprofile: Option<String>,
+    home: Option<String>,
+) -> Option<String> {
+    let nonempty = |v: Option<String>| v.filter(|s| !s.is_empty());
+    if windows {
+        return nonempty(userprofile).or_else(|| nonempty(home));
+    }
+    nonempty(home)
+}
+
+/// Resolve a `$HOME`-relative path, falling back to the CWD when no home dir
+/// is resolvable.
 pub fn home_relative(rel: &str) -> PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
+    let home = user_home().unwrap_or_else(|| ".".into());
     PathBuf::from(home).join(rel)
 }
 
@@ -152,6 +177,7 @@ mod tests {
         assert_eq!(resolve_symlink(&path), path);
     }
 
+    #[cfg(unix)]
     #[test]
     fn resolve_symlink_follows_single_hop() {
         let dir = TempDir::new().unwrap();
@@ -162,6 +188,7 @@ mod tests {
         assert_eq!(resolve_symlink(&link), target);
     }
 
+    #[cfg(unix)]
     #[test]
     fn resolve_symlink_follows_chain() {
         let dir = TempDir::new().unwrap();
@@ -174,6 +201,7 @@ mod tests {
         assert_eq!(resolve_symlink(&link), target);
     }
 
+    #[cfg(unix)]
     #[test]
     fn resolve_symlink_dangling_returns_target() {
         let dir = TempDir::new().unwrap();
@@ -183,6 +211,7 @@ mod tests {
         assert_eq!(resolve_symlink(&link), target);
     }
 
+    #[cfg(unix)]
     #[test]
     fn resolve_symlink_relative_target() {
         let dir = TempDir::new().unwrap();
@@ -199,6 +228,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn resolve_symlink_cycle_terminates_after_budget() {
         // A 2-node cycle a→b→a: symlink_metadata (lstat) + read_link (readlink)
@@ -237,6 +267,7 @@ mod tests {
         assert_eq!(read_config(&p).unwrap(), "a = 1\n");
     }
 
+    #[cfg(unix)]
     #[test]
     fn write_config_atomic_through_symlink_preserves_link() {
         let dir = TempDir::new().unwrap();
@@ -271,5 +302,23 @@ mod tests {
         assert_eq!(remove_backup(&p, "pixtuoid.bak").unwrap(), Some(b1.clone()));
         assert!(!b1.exists());
         assert_eq!(remove_backup(&p, "pixtuoid.bak").unwrap(), None);
+    }
+
+    #[test]
+    fn user_home_is_none_when_no_home_vars() {
+        // resolve_user_home is pure — the Windows arm is testable on macOS.
+        assert_eq!(resolve_user_home(true, None, None), None);
+        assert_eq!(resolve_user_home(false, None, None), None);
+    }
+
+    #[test]
+    fn user_home_userprofile_wins_on_windows_home_wins_on_unix() {
+        let up = Some(r"C:\Users\me".to_string());
+        let posix = Some("/c/Users/me".to_string());
+        assert_eq!(resolve_user_home(true, up.clone(), posix.clone()), up);
+        assert_eq!(
+            resolve_user_home(false, up, Some("/Users/me".into())),
+            Some("/Users/me".into())
+        );
     }
 }

--- a/crates/pixtuoid/src/install/io.rs
+++ b/crates/pixtuoid/src/install/io.rs
@@ -331,9 +331,12 @@ mod tests {
 
     #[test]
     fn default_hook_binary_sibling_appends_exe_suffix() {
-        // Platform-neutral: EXE_SUFFIX is "" on Unix, ".exe" on Windows —
-        // assert the candidate filename is built with it either way.
-        let expected = format!("pixtuoid-hook{}", std::env::consts::EXE_SUFFIX);
-        assert_eq!(hook_sibling_name(), expected);
+        // Pin the per-platform LITERAL (not a re-computation via EXE_SUFFIX,
+        // which would be tautological): catches a base-name typo or an
+        // accidental double-suffix.
+        #[cfg(unix)]
+        assert_eq!(hook_sibling_name(), "pixtuoid-hook");
+        #[cfg(windows)]
+        assert_eq!(hook_sibling_name(), "pixtuoid-hook.exe");
     }
 }

--- a/crates/pixtuoid/src/main.rs
+++ b/crates/pixtuoid/src/main.rs
@@ -242,10 +242,13 @@ fn crash_log_path() -> PathBuf {
     if let Ok(state) = std::env::var("XDG_STATE_HOME") {
         return PathBuf::from(format!("{state}/pixtuoid/crash.log"));
     }
-    if let Ok(home) = std::env::var("HOME") {
-        return PathBuf::from(format!("{home}/.cache/pixtuoid/crash.log"));
+    if let Some(home) = pixtuoid::install::io::user_home() {
+        return PathBuf::from(home)
+            .join(".cache")
+            .join("pixtuoid")
+            .join("crash.log");
     }
-    PathBuf::from("/tmp/pixtuoid-crash.log")
+    std::env::temp_dir().join("pixtuoid-crash.log")
 }
 
 fn log_file_path() -> Result<PathBuf> {
@@ -255,8 +258,12 @@ fn log_file_path() -> Result<PathBuf> {
     if let Ok(state) = std::env::var("XDG_STATE_HOME") {
         return Ok(PathBuf::from(format!("{state}/pixtuoid/log")));
     }
-    let home = std::env::var("HOME")?;
-    Ok(PathBuf::from(format!("{home}/.cache/pixtuoid/log")))
+    let home = pixtuoid::install::io::user_home()
+        .ok_or_else(|| anyhow::anyhow!("no HOME/USERPROFILE for the log dir"))?;
+    Ok(PathBuf::from(home)
+        .join(".cache")
+        .join("pixtuoid")
+        .join("log"))
 }
 
 /// Adapter that gives `tracing-subscriber` a `Write`-able file behind a Mutex.

--- a/crates/pixtuoid/src/main.rs
+++ b/crates/pixtuoid/src/main.rs
@@ -98,12 +98,14 @@ fn main() -> Result<()> {
 
 fn install_crash_hook() {
     std::panic::set_hook(Box::new(|info| {
-        let _ = crossterm::terminal::disable_raw_mode();
+        // Same ordering contract as tui::teardown_terminal: mouse-capture
+        // restore must precede disable_raw_mode (see the WHY there).
         let _ = crossterm::execute!(
             std::io::stderr(),
             crossterm::event::DisableMouseCapture,
             crossterm::terminal::LeaveAlternateScreen
         );
+        let _ = crossterm::terminal::disable_raw_mode();
 
         let version = env!("CARGO_PKG_VERSION");
         let crash_path = crash_log_path();

--- a/crates/pixtuoid/src/tui/embedded_pack.rs
+++ b/crates/pixtuoid/src/tui/embedded_pack.rs
@@ -29,7 +29,7 @@ use pixtuoid_core::sprite::format::{load_pack, load_pack_from_strings, Pack};
 fn xdg_pack_dir() -> Option<PathBuf> {
     let base = std::env::var_os("XDG_CONFIG_HOME")
         .map(PathBuf::from)
-        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".config")))?;
+        .or_else(|| crate::install::io::user_home().map(|h| PathBuf::from(h).join(".config")))?;
     let dir = base.join("pixtuoid").join("sprites");
     if dir.join("pack.toml").is_file() {
         Some(dir)

--- a/crates/pixtuoid/src/tui/mod.rs
+++ b/crates/pixtuoid/src/tui/mod.rs
@@ -107,6 +107,13 @@ fn is_quit_chord(code: KeyCode, mods: KeyModifiers) -> bool {
     )
 }
 
+/// Windows delivers Press AND Release events per keystroke; only Press may
+/// dispatch (Release/Repeat double-fire keys there — `p` would pause then
+/// instantly unpause). Unix only ever delivers Press, so this is a no-op there.
+fn should_dispatch_key(kind: KeyEventKind) -> bool {
+    kind == KeyEventKind::Press
+}
+
 /// Pure key-dispatch: resolve a key press to a `KeyAction` given the current
 /// modal + floor state. Modal precedence (highest first): help overlay,
 /// version popup, theme picker, then the normal scene.
@@ -297,8 +304,7 @@ pub async fn run_tui(
                     // Windows delivers Press AND Release events per
                     // keystroke; without this guard every key double-fires
                     // there (e.g. `p` pauses then instantly unpauses).
-                    // Non-Press key events fall through to the catch-all arm.
-                    Event::Key(k) if k.kind == KeyEventKind::Press => {
+                    Event::Key(k) if should_dispatch_key(k.kind) => {
                         let ctx = KeyCtx {
                             help_open: renderer.help_open(),
                             version_popup,
@@ -625,5 +631,13 @@ mod dispatch_tests {
             dispatch_key(KeyCode::Down, NONE, hi),
             KeyAction::ThemePreview(5)
         );
+    }
+
+    #[test]
+    fn only_press_events_dispatch() {
+        use crossterm::event::KeyEventKind;
+        assert!(super::should_dispatch_key(KeyEventKind::Press));
+        assert!(!super::should_dispatch_key(KeyEventKind::Release));
+        assert!(!super::should_dispatch_key(KeyEventKind::Repeat));
     }
 }

--- a/crates/pixtuoid/src/tui/mod.rs
+++ b/crates/pixtuoid/src/tui/mod.rs
@@ -21,8 +21,8 @@ use std::time::{Duration, Instant, SystemTime};
 
 use anyhow::Result;
 use crossterm::event::{
-    self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyModifiers, MouseButton,
-    MouseEventKind,
+    self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind, KeyModifiers,
+    MouseButton, MouseEventKind,
 };
 use crossterm::execute;
 use crossterm::terminal::{
@@ -290,7 +290,11 @@ pub async fn run_tui(
             let mut quit = false;
             while polled {
                 match event::read()? {
-                    Event::Key(k) => {
+                    // Windows delivers Press AND Release events per
+                    // keystroke; without this guard every key double-fires
+                    // there (e.g. `p` pauses then instantly unpauses).
+                    // Non-Press key events fall through to the catch-all arm.
+                    Event::Key(k) if k.kind == KeyEventKind::Press => {
                         let ctx = KeyCtx {
                             help_open: renderer.help_open(),
                             version_popup,

--- a/crates/pixtuoid/src/tui/mod.rs
+++ b/crates/pixtuoid/src/tui/mod.rs
@@ -186,12 +186,16 @@ pub fn setup_terminal() -> Result<Term> {
 }
 
 pub fn teardown_terminal(term: &mut Term) -> Result<()> {
-    disable_raw_mode()?;
+    // DisableMouseCapture must run while raw mode is still ON: on Windows it
+    // restores the input mode snapshotted at Enable time (which was raw-era),
+    // so running it after disable_raw_mode re-raws the console and leaves
+    // the user's shell echo-less. Raw mode goes off LAST.
     execute!(
         term.backend_mut(),
         DisableMouseCapture,
         LeaveAlternateScreen
     )?;
+    disable_raw_mode()?;
     term.show_cursor()?;
     Ok(())
 }


### PR DESCRIPTION
PR 1 of the Windows-support arc (#128, tracking PR #143, spec approved 2026-06-06). **Zero behavior change on Unix** — every change is either a helper-equivalent refactor or a Windows-only-visible fix.

## What

- **`user_home()` helpers** (USERPROFILE-first on Windows, HOME on Unix, empty=unset): `pixtuoid-core/src/platform.rs` (returns `String`, per-platform fallback) + `pixtuoid/src/install/io.rs` (returns `Option<String>` — call sites keep their own fallbacks). All 10 production home-dir reads rewired (`claude_code`/`codex`/`antigravity` `default_paths` via `PathBuf::join`, `home_relative`, `config_path`, `resolve_pack_dir`, `embedded_pack::xdg_pack_dir`, `crash_log_path`, `log_file_path`, snapshot example). On native Windows, HOME is unset — these sites silently watched `/tmp/.claude/projects` / wrote config into CWD / hard-errored the log path.
- **`EXE_SUFFIX`** in the hook-binary sibling lookup (`hook_sibling_name()`).
- **`KeyEventKind::Press` guard** in the event loop — Windows delivers Press AND Release per keystroke; every key double-fired there (`p` paused then instantly unpaused). No-op on Unix.
- **Teardown ordering** (`teardown_terminal` + panic hook): `DisableMouseCapture` must run while raw mode is still on — on Windows it restores the input mode snapshotted at Enable time (raw-era), so the old order left the shell echo-less on exit. Order-indifferent on Unix.
- **6 symlink tests** gated `#[cfg(unix)]` (they call `std::os::unix::fs::symlink`).

One documented rare-path deviation: the no-HOME/no-XDG crash-log fallback moved from literal `/tmp` to `std::env::temp_dir()`.

## Verification

- `just preflight` green: lint → clippy → hack → **1025/1025 tests**.
- Each task TDD'd (red→green) + two-stage subagent review (spec compliance, then code quality).
- Windows branches of both helpers are pure functions unit-tested on macOS; live Windows verification comes with PR 3's CI job + the #128 community tester.

Part of #128 — next: PR 2 (workspace compiles for `x86_64-pc-windows-msvc`, named-pipe hook transport).

🤖 Generated with [Claude Code](https://claude.com/claude-code)