### PR TITLE
refactor(core)!: remove the dead Activity enum from the event/state model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ docs/superpowers/
 docs/superpowers/
 drift-report.md
 __pycache__/
+lcov.info

--- a/crates/pixtuoid-core/src/lib.rs
+++ b/crates/pixtuoid-core/src/lib.rs
@@ -13,9 +13,7 @@ pub mod walkable;
 
 pub use id::AgentId;
 pub use render::Renderer;
-pub use source::{
-    Activity, AgentEvent, Source, TaggedReceiver, TaggedSender, ToolDetail, Transport,
-};
+pub use source::{AgentEvent, Source, TaggedReceiver, TaggedSender, ToolDetail, Transport};
 pub use sprite::{Frame, Palette, Pixel, Rgb, RgbBuffer, Sprite};
 pub use state::reducer::Reducer;
 pub use state::{ActivityState, AgentSlot, SceneState};

--- a/crates/pixtuoid-core/src/pose/tests.rs
+++ b/crates/pixtuoid-core/src/pose/tests.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::source::Activity;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -38,7 +37,6 @@ fn layout() -> SceneLayout {
 
 fn typing() -> ActivityState {
     ActivityState::Active {
-        activity: Activity::Typing,
         tool_use_id: Some("t".into()),
         detail: Some("Edit".into()),
     }
@@ -631,7 +629,6 @@ fn derive_state_only_skips_entry_override() {
         label: std::sync::Arc::from("cc"),
         // Active state so we can assert a non-Walking result.
         state: ActivityState::Active {
-            activity: crate::source::Activity::Typing,
             tool_use_id: Some("t".into()),
             detail: Some("Edit".into()),
         },

--- a/crates/pixtuoid-core/src/source/antigravity.rs
+++ b/crates/pixtuoid-core/src/source/antigravity.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 
 use crate::source::decoder::{cwd_basename_label, make_tool_detail};
 use crate::source::jsonl::JsonlWatcher;
-use crate::source::{Activity, AgentEvent, Source, TaggedSender};
+use crate::source::{AgentEvent, Source, TaggedSender};
 use crate::AgentId;
 
 pub const SOURCE_NAME: &str = "antigravity";
@@ -115,7 +115,6 @@ fn decode_ag_tool_call(
     let normalized = normalize_ag_tool_input(name, args);
     AgentEvent::ActivityStart {
         agent_id,
-        activity: Activity::Typing,
         tool_use_id: Some(format!("ag-{step_index}-{i}")),
         detail: Some(make_tool_detail(name, Some(&normalized))),
     }

--- a/crates/pixtuoid-core/src/source/claude_code.rs
+++ b/crates/pixtuoid-core/src/source/claude_code.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use crate::source::decoder::{cwd_basename_label, make_tool_detail};
 use crate::source::hook::HookSocketListener;
 use crate::source::jsonl::JsonlWatcher;
-use crate::source::{Activity, AgentEvent, Source, TaggedSender};
+use crate::source::{AgentEvent, Source, TaggedSender};
 use crate::AgentId;
 
 pub const SOURCE_NAME: &str = "claude-code";
@@ -130,7 +130,6 @@ pub fn decode_cc_line(transcript_path: &str, source: &str, v: Value) -> Result<V
                 let name = bobj.get("name").and_then(|s| s.as_str()).unwrap_or("?");
                 out.push(AgentEvent::ActivityStart {
                     agent_id,
-                    activity: Activity::Typing,
                     tool_use_id: id,
                     detail: Some(make_tool_detail(name, bobj.get("input"))),
                 });

--- a/crates/pixtuoid-core/src/source/codex.rs
+++ b/crates/pixtuoid-core/src/source/codex.rs
@@ -16,7 +16,7 @@ use serde_json::{Map, Value};
 
 use crate::source::decoder::{cwd_basename_label, make_tool_detail};
 use crate::source::jsonl::JsonlWatcher;
-use crate::source::{Activity, AgentEvent, Source, TaggedSender};
+use crate::source::{AgentEvent, Source, TaggedSender};
 use crate::AgentId;
 
 pub const SOURCE_NAME: &str = "codex";
@@ -127,9 +127,8 @@ pub fn decode_codex_line(transcript_path: &str, source: &str, v: Value) -> Resul
         .and_then(|s| s.as_str())
         .unwrap_or("");
 
-    let start = |activity| AgentEvent::ActivityStart {
+    let start = || AgentEvent::ActivityStart {
         agent_id,
-        activity,
         tool_use_id: None,
         detail: None,
     };
@@ -139,7 +138,7 @@ pub fn decode_codex_line(transcript_path: &str, source: &str, v: Value) -> Resul
     };
 
     let out = match (outer, inner) {
-        ("event_msg", "task_started") => vec![start(Activity::Typing)],
+        ("event_msg", "task_started") => vec![start()],
         ("response_item", "function_call") => {
             if function_call_needs_approval(payload) {
                 vec![AgentEvent::Waiting {
@@ -157,7 +156,7 @@ pub fn decode_codex_line(transcript_path: &str, source: &str, v: Value) -> Resul
         ("response_item", "function_call_output")
         | ("event_msg", "exec_command_end")
         | ("event_msg", "patch_apply_end") => {
-            vec![start(Activity::Typing)]
+            vec![start()]
         }
         ("event_msg", "task_complete") | ("event_msg", "turn_aborted") => vec![end()],
         _ => vec![],
@@ -196,7 +195,6 @@ fn codex_tool_start(agent_id: AgentId, payload: Option<&Map<String, Value>>) -> 
         .unwrap_or("tool");
     AgentEvent::ActivityStart {
         agent_id,
-        activity: Activity::Typing,
         tool_use_id: None,
         // Codex tool calls are function_calls, never subagent dispatches (those
         // arrive as the SubagentStart hook), so no `subagent_type` to pass.

--- a/crates/pixtuoid-core/src/source/decoder.rs
+++ b/crates/pixtuoid-core/src/source/decoder.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use anyhow::{anyhow, bail, Result};
 use serde_json::Value;
 
-use crate::source::{Activity, AgentEvent, ToolDetail};
+use crate::source::{AgentEvent, ToolDetail};
 use crate::AgentId;
 
 /// `"{prefix}·{basename}"` from a working directory, or `None` when `cwd` is
@@ -141,7 +141,6 @@ pub fn decode_hook_payload(v: Value) -> Result<AgentEvent> {
                 .map(String::from);
             Ok(AgentEvent::ActivityStart {
                 agent_id,
-                activity: Activity::Typing,
                 tool_use_id,
                 detail: Some(make_tool_detail(tool_name, obj.get("tool_input"))),
             })

--- a/crates/pixtuoid-core/src/source/mod.rs
+++ b/crates/pixtuoid-core/src/source/mod.rs
@@ -60,12 +60,6 @@ pub enum Transport {
     Jsonl,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum Activity {
-    Typing,
-    Reading,
-}
-
 /// Structured tool detail. Replaces the free-form `Option<String>` so the
 /// reducer can pattern-match (instead of string-scanning) on semantic
 /// categories like Task-delegation, which is load-bearing for subagent
@@ -132,7 +126,6 @@ pub enum AgentEvent {
     },
     ActivityStart {
         agent_id: AgentId,
-        activity: Activity,
         tool_use_id: Option<String>,
         detail: Option<ToolDetail>,
     },

--- a/crates/pixtuoid-core/src/state/fsm.rs
+++ b/crates/pixtuoid-core/src/state/fsm.rs
@@ -16,7 +16,7 @@
 use std::sync::Arc;
 use std::time::SystemTime;
 
-use crate::source::{Activity, ToolDetail};
+use crate::source::ToolDetail;
 use crate::state::{ActivityState, AgentSlot};
 
 /// Fold the time the slot has spent Active into `active_ms`, then it's safe to
@@ -38,14 +38,12 @@ fn accumulate_active_ms(slot: &mut AgentSlot, until: SystemTime) {
 /// Stamps `last_event_at` (this is the actor's own event).
 pub(crate) fn enter_active(
     slot: &mut AgentSlot,
-    activity: Activity,
     tool_use_id: Option<Arc<str>>,
     detail: Option<Arc<str>>,
     now: SystemTime,
 ) {
     accumulate_active_ms(slot, now);
     slot.state = ActivityState::Active {
-        activity,
         tool_use_id,
         detail,
     };
@@ -67,7 +65,6 @@ pub(crate) fn enter_delegating(
 ) {
     accumulate_active_ms(slot, now);
     slot.state = ActivityState::Active {
-        activity: Activity::Typing,
         tool_use_id,
         // Single source of truth: the tui palette string-matches this against
         // `ToolDetail::Task.display()`, so don't re-spell the literal here.
@@ -162,7 +159,6 @@ mod tests {
     fn active(started: SystemTime) -> AgentSlot {
         slot_at(
             ActivityState::Active {
-                activity: Activity::Typing,
                 tool_use_id: None,
                 detail: None,
             },
@@ -175,13 +171,7 @@ mod tests {
         let t0 = SystemTime::now();
         let mut s = active(t0);
         s.pending_idle_at = Some(t0);
-        enter_active(
-            &mut s,
-            Activity::Typing,
-            None,
-            None,
-            t0 + Duration::from_secs(1),
-        );
+        enter_active(&mut s, None, None, t0 + Duration::from_secs(1));
         assert_eq!(s.active_ms, 1000, "prior Active span folded in");
         assert_eq!(s.state_started_at, t0 + Duration::from_secs(1));
         assert_eq!(s.last_event_at, t0 + Duration::from_secs(1));

--- a/crates/pixtuoid-core/src/state/mod.rs
+++ b/crates/pixtuoid-core/src/state/mod.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 use std::time::SystemTime;
 
 use crate::id::AgentId;
-use crate::source::Activity;
 
 mod fsm;
 pub mod reducer;
@@ -20,7 +19,6 @@ pub const MAX_FLOORS: usize = 5;
 pub enum ActivityState {
     Idle,
     Active {
-        activity: Activity,
         tool_use_id: Option<Arc<str>>,
         detail: Option<Arc<str>>,
     },

--- a/crates/pixtuoid-core/src/state/reducer.rs
+++ b/crates/pixtuoid-core/src/state/reducer.rs
@@ -407,7 +407,6 @@ impl Reducer {
             }
             AgentEvent::ActivityStart {
                 agent_id,
-                activity,
                 tool_use_id,
                 detail,
             } => {
@@ -421,7 +420,6 @@ impl Reducer {
                         }
                         fsm::enter_active(
                             slot,
-                            activity,
                             tool_use_id.map(|s| Arc::<str>::from(s.as_str())),
                             detail.map(|d| Arc::<str>::from(d.display())),
                             now,
@@ -916,7 +914,6 @@ mod tests {
             &mut scene,
             AgentEvent::ActivityStart {
                 agent_id: id,
-                activity: crate::source::Activity::Typing,
                 tool_use_id: None,
                 detail: Some(ToolDetail::Task),
             },
@@ -941,7 +938,6 @@ mod tests {
             &mut scene,
             AgentEvent::ActivityStart {
                 agent_id: id,
-                activity: crate::source::Activity::Typing,
                 tool_use_id: None,
                 detail: Some(ToolDetail::Generic {
                     display: "bash: ls".into(),
@@ -965,7 +961,7 @@ mod tests {
     // and leak a swept Waiting slot's gated tool_use_id.
     #[test]
     fn gated_before_waiting_evicted_on_apply_path_sweep() {
-        use crate::source::{Activity, AgentEvent, ToolDetail, Transport};
+        use crate::source::{AgentEvent, ToolDetail, Transport};
         use crate::state::SceneState;
         use crate::AgentId;
         use std::path::PathBuf;
@@ -992,7 +988,6 @@ mod tests {
             &mut scene,
             AgentEvent::ActivityStart {
                 agent_id: id,
-                activity: Activity::Typing,
                 tool_use_id: Some("toolT".into()),
                 detail: Some(ToolDetail::from("Bash")),
             },

--- a/crates/pixtuoid-core/tests/decoder.rs
+++ b/crates/pixtuoid-core/tests/decoder.rs
@@ -1,7 +1,7 @@
 use pixtuoid_core::source::antigravity;
 use pixtuoid_core::source::claude_code::decode_cc_line;
 use pixtuoid_core::source::decoder::decode_hook_payload;
-use pixtuoid_core::source::{Activity, AgentEvent};
+use pixtuoid_core::source::AgentEvent;
 use pixtuoid_core::AgentId;
 use serde_json::json;
 
@@ -51,10 +51,7 @@ fn decode_session_start_with_custom_source() {
 fn decode_pre_tool_use_write_maps_to_typing() {
     let ev = decode_hook_payload(load("pre_tool_use_write")).unwrap();
     match ev {
-        AgentEvent::ActivityStart {
-            activity, detail, ..
-        } => {
-            assert_eq!(activity, Activity::Typing);
+        AgentEvent::ActivityStart { detail, .. } => {
             assert!(detail.unwrap().display().contains("Write"));
         }
         other => panic!("got {other:?}"),
@@ -227,12 +224,10 @@ fn cc_jsonl_assistant_tool_use_is_activity_start() {
     assert_eq!(events.len(), 1);
     match &events[0] {
         AgentEvent::ActivityStart {
-            activity,
             tool_use_id,
             detail,
             ..
         } => {
-            assert_eq!(*activity, Activity::Typing);
             assert_eq!(tool_use_id.as_deref(), Some("tu_123"));
             assert!(detail.as_ref().unwrap().display().contains("Write"));
         }

--- a/crates/pixtuoid-core/tests/e2e.rs
+++ b/crates/pixtuoid-core/tests/e2e.rs
@@ -5,7 +5,6 @@ use std::time::{Duration, SystemTime};
 
 use pixtuoid_core::render::test_renderer::TestRenderer;
 use pixtuoid_core::render::Renderer;
-use pixtuoid_core::source::Activity;
 use pixtuoid_core::sprite::format::load_pack_from_strings;
 use pixtuoid_core::state::ActivityState;
 use pixtuoid_core::{AgentEvent, AgentId, Reducer, SceneState, Transport};
@@ -47,7 +46,6 @@ fn scripted_timeline_drives_scene_through_states() {
     step(
         vec![AgentEvent::ActivityStart {
             agent_id: id,
-            activity: Activity::Typing,
             tool_use_id: None,
             detail: Some("Bash: ls".into()),
         }],

--- a/crates/pixtuoid-core/tests/reducer.rs
+++ b/crates/pixtuoid-core/tests/reducer.rs
@@ -726,25 +726,37 @@ fn jsonl_event_after_dedup_window_is_applied() {
         AgentEvent::ActivityStart {
             agent_id: id,
             tool_use_id: Some("t-1".into()),
-            detail: None,
+            detail: Some("hook-side".into()),
         },
         t0,
         Transport::Hook,
     );
 
+    // Same tool_use_id but 600ms later — OUTSIDE HOOK_WINS_WINDOW (500ms), so
+    // this JSONL event is NOT deduped and must be applied. Distinct `detail`
+    // is the discriminator: a vacuous `Active { .. }` check passes even if the
+    // event were wrongly suppressed (the hook already made it Active), so
+    // assert the slot reflects the JSONL event's detail specifically.
     r.apply(
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: id,
             tool_use_id: Some("t-1".into()),
-            detail: None,
+            detail: Some("jsonl-side".into()),
         },
         t0 + Duration::from_millis(600),
         Transport::Jsonl,
     );
 
     let slot = scene.agents.get(&id).unwrap();
-    assert!(matches!(slot.state, ActivityState::Active { .. }));
+    match &slot.state {
+        ActivityState::Active { detail, .. } => assert_eq!(
+            detail.as_deref(),
+            Some("jsonl-side"),
+            "JSONL event outside the dedup window must be applied"
+        ),
+        other => panic!("expected Active, got {other:?}"),
+    }
 }
 
 // --- stale-agent sweep ---------------------------------------------------

--- a/crates/pixtuoid-core/tests/reducer.rs
+++ b/crates/pixtuoid-core/tests/reducer.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
 
-use pixtuoid_core::source::{Activity, AgentEvent, Transport};
+use pixtuoid_core::source::{AgentEvent, Transport};
 use pixtuoid_core::state::reducer::{
     Reducer, ACTIVE_GRACE_WINDOW, B1_CASCADE_GRACE, HOOK_WINS_WINDOW,
 };
@@ -112,7 +112,6 @@ fn activity_start_sets_state_active() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: id,
-            activity: Activity::Typing,
             tool_use_id: Some("t1".into()),
             detail: Some("Edit: foo.rs".into()),
         },
@@ -121,13 +120,7 @@ fn activity_start_sets_state_active() {
     );
 
     let slot = scene.agents.get(&id).unwrap();
-    assert!(matches!(
-        slot.state,
-        ActivityState::Active {
-            activity: Activity::Typing,
-            ..
-        }
-    ));
+    assert!(matches!(slot.state, ActivityState::Active { .. }));
 }
 
 #[test]
@@ -147,7 +140,6 @@ fn activity_end_arms_debounce_then_tick_flips_to_idle() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: id,
-            activity: Activity::Typing,
             tool_use_id: Some("t1".into()),
             detail: None,
         },
@@ -197,7 +189,6 @@ fn activity_start_inside_grace_window_cancels_debounce() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: id,
-            activity: Activity::Typing,
             tool_use_id: Some("t1".into()),
             detail: None,
         },
@@ -219,7 +210,6 @@ fn activity_start_inside_grace_window_cancels_debounce() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: id,
-            activity: Activity::Typing,
             tool_use_id: Some("t2".into()),
             detail: None,
         },
@@ -313,7 +303,6 @@ fn jsonl_duplicate_of_recent_hook_is_dropped() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: id,
-            activity: Activity::Typing,
             tool_use_id: Some("t-1".into()),
             detail: None,
         },
@@ -325,7 +314,6 @@ fn jsonl_duplicate_of_recent_hook_is_dropped() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: id,
-            activity: Activity::Reading,
             tool_use_id: Some("t-1".into()),
             detail: Some("FROM_JSONL".into()),
         },
@@ -335,10 +323,7 @@ fn jsonl_duplicate_of_recent_hook_is_dropped() {
 
     let slot = scene.agents.get(&id).unwrap();
     match &slot.state {
-        ActivityState::Active {
-            activity, detail, ..
-        } => {
-            assert_eq!(*activity, Activity::Typing, "hook event must win");
+        ActivityState::Active { detail, .. } => {
             assert_ne!(
                 detail.as_deref(),
                 Some("FROM_JSONL"),
@@ -369,7 +354,6 @@ fn hook_activity_during_active_task_is_suppressed() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: parent,
-            activity: Activity::Typing,
             tool_use_id: Some("task-T".into()),
             detail: Some("Task".into()),
         },
@@ -383,7 +367,6 @@ fn hook_activity_during_active_task_is_suppressed() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: parent,
-            activity: Activity::Typing,
             tool_use_id: Some("subagent-R".into()),
             detail: Some("Read: /foo".into()),
         },
@@ -468,7 +451,6 @@ fn subagent_jsonl_activity_is_unaffected_by_parent_task_suppression() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: parent,
-            activity: Activity::Typing,
             tool_use_id: Some("task-T".into()),
             detail: Some("Task".into()),
         },
@@ -480,7 +462,6 @@ fn subagent_jsonl_activity_is_unaffected_by_parent_task_suppression() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: subagent,
-            activity: Activity::Typing,
             tool_use_id: Some("sub-R".into()),
             detail: Some("Read: /bar".into()),
         },
@@ -507,7 +488,6 @@ fn hook_activity_without_active_task_applies_normally() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: id,
-            activity: Activity::Typing,
             tool_use_id: Some("t".into()),
             detail: Some("Bash: ls".into()),
         },
@@ -691,7 +671,6 @@ fn active_tasks_drained_by_jsonl_end_even_if_hook_end_arrived_first() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: id,
-            activity: Activity::Typing,
             tool_use_id: Some("task-X".into()),
             detail: Some(ToolDetail::Task),
         },
@@ -715,7 +694,6 @@ fn active_tasks_drained_by_jsonl_end_even_if_hook_end_arrived_first() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: id,
-            activity: Activity::Typing,
             tool_use_id: Some("other".into()),
             detail: Some("Bash: ls".into()),
         },
@@ -747,7 +725,6 @@ fn jsonl_event_after_dedup_window_is_applied() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: id,
-            activity: Activity::Typing,
             tool_use_id: Some("t-1".into()),
             detail: None,
         },
@@ -759,7 +736,6 @@ fn jsonl_event_after_dedup_window_is_applied() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: id,
-            activity: Activity::Reading,
             tool_use_id: Some("t-1".into()),
             detail: None,
         },
@@ -768,13 +744,7 @@ fn jsonl_event_after_dedup_window_is_applied() {
     );
 
     let slot = scene.agents.get(&id).unwrap();
-    assert!(matches!(
-        slot.state,
-        ActivityState::Active {
-            activity: Activity::Reading,
-            ..
-        }
-    ));
+    assert!(matches!(slot.state, ActivityState::Active { .. }));
 }
 
 // --- stale-agent sweep ---------------------------------------------------
@@ -843,7 +813,6 @@ fn stale_active_agent_uses_shorter_timeout_than_idle() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: id,
-            activity: Activity::Typing,
             tool_use_id: Some("t".into()),
             detail: None,
         },
@@ -1008,7 +977,6 @@ fn tool_call_count_increments_on_activity_start() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: id,
-            activity: Activity::Typing,
             tool_use_id: Some("t1".into()),
             detail: None,
         },
@@ -1030,7 +998,6 @@ fn tool_call_count_increments_on_activity_start() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: id,
-            activity: Activity::Typing,
             tool_use_id: Some("t2".into()),
             detail: None,
         },
@@ -1052,7 +1019,6 @@ fn active_ms_accumulates_on_state_transitions() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: id,
-            activity: Activity::Typing,
             tool_use_id: Some("t1".into()),
             detail: None,
         },
@@ -1094,7 +1060,6 @@ fn active_ms_does_not_double_count_on_duplicate_activity_end() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: id,
-            activity: Activity::Typing,
             tool_use_id: Some("t1".into()),
             detail: None,
         },
@@ -1150,7 +1115,6 @@ fn active_ms_preserved_when_task_arrives_during_active_tool() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: id,
-            activity: Activity::Typing,
             tool_use_id: Some("t1".into()),
             detail: None,
         },
@@ -1164,7 +1128,6 @@ fn active_ms_preserved_when_task_arrives_during_active_tool() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: id,
-            activity: Activity::Typing,
             tool_use_id: Some("task-1".into()),
             detail: Some(ToolDetail::Task),
         },
@@ -1192,7 +1155,6 @@ fn active_ms_preserved_when_waiting_interrupts_active() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: id,
-            activity: Activity::Typing,
             tool_use_id: Some("t1".into()),
             detail: None,
         },
@@ -1450,7 +1412,6 @@ fn hook_wins_dedup_drops_jsonl_duplicate_within_window() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: id,
-            activity: Activity::Typing,
             tool_use_id: Some("dedup-1".into()),
             detail: Some("Edit: hook.rs".into()),
         },
@@ -1464,7 +1425,6 @@ fn hook_wins_dedup_drops_jsonl_duplicate_within_window() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: id,
-            activity: Activity::Reading,
             tool_use_id: Some("dedup-1".into()),
             detail: Some("Edit: jsonl.rs".into()),
         },
@@ -1824,7 +1784,6 @@ fn long_delegation_keeps_parent_and_live_subagent_alive() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: parent,
-            activity: Activity::Typing,
             tool_use_id: Some("task-T".into()),
             detail: Some("Task".into()),
         },
@@ -1839,7 +1798,6 @@ fn long_delegation_keeps_parent_and_live_subagent_alive() {
             &mut scene,
             AgentEvent::ActivityStart {
                 agent_id: parent,
-                activity: Activity::Typing,
                 tool_use_id: Some(tuid.into()),
                 detail: Some("Read: /x".into()),
             },
@@ -1910,7 +1868,6 @@ fn stale_sweep_spares_subagent_blocked_under_a_waiting_parent() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: child,
-            activity: Activity::Typing,
             tool_use_id: Some("c-tool".into()),
             detail: Some("WebFetch: /x".into()),
         },
@@ -1998,7 +1955,6 @@ fn stale_sweep_spares_grandchild_under_a_waiting_ancestor() {
             &mut scene,
             AgentEvent::ActivityStart {
                 agent_id: id,
-                activity: Activity::Typing,
                 tool_use_id: Some("t".into()),
                 detail: Some("WebFetch: /x".into()),
             },
@@ -2073,7 +2029,6 @@ fn active_subagent_keeps_parent_alive_via_jsonl_events() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: parent,
-            activity: Activity::Typing,
             tool_use_id: Some("task-T".into()),
             detail: Some("Task".into()),
         },
@@ -2087,7 +2042,6 @@ fn active_subagent_keeps_parent_alive_via_jsonl_events() {
             &mut scene,
             AgentEvent::ActivityStart {
                 agent_id: child,
-                activity: Activity::Typing,
                 tool_use_id: Some("c".into()),
                 detail: Some("Read: /x".into()),
             },
@@ -2156,7 +2110,6 @@ fn subagent_is_removed_promptly_when_its_parent_task_completes() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: parent,
-            activity: Activity::Typing,
             tool_use_id: Some("task-T".into()),
             detail: Some("Task".into()),
         },
@@ -2168,7 +2121,6 @@ fn subagent_is_removed_promptly_when_its_parent_task_completes() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: child,
-            activity: Activity::Typing,
             tool_use_id: Some("c1".into()),
             detail: Some("Read: /x".into()),
         },
@@ -2225,7 +2177,6 @@ fn late_jsonl_dispatch_copy_inside_grace_cancels_premature_cascade() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: parent,
-            activity: Activity::Typing,
             tool_use_id: Some("task-1".into()),
             detail: Some("Task".into()),
         },
@@ -2237,7 +2188,6 @@ fn late_jsonl_dispatch_copy_inside_grace_cancels_premature_cascade() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: parent,
-            activity: Activity::Typing,
             tool_use_id: Some("task-2".into()),
             detail: Some("Task".into()),
         },
@@ -2266,7 +2216,6 @@ fn late_jsonl_dispatch_copy_inside_grace_cancels_premature_cascade() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: parent,
-            activity: Activity::Typing,
             tool_use_id: Some("task-2".into()),
             detail: Some("Task".into()),
         },
@@ -2324,7 +2273,6 @@ fn second_drain_inside_grace_restarts_the_cascade_clock() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: parent,
-            activity: Activity::Typing,
             tool_use_id: Some("task-1".into()),
             detail: Some("Task".into()),
         },
@@ -2346,7 +2294,6 @@ fn second_drain_inside_grace_restarts_the_cascade_clock() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: parent,
-            activity: Activity::Typing,
             tool_use_id: Some("task-2".into()),
             detail: Some("Task".into()),
         },
@@ -2404,7 +2351,6 @@ fn late_jsonl_replay_of_drained_task_end_does_not_false_resolve_waiting() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: parent,
-            activity: Activity::Typing,
             tool_use_id: Some("task-T".into()),
             detail: Some("Task".into()),
         },
@@ -2480,7 +2426,6 @@ fn task_drain_keeps_parallel_ordinary_tool_gate() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: parent,
-            activity: Activity::Typing,
             tool_use_id: Some("task-T".into()),
             detail: Some("Task".into()),
         },
@@ -2492,7 +2437,6 @@ fn task_drain_keeps_parallel_ordinary_tool_gate() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: parent,
-            activity: Activity::Typing,
             tool_use_id: Some("bash-1".into()),
             detail: Some("Bash: ls".into()),
         },
@@ -2562,7 +2506,6 @@ fn late_batched_jsonl_pair_after_delivered_hook_end_is_fully_dropped() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: id,
-            activity: Activity::Typing,
             tool_use_id: Some("t-fast".into()),
             detail: Some("Read: /x".into()),
         },
@@ -2593,7 +2536,6 @@ fn late_batched_jsonl_pair_after_delivered_hook_end_is_fully_dropped() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: id,
-            activity: Activity::Typing,
             tool_use_id: Some("t-fast".into()),
             detail: Some("Read: /x".into()),
         },
@@ -2641,7 +2583,6 @@ fn jsonl_task_start_duplicate_does_not_clobber_waiting_parent() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: parent,
-            activity: Activity::Typing,
             tool_use_id: Some("task-T".into()),
             detail: Some("Task".into()),
         },
@@ -2664,7 +2605,6 @@ fn jsonl_task_start_duplicate_does_not_clobber_waiting_parent() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: parent,
-            activity: Activity::Typing,
             tool_use_id: Some("task-T".into()),
             detail: Some("Task".into()),
         },
@@ -2698,7 +2638,6 @@ fn jsonl_ordinary_tool_end_drains_when_hook_end_drops() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: id,
-            activity: Activity::Typing,
             tool_use_id: Some("t-1".into()),
             detail: Some("Read: /x".into()),
         },
