### PR TITLE
refactor(tui): decompose render_to_rgb_buffer into 9 named enqueue phases

### DIFF
--- a/crates/pixtuoid/src/tui/pixel_painter/mod.rs
+++ b/crates/pixtuoid/src/tui/pixel_painter/mod.rs
@@ -549,54 +549,7 @@ pub fn render_to_rgb_buffer(ctx: &mut PixelCtx<'_>) -> PixelPassResult {
     // the painter's algorithm applied to a top-down 2D scene.
     let mut drawables: Vec<Drawable<'_>> = Vec::new();
 
-    // Desk cubicles (each carries its divider + cabinet + bin + screen
-    // glow). Sprite is 16×8, so the actual bottom edge is desk.y + 8 —
-    // just past the seated character's feet (desk.y + 4), which keeps
-    // the seated worker visually behind the desk like it always was.
-    // (`seated_agents` was built once above, before the ambient pass.)
-    for (i, &desk) in ctx.layout.home_desks.iter().enumerate() {
-        let Size {
-            w: desk_fp_w,
-            h: desk_fp_h,
-        } = crate::tui::layout::desk_furniture_def()
-            .footprint
-            .unwrap_or(Size {
-                w: DESK_W,
-                h: DESK_H,
-            });
-        let is_last_col = desk.x + desk_fp_w + DESK_W
-            >= ctx.layout.cubicle_band.x + ctx.layout.cubicle_band.width;
-        let occupant = agents
-            .iter()
-            .find(|a| a.desk_index == i && a.exiting_at.is_none());
-        let screen_glow = occupant
-            .filter(|_| seated_agents.get(&i).copied().unwrap_or(false))
-            .and_then(|a| palette::tool_glow_tint(a, &ctx.theme.tool_glow));
-        let has_coffee = occupant.is_some_and(|a| ctx.coffee_holders.contains(&a.agent_id));
-        let coffee_steam = has_coffee
-            && occupant.is_some_and(|a| {
-                ctx.coffee_fetched_at
-                    .get(&a.agent_id)
-                    .and_then(|t| ctx.now.duration_since(*t).ok())
-                    .is_some_and(|d| d.as_secs() < COFFEE_STEAM_WINDOW_SECS)
-            });
-        drawables.push(Drawable {
-            // z-sort baseline = the footprint's south/front edge + the desk
-            // sprite's front-lip overhang, mirroring every other drawable's
-            // "footprint front + sprite overhang" form (here: 6 + 2 = 8). The
-            // desk's front legs/lip extend DESK_FRONT_OVERHANG px past its
-            // blocked footprint (top-down 3/4 bevel), so it sorts there.
-            anchor_y: desk.y + desk_fp_h + DESK_FRONT_OVERHANG,
-            kind: DrawableKind::DeskCubicle {
-                desk,
-                is_last_col,
-                has_cabinet: i % 2 == 0,
-                screen_glow,
-                has_coffee,
-                coffee_steam,
-            },
-        });
-    }
+    enqueue_desk_cubicles(ctx, &agents, &seated_agents, &mut drawables);
 
     enqueue_meeting_furniture(ctx.layout, &mut drawables);
 
@@ -606,71 +559,7 @@ pub fn render_to_rgb_buffer(ctx: &mut PixelCtx<'_>) -> PixelPassResult {
     enqueue_floor_fixtures(ctx, &agents, &mut drawables);
     enqueue_wall_decor(ctx.layout, &mut drawables);
 
-    let idle_desk_indices: Vec<usize> = agents
-        .iter()
-        .filter(|a| {
-            matches!(a.state, ActivityState::Idle)
-                && a.desk_index < ctx.layout.home_desks.len()
-                && a.exiting_at.is_none()
-        })
-        .map(|a| a.desk_index)
-        .collect();
-    let all_idle = agents
-        .iter()
-        .all(|a| matches!(a.state, ActivityState::Idle));
-
-    if let Some(kind) = ctx.floor_pet.map(|p| p.kind) {
-        let active_pet = ctx.active_pet.filter(|p| {
-            p.is_active(ctx.now) && p.kind == kind && p.floor_idx == ctx.floor.floor_idx
-        });
-        let pet_data = if let Some(pet) = active_pet {
-            Some((
-                pet.pet_pos,
-                false,
-                kind.sit_anim(),
-                0usize,
-                Some(pet.elapsed_ms(ctx.now)),
-            ))
-        } else {
-            pet_position(
-                kind,
-                ctx.layout,
-                ctx.pack,
-                ctx.now,
-                &idle_desk_indices,
-                all_idle,
-                ctx.floor.floor_seed,
-            )
-            .map(|(pos, flip, anim, frame)| (pos, flip, anim, frame, None))
-        };
-        if let Some((pos, flip, anim_name, frame_idx, pet_elapsed)) = pet_data {
-            resolved_pet_pos = Some(PetFrame {
-                pos,
-                anim: anim_name,
-                kind,
-            });
-            // South row derived from the CHOSEN anim's sprite height, not a
-            // literal: the h=4 sleep sprite sorts at pos.y+1, the h=6 walk/sit
-            // sprites at pos.y+2. A hardcoded +2 rendered a sleeping pet OVER a
-            // character whose feet land on pos.y+1 (one row too far south).
-            let pet_h = ctx
-                .pack
-                .animation(anim_name)
-                .and_then(|a| a.frames.first())
-                .map_or(6, |f| f.height);
-            drawables.push(Drawable {
-                anchor_y: z_sort_row(Anchor::Center, pos, pet_h),
-                kind: DrawableKind::Pet {
-                    kind,
-                    pos,
-                    flip,
-                    anim_name,
-                    frame_idx,
-                    pet_elapsed_ms: pet_elapsed,
-                },
-            });
-        }
-    }
+    resolved_pet_pos = enqueue_pet(ctx, &agents, &mut drawables);
 
     // Characters. Anchor = feet (anchor.y + sprite_height). Decollision
     // rank for crowded waypoints — stable across frames thanks to
@@ -1050,6 +939,131 @@ pub fn render_to_rgb_buffer(ctx: &mut PixelCtx<'_>) -> PixelPassResult {
         chitchat_bubbles,
         new_coffee_carriers,
     }
+}
+
+/// Desk cubicles — each carries its divider + cabinet + bin + screen glow.
+/// The desk sprite (16×8) sorts at `desk.y + footprint_h + DESK_FRONT_OVERHANG`
+/// (front-lip overhang past the blocked footprint), just past the seated
+/// worker's feet (`desk.y + 4`) so the sitter stays visually behind the desk.
+/// `seated_agents` (built once before the ambient pass) gates the screen glow
+/// so it only paints for a worker actually at the desk. The DeskCubicle
+/// drawable is Copy, so this borrows nothing from the agent set.
+fn enqueue_desk_cubicles<'a>(
+    ctx: &PixelCtx<'_>,
+    agents: &[AgentSlot],
+    seated_agents: &HashMap<usize, bool>,
+    drawables: &mut Vec<Drawable<'a>>,
+) {
+    for (i, &desk) in ctx.layout.home_desks.iter().enumerate() {
+        let Size {
+            w: desk_fp_w,
+            h: desk_fp_h,
+        } = crate::tui::layout::desk_furniture_def()
+            .footprint
+            .unwrap_or(Size {
+                w: DESK_W,
+                h: DESK_H,
+            });
+        let is_last_col = desk.x + desk_fp_w + DESK_W
+            >= ctx.layout.cubicle_band.x + ctx.layout.cubicle_band.width;
+        let occupant = agents
+            .iter()
+            .find(|a| a.desk_index == i && a.exiting_at.is_none());
+        let screen_glow = occupant
+            .filter(|_| seated_agents.get(&i).copied().unwrap_or(false))
+            .and_then(|a| palette::tool_glow_tint(a, &ctx.theme.tool_glow));
+        let has_coffee = occupant.is_some_and(|a| ctx.coffee_holders.contains(&a.agent_id));
+        let coffee_steam = has_coffee
+            && occupant.is_some_and(|a| {
+                ctx.coffee_fetched_at
+                    .get(&a.agent_id)
+                    .and_then(|t| ctx.now.duration_since(*t).ok())
+                    .is_some_and(|d| d.as_secs() < COFFEE_STEAM_WINDOW_SECS)
+            });
+        drawables.push(Drawable {
+            anchor_y: desk.y + desk_fp_h + DESK_FRONT_OVERHANG,
+            kind: DrawableKind::DeskCubicle {
+                desk,
+                is_last_col,
+                has_cabinet: i % 2 == 0,
+                screen_glow,
+                has_coffee,
+                coffee_steam,
+            },
+        });
+    }
+}
+
+/// The office pet (one per floor). An `active_pet` (mid heart-animation) is
+/// pinned in place; otherwise `pet_position` roams it around the idle desks.
+/// Returns the resolved `PetFrame` (for hit-testing) and enqueues the Pet
+/// drawable, y-sorted at the chosen anim's south row (the h=4 sleep sprite
+/// sorts one row shallower than the h=6 walk/sit sprites — a hardcoded +2 once
+/// painted a sleeping pet over a character whose feet land at pos.y+1).
+fn enqueue_pet<'a>(
+    ctx: &PixelCtx<'_>,
+    agents: &[AgentSlot],
+    drawables: &mut Vec<Drawable<'a>>,
+) -> Option<PetFrame> {
+    let kind = ctx.floor_pet.map(|p| p.kind)?;
+    let idle_desk_indices: Vec<usize> = agents
+        .iter()
+        .filter(|a| {
+            matches!(a.state, ActivityState::Idle)
+                && a.desk_index < ctx.layout.home_desks.len()
+                && a.exiting_at.is_none()
+        })
+        .map(|a| a.desk_index)
+        .collect();
+    let all_idle = agents
+        .iter()
+        .all(|a| matches!(a.state, ActivityState::Idle));
+
+    let active_pet = ctx
+        .active_pet
+        .filter(|p| p.is_active(ctx.now) && p.kind == kind && p.floor_idx == ctx.floor.floor_idx);
+    let pet_data = if let Some(pet) = active_pet {
+        Some((
+            pet.pet_pos,
+            false,
+            kind.sit_anim(),
+            0usize,
+            Some(pet.elapsed_ms(ctx.now)),
+        ))
+    } else {
+        pet_position(
+            kind,
+            ctx.layout,
+            ctx.pack,
+            ctx.now,
+            &idle_desk_indices,
+            all_idle,
+            ctx.floor.floor_seed,
+        )
+        .map(|(pos, flip, anim, frame)| (pos, flip, anim, frame, None))
+    };
+    let (pos, flip, anim_name, frame_idx, pet_elapsed) = pet_data?;
+    let pet_h = ctx
+        .pack
+        .animation(anim_name)
+        .and_then(|a| a.frames.first())
+        .map_or(6, |f| f.height);
+    drawables.push(Drawable {
+        anchor_y: z_sort_row(Anchor::Center, pos, pet_h),
+        kind: DrawableKind::Pet {
+            kind,
+            pos,
+            flip,
+            anim_name,
+            frame_idx,
+            pet_elapsed_ms: pet_elapsed,
+        },
+    });
+    Some(PetFrame {
+        pos,
+        anim: anim_name,
+        kind,
+    })
 }
 
 /// Meeting-room rugs + sofas + tables. For dual-meeting layouts sofas come in

