### PR TITLE
test(cc-decoder): pin real-data edge cases mined from 2379 local sessions

### DIFF
--- a/crates/pixtuoid-core/src/source/claude_code.rs
+++ b/crates/pixtuoid-core/src/source/claude_code.rs
@@ -398,4 +398,34 @@ mod tests {
             "cc·bar"
         );
     }
+
+    // CC writes `message.content` as a plain STRING (not a block array) for
+    // simple text turns — 4709 such lines in a local 2379-session / 822 MB
+    // corpus. The tool-event match only fires on `Value::Array`, so a
+    // string-content turn must decode to NOTHING (no events, no panic) unless
+    // it's an /exit marker. A fuzz of all 291k real lines through
+    // decode_cc_line confirmed zero panics; this pins the common
+    // string-content shape the array-only fixtures never exercise.
+    #[test]
+    fn string_content_turns_emit_no_tool_events() {
+        for ty in ["assistant", "user"] {
+            let v = serde_json::json!({
+                "type": ty,
+                "message": { "role": ty, "content": "just some prose, no tool blocks" }
+            });
+            let out = decode_cc_line("/x/.claude/projects/p/s.jsonl", "claude-code", v).unwrap();
+            assert!(
+                out.is_empty(),
+                "{ty} turn with string content must emit no events"
+            );
+        }
+        // The one string-content case that IS load-bearing: a /exit slash
+        // command on a user turn still ends the session.
+        let exit = serde_json::json!({
+            "type": "user",
+            "message": { "role": "user", "content": "<command-name>/exit</command-name>" }
+        });
+        let out = decode_cc_line("/x/.claude/projects/p/s.jsonl", "claude-code", exit).unwrap();
+        assert!(matches!(out.as_slice(), [AgentEvent::SessionEnd { .. }]));
+    }
 }

--- a/crates/pixtuoid-core/src/source/decoder.rs
+++ b/crates/pixtuoid-core/src/source/decoder.rs
@@ -265,6 +265,43 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    // Real CC sessions are full of task-management tools whose names START WITH
+    // "Task" — TaskCreate/TaskUpdate/TaskList/TaskStop/TaskOutput (1757
+    // occurrences across a local 822 MB / 2379-session corpus) — but NONE carry
+    // a `subagent_type`, so they are ordinary tools, NOT the subagent dispatch.
+    // make_tool_detail must key the dispatch on the EXACT name (`Task`/`Agent`)
+    // or the `subagent_type` field, never a `starts_with("Task")` prefix — a
+    // prefix match would mis-class every TaskUpdate as a delegation and wrongly
+    // trip `active_tasks` subagent-leak suppression. The existing negative test
+    // uses `Read` (doesn't start with "Task"), so it cannot catch a prefix
+    // regression — this one pins the exact collision boundary.
+    #[test]
+    fn task_prefixed_tools_without_subagent_type_are_not_the_dispatch() {
+        for name in [
+            "TaskCreate",
+            "TaskUpdate",
+            "TaskList",
+            "TaskStop",
+            "TaskOutput",
+        ] {
+            assert!(
+                !make_tool_detail(name, Some(&json!({"id": "t-1"}))).is_task(),
+                "{name} (no subagent_type) must be a Generic tool, not the subagent dispatch"
+            );
+        }
+        // The exact dispatch names + the semantic signal still resolve to Task.
+        assert!(make_tool_detail("Task", None).is_task());
+        assert!(make_tool_detail("Agent", None).is_task());
+        assert!(
+            make_tool_detail(
+                "WhateverUpstreamRenamesItTo",
+                Some(&json!({"subagent_type": "x"}))
+            )
+            .is_task(),
+            "a renamed dispatch is still caught by the subagent_type field"
+        );
+    }
+
     #[test]
     fn normalize_path_key_is_identity_on_unix() {
         // The unix arm must be byte-identity — every existing AgentId


### PR DESCRIPTION
Hardening from mining the **real** CC output on this machine: I fuzzed `decode_cc_line` over a local **822 MB / 2379-session** corpus (291,359 JSON lines) — **zero panics, zero decode errors**, so the never-panic contract holds on real data, not just fixtures. The mining surfaced two real shapes the array-only test fixtures never exercised:

### 1. Task-PREFIXED tool names (the high-value one)
Real sessions are full of `TaskCreate` (565×), `TaskUpdate` (1046×), `TaskList`/`TaskStop`/`TaskOutput` — names that **start with "Task"** but are **not** the subagent-dispatch tool (verified across the corpus: **none** carry a `subagent_type`). `make_tool_detail` correctly keys the dispatch on the *exact* name (`Task`/`Agent`) or the `subagent_type` field — but the existing negative test used `Read` (which doesn't start with "Task"), so it could **not** catch a future `starts_with("Task")` regression that would mis-class every `TaskUpdate` as a delegation and wrongly trip `active_tasks` subagent-leak suppression. The new test pins the exact collision boundary + the rename-resilient `subagent_type` path.

### 2. String `message.content`
CC writes `content` as a plain **string** (not a block array) for simple text turns — **4709** such lines in the corpus. The tool-event match only fires on `Value::Array`, so a string-content turn must decode to nothing unless it's an `/exit` marker. Pinned both directions.

Both are unit tests with synthetic, sanitized JSON — **no real session data committed**. Also confirmed (no action needed): the new top-level line types CC has added since the decoder was written (`agent-name`, `custom-title`, `queue-operation`, `worktree-state`, `bridge-session`, …) and the new tool names (AskUserQuestion, Workflow, Skill, ToolSearch, …) all decode gracefully — `agent-name` is a session-title concept, not subagent attribution, so it's correctly ignored.

Preflight green, 1069/1069.

🤖 Generated with [Claude Code](https://claude.com/claude-code)