@@ -2744,7 +2683,6 @@ fn suppressed_parallel_task_dispatch_jsonl_copy_survives_dedup_and_tracks() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: parent,
-            activity: Activity::Typing,
             tool_use_id: Some("task-1".into()),
             detail: Some("Task".into()),
         },
@@ -2757,7 +2695,6 @@ fn suppressed_parallel_task_dispatch_jsonl_copy_survives_dedup_and_tracks() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: parent,
-            activity: Activity::Typing,
             tool_use_id: Some("task-2".into()),
             detail: Some("Task".into()),
         },
@@ -2772,7 +2709,6 @@ fn suppressed_parallel_task_dispatch_jsonl_copy_survives_dedup_and_tracks() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: parent,
-            activity: Activity::Typing,
             tool_use_id: Some("task-2".into()),
             detail: Some("Task".into()),
         },
@@ -2855,7 +2791,6 @@ fn jsonl_task_self_end_drains_when_hook_end_drops() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: parent,
-            activity: Activity::Typing,
             tool_use_id: Some("task-T".into()),
             detail: Some("Task".into()),
         },
@@ -2892,7 +2827,6 @@ fn jsonl_task_self_end_drains_when_hook_end_drops() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: parent,
-            activity: Activity::Typing,
             tool_use_id: Some("b-1".into()),
             detail: Some("Bash: ls".into()),
         },