--- a/crates/pixtuoid/src/tui/pixel_painter/mod.rs
+++ b/crates/pixtuoid/src/tui/pixel_painter/mod.rs
@@ -179,7 +179,6 @@ pub fn render_to_rgb_buffer(ctx: &mut PixelCtx<'_>) -> PixelPassResult {
     let agents: Vec<_> = ctx.scene.agents.values().cloned().collect();
     let buf_w = ctx.layout.buf_w;
     let buf_h = ctx.layout.buf_h;
-    let mut resolved_pet_pos: Option<PetFrame> = None;
     let mut new_coffee_carriers: Vec<pixtuoid_core::AgentId> = Vec::new();
 
     // Compute time-of-day once per frame and pass to every paint
@@ -559,11 +558,66 @@ pub fn render_to_rgb_buffer(ctx: &mut PixelCtx<'_>) -> PixelPassResult {
     enqueue_floor_fixtures(ctx, &agents, &mut drawables);
     enqueue_wall_decor(ctx.layout, &mut drawables);
 
-    resolved_pet_pos = enqueue_pet(ctx, &agents, &mut drawables);
+    let resolved_pet_pos = enqueue_pet(ctx, &agents, &mut drawables);
 
-    // Characters. Anchor = feet (anchor.y + sprite_height). Decollision
-    // rank for crowded waypoints — stable across frames thanks to
-    // BTreeMap iteration order.
+    let waypoint_visitors =
+        enqueue_characters(ctx, &agents, &mut drawables, &mut new_coffee_carriers);
+
+    enqueue_room_walls_h(ctx.layout, &mut drawables);
+
+    // Stable sort (Rust's `sort_by_key` is stable) — ties preserve
+    // insertion order. Insertion order above: decor first, characters
+    // last, so a character tied with a piece of furniture paints
+    // BEFORE the furniture (matches the prior pass-1 → pass-1.5
+    // → pass-2 layering for waypoint couch / pantry counter).
+    drawables.sort_by_key(|d| d.anchor_y);
+    // Occlusion is emergent now: every overhanging object's mask footprint is a
+    // shallow south-anchored ground strip, so a walker parks DEEP behind it and
+    // the object's own sprite (y-sorted at its south base, painted after the
+    // walker) hides their lower body — no snapshot, no synthetic back-cap.
+    for d in &drawables {
+        paint_drawable(d, ctx.buf, ctx.pack, ctx.cache, ctx.now, ctx.theme);
+    }
+
+    // Room-wide lightning bounce — LAST, so a Storm strike briefly flares the
+    // whole interior (floor, walls, furniture, characters), not just the window
+    // strip. No-op outside a strike / non-storm weather.
+    background::paint_lightning_flash(ctx.buf, ctx.now, background::weather_state(ctx.now));
+
+    // Debug layer (the `w` toggle) — composited LAST, over the finished scene:
+    // walkable mask + approach sides + live A* routes. Off by default.
+    if ctx.debug_walkable {
+        debug_overlay::paint(ctx.buf, ctx.layout, ctx.scene, ctx.motion);
+    }
+
+    let chitchat_bubbles = chitchat::update_and_collect(
+        ctx.chitchat_state,
+        ctx.floor.floor_idx,
+        &waypoint_visitors,
+        ctx.now,
+    );
+
+    PixelPassResult {
+        pet_pos: resolved_pet_pos,
+        chitchat_bubbles,
+        new_coffee_carriers,
+    }
+}
+
+/// All character sprites — the y-sorted middle pass's main subject. For each
+/// agent it derives the routed pose (entry/exit/wander/seated via the motion
+/// authority in `derive_with_routing`, which reads/writes ctx.router/overlay/
+/// history/motion) and enqueues the sprite at the feet anchor. Returns the
+/// waypoint visitors (for the chitchat venues) and pushes any agent seen
+/// carrying coffee this frame into `new_coffee_carriers`. The Character
+/// drawable borrows the agent, so this is the ONE phase tied to the agent
+/// set's lifetime `'a`.
+fn enqueue_characters<'a>(
+    ctx: &mut PixelCtx<'_>,
+    agents: &'a [AgentSlot],
+    drawables: &mut Vec<Drawable<'a>>,
+    new_coffee_carriers: &mut Vec<pixtuoid_core::AgentId>,
+) -> Vec<chitchat::Visitor> {
     let mut wp_rank: HashMap<usize, usize> = HashMap::new();
     let mut waypoint_visitors: Vec<chitchat::Visitor> = Vec::new();
     // All 3 lounge-couch seat waypoints collapse to ONE chitchat venue (keyed
@@ -585,7 +639,7 @@ pub fn render_to_rgb_buffer(ctx: &mut PixelCtx<'_>) -> PixelPassResult {
         .animation("standing")
         .and_then(|a| a.frames.first())
         .map_or(CHARACTER_SPRITE_W, |f| f.width);
-    for agent in &agents {
+    for agent in agents {
         let Some(desk) = ctx.layout.home_desks.get(agent.desk_index).copied() else {
             continue;
         };
@@ -884,12 +938,16 @@ pub fn render_to_rgb_buffer(ctx: &mut PixelCtx<'_>) -> PixelPassResult {
             }
         }
     }
+    waypoint_visitors
+}
 
-    // Horizontal (E-W) room dividers join the y-sort, anchored at their south
-    // (front) edge, so a character standing behind (north of) the wall is
-    // composited over by the frosted glass instead of painting on top of it.
-    // The vertical (edge-on) dividers already painted in the background pass.
-    for &WallSegment { start, end } in &ctx.layout.room_walls {
+/// Horizontal (E-W) room dividers join the y-sort, anchored at their south
+/// (front) edge so a character standing behind (north of) the wall is
+/// composited over by the frosted glass rather than painting on top of it.
+/// The vertical (edge-on) dividers already painted in the background pass.
+/// Emitted LAST so a character tied with a wall row still paints behind it.
+fn enqueue_room_walls_h<'a>(layout: &'a Layout, drawables: &mut Vec<Drawable<'a>>) {
+    for &WallSegment { start, end } in &layout.room_walls {
         if start.y == end.y {
             drawables.push(Drawable {
                 anchor_y: start.y + (WALL_THICK_H_PX - 1),
@@ -900,44 +958,6 @@ pub fn render_to_rgb_buffer(ctx: &mut PixelCtx<'_>) -> PixelPassResult {
                 },
             });
         }
-    }
-
-    // Stable sort (Rust's `sort_by_key` is stable) — ties preserve
-    // insertion order. Insertion order above: decor first, characters
-    // last, so a character tied with a piece of furniture paints
-    // BEFORE the furniture (matches the prior pass-1 → pass-1.5
-    // → pass-2 layering for waypoint couch / pantry counter).
-    drawables.sort_by_key(|d| d.anchor_y);
-    // Occlusion is emergent now: every overhanging object's mask footprint is a
-    // shallow south-anchored ground strip, so a walker parks DEEP behind it and
-    // the object's own sprite (y-sorted at its south base, painted after the
-    // walker) hides their lower body — no snapshot, no synthetic back-cap.
-    for d in &drawables {
-        paint_drawable(d, ctx.buf, ctx.pack, ctx.cache, ctx.now, ctx.theme);
-    }
-
-    // Room-wide lightning bounce — LAST, so a Storm strike briefly flares the
-    // whole interior (floor, walls, furniture, characters), not just the window
-    // strip. No-op outside a strike / non-storm weather.
-    background::paint_lightning_flash(ctx.buf, ctx.now, background::weather_state(ctx.now));
-
-    // Debug layer (the `w` toggle) — composited LAST, over the finished scene:
-    // walkable mask + approach sides + live A* routes. Off by default.
-    if ctx.debug_walkable {
-        debug_overlay::paint(ctx.buf, ctx.layout, ctx.scene, ctx.motion);
-    }
-
-    let chitchat_bubbles = chitchat::update_and_collect(
-        ctx.chitchat_state,
-        ctx.floor.floor_idx,
-        &waypoint_visitors,
-        ctx.now,
-    );
-
-    PixelPassResult {
-        pet_pos: resolved_pet_pos,
-        chitchat_bubbles,
-        new_coffee_carriers,
     }
 }
 

--- a/crates/pixtuoid/src/tui/pixel_painter/mod.rs
+++ b/crates/pixtuoid/src/tui/pixel_painter/mod.rs
@@ -598,266 +598,12 @@ pub fn render_to_rgb_buffer(ctx: &mut PixelCtx<'_>) -> PixelPassResult {
         });
     }
 
