### PR TITLE
refactor(core)!: 0.6.0 API finalization — mutation hardening + semver hygiene

### DIFF
--- a/crates/pixtuoid-core/src/id.rs
+++ b/crates/pixtuoid-core/src/id.rs
@@ -20,7 +20,10 @@ impl AgentId {
     /// i.e. the id production derives for a transcript path on every platform
     /// (identity on Unix; `\`→`/` + casefold on Windows). A test/example
     /// ergonomics shim only: production code calls `from_parts` with an
-    /// explicit source at the three normalized keying sites. Kept because the
+    /// explicit source at the four normalized keying sites (hook decoder,
+    /// watcher `default_id_from_path`, `walk_jsonl`'s per-line key, and
+    /// `detect_parent_id`'s rebuilt parent key — see the core CLAUDE.md sharp
+    /// edge). Kept because the
     /// test + snapshot suites lean on it heavily — and normalizing here keeps
     /// every expectation they build platform-consistent by construction.
     pub fn from_transcript_path(path: &str) -> Self {

--- a/crates/pixtuoid-core/src/source/mod.rs
+++ b/crates/pixtuoid-core/src/source/mod.rs
@@ -70,7 +70,11 @@ pub enum Activity {
 /// reducer can pattern-match (instead of string-scanning) on semantic
 /// categories like Task-delegation, which is load-bearing for subagent
 /// suppression.
+/// `#[non_exhaustive]`: new tool categories (beyond Task/Generic) are
+/// expected as more agent semantics get modeled, so downstream `match`es
+/// must carry a wildcard arm — adding a variant then stays non-breaking.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum ToolDetail {
     /// CC `Task` tool — kicks off a subagent. Reducer suppresses
     /// hook-sourced Activity events for the parent until the matching
@@ -112,7 +116,12 @@ impl From<&str> for ToolDetail {
     }
 }
 
+/// `#[non_exhaustive]`: the event vocabulary grows as new agent CLIs and
+/// lifecycle signals are modeled (Codex subagent hooks, future
+/// permission/compaction events), so external `match`es must carry a
+/// wildcard — adding a variant then stays a minor, non-breaking change.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum AgentEvent {
     SessionStart {
         agent_id: AgentId,

--- a/crates/pixtuoid-core/src/state/reducer.rs
+++ b/crates/pixtuoid-core/src/state/reducer.rs
@@ -10,6 +10,15 @@ use crate::AgentId;
 /// tool_use_id. The suppression is asymmetric by event kind — a recorded hook
 /// End drops both JSONL kinds, a recorded hook Start drops only JSONL Starts
 /// (see `ToolEventKind`, #150).
+///
+// These reducer tuning constants are `pub` ONLY so the integration test
+// (`tests/reducer.rs`, a separate crate) can derive its timing offsets from
+// them instead of hardcoding ms. They are internal knobs, not a stable API:
+// `#[doc(hidden)]` keeps the cross-crate visibility the test needs while
+// excluding them from the rendered docs AND from cargo-semver-checks, so a
+// future retune/rename is not a breaking change. (`EXIT_GRACE_WINDOW` below
+// is deliberately NOT hidden — the binary's pose module is a real consumer.)
+#[doc(hidden)]
 pub const HOOK_WINS_WINDOW: Duration = Duration::from_millis(500);
 
 /// How long to keep an exiting agent's slot alive after `SessionEnd` so the
@@ -34,6 +43,7 @@ pub const EXIT_GRACE_WINDOW: Duration = Duration::from_millis(4500);
 /// to the 60s scan_root poll backstop — covering that double-missed-notify
 /// outlier would cost a minute's linger on EVERY completed delegation
 /// (residual documented in #151).
+#[doc(hidden)]
 pub const B1_CASCADE_GRACE: Duration = Duration::from_millis(2500);
 
 /// How long the slot stays visually Active after an `ActivityEnd` before
@@ -41,6 +51,7 @@ pub const B1_CASCADE_GRACE: Duration = Duration::from_millis(2500);
 /// flicker that rapid PreToolUse → PostToolUse chains produce in CC; any
 /// `ActivityStart` arriving within this window cancels the pending idle,
 /// so the slot reads as continuously Active for chained tool work.
+#[doc(hidden)]
 pub const ACTIVE_GRACE_WINDOW: Duration = Duration::from_millis(1500);
 
 /// State-adaptive stale-agent thresholds. If `now - last_event_at`
@@ -58,9 +69,13 @@ pub const ACTIVE_GRACE_WINDOW: Duration = Duration::from_millis(1500);
 /// Unknown cwd (cc#N label): almost always a ghost from startup JSONL
 ///   seeding that never gets a follow-up event. 3 min is aggressive
 ///   but the false-positive cost is low (just a desk slot freed).
+#[doc(hidden)]
 pub const STALE_ACTIVE_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+#[doc(hidden)]
 pub const STALE_IDLE_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+#[doc(hidden)]
 pub const STALE_WAITING_TIMEOUT: Duration = Duration::from_secs(60 * 60);
+#[doc(hidden)]
 pub const STALE_UNKNOWN_CWD_TIMEOUT: Duration = Duration::from_secs(3 * 60);
 
 /// Idle timeout for sources with `SourceCaps::short_idle_reap()` — much
@@ -83,6 +98,7 @@ pub const STALE_UNKNOWN_CWD_TIMEOUT: Duration = Duration::from_secs(3 * 60);
 /// hook plus the durable `/exit` marker) for the common clean exit, so a
 /// short reaper there would only evict genuinely live-but-idle sessions
 /// (lunch-break idle) with no upside.
+#[doc(hidden)]
 pub const STALE_SHORT_IDLE_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 
 /// The state-adaptive stale timeout for one slot. Unknown-cwd ghosts reap on the

--- a/crates/pixtuoid-core/src/state/reducer.rs
+++ b/crates/pixtuoid-core/src/state/reducer.rs
@@ -834,6 +834,37 @@ mod tests {
         }
     }
 
+    // Accepted-equivalent mutation residuals (cargo-mutants, state files):
+    // three boundary flips survive deliberately — `< → <=` in `gc`'s dedup
+    // retain (reducer.rs:659), `> → >=` in `sweep_stale` (716) and
+    // `sweep_exited` (767). Each only changes behavior at the EXACT threshold
+    // instant (age == timeout, to the nanosecond), a measure-zero event in
+    // wall-clock time and immaterial to a stale-sweep (one tick either way).
+    // Pinning them needs a hand-built exact-boundary SystemTime, which is
+    // brittle for no product value — left as documented equivalents, not gaps.
+
+    /// Pin the deliberate stale-timeout DURATIONS. Every timing test correctly
+    /// derives its offsets FROM these constants (hardcoded ms make leg tests
+    /// vacuous), so mutating `10 * 60` also mutates each test's own
+    /// expectation — leaving the literal value unguarded. A direct pin is the
+    /// only thing that catches `*`→`/` collapsing a window to 0s (everything
+    /// reaped on the next tick) or a typo'd minute count. The values ARE the
+    /// product decision (see the doc comments on each const); change this test
+    /// deliberately when a window changes, never to make it pass.
+    #[test]
+    fn stale_timeout_constants_have_their_intended_durations() {
+        use super::{
+            STALE_ACTIVE_TIMEOUT, STALE_IDLE_TIMEOUT, STALE_SHORT_IDLE_TIMEOUT,
+            STALE_UNKNOWN_CWD_TIMEOUT, STALE_WAITING_TIMEOUT,
+        };
+        use std::time::Duration;
+        assert_eq!(STALE_ACTIVE_TIMEOUT, Duration::from_secs(600)); // 10 min
+        assert_eq!(STALE_IDLE_TIMEOUT, Duration::from_secs(1800)); // 30 min
+        assert_eq!(STALE_WAITING_TIMEOUT, Duration::from_secs(3600)); // 60 min
+        assert_eq!(STALE_UNKNOWN_CWD_TIMEOUT, Duration::from_secs(180)); // 3 min
+        assert_eq!(STALE_SHORT_IDLE_TIMEOUT, Duration::from_secs(300)); // 5 min
+    }
+
     // The Delegating stale carve-out is caps-driven; no REGISTERED source
     // sets `delegations_are_hook_silent` yet (the first is Reasonix, PR
     // #134), so pin the policy half with a synthetic caps value — that's

--- a/crates/pixtuoid-core/tests/reducer.rs
+++ b/crates/pixtuoid-core/tests/reducer.rs
@@ -416,6 +416,16 @@ fn hook_activity_during_active_task_is_suppressed() {
         matches!(slot.state, ActivityState::Active { .. }),
         "parent must remain Active(Task) while task in flight"
     );
+    // The suppressed subagent End must be DROPPED, not merely state-neutral:
+    // an un-suppressed ActivityEnd arms pending_idle (the grace debounce keeps
+    // the slot Active, so the state check above can't see the leak). A None
+    // pending_idle is what proves the End never reached apply — this is the
+    // assertion that kills the `delete ActivityEnd arm in suppress_subagent_leak`
+    // mutant the state check alone leaves alive.
+    assert!(
+        slot.pending_idle_at.is_none(),
+        "a suppressed subagent End must not arm the parent's pending-idle"
+    );
 
     // Task's own PostToolUse: tool_use_id matches the in-flight Task, so the
     // hook IS allowed through. With the Active-grace debounce, the


### PR DESCRIPTION
First of the whole-codebase v0.6.0 sweep PRs (Engine 1 bugs + Engine 2 refactors + cargo-mutants, adversarially verified). This is the **pre-freeze core hygiene** batch — all `pixtuoid-core`, all time-sensitive (the breaking window closes at the v0.6.0 tag).

### 1. Mutation hardening (cargo-mutants on state/{reducer,scope,fsm})
86/98 mutants caught on first run. Triaged the 9 survivors:
- **5 const-arithmetic** (`10*60`, `3*60`, `5*60` → `+`/`/`) survived because every timing test correctly *derives* its offsets from the constant, so the mutant moves the test's own expectation too. The `*`→`/` case collapses a window to **0s** (instant reaping) with nothing catching it → killed with one value-pinning test on the five `STALE_*` durations.
- **1 arm-deletion** in `suppress_subagent_leak`: the existing test only checked the parent stays `Active`, but an un-suppressed subagent `End` merely *arms* `pending_idle` (the grace debounce keeps it `Active`), so the state check can't see the leak → added the `pending_idle_at.is_none()` assertion that proves the `End` was dropped.
- **3 boundary mutants** (`<`→`<=`, `>`→`>=`) documented as accepted equivalents — they diverge only at the exact-threshold nanosecond, measure-zero in wall-clock.

Re-run confirms 92/95 viable now caught; the 3 residuals are the documented boundary set.

### 2. Semver-surface hygiene (Engine 1 confirmed)
- **8 reducer tuning consts** with no production consumer → `#[doc(hidden)]`. They're `pub` only so `tests/reducer.rs` (separate crate) can derive offsets; hiding keeps that visibility while excluding them from rendered docs AND cargo-semver-checks, so future retunes/renames stop being breaking. `EXIT_GRACE_WINDOW` stays public (the binary's pose module is a real consumer).
- **`AgentEvent` + `ToolDetail` → `#[non_exhaustive]`**: their variant sets grow as new CLIs/lifecycle signals are modeled, so external matches must carry a wildcard. Zero in-tree blast radius.

### Scoping decisions (documented, not omissions)
- **`AgentSlot`/`SceneState` deliberately NOT `non_exhaustive`**: literal-constructed in ~12 binary files with no constructor → the attribute would force a builder + rewrite every site, for protection whose only consumer is the in-workspace binary. Disproportionate churn; the not-worth-churn verifier agreed.
- **Dead `Activity` enum removal + typed `Delegating`**: follow as separate PRs (the Activity removal is a ~90-site mechanical ripple; verified visually safe — the working pose keys on `ActivityState::Active` + a time counter, the monitor glow on the `detail` tool-name string; `Activity::{Typing,Reading}` feeds nothing).

Preflight green, 1066/1066.

🤖 Generated with [Claude Code](https://claude.com/claude-code)