### PR TITLE
feat: Windows CI runs the full suite — pipe twins + SDDL (#128)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# No EOL translation anywhere: sprite goldens, insta snapshots and JSONL
+# fixtures are byte-compared; autocrlf=true (Git for Windows default on GHA
+# runners) would corrupt them on checkout.
+* -text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,21 @@ jobs:
       - uses: extractions/setup-just@v4
       - run: just check-windows
 
+  windows-test:
+    name: windows-test
+    # Pinned to windows-2022 during the VS 2026 migration of windows-latest
+    # (June 8-15, 2026); unpin once the migration settles (tracked carry-item).
+    runs-on: windows-2022
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: extractions/setup-just@v4
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@cargo-nextest
+      - run: just test
+
   semver:
     name: semver-checks
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ The `test-renderer` feature is needed for the `e2e.rs` integration test; **`just
 ### Test organization (three tiers)
 
 - **Unit tests** — `#[cfg(test)] mod tests` next to the code. For large modules this is a *sibling file* declared `#[cfg(test)] mod tests;` (e.g. `motion/tests.rs`, `pose/tests.rs`, `layout/tests.rs`, `pixel_painter/tests.rs`) so production stays readable; it keeps `use super::*` and full crate-internal access (no API widening).
-- **Integration / public-contract** — `crates/<crate>/tests/*.rs` (separate crate, only `pub` API): `reducer.rs`, `e2e.rs`, `hook_socket.rs`, `jsonl_watcher.rs`. One deliberate exception: `socket_path_parity.rs` `#[path]`-includes the hook shim's `paths.rs` (source inclusion, not a dep) to pin shim↔daemon socket-path equality across crates without violating the no-core-dep-in-shim invariant; it's `exclude`d from the published tarball (the included file can't exist there).
+- **Integration / public-contract** — `crates/<crate>/tests/*.rs` (separate crate, only `pub` API): `reducer.rs`, `e2e.rs`, `hook_socket.rs`, `jsonl_watcher.rs`. One deliberate exception: `socket_path_parity.rs` `#[path]`-includes the hook shim's `paths.rs` (source inclusion, not a dep) to pin shim↔daemon socket-path equality across crates without violating the no-core-dep-in-shim invariant; it's `exclude`d from the published tarball (the included file can't exist there). Windows pipe parity: `pixtuoid-core/tests/hook_pipe.rs` and `pixtuoid-hook/tests/shim_pipe.rs` are `#[cfg(windows)]` twins of `hook_socket.rs` and `shim.rs` respectively — they run only on the `windows-test` CI job (windows-2022, full nextest suite); from PR 3 onward the windows job is part of the parity invariant (each branch only executes on its target OS).
 - **Headless render harness** — `tui_renderer/harness.rs` (`#[cfg(test)] mod harness;`). Drives the *real* `TuiRenderer` through `render()` / `navigate_floor()` via ratatui `TestBackend` (no terminal). Output-first assertions: `buf()` (RgbBuffer pixels) + the `#[cfg(test)] frame_buffer()` ratatui-cell inspector; white-box seams (`floor_motion`, `floor_buf`, `inject_coffee`) only where an invariant isn't observable from output. NOT coverable headlessly (excluded in `codecov.yml`): the crossterm event loop + terminal lifecycle (`tui/mod.rs`, reads/writes the real TTY), the async runtime glue (`runtime/driver.rs`, tokio `block_on` + `ctrl_c` + socket bind), and `main.rs`.
 
 Coverage: `just coverage` (writes lcov.info + JUnit XML — the exact command CI runs).
@@ -111,7 +111,7 @@ with `test-renderer` on. `semver` and `coverage`/`smoke` are CI-only. The
 semver gate checks **`pixtuoid-core` only** — the `pixtuoid` binary's lib
 target is an internal-facing surface for examples/integration tests, not a
 semver surface, so its `pub` paths may move without a major bump.
-`check-windows` cross-checks the workspace for `x86_64-pc-windows-msvc` on every PR (compile-only, no linking).)
+`check-windows` cross-lints the workspace for `x86_64-pc-windows-msvc` on every PR (clippy, no linking).)
 
 Run `just preflight` locally to avoid the round-trip of "push → wait for CI →
 red → fix → push again."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1442,6 +1442,7 @@ dependencies = [
  "anyhow",
  "libc",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,6 +1433,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/pixtuoid-core/CLAUDE.md
+++ b/crates/pixtuoid-core/CLAUDE.md
@@ -16,7 +16,7 @@ src/
 │                       registry.rs (THE per-source fact table: SourceDescriptor{label_prefix, line_decoder,
 │                       hook{id_key,custom}, caps} — one row per CLI; doc(hidden), not public API),
 │                       decoder.rs (shared utils + decode_hook_payload, a registry-driven dispatcher),
-│                       hook/ (HookSocketListener facade — mod.rs shared generic handle_conn over AsyncRead [ONE framing/decode path for both transports], unix.rs UnixListener+umask, windows.rs named-pipe accept loop), jsonl.rs (JsonlWatcher + walk_jsonl's unified first-sight gate should_seed_at_eof),
+│                       hook/ (HookSocketListener facade — mod.rs shared generic handle_conn over AsyncRead [ONE framing/decode path for both transports], unix.rs UnixListener+umask, windows.rs named-pipe accept loop — pipe uses owner-only SDDL `D:P(A;;GA;;;OW)` [umask-0700 equivalent; the kernel copies the descriptor at each CreateNamedPipe]; a failed connect is NOT a reusable instance, so windows.rs recreates the server after each connect error), jsonl.rs (JsonlWatcher + walk_jsonl's unified first-sight gate should_seed_at_eof),
 │                       claude_code.rs / codex.rs / antigravity.rs (per-source decode + label fns + Source impls),
 │                       manager.rs (SourceManager::spawn / with_source)
 ├── state/              SceneState + Reducer (event coordinator: Transport-tagged dedup, the

--- a/crates/pixtuoid-core/Cargo.toml
+++ b/crates/pixtuoid-core/Cargo.toml
@@ -33,6 +33,11 @@ notify      = { workspace = true }
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+# 0.61 to match the major tokio already pulls (via mio) for this target —
+# a second windows-sys major would double-compile the bindings.
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization"] }
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["sync", "rt", "macros", "fs", "net", "time", "io-util", "rt-multi-thread"] }
 tempfile = "3"

--- a/crates/pixtuoid-core/src/source/claude_code.rs
+++ b/crates/pixtuoid-core/src/source/claude_code.rs
@@ -231,7 +231,7 @@ pub fn cc_session_ended(tail: &[u8]) -> bool {
 /// last segment is the project basename. Without this, an empty-cwd Rename
 /// silently degrades a good hook-derived `cc·dotfiles` back to `cc`.
 pub fn cc_derive_label(path: &Path, _source: &str, cwd: &Path) -> String {
-    // ONE shared predicate with `detect_parent_id` (both via `SUBAGENTS_SEGMENT`)
+    // ONE shared predicate with `detect_parent_id` (both via the `SUBAGENTS_DIR` component)
     // so the two can't diverge — a loose `"subagents"` substring once mislabeled a
     // `subagents-paper` repo's parent transcript "subagent" with parent_id=None
     // (bug_004); the slash-bounded predicate fixes that at a single source.

--- a/crates/pixtuoid-core/src/source/hook/mod.rs
+++ b/crates/pixtuoid-core/src/source/hook/mod.rs
@@ -42,8 +42,9 @@ impl HookSocketListener {
 
 /// Per-connection byte ceiling: 2× the shim's 1MiB stdin cap. lines() buffers
 /// until a newline, so without this an adversarial client could grow the
-/// buffer unboundedly for the whole CONN_TIMEOUT window × 128 slots (the Unix
-/// socket is 0700, but the Windows pipe DACL only hardens in PR 3).
+/// buffer unboundedly for the whole CONN_TIMEOUT window × 128 slots —
+/// defense-in-depth behind the owner-only endpoint (Unix socket 0700, Windows
+/// pipe owner-only SDDL).
 const MAX_CONN_BYTES: u64 = 2 * 1024 * 1024;
 
 pub(crate) async fn handle_conn(stream: impl AsyncRead + Unpin, tx: TaggedSender) {

--- a/crates/pixtuoid-core/src/source/hook/windows.rs
+++ b/crates/pixtuoid-core/src/source/hook/windows.rs
@@ -1,3 +1,4 @@
+use std::ffi::c_void;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -5,6 +6,11 @@ use anyhow::{Context, Result};
 use tokio::net::windows::named_pipe::{NamedPipeServer, PipeMode, ServerOptions};
 use tokio::sync::Semaphore;
 use tracing::warn;
+use windows_sys::Win32::Foundation::LocalFree;
+use windows_sys::Win32::Security::Authorization::{
+    ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1,
+};
+use windows_sys::Win32::Security::{PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES};
 
 use crate::source::TaggedSender;
 
@@ -15,30 +21,104 @@ use super::{handle_conn, CONN_TIMEOUT, MAX_CONCURRENT_CONNS};
 /// sync write can't stall behind a momentarily busy daemon task.
 const IN_BUFFER_SIZE: u32 = 1 << 20;
 
+/// Owner-only security descriptor via SDDL `D:P(A;;GA;;;OW)` — protected
+/// DACL, single ACE granting GENERIC_ALL to OWNER_RIGHTS (the creating
+/// user). The named-pipe equivalent of the Unix socket's umask-0700: closes
+/// the default DACL's Everyone-READ while keeping the owner fully able to
+/// connect. Held alive for the daemon's lifetime; the kernel copies the
+/// descriptor at each CreateNamedPipe, but keeping the allocation around
+/// makes the raw-pointer SECURITY_ATTRIBUTES trivially valid at every
+/// create site.
+struct OwnerOnlySd {
+    psd: PSECURITY_DESCRIPTOR,
+    attrs: SECURITY_ATTRIBUTES,
+}
+
+// SAFETY: the descriptor is immutable after creation (the Win32 calls only
+// read through these pointers) and freed exactly once in Drop; none of the
+// APIs involved carry thread affinity, so moving the owner across threads
+// (tokio::spawn of the listener task) is sound.
+unsafe impl Send for OwnerOnlySd {}
+
+impl OwnerOnlySd {
+    fn new() -> Result<Self> {
+        let mut psd: PSECURITY_DESCRIPTOR = std::ptr::null_mut();
+        // SAFETY: the SDDL literal is a valid NUL-terminated UTF-16 string,
+        // psd is a live out-pointer, and the size out-param is documented
+        // optional (null allowed).
+        let ok = unsafe {
+            ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                windows_sys::w!("D:P(A;;GA;;;OW)"),
+                SDDL_REVISION_1,
+                &mut psd,
+                std::ptr::null_mut(),
+            )
+        };
+        if ok == 0 {
+            return Err(anyhow::Error::new(std::io::Error::last_os_error())
+                .context("converting owner-only SDDL into a pipe security descriptor"));
+        }
+        Ok(Self {
+            psd,
+            attrs: SECURITY_ATTRIBUTES {
+                nLength: std::mem::size_of::<SECURITY_ATTRIBUTES>() as u32,
+                lpSecurityDescriptor: psd,
+                bInheritHandle: 0,
+            },
+        })
+    }
+
+    /// Pointer for tokio's `create_with_security_attributes_raw`. Only ever
+    /// read by CreateNamedPipeW for the duration of that call.
+    fn attributes_ptr(&self) -> *mut c_void {
+        std::ptr::from_ref(&self.attrs).cast_mut().cast()
+    }
+}
+
+impl Drop for OwnerOnlySd {
+    fn drop(&mut self) {
+        // SAFETY: psd was LocalAlloc'd by the SDDL conversion (documented
+        // contract: caller frees with LocalFree) and is freed exactly once
+        // here; no other reads can follow Drop.
+        unsafe {
+            LocalFree(self.psd);
+        }
+    }
+}
+
 pub(super) struct Listener {
     server: NamedPipeServer,
     name: String,
+    sd: OwnerOnlySd,
 }
 
 impl Listener {
     pub(super) async fn bind(path: &Path) -> Result<Self> {
         let name = path.to_string_lossy().into_owned();
+        let sd = OwnerOnlySd::new()?;
         // first_pipe_instance: if another process already owns this name
         // (squatting), creation fails ACCESS_DENIED — bail loudly rather
         // than silently queueing behind an impostor. reject_remote_clients
         // is the tokio default; pinned here explicitly. The server stays
         // DUPLEX (tokio default) — the shim's client opens read+write, so an
         // inbound-only pipe would reject it with ACCESS_DENIED (silent event
-        // drop). Owner-only SDDL hardening lands in PR 3 (needs the Windows
-        // runner) — the default DACL already denies cross-user WRITES.
-        let server = ServerOptions::new()
-            .first_pipe_instance(true)
-            .reject_remote_clients(true)
-            .pipe_mode(PipeMode::Byte)
-            .in_buffer_size(IN_BUFFER_SIZE)
-            .create(&name)
-            .with_context(|| format!("creating hook pipe at {name}"))?;
-        Ok(Self { server, name })
+        // drop).
+        //
+        // SAFETY: sd outlives the call (it moves into Self below) and
+        // attributes_ptr points at its well-formed SECURITY_ATTRIBUTES whose
+        // lpSecurityDescriptor is the valid converted descriptor; the kernel
+        // copies the descriptor during CreateNamedPipeW, so nothing borrows
+        // past the call.
+        let server = unsafe {
+            ServerOptions::new()
+                .first_pipe_instance(true)
+                .reject_remote_clients(true)
+                .pipe_mode(PipeMode::Byte)
+                .in_buffer_size(IN_BUFFER_SIZE)
+                .create_with_security_attributes_raw(&name, sd.attributes_ptr())
+        }
+        .with_context(|| format!("creating hook pipe at {name}"))?;
+        Ok(Self { server, name, sd })
     }
 
     pub(super) async fn run(mut self, tx: TaggedSender) -> Result<()> {
@@ -57,26 +137,35 @@ impl Listener {
                 // with the recreate-bail below. Unix accept errors leave the
                 // listener fd valid, hence its plain warn+continue.
                 warn!("hook pipe connect error: {e}; recreating instance");
-                self.server = ServerOptions::new()
-                    .reject_remote_clients(true)
-                    .pipe_mode(PipeMode::Byte)
-                    .in_buffer_size(IN_BUFFER_SIZE)
-                    .create(&self.name)
-                    .with_context(|| {
-                        format!("re-creating hook pipe after connect error at {}", self.name)
-                    })?;
+                // SAFETY: self.sd lives for the whole loop; same descriptor
+                // validity argument as bind().
+                self.server = unsafe {
+                    ServerOptions::new()
+                        .reject_remote_clients(true)
+                        .pipe_mode(PipeMode::Byte)
+                        .in_buffer_size(IN_BUFFER_SIZE)
+                        .create_with_security_attributes_raw(&self.name, self.sd.attributes_ptr())
+                }
+                .with_context(|| {
+                    format!("re-creating hook pipe after connect error at {}", self.name)
+                })?;
                 continue;
             }
             // Create the NEXT instance BEFORE handing this one off —
             // tokio's documented pattern; in the gap between handoff and
             // re-create, clients would get ERROR_PIPE_BUSY or NotFound
             // depending on timing.
-            let next = ServerOptions::new()
-                .reject_remote_clients(true)
-                .pipe_mode(PipeMode::Byte)
-                .in_buffer_size(IN_BUFFER_SIZE)
-                .create(&self.name)
-                .with_context(|| format!("re-creating hook pipe at {}", self.name))?;
+            //
+            // SAFETY: self.sd lives for the whole loop; same descriptor
+            // validity argument as bind().
+            let next = unsafe {
+                ServerOptions::new()
+                    .reject_remote_clients(true)
+                    .pipe_mode(PipeMode::Byte)
+                    .in_buffer_size(IN_BUFFER_SIZE)
+                    .create_with_security_attributes_raw(&self.name, self.sd.attributes_ptr())
+            }
+            .with_context(|| format!("re-creating hook pipe at {}", self.name))?;
             let conn = std::mem::replace(&mut self.server, next);
             let tx = tx.clone();
             tokio::spawn(async move {

--- a/crates/pixtuoid-core/src/source/jsonl.rs
+++ b/crates/pixtuoid-core/src/source/jsonl.rs
@@ -432,29 +432,45 @@ async fn check_session_ended(path: &Path, checker: SessionEndChecker) -> bool {
     checker(&buf)
 }
 
-/// The path segment a CC subagent transcript carries: `<parent>/subagents/
-/// agent-*.jsonl`. Slash-bounded so a project dir merely *containing* the word
-/// (e.g. `subagents-paper`) is not mistaken for one — single source of truth for
-/// both `is_subagent_path` and `detect_parent_id` so they cannot diverge (they
-/// did once: see the `bug_004` fix in `cc_derive_label`).
-const SUBAGENTS_SEGMENT: &str = "/subagents/";
+/// The directory a CC subagent transcript sits under: `<parent>/subagents/
+/// agent-*.jsonl`. Matched as a whole path COMPONENT (never a substring) so a
+/// project dir merely *containing* the word (e.g. `subagents-paper`) is not
+/// mistaken for one, and so Windows backslash-separated paths match too (the
+/// old `"/subagents/"` string scan was '/'-literal — found by the windows-test
+/// CI job). Single source of truth for both `is_subagent_path` and
+/// `detect_parent_id` so they cannot diverge (they did once: see the
+/// `bug_004` fix in `cc_derive_label`).
+const SUBAGENTS_DIR: &str = "subagents";
 
 /// Whether a transcript path is a CC subagent transcript (vs a top-level
 /// session). Codex subagents are FLAT (no such segment) — they're linked via the
 /// `SubagentStart` hook instead, so this predicate is CC-layout-specific.
 pub(crate) fn is_subagent_path(path: &Path) -> bool {
-    path.to_string_lossy().contains(SUBAGENTS_SEGMENT)
+    path.components().any(|c| c.as_os_str() == SUBAGENTS_DIR)
 }
 
-/// Detect if this transcript is a CC subagent by checking for the `/subagents/`
-/// path segment. If found, derive the parent's AgentId from the grandparent
+/// Detect if this transcript is a CC subagent by checking for the `subagents`
+/// path component. If found, derive the parent's AgentId from the grandparent
 /// directory (the parent session's transcript directory). CC-layout-specific —
 /// Codex subagent parent links come from the `SubagentStart` hook, not the path.
+///
+/// The parent key is rebuilt from the components BEFORE the first `subagents`
+/// (`<parent-dir>.jsonl`), using native separators — byte-identical to the
+/// parent transcript's own watcher-derived key on every platform.
 fn detect_parent_id(path: &Path, source: &str) -> Option<AgentId> {
-    let path_str = path.to_string_lossy();
-    let idx = path_str.find(SUBAGENTS_SEGMENT)?;
-    let parent_dir = &path_str[..idx];
-    let parent_jsonl = format!("{parent_dir}.jsonl");
+    let mut parent_dir = PathBuf::new();
+    let mut found = false;
+    for c in path.components() {
+        if c.as_os_str() == SUBAGENTS_DIR {
+            found = true;
+            break;
+        }
+        parent_dir.push(c);
+    }
+    if !found || parent_dir.as_os_str().is_empty() {
+        return None;
+    }
+    let parent_jsonl = format!("{}.jsonl", parent_dir.display());
     Some(AgentId::from_parts(source, &parent_jsonl))
 }
 

--- a/crates/pixtuoid-core/src/source/jsonl.rs
+++ b/crates/pixtuoid-core/src/source/jsonl.rs
@@ -512,6 +512,53 @@ mod tests {
         );
     }
 
+    // These call the REAL detect_parent_id/is_subagent_path (they're private —
+    // an integration test can't reach them; an old decoder.rs test re-simulated
+    // the algorithm inline and silently pinned the superseded string-scan).
+    #[test]
+    fn detect_parent_id_derives_grandparent_transcript_key() {
+        let p = Path::new("/Users/me/.claude/projects/x/abc123/subagents/agent-1.jsonl");
+        let expected =
+            AgentId::from_parts("claude-code", "/Users/me/.claude/projects/x/abc123.jsonl");
+        assert_eq!(detect_parent_id(p, "claude-code"), Some(expected));
+        assert!(is_subagent_path(p));
+    }
+
+    #[test]
+    fn detect_parent_id_none_for_regular_and_lookalike_paths() {
+        assert_eq!(
+            detect_parent_id(
+                Path::new("/Users/me/.claude/projects/x/ses.jsonl"),
+                "claude-code"
+            ),
+            None
+        );
+        // Component matching: a dir merely CONTAINING the word never matches.
+        let lookalike = Path::new("/Users/me/.claude/projects/subagents-paper/ses.jsonl");
+        assert_eq!(detect_parent_id(lookalike, "claude-code"), None);
+        assert!(!is_subagent_path(lookalike));
+        // A bare relative path starting AT `subagents` has no parent to derive.
+        assert_eq!(
+            detect_parent_id(Path::new("subagents/agent-1.jsonl"), "claude-code"),
+            None
+        );
+    }
+
+    // Only RUNS on the windows-test CI job (backslashes are ordinary filename
+    // bytes on Unix, so this shape is only meaningful there) — pins the
+    // components rewrite's whole reason to exist.
+    #[cfg(windows)]
+    #[test]
+    fn detect_parent_id_handles_backslash_paths() {
+        let p = Path::new(r"C:\Users\me\.claude\projects\x\abc123\subagents\agent-1.jsonl");
+        let expected = AgentId::from_parts(
+            "claude-code",
+            r"C:\Users\me\.claude\projects\x\abc123.jsonl",
+        );
+        assert_eq!(detect_parent_id(p, "claude-code"), Some(expected));
+        assert!(is_subagent_path(p));
+    }
+
     #[test]
     fn extract_cwd_reads_top_level_and_nested_payload() {
         // CC/AG shape: top-level cwd.

--- a/crates/pixtuoid-core/src/source/jsonl.rs
+++ b/crates/pixtuoid-core/src/source/jsonl.rs
@@ -517,11 +517,15 @@ mod tests {
     // the algorithm inline and silently pinned the superseded string-scan).
     #[test]
     fn detect_parent_id_derives_grandparent_transcript_key() {
-        let p = Path::new("/Users/me/.claude/projects/x/abc123/subagents/agent-1.jsonl");
-        let expected =
-            AgentId::from_parts("claude-code", "/Users/me/.claude/projects/x/abc123.jsonl");
-        assert_eq!(detect_parent_id(p, "claude-code"), Some(expected));
-        assert!(is_subagent_path(p));
+        // Built via PathBuf so separators are NATIVE on every platform: the
+        // rebuilt parent key uses native separators, matching the watcher's
+        // own to_string_lossy for the parent transcript (a separator-literal
+        // expectation broke on the windows runner — backslash rebuild).
+        let parent: PathBuf = ["projects", "x", "abc123"].iter().collect();
+        let p = parent.join("subagents").join("agent-1.jsonl");
+        let expected = AgentId::from_parts("claude-code", &format!("{}.jsonl", parent.display()));
+        assert_eq!(detect_parent_id(&p, "claude-code"), Some(expected));
+        assert!(is_subagent_path(&p));
     }
 
     #[test]

--- a/crates/pixtuoid-core/tests/decoder.rs
+++ b/crates/pixtuoid-core/tests/decoder.rs
@@ -670,33 +670,6 @@ fn cc_session_ended_exit_then_session_start_is_not_ended() {
 }
 
 #[test]
-fn detect_parent_id_for_subagent_path() {
-    use pixtuoid_core::AgentId;
-    use std::path::Path;
-
-    // Simulate what jsonl.rs::detect_parent_id does
-    let path = Path::new("/Users/me/.claude/projects/x/abc123/subagents/agent-1.jsonl");
-    let path_str = path.to_string_lossy();
-    let idx = path_str.find("/subagents/");
-    assert!(idx.is_some(), "should find /subagents/ in path");
-    let parent_dir = &path_str[..idx.unwrap()];
-    let parent_jsonl = format!("{parent_dir}.jsonl");
-    let parent_id = AgentId::from_parts("claude-code", &parent_jsonl);
-    let expected = AgentId::from_parts("claude-code", "/Users/me/.claude/projects/x/abc123.jsonl");
-    assert_eq!(parent_id, expected);
-}
-
-#[test]
-fn detect_parent_id_returns_none_for_regular_path() {
-    let path = std::path::Path::new("/Users/me/.claude/projects/x/ses-abc.jsonl");
-    let path_str = path.to_string_lossy();
-    assert!(
-        path_str.find("/subagents/").is_none(),
-        "regular path should not match subagent pattern"
-    );
-}
-
-#[test]
 fn decode_hook_payload_missing_session_id_returns_err() {
     let payload = serde_json::json!({
         "hook_event_name": "SessionStart",

--- a/crates/pixtuoid-core/tests/fixture_harness.rs
+++ b/crates/pixtuoid-core/tests/fixture_harness.rs
@@ -122,13 +122,16 @@ fn decode_fixture(source: &str, dir: &Path) -> Decoded {
 
     // Hook-only scenarios key the {{TRANSCRIPT_PATH}} substitution on the
     // scenario dir instead (stable + machine-independent, same property).
+    // Separators are normalized to '/' so the key — and therefore every
+    // AgentId hash baked into the snapshots — is byte-identical on Windows
+    // (where strip_prefix yields backslash-separated components).
     let logical = transcripts
         .first()
         .map_or(dir, PathBuf::as_path)
         .strip_prefix(fixtures_root())
         .unwrap()
         .to_string_lossy()
-        .into_owned();
+        .replace('\\', "/");
 
     let mut jsonl = Vec::new();
     if let Some(transcript) = transcripts.first() {

--- a/crates/pixtuoid-core/tests/hook_pipe.rs
+++ b/crates/pixtuoid-core/tests/hook_pipe.rs
@@ -1,0 +1,289 @@
+#![cfg(windows)]
+//! Windows twin of hook_socket.rs: the same listener contract over a real
+//! named pipe, plus the accept-loop behaviors only a pipe has (instance
+//! recreate on connect error, create-next-before-handoff under concurrency).
+
+use std::time::Duration;
+
+use tokio::io::AsyncWriteExt;
+use tokio::net::windows::named_pipe::ClientOptions;
+use tokio::sync::mpsc;
+use tokio::time::sleep;
+
+use pixtuoid_core::source::hook::HookSocketListener;
+use pixtuoid_core::source::{AgentEvent, Transport};
+
+/// Each test gets a unique pipe name to avoid cross-test interference.
+/// Format: `\\.\pipe\pixtuoid-test-{pid}-{suffix}`
+fn pipe_name(suffix: &str) -> String {
+    format!(r"\\.\pipe\pixtuoid-test-{}-{}", std::process::id(), suffix)
+}
+
+/// Connect to a named pipe, retrying on ERROR_PIPE_BUSY (os error 231).
+///
+/// Named pipes require the client to retry when the server is between
+/// instances (create-next-before-handoff window). Bounded to ~20 tries
+/// at 50 ms intervals (~1 s total).
+async fn connect_client(name: &str) -> tokio::net::windows::named_pipe::NamedPipeClient {
+    const MAX_TRIES: u32 = 20;
+    for attempt in 0..MAX_TRIES {
+        match ClientOptions::new().open(name) {
+            Ok(c) => return c,
+            Err(e) if e.raw_os_error() == Some(231) => {
+                // ERROR_PIPE_BUSY — server is swapping instances; retry
+                sleep(Duration::from_millis(50)).await;
+            }
+            Err(e) if attempt == 0 && e.kind() == std::io::ErrorKind::NotFound => {
+                // Listener may not be ready yet; brief back-off on first try
+                sleep(Duration::from_millis(20)).await;
+            }
+            Err(e) => panic!("connect_client({name}) failed: {e}"),
+        }
+    }
+    panic!("connect_client({name}): still ERROR_PIPE_BUSY after {MAX_TRIES} tries");
+}
+
+// ── Mirrored cases ────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn listener_parses_line_and_emits_event() {
+    let name = pipe_name("parse");
+    let (tx, mut rx) = mpsc::channel::<(Transport, AgentEvent)>(16);
+    let listener = HookSocketListener::bind(&name).await.unwrap();
+    let handle = tokio::spawn(async move { listener.run(tx).await });
+
+    sleep(Duration::from_millis(20)).await;
+
+    let mut c = connect_client(&name).await;
+    let payload = serde_json::json!({
+        "hook_event_name": "SessionStart",
+        "session_id": "ses-1",
+        "transcript_path": "/p/a.jsonl",
+        "cwd": "/repo"
+    });
+    let mut line = serde_json::to_vec(&payload).unwrap();
+    line.push(b'\n');
+    c.write_all(&line).await.unwrap();
+    drop(c);
+
+    let (transport, ev) = tokio::time::timeout(Duration::from_millis(500), rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(transport, Transport::Hook);
+    assert!(matches!(ev, AgentEvent::SessionStart { .. }));
+
+    handle.abort();
+}
+
+#[tokio::test]
+async fn listener_skips_malformed_line_and_keeps_going() {
+    let name = pipe_name("malformed");
+    let (tx, mut rx) = mpsc::channel::<(Transport, AgentEvent)>(16);
+    let listener = HookSocketListener::bind(&name).await.unwrap();
+    let handle = tokio::spawn(async move { listener.run(tx).await });
+    sleep(Duration::from_millis(20)).await;
+
+    let mut c = connect_client(&name).await;
+    c.write_all(b"not json\n").await.unwrap();
+    let payload = serde_json::json!({
+        "hook_event_name": "SessionEnd",
+        "session_id": "ses-1",
+        "transcript_path": "/p/a.jsonl",
+        "cwd": "/repo",
+        "reason": "exit"
+    });
+    let mut line = serde_json::to_vec(&payload).unwrap();
+    line.push(b'\n');
+    c.write_all(&line).await.unwrap();
+    drop(c);
+
+    let (transport, ev) = tokio::time::timeout(Duration::from_millis(500), rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(transport, Transport::Hook);
+    assert!(matches!(ev, AgentEvent::SessionEnd { .. }));
+    handle.abort();
+}
+
+#[tokio::test]
+async fn listener_survives_non_utf8_read_error() {
+    let name = pipe_name("nonutf8");
+    let (tx, mut rx) = mpsc::channel::<(Transport, AgentEvent)>(16);
+    let listener = HookSocketListener::bind(&name).await.unwrap();
+    let handle = tokio::spawn(async move { listener.run(tx).await });
+    sleep(Duration::from_millis(20)).await;
+
+    // First connection: invalid UTF-8 → BufReader::lines() Err arm fires.
+    let mut bad = connect_client(&name).await;
+    bad.write_all(&[0xFF, 0xFE, b'\n']).await.unwrap();
+    drop(bad);
+
+    // Second connection: a valid payload must still be delivered.
+    let mut c = connect_client(&name).await;
+    let payload = serde_json::json!({
+        "hook_event_name": "SessionStart",
+        "session_id": "after-bad-read",
+        "transcript_path": "/p/c.jsonl",
+        "cwd": "/repo"
+    });
+    let mut line = serde_json::to_vec(&payload).unwrap();
+    line.push(b'\n');
+    c.write_all(&line).await.unwrap();
+    drop(c);
+
+    let (transport, ev) = tokio::time::timeout(Duration::from_millis(500), rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(transport, Transport::Hook);
+    assert!(matches!(ev, AgentEvent::SessionStart { .. }));
+    handle.abort();
+}
+
+#[tokio::test]
+async fn listener_handles_concurrent_connections() {
+    let name = pipe_name("concurrent");
+    let (tx, mut rx) = mpsc::channel::<(Transport, AgentEvent)>(64);
+    let listener = HookSocketListener::bind(&name).await.unwrap();
+    let handle = tokio::spawn(async move { listener.run(tx).await });
+    sleep(Duration::from_millis(20)).await;
+
+    // 5 concurrent clients — also pins create-next-before-handoff: a handoff
+    // gap would cause some clients to get NotFound, failing here.
+    let mut handles = Vec::new();
+    for i in 0..5usize {
+        let n = name.clone();
+        handles.push(tokio::spawn(async move {
+            let mut c = connect_client(&n).await;
+            let payload = serde_json::json!({
+                "hook_event_name": "SessionStart",
+                "session_id": format!("ses-{i}"),
+                "transcript_path": format!("/p/{i}.jsonl"),
+                "cwd": "/repo"
+            });
+            let mut line = serde_json::to_vec(&payload).unwrap();
+            line.push(b'\n');
+            c.write_all(&line).await.unwrap();
+            drop(c);
+        }));
+    }
+    for h in handles {
+        h.await.unwrap();
+    }
+
+    let mut count = 0;
+    while let Ok(Some(_)) = tokio::time::timeout(Duration::from_millis(500), rx.recv()).await {
+        count += 1;
+        if count == 5 {
+            break;
+        }
+    }
+    assert_eq!(
+        count, 5,
+        "all 5 concurrent connections should produce events"
+    );
+    handle.abort();
+}
+
+#[tokio::test]
+async fn listener_drops_slow_connection_via_timeout() {
+    let name = pipe_name("slowconn");
+    let (tx, mut rx) = mpsc::channel::<(Transport, AgentEvent)>(16);
+    let listener = HookSocketListener::bind(&name).await.unwrap();
+    let handle = tokio::spawn(async move { listener.run(tx).await });
+    sleep(Duration::from_millis(20)).await;
+
+    // Open a connection but hold it without sending; the 1s CONN_TIMEOUT
+    // should drop it. Then a second valid connection proves the loop is alive.
+    let _slow = connect_client(&name).await;
+    sleep(Duration::from_millis(1_200)).await;
+
+    let mut c = connect_client(&name).await;
+    let payload = serde_json::json!({
+        "hook_event_name": "SessionStart",
+        "session_id": "after-timeout",
+        "transcript_path": "/p/b.jsonl",
+        "cwd": "/repo"
+    });
+    let mut line = serde_json::to_vec(&payload).unwrap();
+    line.push(b'\n');
+    c.write_all(&line).await.unwrap();
+    drop(c);
+
+    let (transport, ev) = tokio::time::timeout(Duration::from_millis(500), rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(transport, Transport::Hook);
+    assert!(matches!(ev, AgentEvent::SessionStart { .. }));
+    handle.abort();
+}
+
+#[tokio::test]
+async fn listener_path_accessor_returns_bound_path() {
+    let name = pipe_name("path");
+    let path = std::path::PathBuf::from(&name);
+    let listener = HookSocketListener::bind(path.clone()).await.unwrap();
+    assert_eq!(listener.path(), path.as_path());
+}
+
+// ── New cases ─────────────────────────────────────────────────────────────────
+
+/// Open and immediately drop a client 5× in a loop (zero bytes written), then
+/// connect a real client and assert the decoded event arrives. Pins the
+/// connect-error/instance-recreate path: after each broken-pipe the server must
+/// recreate its instance and stay alive for the next connect.
+#[tokio::test]
+async fn clients_reconnect_after_open_close_churn() {
+    let name = pipe_name("churn");
+    let (tx, mut rx) = mpsc::channel::<(Transport, AgentEvent)>(16);
+    let listener = HookSocketListener::bind(&name).await.unwrap();
+    let handle = tokio::spawn(async move { listener.run(tx).await });
+    sleep(Duration::from_millis(20)).await;
+
+    // 5 open-and-drop cycles with zero bytes — the server sees a connect +
+    // immediate EOF/broken-pipe on each, triggering its recreate path.
+    for _ in 0..5 {
+        let _c = connect_client(&name).await;
+        // drop immediately — the server gets a broken read
+        sleep(Duration::from_millis(10)).await;
+    }
+
+    // After all the churn the listener must still be live.
+    let mut c = connect_client(&name).await;
+    let payload = serde_json::json!({
+        "hook_event_name": "SessionStart",
+        "session_id": "after-churn",
+        "transcript_path": "/p/churn.jsonl",
+        "cwd": "/repo"
+    });
+    let mut line = serde_json::to_vec(&payload).unwrap();
+    line.push(b'\n');
+    c.write_all(&line).await.unwrap();
+    drop(c);
+
+    let (transport, ev) = tokio::time::timeout(Duration::from_millis(1_000), rx.recv())
+        .await
+        .expect("timed out waiting for event after churn")
+        .unwrap();
+    assert_eq!(transport, Transport::Hook);
+    assert!(matches!(ev, AgentEvent::SessionStart { .. }));
+    handle.abort();
+}
+
+/// Binding two listeners on the same pipe name must fail: the first instance
+/// held `first_pipe_instance(true)`, so the second attempt returns an
+/// ACCESS_DENIED error — squatting is detected loudly rather than silently
+/// queuing behind an impostor.
+#[tokio::test]
+async fn second_listener_on_same_name_fails_loudly() {
+    let name = pipe_name("squat");
+    let _first = HookSocketListener::bind(&name).await.unwrap();
+    let second = HookSocketListener::bind(&name).await;
+    assert!(
+        second.is_err(),
+        "expected bind on an already-owned pipe to fail, got Ok"
+    );
+}

--- a/crates/pixtuoid-core/tests/jsonl_watcher.rs
+++ b/crates/pixtuoid-core/tests/jsonl_watcher.rs
@@ -275,7 +275,10 @@ async fn watcher_emits_session_start_for_recent_files_on_startup() {
     std::fs::write(&fresh, format!("{line}\n")).unwrap();
     // fsync the parent directory so the directory entry is guaranteed visible
     // to read_dir — without this, APFS metadata propagation can race with
-    // the watcher's initial seed walk under heavy concurrent I/O.
+    // the watcher's initial seed walk under heavy concurrent I/O. Unix-only:
+    // Windows can't open a directory as a plain file (and the APFS race
+    // doesn't exist there).
+    #[cfg(unix)]
     std::fs::File::open(&project_dir)
         .unwrap()
         .sync_all()

--- a/crates/pixtuoid-core/tests/jsonl_watcher.rs
+++ b/crates/pixtuoid-core/tests/jsonl_watcher.rs
@@ -787,7 +787,16 @@ async fn antigravity_source_run_emits_events_from_transcript() {
 async fn claude_code_source_run_binds_socket_and_emits_events() {
     fast_watch();
     let dir = TempDir::new().unwrap();
+    // The hook endpoint must be platform-shaped: a filesystem path is an
+    // invalid pipe name on Windows and would fail run()'s bind before the
+    // JSONL leg (the thing under test) ever starts.
+    #[cfg(unix)]
     let socket_path = dir.path().join("pixtuoid-test.sock");
+    #[cfg(windows)]
+    let socket_path = std::path::PathBuf::from(format!(
+        r"\\.\pipe\pixtuoid-test-jsonlw-{}",
+        std::process::id()
+    ));
     let projects_root = dir.path().join("projects");
     let project_dir = projects_root.join("proj-cc");
     tokio::fs::create_dir_all(&project_dir).await.unwrap();

--- a/crates/pixtuoid-hook/Cargo.toml
+++ b/crates/pixtuoid-hook/Cargo.toml
@@ -22,6 +22,9 @@ anyhow     = { workspace = true }
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+[target.'cfg(windows)'.dev-dependencies]
+tokio = { workspace = true, features = ["sync", "rt", "macros", "net", "time", "io-util", "rt-multi-thread"] }
+
 [package.metadata.deb]
 section = "utils"
 assets = [

--- a/crates/pixtuoid-hook/tests/shim_pipe.rs
+++ b/crates/pixtuoid-hook/tests/shim_pipe.rs
@@ -1,0 +1,88 @@
+#![cfg(windows)]
+//! Windows twins of tests/shim.rs — the invariant-#5 contract against a real
+//! named pipe, plus the watchdog's own pin (stalled daemon → exit 0 ~200ms).
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use tokio::io::AsyncReadExt;
+use tokio::net::windows::named_pipe::{ClientOptions, PipeMode, ServerOptions};
+
+fn shim_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_pixtuoid-hook")
+}
+
+fn run_shim(pipe_name: &str, stdin_json: &str) -> (std::process::ExitStatus, Duration) {
+    let started = Instant::now();
+    let mut child = Command::new(shim_bin())
+        .env("PIXTUOID_SOCKET", pipe_name)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn shim");
+    child
+        .stdin
+        .take()
+        .expect("stdin")
+        .write_all(stdin_json.as_bytes())
+        .expect("write stdin");
+    let status = child.wait().expect("wait shim");
+    (status, started.elapsed())
+}
+
+#[tokio::test]
+async fn delivers_one_json_line_to_pipe_listener_and_exits_zero() {
+    let name = format!(r"\\.\pipe\pixtuoid-test-{}", std::process::id());
+    let mut server = ServerOptions::new()
+        .first_pipe_instance(true)
+        .pipe_mode(PipeMode::Byte)
+        .create(&name)
+        .expect("create pipe");
+
+    let name2 = name.clone();
+    let shim = std::thread::spawn(move || {
+        run_shim(&name2, r#"{"hook_event_name":"Stop","session_id":"s1"}"#)
+    });
+
+    server.connect().await.expect("connect");
+    let mut got = Vec::new();
+    server.read_to_end(&mut got).await.expect("read");
+    let line = String::from_utf8(got).expect("utf8");
+    assert!(line.ends_with('\n'), "newline-terminated: {line:?}");
+    assert!(line.contains(r#""hook_event_name":"Stop""#));
+    assert!(line.contains("_shim_ts_ms"), "shim enrichment present");
+
+    let (status, _) = shim.join().expect("join");
+    assert!(status.success(), "exit 0");
+}
+
+#[test]
+fn missing_pipe_exits_zero_without_blocking() {
+    let (status, elapsed) = run_shim(r"\\.\pipe\pixtuoid-test-nonexistent", "{}");
+    assert!(status.success(), "exit 0 on missing daemon");
+    // NotFound is the fast path — generous CI margin, but well under any hang.
+    assert!(elapsed < Duration::from_secs(2), "took {elapsed:?}");
+}
+
+#[tokio::test]
+async fn stalled_daemon_shim_exits_zero_within_watchdog_bound() {
+    // A pipe whose single instance is already taken by another client: the
+    // shim's open() gets ERROR_PIPE_BUSY → busy-retry → the 200ms watchdog
+    // fires and exits 0. Pins invariant #5's whole-phase bound.
+    let name = format!(r"\\.\pipe\pixtuoid-test-stall-{}", std::process::id());
+    let _server = ServerOptions::new()
+        .first_pipe_instance(true)
+        .pipe_mode(PipeMode::Byte)
+        .create(&name)
+        .expect("create pipe");
+    // Occupy the lone instance so the shim's open() stays BUSY.
+    let _client = ClientOptions::new().open(&name).expect("occupy instance");
+
+    let (status, elapsed) = run_shim(&name, r#"{"hook_event_name":"Stop","session_id":"s2"}"#);
+    assert!(status.success(), "watchdog exits 0");
+    // Watchdog bound is 200ms; generous runner-jitter headroom while still
+    // proving "never blocks CC".
+    assert!(elapsed < Duration::from_millis(1500), "took {elapsed:?}");
+}

--- a/crates/pixtuoid/src/config.rs
+++ b/crates/pixtuoid/src/config.rs
@@ -515,8 +515,14 @@ mod tests {
             ..AppConfig::default()
         };
         let result = resolve_pack_dir(&cfg, None);
-        if let Ok(home) = std::env::var("HOME") {
-            assert_eq!(result, Some(PathBuf::from(format!("{home}/my-pack"))));
+        // Expectation derives from the SAME helper production uses
+        // (user_home(), USERPROFILE-first on Windows) — pinning raw $HOME
+        // here diverges under the Windows runner's Git Bash.
+        match crate::install::io::user_home() {
+            Some(home) => {
+                assert_eq!(result, Some(PathBuf::from(format!("{home}/my-pack"))));
+            }
+            None => assert_eq!(result, Some(PathBuf::from("~/my-pack"))),
         }
     }
 

--- a/justfile
+++ b/justfile
@@ -83,11 +83,11 @@ test *args:
 hack:
     cargo hack --feature-powerset --no-dev-deps check --workspace
 
-# Cross-check the workspace compiles for Windows (no linking — no MSVC needed).
+# Cross-lint the workspace for Windows (clippy subsumes check; no linking).
 [group('check')]
-[doc('Cross-check the workspace compiles for x86_64-pc-windows-msvc (no linking; ubuntu runner suffices)')]
+[doc('Cross-lint the workspace for x86_64-pc-windows-msvc via clippy (no linking; ubuntu runner suffices)')]
 check-windows:
-    cargo check --workspace --all-targets --features {{ features }} --target x86_64-pc-windows-msvc
+    cargo clippy --workspace --all-targets --features {{ features }} --target x86_64-pc-windows-msvc -- -D warnings
 
 # SemVer-check the published library against its crates.io baseline. CI-only in
 # practice: needs network to fetch the baseline crate. Scoped to pixtuoid-core

--- a/justfile
+++ b/justfile
@@ -11,6 +11,10 @@
 #   docs     — regenerate the repo's screenshots / demo art
 #   site     — the Astro landing page under site/ (npm, its own CI)
 
+# Git Bash is preinstalled on GHA windows runners; keeps every recipe
+# single-sourced cross-platform (CI never writes inline commands).
+set windows-shell := ["bash", "-cu"]
+
 features := "pixtuoid-core/test-renderer"
 
 # List available recipes.


### PR DESCRIPTION
PR 3 of the Windows-support arc (#128, tracking #143). **The GHA Windows VM now replaces the missing local Windows machine**: a `windows-2022` job runs the full nextest suite (1039 tests) on every PR, including real named-pipe integration twins.

## What

- **`windows-test` CI job** (`windows-2022`, pinned through the VS 2026 migration week): full `just test` via nextest. Green 6× across the dev loop incl. a flake-shake rerun.
- **`shim_pipe.rs` twins**: real-binary pipe delivery, missing-daemon fast exit, and the invariant-#5 pin — *a stalled daemon makes the shim exit 0 within the 200ms watchdog bound*.
- **`hook_pipe.rs` twins**: the 6 hook_socket contract cases over a real pipe + open/close-churn recovery (the connect-error→instance-recreate path) + `first_pipe_instance` squat detection.
- **SDDL hardening**: owner-only `D:P(A;;GA;;;OW)` security descriptor on all three pipe-create sites (`windows-sys` 0.61, the major already in tokio's tree; LocalFree-on-Drop; SAFETY-commented). Behaviorally validated by the twins on the runner — same-user connects pass, the umask-0700 equivalent.
- **Production fix pulled forward from PR 4** (the runner exposed it): `is_subagent_path`/`detect_parent_id` rewritten on `Path::components()` — the old `"/subagents/"` string scan was `/`-literal, silently disabling subagent labeling + parent derivation on Windows. Unix equivalence proven (full suite byte-identical); component matching also kills the substring false-positive class. Real-fn unit pins added (incl. a cfg(windows) backslash pin) replacing decoder.rs tests that re-simulated the old algorithm inline.
- **Platform-honest test fixes** found by the loop: fixture-harness logical key normalized to `/` (platform-stable FNV AgentIds), pipe-shaped endpoint in the `ClaudeCodeSource::run` test, cfg(unix) on the APFS dir-fsync trick, `pack_dir` tilde expectation via `user_home()`.
- **`check-windows` → windows-target clippy** (first lint of the cfg(windows) arms — clean), `set windows-shell`, `.gitattributes * -text` (byte-compared goldens vs autocrlf), CLAUDE.md currency.

## Verification

- windows-test: 6 green runs (incl. flake-shake rerun + post-SDDL); the 2 red rounds each caught real platform issues, fixed properly — zero bypass flags.
- Unix: `just preflight` 1039/1039, behavior byte-identical.
- Holistic review: MERGE-READY; its one finding (re-simulated tests) fixed in `d7ca550`/`acaead4`.

Part of #128 — next: PR 4 (`normalize_path_key` at the AgentId keying sites), then PR 5 (CC install exec-form + VT gate + release zips → first artifact to the #128 tester).

🤖 Generated with [Claude Code](https://claude.com/claude-code)