-    // Meeting-room area rug — sized to span both sofas + the coffee
-    // table with a small margin. Anchored at the TOP so y-sort paints
-    // it before the furniture sitting on top of it.
-    // Meeting-room area rugs + sofas + tables. For dual-meeting layouts,
-    // sofas come in pairs (2 per room), tables 1 per room.
-    let sofas_per_room = if ctx.layout.meeting_tables.len() > 1 {
-        2
-    } else {
-        ctx.layout.meeting_sofas.len()
-    };
-    for (room_idx, &table) in ctx.layout.meeting_tables.iter().enumerate() {
-        let sofa_start = room_idx * sofas_per_room;
-        let top_sofa = ctx.layout.meeting_sofas.get(sofa_start);
-        let bot_sofa = ctx.layout.meeting_sofas.get(sofa_start + 1);
-        if let (Some(&ts), Some(&bs)) = (top_sofa, bot_sofa) {
-            let rug_w = 18u16;
-            let rug_h =
-                bs.y.saturating_sub(ts.y)
-                    .saturating_add(8)
-                    .min(ctx.layout.buf_h.saturating_sub(table.y).saturating_add(8));
-            drawables.push(Drawable {
-                anchor_y: table.y.saturating_sub(rug_h / 2),
-                kind: DrawableKind::AreaRug {
-                    pos: table,
-                    width: rug_w,
-                    height: rug_h,
-                },
-            });
-        }
-    }
-    for (i, &sofa) in ctx.layout.meeting_sofas.iter().enumerate() {
-        let mirrored = i % 2 != 0;
-        // A south-of-table sofa faces away (Facing::North → `back_couch`
-        // sprite), so the sitter sits BEHIND the sofa back and must be
-        // occluded by it — same as the lounge couch. The sitter's y-sort
-        // key is `sofa.y + 2`, so the back sofa needs +3 to win that tie;
-        // the front (north) sofa stays +2 so its sitter paints on top
-        // (insertion order breaks the tie in the sitter's favor). Mirrors
-        // core's facing rule (`compute.rs`): back iff sofa.y >= table.y.
-        let room_id = i / 2;
-        let table_y = ctx
-            .layout
-            .meeting_tables
-            .get(room_id)
-            .map_or(sofa.y, |t| t.y);
-        let faces_away = sofa.y >= table_y;
-        drawables.push(Drawable {
-            anchor_y: sofa.y + if faces_away { 3 } else { 2 },
-            kind: DrawableKind::MeetingSofa {
-                pos: sofa,
-                mirrored,
-            },
-        });
-    }
-    for &table in &ctx.layout.meeting_tables {
-        drawables.push(Drawable {
-            // z-key = sprite south row, derived from the table (== +2 for the
-            // 11×5 coffee-table sprite) so it can't drift from a visual edit.
-            anchor_y: z_sort_row(
-                Anchor::Center,
-                table,
-                crate::tui::layout::furniture_def(crate::tui::layout::Furniture::MeetingTable)
-                    .visual
-                    .h,
-            ),
-            kind: DrawableKind::MeetingTable { pos: table },
-        });
-    }
+    enqueue_meeting_furniture(ctx.layout, &mut drawables);
 
