### PR TITLE
docs: fix two pre-existing factual drifts (docs-drift audit)

### DIFF
--- a/.github/prompts/pr_review_rules.md
+++ b/.github/prompts/pr_review_rules.md
@@ -18,7 +18,7 @@ by reading actual code — no guessing, no "this might be an issue."
    - `pixtuoid-core` importing terminal dependencies (ratatui, crossterm)
    - Events bypassing the typed `mpsc` channel or hardcoding `Transport::Hook`
    - Source implementations not going through the `Source` trait
-   - `install-hooks` not using `write_settings_atomic` for settings.json
+   - `install-hooks` not using `write_config_atomic` for settings.json
    - Hook shim doing anything other than exit 0 on error
    - Walkable mask blocking more than ground footprint
 

--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -41,7 +41,7 @@ jobs:
 
             Review this PR for security issues. Focus on:
             1. Hook shim safety: must always exit 0, must never block CC, 200ms timeout non-negotiable
-            2. settings.json writes: must go through write_settings_atomic (advisory lock + atomic rename + symlink resolution)
+            2. settings.json writes: must go through write_config_atomic (advisory lock + atomic rename + symlink resolution)
             3. Unix socket handling: no path traversal, no symlink attacks
             4. Input validation on hook payloads and JSONL lines — malformed input must be logged and skipped, never panic
             5. No raw secrets in command strings or log output

--- a/crates/pixtuoid/src/tui/CLAUDE.md
+++ b/crates/pixtuoid/src/tui/CLAUDE.md
@@ -49,7 +49,7 @@ tui/
 │                   tests.rs (#[cfg(test)] mod tests: unit + frame-by-frame continuity guards)
 ├── pathfind.rs     Router trait + AStarRouter with selective cache invalidation
 ├── floor.rs        FloorCtx (per-floor render state), FloorTransition, LightingState, build_floor_scene
-├── pet.rs          PetKind (Cat, Dog) + per-kind static data; Pet{kind,name} (a configured office pet) + Pet::defaulted; select_pet_for_floor(&[Pet])->Option<&Pet>; PetState (heart-anim interaction)
+├── pet.rs          PetKind (Cat, Dog) + per-kind static data; Pet{kind,name} (a configured office pet) + Pet::defaulted; select_pet_for_floor(u64,&[Pet])->Option<&Pet>; PetState (heart-anim interaction)
 ├── chitchat.rs     venue-keyed group/solo speech bubbles (VenueKey::Room vs ::Waypoint)
 └── pixel_painter/  pure-pixel pass — split into focused child modules:
                     mod.rs (PixelCtx struct, orchestrator), background/ (weather, sunset, skyline,


### PR DESCRIPTION
A whole-docs drift audit — 7 doc areas (root + 3 nested CLAUDE.md, README, docs/, .github instructions) each cross-checked claim-by-claim against the current code, every flagged drift adversarially re-verified.

**Headline: the docs are remarkably current.** Every 0.5.0→0.6.0 sweep change is accurately reflected — Activity enum removal, `render_to_rgb_buffer` → 9 `enqueue_*` phases, async-trait → native RPITIT + `DynSource`, fs2 → fs4, `STALE_CODEX_IDLE_TIMEOUT` → `STALE_SHORT_IDLE_TIMEOUT`, the `doc(hidden)` tuning consts, `#[non_exhaustive]` on `AgentEvent`/`ToolDetail`, the empty-`RUST_LOG` fix, the Windows arc. The "keep docs current in the same commit" discipline held throughout.

Only **two** stale claims survived verification, and **both are pre-existing typos, not sweep fallout**:

1. **`crates/pixtuoid/src/tui/CLAUDE.md`** — the terse layout-tree line dropped the `floor_seed` param from `select_pet_for_floor`'s signature (`(&[Pet])` → `(u64, &[Pet])`). The prose entry at line 88 already had it right; only the one-line summary was stale.
2. **`.github/prompts/pr_review_rules.md`** — named a nonexistent `write_settings_atomic`; the real function is `write_config_atomic` (consistent with root CLAUDE.md and `install/io.rs`).

Doc-only, no code change. One rejected candidate (a `debug_overlay` "missing from the module list" claim) was refuted by verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)