### PR TITLE
chore(release): curate the 0.6.0 in-app release notes for the tag

### DIFF
--- a/crates/pixtuoid/src/version.rs
+++ b/crates/pixtuoid/src/version.rs
@@ -64,10 +64,10 @@ pub fn release_notes(version: &str) -> Option<&'static [&'static str]> {
         // the window stabilizes. Re-curate from `git log v0.5.0..HEAD` before
         // tagging.
         "0.6.0" => Some(&[
-            "Windows support: named-pipe hook transport + full CI suite",
-            "Diagnostics you can see: source-death footer warning, config warnings on stderr, always-on log file",
-            "Session-lifecycle hardening: dedup, completion-cascade, and permission-gate race fixes",
-            "Marketing site: live demos, architecture docs, weather gallery",
+            "Windows support — native hook transport, installer, and release builds",
+            "Diagnostics you can see — source-death footer warnings, config warnings on stderr, an always-on log file",
+            "Fewer ghost & duplicate sprites — hook/JSONL dedup + subagent completion-cascade + permission-gate race fixes",
+            "New project site — live demos, architecture & contributing docs, weather gallery",
         ]),
         "0.4.0" => Some(&[
             "Renamed from ascii-agents to pixtuoid",


### PR DESCRIPTION
Final pre-tag curation of the in-app `release_notes("0.6.0")` arm, re-curated from `git log v0.5.0..HEAD` (38 merged PRs).

**Final 4 user-facing highlights:**
- Windows support — native hook transport, installer, and release builds
- Diagnostics you can see — source-death footer warnings, config warnings on stderr, an always-on log file
- Fewer ghost & duplicate sprites — hook/JSONL dedup + subagent completion-cascade + permission-gate race fixes
- New project site — live demos, architecture & contributing docs, weather gallery

**Curation rationale:** the in-app notes are shown to end users on upgrade, so they list only what's user-visible. Tightened the wording away from internal jargon ("full CI suite" → "installer, release builds"; "session-lifecycle hardening: dedup/cascade" → the visible effect, "fewer ghost & duplicate sprites"). The 30+ other merged PRs — async-trait→RPITIT, dead-Activity removal, `render_to_rgb_buffer` decomposition, mutation hardening, `doc(hidden)`/`non_exhaustive`, fs2→fs4, the whole docs/CI/coverage sweep — are internal-only and correctly excluded.

**No upgrade action for existing Unix users** (hook config format unchanged; the shim's fs4/watchdog changes ride `cargo install`). Unlike 0.4.0/0.5.0, no "re-run install-hooks" bullet is needed.

`just notes-curated` ✓, preflight green (1067/1067). The `LIVING DRAFT` comment stays as the standing bump-at-window-start + re-curate-before-tag reminder (re-curate again if more user-facing PRs land before the `v0.6.0` tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)