-    // Pantry bistro table — z-key = sprite south row, derived from the table's
-    // own visual height (was a hand-rolled `table.y + 1`).
-    if let Some(table) = ctx.layout.pantry_table {
-        drawables.push(Drawable {
-            anchor_y: z_sort_row(
-                Anchor::Center,
-                table,
-                crate::tui::layout::furniture_def(crate::tui::layout::Furniture::PantryTable)
-                    .visual
-                    .h,
-            ),
-            kind: DrawableKind::PantryTable { pos: table },
-        });
-    }
-    // Pantry stools (centered) — z-key derived from the stool visual height.
-    for chair in &ctx.layout.pantry_chairs {
-        drawables.push(Drawable {
-            anchor_y: z_sort_row(
-                Anchor::Center,
-                *chair,
-                crate::tui::layout::furniture_def(crate::tui::layout::Furniture::PantryChair)
-                    .visual
-                    .h,
-            ),
-            kind: DrawableKind::PantryChair { pos: *chair },
-        });
-    }
+    enqueue_lounge_pantry_appliances(ctx.layout, &mut drawables);
 
-    // Lounge couch furniture — emitted ONCE, centred on the sofa via
-    // `couch_sprite_center`. The couch is now 3 separate seat waypoints, so
-    // per-seat emission would triple-paint the sofa/rug/table. Decor → pushed
-    // before the character loop so the y-sort tie-break keeps the couch behind
-    // its sitters. The rug anchors BEHIND (north of) the couch so it spans the
-    // floor on the south side; y-sort anchor at the top so the couch sits on it.
-    if let Some(center) = ctx.layout.couch_sprite_center {
-        drawables.push(Drawable {
-            anchor_y: center.y.saturating_sub(2),
-            kind: DrawableKind::AreaRug {
-                pos: Point {
-                    x: center.x,
-                    y: center.y + 3,
-                },
-                width: 22,
-                height: 7,
-            },
-        });
-        drawables.push(Drawable {
-            anchor_y: z_sort_row(
-                Anchor::Center,
-                center,
-                crate::tui::layout::furniture_def(crate::tui::layout::Furniture::Couch)
-                    .visual
-                    .h,
-            ),
-            kind: DrawableKind::WaypointCouch { pos: center },
-        });
-        if let Some(table) = ctx.layout.lounge_side_table {
-            drawables.push(Drawable {
-                anchor_y: z_sort_row(
-                    Anchor::Center,
-                    table,
-                    crate::tui::layout::furniture_def(
-                        crate::tui::layout::Furniture::LoungeSideTable,
-                    )
-                    .visual
-                    .h,
-                ),
-                kind: DrawableKind::LoungeSideTable { pos: table },
-            });
-        }
-    }
-
-    // Waypoint furniture — pantry counter, vending, printer — centered on the
-    // waypoint position. PhoneBooth/StandingDesk render via the `pod_decor`
-    // drawables below (they ARE the decor). The lounge couch is emitted once
-    // above (it spans 3 seat waypoints).
-    for wp in &ctx.layout.waypoints {
-        use crate::tui::layout::{furniture_def, WaypointKind};
-        // Depth (y-sort) baseline = the sprite's south row, via
-        // `center_pin_south_offset` (these appliances are center-pinned at
-        // `pos`). Read the VISUAL height — the drawn sprite's south, NOT the
-        // (now shallow) footprint: if an appliance ever grows an overhang the
-        // z-key must still track what's painted. Equal for today's flat boxes.
-        let visual_h = furniture_def(wp.kind.furniture()).visual.h;
-        match wp.kind {
-            // Rendered once via `couch_sprite_center` above (3 seats, 1 sprite).
-            WaypointKind::Couch => {}
-            WaypointKind::Pantry => {
-                let Size { w: cw, h: ch } = ctx.layout.pantry_counter_size; // runtime-sized
-                drawables.push(Drawable {
-                    anchor_y: z_sort_row(Anchor::Center, wp.pos, ch),
-                    kind: DrawableKind::WaypointPantry {
-                        pos: wp.pos,
-                        use_large: cw >= 32,
-                    },
-                });
-            }
-            // Rendered via the `pod_decor` drawables below (they ARE the decor).
-            WaypointKind::PhoneBooth | WaypointKind::StandingDesk => {}
-            WaypointKind::VendingMachine => {
-                drawables.push(Drawable {
-                    anchor_y: z_sort_row(Anchor::Center, wp.pos, visual_h),
-                    kind: DrawableKind::VendingMachine { pos: wp.pos },
-                });
-            }
-            WaypointKind::Printer => {
-                drawables.push(Drawable {
-                    anchor_y: z_sort_row(Anchor::Center, wp.pos, visual_h),
-                    kind: DrawableKind::Printer { pos: wp.pos },
-                });
-            }
-            // Rendered via the `meeting_sofas` / `meeting_tables` drawables
-            // elsewhere (the slots ride on the sofa/table) — nothing per-slot.
-            WaypointKind::MeetingSofa | WaypointKind::MeetingStand => {}
-        }
-    }
-
-    // Pod-aisle decor (plant / whiteboard / TV / phone booth /
-    // standing desk). All centered at `pos`; anchor at the bottom of
-    // the sprite footprint so y-sort places them correctly against
-    // walkers and characters in the aisles.
-    for &PodDecorItem { kind, pos } in &ctx.layout.pod_decor {
-        // Visual sprite height from the one furniture table (the mask reads the
-        // separate `footprint` off the same row — so a tall plant's canopy can
-        // sort correctly without blocking the aisle).
-        let Size { h, .. } = crate::tui::layout::furniture_def(kind.furniture()).visual;
-        drawables.push(Drawable {
-            anchor_y: z_sort_row(Anchor::Center, pos, h),
-            kind: DrawableKind::PodDecorItem { kind, pos },
-        });
-    }
-
-    // Plants — center-pinned; z-key = sprite south row. Height is the single
-    // source `furniture_def(kind.furniture()).visual.1` (was a parallel fudged
-    // match that drifted: it over-shot Flower/Succulent by one and faked Tall
-    // via `9` instead of `(10-1)/2`). The drop-shadow uses the same offset off
-    // the same height, so the two can't diverge.
-    for &PlantItem { kind, pos } in &ctx.layout.plants {
-        drawables.push(Drawable {
-            anchor_y: z_sort_row(
-                Anchor::Center,
-                pos,
-                crate::tui::layout::furniture_def(kind.furniture()).visual.h,
-            ),
-            kind: DrawableKind::Plant { kind, pos },
-        });
-    }
-
-    // Floor lamp (4×10 centered). z-key = sprite south row = lamp.y + h/2 - 1
-    // (10/2 - 1 = 4), the visual base — was +5 (one row past, floated the
-    // shadow + let the lamp paint over a character standing just in front).
-    if let Some(lamp) = ctx.layout.floor_lamp {
-        drawables.push(Drawable {
-            anchor_y: lamp.y + floor_lamp_south_offset(),
-            kind: DrawableKind::FloorLamp { pos: lamp },
-        });
-    }
-
-    // Meeting-room coat rack — y-sorted at its base row (cy+7) so a character
-    // in front occludes it. Same geometry the background pass used to draw.
-    if let Some(mr) = ctx.layout.meeting_room {
-        if mr.width > 20 {
-            let cx = mr.x + mr.width - 5;
-            let cy = mr.y + mr.height / 2 - 4;
-            drawables.push(Drawable {
-                anchor_y: cy + 7,
-                kind: DrawableKind::CoatRack {
-                    pos: Point { x: cx, y: cy },
-                },
-            });
-        }
-    }
-
-    // Elevator door (16×14, top-left anchored). Frame is computed
-    // stateless from agents in their entry/exit window: door opens
-    // (0→1→2) over the first DOOR_TRANSITION_MS of the agent's
-    // transit, holds open (2) in the middle, then closes (2→1→0)
-    // over the final DOOR_TRANSITION_MS. With multiple agents in
-    // flight we take the MAX frame so the door is at least as open
-    // as the most-in-progress agent needs.
-    if let Some(door_pos) = ctx.layout.door {
-        let frame_idx = compute_door_frame_idx(&agents, ctx.now, ctx.door_anim_max_ms);
-        drawables.push(Drawable {
-            anchor_y: door_pos.y + ELEVATOR_H,
-            kind: DrawableKind::Door {
-                pos: door_pos,
-                frame_idx,
-            },
-        });
-    }
-
+    enqueue_pod_decor_and_plants(ctx.layout, &mut drawables);
+    enqueue_floor_fixtures(ctx, &agents, &mut drawables);
     enqueue_wall_decor(ctx.layout, &mut drawables);
 
     let idle_desk_indices: Vec<usize> = agents
