### PR TITLE
feat(codex): web/tool search keeps the agent Active, not idle

### DIFF
--- a/crates/pixtuoid-core/src/source/codex.rs
+++ b/crates/pixtuoid-core/src/source/codex.rs
@@ -158,6 +158,20 @@ pub fn decode_codex_line(transcript_path: &str, source: &str, v: Value) -> Resul
         | ("event_msg", "patch_apply_end") => {
             vec![start()]
         }
+        // Web/tool search are turn-INTERNAL work pulses — the agent is actively
+        // searching, not idle — so they keep it Active (→ ActivityStart), the
+        // same as every other intra-turn step above; only task_complete /
+        // turn_aborted end the turn. `web_search_{begin,end}` are EventMsg
+        // lifecycle events (codex-rs `protocol.rs` `EventMsg::WebSearch{Begin,
+        // End}`); `web_search_call` + `tool_search_{call,output}` are raw OpenAI
+        // Responses items (response_item) — both forms appear in real rollouts
+        // (verified, codex-cli 0.137). No approval gate: searching is never
+        // permission-prompted, so unlike function_call there's no Waiting branch.
+        ("response_item", "web_search_call")
+        | ("event_msg", "web_search_begin")
+        | ("event_msg", "web_search_end")
+        | ("response_item", "tool_search_call")
+        | ("response_item", "tool_search_output") => vec![start()],
         ("event_msg", "task_complete") | ("event_msg", "turn_aborted") => vec![end()],
         _ => vec![],
     };
@@ -309,6 +323,27 @@ mod tests {
         let out =
             ev(json!({"type":"event_msg","payload":{"type":"patch_apply_end","success":true}}));
         assert!(matches!(out.as_slice(), [AgentEvent::ActivityStart { .. }]));
+    }
+
+    // Web/tool search are turn-internal work — the agent must read as Active,
+    // not idle, while it searches. Payload shapes are the real ones captured
+    // from local codex-cli 0.137 rollouts (web_search_call is a response_item;
+    // web_search_end is an event_msg; tool_search_call/output are response_items).
+    #[test]
+    fn web_and_tool_search_keep_the_agent_active() {
+        for line in [
+            json!({"type":"response_item","payload":{"type":"web_search_call","status":"completed","action":{}}}),
+            json!({"type":"event_msg","payload":{"type":"web_search_begin","call_id":"c"}}),
+            json!({"type":"event_msg","payload":{"type":"web_search_end","call_id":"c","query":"q","action":{}}}),
+            json!({"type":"response_item","payload":{"type":"tool_search_call","call_id":"c","status":"in_progress","arguments":"{}"}}),
+            json!({"type":"response_item","payload":{"type":"tool_search_output","call_id":"c","status":"completed","tools":[]}}),
+        ] {
+            let out = ev(line.clone());
+            assert!(
+                matches!(out.as_slice(), [AgentEvent::ActivityStart { .. }]),
+                "search event {line} must keep the agent Active"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Found by mining the **real** Codex output on this machine (36 local `codex-cli 0.137` rollouts).

**The gap:** Codex emits web search and tool search as their *own* rollout events — `web_search_call`/`web_search_end` and `tool_search_call`/`tool_search_output` — **not** as `function_call`s. `decode_codex_line` only recognised `function_call`/`task_started`/etc., so it ignored these → a Codex sprite read as **idle** while the agent was actively searching the web or for tools.

**The fix:** they're turn-internal work pulses (exactly like `exec_command_end` / `function_call_output`), so they now map to `ActivityStart`, keeping the agent Active until `task_complete`/`turn_aborted` ends the turn. No approval gate — searching is never permission-prompted, so unlike `function_call` there's no `Waiting` branch.

**Wire facts pinned (verified):**
- `web_search_{begin,end}` are EventMsg lifecycle events (codex-rs `protocol.rs` `EventMsg::WebSearch{Begin,End}`) — confirmed against upstream `main`.
- `web_search_call` + `tool_search_{call,output}` are raw OpenAI Responses items (`response_item`) — `tool_search_*` aren't in `protocol.rs`'s EventMsg (they're model-API items), captured live from real rollouts.

Also re-ran the never-panic fuzz over all 36 local rollouts (1787 lines): **0 panics, 0 errors** — symmetric with the CC decoder hardening (#177). Test pins all five event shapes (the real captured payloads) → `ActivityStart`. Preflight green, 1070/1070.

🤖 Generated with [Claude Code](https://claude.com/claude-code)