### PR TITLE
chore(release): open the v0.6.0 breaking-dev window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1393,7 +1393,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pixtuoid"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "pixtuoid-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1438,7 +1438,7 @@ dependencies = [
 
 [[package]]
 name = "pixtuoid-hook"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members  = [
 ]
 
 [workspace.package]
-version      = "0.5.0"
+version      = "0.6.0"
 edition      = "2021"
 rust-version = "1.78"
 license      = "MIT"

--- a/crates/pixtuoid/Cargo.toml
+++ b/crates/pixtuoid/Cargo.toml
@@ -16,7 +16,7 @@ name = "pixtuoid"
 path = "src/main.rs"
 
 [dependencies]
-pixtuoid-core  = { path = "../pixtuoid-core", version = "0.5.0" }
+pixtuoid-core  = { path = "../pixtuoid-core", version = "0.6.0" }
 tokio              = { workspace = true, features = ["rt-multi-thread", "macros", "signal", "sync", "time", "net", "fs", "io-util"] }
 ratatui            = { workspace = true }
 crossterm          = { workspace = true }

--- a/crates/pixtuoid/src/version.rs
+++ b/crates/pixtuoid/src/version.rs
@@ -58,6 +58,17 @@ pub fn release_notes(version: &str) -> Option<&'static [&'static str]> {
         // anchoring on a marker is whitespace-independent — matching the `match`
         // brace would silently break if the indentation ever shifted.
         // [bump-inject-here]
+        // LIVING DRAFT — 0.6.0 is the open breaking-dev window: the version is
+        // bumped at window START so the CI semver gate admits the batched
+        // breaking changes (#145, #131, …); the tag/publish only happens when
+        // the window stabilizes. Re-curate from `git log v0.5.0..HEAD` before
+        // tagging.
+        "0.6.0" => Some(&[
+            "Windows support: named-pipe hook transport + full CI suite",
+            "Diagnostics you can see: source-death footer warning, config warnings on stderr, always-on log file",
+            "Session-lifecycle hardening: dedup, completion-cascade, and permission-gate race fixes",
+            "Marketing site: live demos, architecture docs, weather gallery",
+        ]),
         "0.4.0" => Some(&[
             "Renamed from ascii-agents to pixtuoid",
             "Run `pixtuoid install-hooks` to update hooks",


### PR DESCRIPTION
Bumps the workspace version 0.5.0 → 0.6.0 **without tagging** — this opens the breaking-dev window, it is NOT the release.

## Why now

#145 (native async traits — `Source` loses dyn-compatibility) and #131 (`Activity::Thinking` removal) are semver-major on the published `pixtuoid-core` and are hard-blocked by the required `semver-checks` gate while Cargo.toml says 0.5.0. Bumping the declared version to 0.6.0 tells the gate the next published version is a major — the batched breaking changes become in-contract and their PRs go green. Nothing reaches crates.io until the `v0.6.0` tag is pushed, which stays a separate human decision at the end of the window (the bump recipe deliberately stops before the tag).

Per `just bump`: all four coordinated edits (workspace version, core path-dep requirement, `release_notes()` arm + guard test, Cargo.lock), preflight green (1052/1052). The in-app release-notes arm is marked as a **living draft** to re-curate before tagging.

## The 0.6.0 breaking batch (merge after this)

- #145 — eliminate async-trait (native async `Source` + object-safe `DynSource`)
- #131 / #94 — remove the never-used `Activity::Thinking` variant
- `STALE_CODEX_IDLE_TIMEOUT` → `STALE_SHORT_IDLE_TIMEOUT` rename (the documented naming-note debt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)