@@ -1303,6 +1049,238 @@ pub fn render_to_rgb_buffer(ctx: &mut PixelCtx<'_>) -> PixelPassResult {
         pet_pos: resolved_pet_pos,
         chitchat_bubbles,
         new_coffee_carriers,
+    }
+}
+
+/// Meeting-room rugs + sofas + tables. For dual-meeting layouts sofas come in
+/// pairs (2 per room), tables 1 per room. A south-of-table sofa faces away
+/// (`Facing::North` → `back_couch`), so it y-sorts +3 to occlude its sitter
+/// (whose key is `sofa.y + 2`); the north sofa stays +2 so insertion order
+/// breaks the tie in its sitter's favor.
+fn enqueue_meeting_furniture<'a>(layout: &'a Layout, drawables: &mut Vec<Drawable<'a>>) {
+    let sofas_per_room = if layout.meeting_tables.len() > 1 {
+        2
+    } else {
+        layout.meeting_sofas.len()
+    };
+    for (room_idx, &table) in layout.meeting_tables.iter().enumerate() {
+        let sofa_start = room_idx * sofas_per_room;
+        let top_sofa = layout.meeting_sofas.get(sofa_start);
+        let bot_sofa = layout.meeting_sofas.get(sofa_start + 1);
+        if let (Some(&ts), Some(&bs)) = (top_sofa, bot_sofa) {
+            let rug_w = 18u16;
+            let rug_h =
+                bs.y.saturating_sub(ts.y)
+                    .saturating_add(8)
+                    .min(layout.buf_h.saturating_sub(table.y).saturating_add(8));
+            drawables.push(Drawable {
+                anchor_y: table.y.saturating_sub(rug_h / 2),
+                kind: DrawableKind::AreaRug {
+                    pos: table,
+                    width: rug_w,
+                    height: rug_h,
+                },
+            });
+        }
+    }
+    for (i, &sofa) in layout.meeting_sofas.iter().enumerate() {
+        let mirrored = i % 2 != 0;
+        let room_id = i / 2;
+        let table_y = layout.meeting_tables.get(room_id).map_or(sofa.y, |t| t.y);
+        let faces_away = sofa.y >= table_y;
+        drawables.push(Drawable {
+            anchor_y: sofa.y + if faces_away { 3 } else { 2 },
+            kind: DrawableKind::MeetingSofa {
+                pos: sofa,
+                mirrored,
+            },
+        });
+    }
+    for &table in &layout.meeting_tables {
+        drawables.push(Drawable {
+            // z-key = sprite south row, derived from the table (== +2 for the
+            // 11×5 coffee-table sprite) so it can't drift from a visual edit.
+            anchor_y: z_sort_row(
+                Anchor::Center,
+                table,
+                crate::tui::layout::furniture_def(crate::tui::layout::Furniture::MeetingTable)
+                    .visual
+                    .h,
+            ),
+            kind: DrawableKind::MeetingTable { pos: table },
+        });
+    }
+}
+
+/// Pantry bistro table + stools, the lounge couch (emitted ONCE via
+/// `couch_sprite_center` — 3 seat waypoints share one sprite), and the
+/// center-pinned waypoint appliances (pantry counter, vending, printer).
+/// PhoneBooth/StandingDesk render via pod-decor; meeting slots ride the
+/// sofa/table — so those waypoint kinds emit nothing here.
+fn enqueue_lounge_pantry_appliances<'a>(layout: &'a Layout, drawables: &mut Vec<Drawable<'a>>) {
+    if let Some(table) = layout.pantry_table {
+        drawables.push(Drawable {
+            anchor_y: z_sort_row(
+                Anchor::Center,
+                table,
+                crate::tui::layout::furniture_def(crate::tui::layout::Furniture::PantryTable)
+                    .visual
+                    .h,
+            ),
+            kind: DrawableKind::PantryTable { pos: table },
+        });
+    }
+    for chair in &layout.pantry_chairs {
+        drawables.push(Drawable {
+            anchor_y: z_sort_row(
+                Anchor::Center,
+                *chair,
+                crate::tui::layout::furniture_def(crate::tui::layout::Furniture::PantryChair)
+                    .visual
+                    .h,
+            ),
+            kind: DrawableKind::PantryChair { pos: *chair },
+        });
+    }
+
+    // Lounge couch — pushed before the character loop so the y-sort tie-break
+    // keeps the couch behind its sitters. The rug anchors north of the couch
+    // (y-sort at its top) so the couch sits on it.
+    if let Some(center) = layout.couch_sprite_center {
+        drawables.push(Drawable {
+            anchor_y: center.y.saturating_sub(2),
+            kind: DrawableKind::AreaRug {
+                pos: Point {
+                    x: center.x,
+                    y: center.y + 3,
+                },
+                width: 22,
+                height: 7,
+            },
+        });
+        drawables.push(Drawable {
+            anchor_y: z_sort_row(
+                Anchor::Center,
+                center,
+                crate::tui::layout::furniture_def(crate::tui::layout::Furniture::Couch)
+                    .visual
+                    .h,
+            ),
+            kind: DrawableKind::WaypointCouch { pos: center },
+        });
+        if let Some(table) = layout.lounge_side_table {
+            drawables.push(Drawable {
+                anchor_y: z_sort_row(
+                    Anchor::Center,
+                    table,
+                    crate::tui::layout::furniture_def(
+                        crate::tui::layout::Furniture::LoungeSideTable,
+                    )
+                    .visual
+                    .h,
+                ),
+                kind: DrawableKind::LoungeSideTable { pos: table },
+            });
+        }
+    }
+
+    for wp in &layout.waypoints {
+        use crate::tui::layout::{furniture_def, WaypointKind};
+        // y-sort baseline = the sprite's south row (these appliances are
+        // center-pinned at `pos`). Read the VISUAL height, not the (shallow)
+        // footprint, so an overhang would still sort by what's painted.
+        let visual_h = furniture_def(wp.kind.furniture()).visual.h;
+        match wp.kind {
+            WaypointKind::Couch => {}
+            WaypointKind::Pantry => {
+                let Size { w: cw, h: ch } = layout.pantry_counter_size; // runtime-sized
+                drawables.push(Drawable {
+                    anchor_y: z_sort_row(Anchor::Center, wp.pos, ch),
+                    kind: DrawableKind::WaypointPantry {
+                        pos: wp.pos,
+                        use_large: cw >= 32,
+                    },
+                });
+            }
+            WaypointKind::PhoneBooth | WaypointKind::StandingDesk => {}
+            WaypointKind::VendingMachine => {
+                drawables.push(Drawable {
+                    anchor_y: z_sort_row(Anchor::Center, wp.pos, visual_h),
+                    kind: DrawableKind::VendingMachine { pos: wp.pos },
+                });
+            }
+            WaypointKind::Printer => {
+                drawables.push(Drawable {
+                    anchor_y: z_sort_row(Anchor::Center, wp.pos, visual_h),
+                    kind: DrawableKind::Printer { pos: wp.pos },
+                });
+            }
+            WaypointKind::MeetingSofa | WaypointKind::MeetingStand => {}
+        }
+    }
+}
+
+/// Pod-aisle decor (plant / whiteboard / TV / phone booth / standing desk)
+/// and free-standing plants — all center-pinned, y-sorted at the sprite's
+/// south row from the one furniture table (the mask reads the separate,
+/// shallower `footprint` off the same row, so a tall canopy sorts without
+/// blocking the aisle).
+fn enqueue_pod_decor_and_plants<'a>(layout: &'a Layout, drawables: &mut Vec<Drawable<'a>>) {
+    for &PodDecorItem { kind, pos } in &layout.pod_decor {
+        let Size { h, .. } = crate::tui::layout::furniture_def(kind.furniture()).visual;
+        drawables.push(Drawable {
+            anchor_y: z_sort_row(Anchor::Center, pos, h),
+            kind: DrawableKind::PodDecorItem { kind, pos },
+        });
+    }
+    for &PlantItem { kind, pos } in &layout.plants {
+        drawables.push(Drawable {
+            anchor_y: z_sort_row(
+                Anchor::Center,
+                pos,
+                crate::tui::layout::furniture_def(kind.furniture()).visual.h,
+            ),
+            kind: DrawableKind::Plant { kind, pos },
+        });
+    }
+}
+
+/// Free-standing fixtures: the floor lamp, the meeting-room coat rack, and the
+/// elevator door (whose open/close frame is computed stateless from the agents
+/// currently in their entry/exit window — the MAX frame so the door is at least
+/// as open as the most-in-progress agent needs).
+fn enqueue_floor_fixtures<'a>(
+    ctx: &PixelCtx<'_>,
+    agents: &[AgentSlot],
+    drawables: &mut Vec<Drawable<'a>>,
+) {
+    if let Some(lamp) = ctx.layout.floor_lamp {
+        drawables.push(Drawable {
+            anchor_y: lamp.y + floor_lamp_south_offset(),
+            kind: DrawableKind::FloorLamp { pos: lamp },
+        });
+    }
+    if let Some(mr) = ctx.layout.meeting_room {
+        if mr.width > 20 {
+            let cx = mr.x + mr.width - 5;
+            let cy = mr.y + mr.height / 2 - 4;
+            drawables.push(Drawable {
+                anchor_y: cy + 7,
+                kind: DrawableKind::CoatRack {
+                    pos: Point { x: cx, y: cy },
+                },
+            });
+        }
+    }
+    if let Some(door_pos) = ctx.layout.door {
+        let frame_idx = compute_door_frame_idx(agents, ctx.now, ctx.door_anim_max_ms);
+        drawables.push(Drawable {
+            anchor_y: door_pos.y + ELEVATOR_H,
+            kind: DrawableKind::Door {
+                pos: door_pos,
+                frame_idx,
+            },
+        });
     }
 }
 

