### PR TITLE
fix: deflake shim latency tests under full-suite load

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,2 +1,13 @@
 [profile.ci.junit]
 path = "junit.xml"
+
+# The shim latency tests assert wall-clock bounds on a CHILD PROCESS's
+# spawn+exit; under the fully-parallel suite on a loaded machine, exec/dyld
+# scheduling jitter alone can blow the bound (#161 — flaked at 1051/1052
+# during a `just bump` preflight, passed 3/3 in isolation). Give them the
+# machine to themselves; profiles inherit from default, so `ci` gets this
+# too. Covers the Unix test and its two Windows twins (shim_pipe.rs).
+# (Plain `cargo test` runs test binaries sequentially — never affected.)
+[[profile.default.overrides]]
+filter = 'test(_exits_zero_without_blocking) | test(_within_watchdog_bound)'
+threads-required = "num-cpus"

--- a/crates/pixtuoid-hook/tests/shim.rs
+++ b/crates/pixtuoid-hook/tests/shim.rs
@@ -115,10 +115,14 @@ fn missing_socket_exits_zero_without_blocking() {
     // — it never reaches the 200ms WRITE_TIMEOUT (that guards the write AFTER a
     // successful connect). So this bound isn't testing the 200ms invariant; it
     // guards against a regression that added a blocking retry/backoff on connect
-    // failure. 1s is tight enough to catch a real hang while leaving generous
-    // headroom for process-spawn jitter on a loaded CI runner.
+    // failure — don't delete it. The bound measures a CHILD PROCESS's whole
+    // spawn+exit wall-clock, so it is load-sensitive: under the fully-parallel
+    // suite it flaked at 1s from exec/dyld scheduling jitter alone (#161). Two
+    // defenses: .config/nextest.toml gives this test the machine to itself
+    // (threads-required), and 3s keeps headroom for slow runners while still
+    // catching any real hang or retry loop.
     assert!(
-        start.elapsed() < Duration::from_secs(1),
+        start.elapsed() < Duration::from_secs(3),
         "shim must not block when the socket is absent"
     );
 }


### PR DESCRIPTION
Closes #161.

The shim latency tests assert wall-clock bounds on a **child process's** spawn+exit; under the fully-parallel 1066-test suite on a loaded machine, exec/dyld scheduling jitter alone can exceed them (observed: failed at 1051/1052 during the `just bump 0.6.0` preflight, then passed 3/3 isolated). Per the issue's fix menu, two defenses — and deliberately NOT deleting the bounds, which pin the "never block CC" invariant (#5) against an added connect retry/backoff:

1. **`.config/nextest.toml` override**: `threads-required = "num-cpus"` for the latency-bounded tests — each runs with the machine to itself. The filterset covers the Unix test (`missing_socket_exits_zero_without_blocking`, verified to match exactly 1 test via `cargo nextest list -E`) and its two `#[cfg(windows)]` twins in `shim_pipe.rs` (`missing_pipe_exits_zero_without_blocking`, `stalled_daemon_shim_exits_zero_within_watchdog_bound` — windows-2022 runners are slow spawners, same flake class). `profile.ci` inherits from default; plain `cargo test` was never affected (it runs test binaries sequentially).
2. **Unix bound 1s → 3s** with the load-reality rationale in the comment (still far below any real hang or 200ms-step retry loop).

Verified: config parses clean on nextest 0.9.137 (strict about unknown keys), full suite 3× green, `just preflight` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)