@@ -2953,7 +2887,6 @@ fn parent_waiting_on_subagent_permission_resolves_when_the_subagent_resumes() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: parent,
-            activity: Activity::Typing,
             tool_use_id: Some("task-T".into()),
             detail: Some("Task".into()),
         },
@@ -2984,7 +2917,6 @@ fn parent_waiting_on_subagent_permission_resolves_when_the_subagent_resumes() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: parent,
-            activity: Activity::Typing,
             tool_use_id: Some("sub-bash".into()),
             detail: Some("Bash: ls".into()),
         },
@@ -3105,7 +3037,6 @@ fn gated_tool_end_while_waiting_resolves_to_idle_after_grace() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: id,
-            activity: Activity::Typing,
             tool_use_id: Some("t1".into()),
             detail: None,
         },
@@ -3173,7 +3104,6 @@ fn parallel_tool_end_while_waiting_keeps_waiting() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: id,
-            activity: Activity::Typing,
             tool_use_id: Some("t1".into()),
             detail: None,
         },
@@ -3245,7 +3175,6 @@ fn task_drain_while_parent_waiting_keeps_waiting() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: id,
-            activity: Activity::Typing,
             tool_use_id: Some("task-T".into()),
             detail: Some(ToolDetail::Task),
         },
@@ -3338,7 +3267,6 @@ fn codex_permission_then_jsonl_output_resumes_to_active() {
         &mut scene,
         AgentEvent::ActivityStart {
             agent_id: id,
-            activity: Activity::Typing,
             tool_use_id: None,
             detail: Some(ToolDetail::from("exec_command")),
         },

--- a/crates/pixtuoid-core/tests/snapshots/fixture_harness__antigravity__tool-run.snap
+++ b/crates/pixtuoid-core/tests/snapshots/fixture_harness__antigravity__tool-run.snap
@@ -4,7 +4,6 @@ expression: events
 ---
 - ActivityStart:
     agent_id: 5893914776247809446
-    activity: Typing
     tool_use_id: ag-1-0
     detail:
       Generic:

--- a/crates/pixtuoid-core/tests/snapshots/fixture_harness__claude-code__tool-call.snap
+++ b/crates/pixtuoid-core/tests/snapshots/fixture_harness__claude-code__tool-call.snap
@@ -7,7 +7,6 @@ expression: events
     label: code-architect
 - ActivityStart:
     agent_id: 13551487942093082797
-    activity: Typing
     tool_use_id: toolu_demo0000000000000001
     detail:
       Generic:
@@ -23,7 +22,6 @@ expression: events
     parent_id: ~
 - ActivityStart:
     agent_id: 13551487942093082797
-    activity: Typing
     tool_use_id: toolu_demo0000000000000001
     detail:
       Generic:

--- a/crates/pixtuoid-core/tests/snapshots/fixture_harness__codex__permission-flow.snap
+++ b/crates/pixtuoid-core/tests/snapshots/fixture_harness__codex__permission-flow.snap
@@ -4,7 +4,6 @@ expression: events
 ---
 - ActivityStart:
     agent_id: 6841382808792371786
-    activity: Typing
     tool_use_id: ~
     detail: ~
 - Waiting:
@@ -12,7 +11,6 @@ expression: events
     reason: permission
 - ActivityStart:
     agent_id: 6841382808792371786
-    activity: Typing
     tool_use_id: ~
     detail: ~
 - ActivityEnd:

--- a/crates/pixtuoid-core/tests/snapshots/fixture_harness__codex__tool-run.snap
+++ b/crates/pixtuoid-core/tests/snapshots/fixture_harness__codex__tool-run.snap
@@ -4,19 +4,16 @@ expression: events
 ---
 - ActivityStart:
     agent_id: 6841381709280743575
-    activity: Typing
     tool_use_id: ~
     detail: ~
 - ActivityStart:
     agent_id: 6841381709280743575
-    activity: Typing
     tool_use_id: ~
     detail:
       Generic:
         display: exec_command
 - ActivityStart:
     agent_id: 6841381709280743575
-    activity: Typing
     tool_use_id: ~
     detail: ~
 - ActivityEnd:

--- a/crates/pixtuoid/examples/snapshot.rs
+++ b/crates/pixtuoid/examples/snapshot.rs
@@ -15,7 +15,7 @@ use pixtuoid::tui::embedded_pack::load_sprite_pack;
 use pixtuoid::tui::frame_cache::FrameCache;
 use pixtuoid::tui::renderer::{draw_scene, DrawCtx, TickerQueue};
 use pixtuoid_core::source::jsonl::JsonlWatcher;
-use pixtuoid_core::source::{Activity, AgentEvent};
+use pixtuoid_core::source::AgentEvent;
 use pixtuoid_core::sprite::{Rgb, RgbBuffer};
 use pixtuoid_core::state::ActivityState;
 use pixtuoid_core::{AgentId, AgentSlot, Reducer, SceneState, Transport};
@@ -660,7 +660,6 @@ fn sample_scene(now: SystemTime, max_desks: usize, n_agents: usize) -> SceneStat
         (
             "working",
             ActivityState::Active {
-                activity: Activity::Typing,
                 tool_use_id: Some("tu_a".into()),
                 detail: Some("Write: src/foo.rs".into()),
             },
@@ -680,7 +679,6 @@ fn sample_scene(now: SystemTime, max_desks: usize, n_agents: usize) -> SceneStat
         (
             "couch-act",
             ActivityState::Active {
-                activity: Activity::Typing,
                 tool_use_id: Some("tu_c".into()),
                 detail: Some("Read: README.md".into()),
             },
@@ -696,7 +694,6 @@ fn sample_scene(now: SystemTime, max_desks: usize, n_agents: usize) -> SceneStat
         (
             "floor-act",
             ActivityState::Active {
-                activity: Activity::Typing,
                 tool_use_id: Some("tu_d".into()),
                 detail: Some("Bash: cargo test".into()),
             },
@@ -706,7 +703,6 @@ fn sample_scene(now: SystemTime, max_desks: usize, n_agents: usize) -> SceneStat
         (
             "floor-act2",
             ActivityState::Active {
-                activity: Activity::Typing,
                 tool_use_id: Some("tu_e".into()),
                 detail: Some("Grep: TODO".into()),
             },

--- a/crates/pixtuoid/src/runtime/mod.rs
+++ b/crates/pixtuoid/src/runtime/mod.rs
@@ -209,7 +209,7 @@ mod tests {
     // agents on non-existent desks on small terminals until the terminal grows.
     #[test]
     fn summarize_reports_each_activity_state() {
-        use pixtuoid_core::source::{Activity, AgentEvent};
+        use pixtuoid_core::source::AgentEvent;
         use pixtuoid_core::AgentId;
 
         let mut scene = SceneState::new([8; MAX_FLOORS]);
@@ -238,7 +238,6 @@ mod tests {
             &mut scene,
             AgentEvent::ActivityStart {
                 agent_id: a,
-                activity: Activity::Typing,
                 tool_use_id: Some("t1".into()),
                 detail: Some("Edit: foo.rs".into()),
             },

--- a/crates/pixtuoid/src/tui/pixel_painter/tests.rs
+++ b/crates/pixtuoid/src/tui/pixel_painter/tests.rs
@@ -307,12 +307,10 @@ fn agent_palette_glow_tint_shifts_skin_toward_given_color() {
 
 #[test]
 fn tool_glow_tint_maps_known_tools() {
-    use pixtuoid_core::source::Activity;
     let id = pixtuoid_core::AgentId::from_transcript_path("/t.jsonl");
     let edit_slot = make_slot(
         id,
         ActivityState::Active {
-            activity: Activity::Typing,
             tool_use_id: None,
             detail: Some(Arc::from("Edit src/main.rs")),
         },
@@ -320,7 +318,6 @@ fn tool_glow_tint_maps_known_tools() {
     let bash_slot = make_slot(
         id,
         ActivityState::Active {
-            activity: Activity::Typing,
             tool_use_id: None,
             detail: Some(Arc::from("Bash: ls")),
         },
@@ -1173,14 +1170,12 @@ fn waypoint_rank_offset_x_decollision_table() {
 
 #[test]
 fn tool_glow_tint_maps_delegation_search_and_unknown_tokens() {
-    use pixtuoid_core::source::Activity;
     let id = pixtuoid_core::AgentId::from_transcript_path("/g.jsonl");
     let glow = &crate::tui::theme::NORMAL.tool_glow;
     let active = |detail: &str| {
         make_slot(
             id,
             ActivityState::Active {
-                activity: Activity::Typing,
                 tool_use_id: None,
                 detail: Some(Arc::from(detail)),
             },

--- a/crates/pixtuoid/src/tui/pose/tests.rs
+++ b/crates/pixtuoid/src/tui/pose/tests.rs
@@ -1,5 +1,4 @@
 use super::*;
-use pixtuoid_core::source::Activity;
 use pixtuoid_core::state::ActivityState;
 use pixtuoid_core::walkable::WalkableMask;
 use std::path::PathBuf;
@@ -172,7 +171,6 @@ fn active_slot(state_started_at: SystemTime, created_at: SystemTime) -> AgentSlo
         cwd: Arc::from(PathBuf::from("/p").as_path()),
         label: Arc::from("cc"),
         state: ActivityState::Active {
-            activity: Activity::Typing,
             tool_use_id: Some(Arc::from("t")),
             detail: Some(Arc::from("Edit")),
         },
@@ -2105,7 +2103,6 @@ fn wander_interrupted_by_active_does_not_teleport() {
     // Flip to Active at this frame; continue stepping ~1.5 s of snap-back.
     let active = AgentSlot {
         state: ActivityState::Active {
-            activity: Activity::Typing,
             tool_use_id: Some(Arc::from("t")),
             detail: Some(Arc::from("Edit")),
         },

--- a/crates/pixtuoid/src/tui/tui_renderer/harness.rs
+++ b/crates/pixtuoid/src/tui/tui_renderer/harness.rs
@@ -95,7 +95,6 @@ fn idle(id: &str, desk: usize, started: SystemTime) -> AgentSlot {
 fn active(id: &str, desk: usize, detail: &str, started: SystemTime) -> AgentSlot {
     let mut s = idle(id, desk, started);
     s.state = ActivityState::Active {
-        activity: pixtuoid_core::source::Activity::Typing,
         tool_use_id: Some(Arc::from("t")),
         detail: Some(Arc::from(detail)),
     };

--- a/crates/pixtuoid/src/tui/widgets/hud.rs
+++ b/crates/pixtuoid/src/tui/widgets/hud.rs
@@ -774,7 +774,6 @@ mod hud_tests {
     // empty (leading non-alphanumeric) must be SKIPPED, not counted as a tool.
     #[test]
     fn status_segments_skips_empty_leading_token() {
-        use pixtuoid_core::source::Activity;
         use pixtuoid_core::{AgentId, AgentSlot};
         use std::path::PathBuf;
         use std::sync::Arc;
@@ -786,7 +785,6 @@ mod hud_tests {
             label: Arc::from("lead"),
             // Leading '/' ⇒ first token after split-on-non-alphanumeric is "".
             state: ActivityState::Active {
-                activity: Activity::Typing,
                 tool_use_id: Some(Arc::from("t")),
                 detail: Some(Arc::from("/usr/bin/thing")),
             },

--- a/crates/pixtuoid/src/tui/widgets/mod.rs
+++ b/crates/pixtuoid/src/tui/widgets/mod.rs
@@ -133,7 +133,6 @@ impl TickerQueue {
 mod tests {
     use super::*;
     use hud::{build_status_spans, build_status_summary};
-    use pixtuoid_core::source::Activity;
     use pixtuoid_core::{AgentId, AgentSlot};
     use std::path::PathBuf;
     use std::sync::Arc;
@@ -235,7 +234,6 @@ mod tests {
     fn active_with(detail: &str, label: &str) -> AgentSlot {
         slot_with(
             ActivityState::Active {
-                activity: Activity::Typing,
                 tool_use_id: Some(Arc::from("t")),
                 detail: Some(Arc::from(detail)),
             },

--- a/crates/pixtuoid/tests/golden_image.rs
+++ b/crates/pixtuoid/tests/golden_image.rs
@@ -15,7 +15,6 @@ use std::time::{Duration, SystemTime};
 use pixtuoid::tui::embedded_pack::load_sprite_pack;
 use pixtuoid::tui::renderer::draw_scene;
 use pixtuoid::tui::theme;
-use pixtuoid_core::source::Activity;
 use pixtuoid_core::state::ActivityState;
 use pixtuoid_core::{AgentId, AgentSlot, SceneState};
 use ratatui::backend::TestBackend;
@@ -35,7 +34,6 @@ fn populated_scene(now: SystemTime) -> SceneState {
     let labels = ["alice", "bob", "carol", "dave"];
     let states = [
         ActivityState::Active {
-            activity: Activity::Typing,
             tool_use_id: None,
             detail: Some("Edit src/main.rs".into()),
         },
@@ -44,7 +42,6 @@ fn populated_scene(now: SystemTime) -> SceneState {
             reason: "user input".into(),
         },
         ActivityState::Active {
-            activity: Activity::Typing,
             tool_use_id: None,
             detail: Some("Bash ls".into()),
         },

--- a/crates/pixtuoid/tests/pixel_regression.rs
+++ b/crates/pixtuoid/tests/pixel_regression.rs
@@ -17,7 +17,6 @@ use pixtuoid::tui::embedded_pack::load_sprite_pack;
 use pixtuoid::tui::floor::FloorMeta;
 use pixtuoid::tui::renderer::draw_scene;
 use pixtuoid::tui::theme::{self, Theme};
-use pixtuoid_core::source::Activity;
 use pixtuoid_core::state::ActivityState;
 use pixtuoid_core::{AgentId, AgentSlot, SceneState};
 use ratatui::backend::TestBackend;
@@ -30,7 +29,6 @@ fn fixture_scene(now: SystemTime) -> SceneState {
         (
             "agent-a",
             ActivityState::Active {
-                activity: Activity::Typing,
                 tool_use_id: Some("tu_a".into()),
                 detail: Some("Write".into()),
             },

--- a/crates/pixtuoid/tests/snapshot_regression.rs
+++ b/crates/pixtuoid/tests/snapshot_regression.rs
@@ -20,7 +20,6 @@ use std::time::{Duration, SystemTime};
 
 use pixtuoid::tui::embedded_pack::load_sprite_pack;
 use pixtuoid::tui::renderer::draw_scene;
-use pixtuoid_core::source::Activity;
 use pixtuoid_core::state::ActivityState;
 use pixtuoid_core::{AgentId, AgentSlot, SceneState};
 use ratatui::backend::TestBackend;
@@ -33,7 +32,6 @@ fn fixture_scene(now: SystemTime) -> SceneState {
         (
             "agent-a",
             ActivityState::Active {
-                activity: Activity::Typing,
                 tool_use_id: Some("tu_a".into()),
                 detail: Some("Write".into()),
             },

--- a/crates/pixtuoid/tests/tui_renderer.rs
+++ b/crates/pixtuoid/tests/tui_renderer.rs
@@ -8,7 +8,6 @@ use std::time::{Duration, SystemTime};
 
 use pixtuoid::tui::embedded_pack::load_sprite_pack;
 use pixtuoid::tui::tui_renderer::TuiRenderer;
-use pixtuoid_core::source::Activity;
 use pixtuoid_core::state::ActivityState;
 use pixtuoid_core::{AgentId, AgentSlot, Renderer, SceneState};
 use ratatui::backend::TestBackend;
@@ -28,7 +27,6 @@ fn tui_renderer_render_paints_a_full_frame() {
             cwd: std::sync::Arc::from(PathBuf::from("/demo").as_path()),
             label: std::sync::Arc::from("demo"),
             state: ActivityState::Active {
-                activity: Activity::Typing,
                 tool_use_id: Some(std::sync::Arc::from("t1")),
                 detail: Some(std::sync::Arc::from("Write")),
             },

--- a/crates/pixtuoid/tests/widget_cells.rs
+++ b/crates/pixtuoid/tests/widget_cells.rs
@@ -13,7 +13,6 @@ use std::time::{Duration, SystemTime};
 use pixtuoid::tui::embedded_pack::load_sprite_pack;
 use pixtuoid::tui::renderer::draw_scene;
 use pixtuoid::tui::theme;
-use pixtuoid_core::source::Activity;
 use pixtuoid_core::state::ActivityState;
 use pixtuoid_core::{AgentId, AgentSlot, SceneState};
 use ratatui::backend::TestBackend;
@@ -34,7 +33,6 @@ fn fixture_scene(now: SystemTime) -> SceneState {
         (
             "agent-a",
             ActivityState::Active {
-                activity: Activity::Typing,
                 tool_use_id: Some("tu_a".into()),
                 detail: Some("Write".into()),
             },


### PR DESCRIPTION
Part of the v0.6.0 whole-codebase sweep. `Activity {Typing, Reading}` rode in every `AgentEvent::ActivityStart` and `ActivityState::Active` but **fed nothing** — verified zero reads in any non-test code.

### Why it's dead — the model evolved past it
Character status is fully expressed by a strictly-better two-axis model that subsumes `Activity`:

- **`ActivityState` (Idle / Active / Waiting)** — the coarse *mode*. Drives the pose (`Active` → `SeatedTyping`, `Waiting` → `StandingAtDesk`) and all lifecycle/stale logic.
- **`ToolDetail` / `detail` (Read / Edit / Bash / Delegating / …)** — the concrete *what*. Drives the monitor-glow tint, at **finer grain** than Typing/Reading (`Read` is more specific than "Reading").

`Activity` sat between them and was dominated by both. It's a vestige of the pre-`ToolDetail` era — when `detail` was a free-form `Option<String>`. Once `detail` became the typed `ToolDetail`, the tool name *became* the activity at higher resolution and the middle layer had no job.

### Why the removal is provably a no-op
- The working pose keys on `ActivityState::Active` + a time counter; the glow on the `detail` string — **neither ever reads `.activity`** (traced live).
- The **golden-image / pixel-regression tests pass byte-identical** — empirical proof of the visual no-op.
- The only golden churn is the insta *event* snapshots dropping the serialized `activity: Typing` line — verified that line was the **sole delta** across all 4 snapshots before accepting.

### Scope
Drops the field from `AgentEvent::ActivityStart` + `ActivityState::Active`, the `Activity` enum + its lib re-export, and the `enter_active` param. ~90 mechanical construction-site edits across the 3 crates; 20 insertions / 169 deletions. Preflight green, 1067/1067.

(Also gitignores `lcov.info`, which was never ignored.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)