--- a/crates/pixtuoid/src/tui/pixel_painter/mod.rs
+++ b/crates/pixtuoid/src/tui/pixel_painter/mod.rs
@@ -858,17 +858,7 @@ pub fn render_to_rgb_buffer(ctx: &mut PixelCtx<'_>) -> PixelPassResult {
         });
     }
 
-    // Wall decor — hung on walls, TOP-LEFT anchored at `pos`, so its y-sort
-    // row is its south base (`pos.y + h - 1`), same helper the mask + every
-    // other drawable use. (Was a hand-rolled `pos.y + h`, one row past the
-    // sprite's actual bottom.)
-    for &WallDecorItem { kind, pos } in &ctx.layout.wall_decor {
-        let Size { h, .. } = crate::tui::layout::furniture_def(kind.furniture()).visual;
-        drawables.push(Drawable {
-            anchor_y: z_sort_row(Anchor::TopLeft, pos, h),
-            kind: DrawableKind::WallDecor { kind, pos },
-        });
-    }
+    enqueue_wall_decor(ctx.layout, &mut drawables);
 
     let idle_desk_indices: Vec<usize> = agents
         .iter()
@@ -1313,6 +1303,21 @@ pub fn render_to_rgb_buffer(ctx: &mut PixelCtx<'_>) -> PixelPassResult {
         pet_pos: resolved_pet_pos,
         chitchat_bubbles,
         new_coffee_carriers,
+    }
+}
+
+/// Enqueue wall decor (clocks/whiteboards hung on walls). TOP-LEFT anchored
+/// at `pos`, so the y-sort row is the sprite's south base (`pos.y + h - 1`),
+/// the same `z_sort_row` helper the mask and every other drawable use. A
+/// pure furniture phase of `render_to_rgb_buffer` — borrows nothing from the
+/// agent set, so it carries no character lifetime.
+fn enqueue_wall_decor<'a>(layout: &'a Layout, drawables: &mut Vec<Drawable<'a>>) {
+    for &WallDecorItem { kind, pos } in &layout.wall_decor {
+        let Size { h, .. } = crate::tui::layout::furniture_def(kind.furniture()).visual;
+        drawables.push(Drawable {
+            anchor_y: z_sort_row(Anchor::TopLeft, pos, h),
+            kind: DrawableKind::WallDecor { kind, pos },
+        });
     }
 }
 


### PR DESCRIPTION
The one HIGH refactor from the whole-codebase sweep (Engine 2). `render_to_rgb_buffer`'s 735-line drawable-enqueue monolith is split into nine named phases, so the function reads as a coordinator: **background → lighting → ambient → 9 enqueue phases → sort → paint**. The function shrinks from ~1140 lines to a **428-line orchestrator**.

Done exactly as the verifier mandated — **incremental (4 commits), each verified byte-identical**:
1. `enqueue_wall_decor`
2. furniture batch — `enqueue_meeting_furniture`, `enqueue_lounge_pantry_appliances`, `enqueue_pod_decor_and_plants`, `enqueue_floor_fixtures`
3. `enqueue_desk_cubicles` + `enqueue_pet` (pet now returns its `Option<PetFrame>` and pulls `idle_desk_indices`/`all_idle` inside)
4. `enqueue_characters` + `enqueue_room_walls_h` (the capstone)

### Lifetime design
Only the **Character** drawable borrows the agent set, so only `enqueue_characters<'a>(agents: &'a [AgentSlot], drawables: &mut Vec<Drawable<'a>>, …)` carries the `'a`. Every furniture/pet/wall phase pushes Copy-data drawables, so they take their inputs by an **independent** lifetime — `enqueue_floor_fixtures`'s `ctx: &PixelCtx<'_>` is deliberately decoupled from `drawables`' `'a` (the Door drawable reads the agent set for the door-frame calc but stores only Copy data). `enqueue_characters` takes `&mut ctx` for the routed-pose derivation (`derive_with_routing` reads/writes `router`/`overlay`/`history`/`motion`), fills `drawables` + `new_coffee_carriers`, and **returns** the waypoint visitors for the chitchat venues.

### Verification — pure code motion, zero behavior change
The verifier flagged that the headless harness is targeted-assertion (necessary but not sufficient to catch an insertion-order slip). So every commit was gated on a **full-frame byte-identical matrix**: 60 frames (2 themes × 5 floor seeds × 2 sizes × 3 clock hours, `TZ=UTC`), per-file content diff → **0/60 changed after every phase**. Plus #148's `reference-*.png` identical, clippy clean, and the full suite (1067) green. Insertion order — load-bearing for the z-sort tie-breaks (decor first, characters last, room-walls after) — is preserved exactly: the phase calls run in the original order.

No production behavior changes; this is legibility only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)