### PR TITLE
tooling: just fuzz — repeatable never-panic decoder harness over real sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,8 @@ The `test-renderer` feature is needed for the `e2e.rs` integration test; **`just
 
 Coverage: `just coverage` (writes lcov.info + JUnit XML — the exact command CI runs).
 
+Decoder never-panic fuzz: `just fuzz <jsonl-dir>` (→ `examples/decoder_fuzz.rs`) runs every line of a real session corpus through the CC / Codex / hook decoder (auto-routed by shape) and fails on any panic — the "log + continue, never panic" contract (invariant #5) checked on real data, not just fixtures. On-demand, NOT in preflight/CI: point it at your own `~/.claude/projects` / `~/.codex/sessions` or a cloned public corpus (e.g. `daaain/claude-code-log`'s `test_data/real_projects`) — sessions are a target, not committed data.
+
 ### Visual verification (Python venv)
 
 ```

--- a/crates/pixtuoid-core/examples/decoder_fuzz.rs
+++ b/crates/pixtuoid-core/examples/decoder_fuzz.rs
@@ -1,0 +1,96 @@
+//! Real-corpus never-panic harness for the per-source decoders.
+//!
+//! Reads JSONL lines on stdin and runs each through the decoder its shape
+//! selects — `decode_hook_payload` for a hook payload (`hook_event_name`
+//! present), `decode_codex_line` for a Codex rollout line (`type` is
+//! `event_msg`/`response_item`/`session_meta`/`turn_context`), else
+//! `decode_cc_line` for a Claude Code transcript line — inside
+//! `catch_unwind`, and asserts the **never-panic** invariant (workspace
+//! invariant #5 / the "log + continue, never panic" decoder contract).
+//!
+//! It is a TOOL, not a committed corpus: point it at any JSONL tree —
+//! ```
+//! just fuzz ~/.claude/projects                 # your own CC sessions (newest formats)
+//! just fuzz ~/.codex/sessions                  # your own Codex rollouts
+//! git clone https://github.com/daaain/claude-code-log /tmp/cc \
+//!   && just fuzz /tmp/cc/test_data/real_projects   # a public real-world CC corpus
+//! ```
+//! Nothing is committed or redistributed, so there's no license / size /
+//! sanitization concern — the public sessions are a target, not a dependency.
+//! Exits non-zero if any line panics (so `just fuzz` fails loudly).
+//!
+//! Decode `Err` is allowed (the watcher logs + skips malformed lines); only a
+//! PANIC is a contract violation.
+
+use std::io::BufRead;
+
+use pixtuoid_core::source::claude_code::decode_cc_line;
+use pixtuoid_core::source::codex::decode_codex_line;
+use pixtuoid_core::source::decoder::decode_hook_payload;
+
+fn main() {
+    // A placeholder path: the decoders fold it into an AgentId but the
+    // never-panic contract is path-independent, so one stand-in is fine.
+    let cc_path = "/home/u/.claude/projects/p/session.jsonl";
+    let codex_path =
+        "/home/u/.codex/sessions/2026/01/01/rollout-1-019e7762-9ded-7e33-be41-946ecf105bf4.jsonl";
+
+    let (mut lines, mut parsed, mut events, mut errs, mut panics) = (0u64, 0u64, 0u64, 0u64, 0u64);
+    let mut panic_shapes: Vec<String> = Vec::new();
+
+    for line in std::io::stdin().lock().lines() {
+        let Ok(line) = line else { continue };
+        if line.trim().is_empty() {
+            continue;
+        }
+        lines += 1;
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) else {
+            continue; // non-JSON: the watcher skips it — outside the decoder contract
+        };
+        parsed += 1;
+
+        let ty = v.get("type").and_then(|t| t.as_str()).unwrap_or("");
+        let is_hook = v.get("hook_event_name").is_some();
+        let is_codex = matches!(
+            ty,
+            "event_msg" | "response_item" | "session_meta" | "turn_context"
+        );
+
+        let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            if is_hook {
+                decode_hook_payload(v.clone()).map(|e| vec![e])
+            } else if is_codex {
+                decode_codex_line(codex_path, "codex", v.clone())
+            } else {
+                decode_cc_line(cc_path, "claude-code", v.clone())
+            }
+        }));
+
+        match res {
+            Ok(Ok(evs)) => events += evs.len() as u64,
+            Ok(Err(_)) => errs += 1,
+            Err(_) => {
+                panics += 1;
+                if panic_shapes.len() < 10 {
+                    // Print STRUCTURE only (top-level keys), never the content —
+                    // a transcript line carries real prose/code.
+                    let keys = v
+                        .as_object()
+                        .map(|o| o.keys().cloned().collect::<Vec<_>>().join(","))
+                        .unwrap_or_else(|| "<non-object>".into());
+                    panic_shapes.push(format!("type={ty:?} keys=[{keys}]"));
+                }
+            }
+        }
+    }
+
+    eprintln!(
+        "decoder_fuzz: {lines} lines, {parsed} parsed, {events} events, {errs} decode-err, {panics} PANIC"
+    );
+    for s in &panic_shapes {
+        eprintln!("  PANIC on: {s}");
+    }
+    if panics > 0 {
+        std::process::exit(1);
+    }
+}

--- a/justfile
+++ b/justfile
@@ -105,6 +105,19 @@ semver:
 coverage:
     cargo llvm-cov nextest --workspace --features {{ features }} --lcov --output-path lcov.info --profile ci
 
+# Never-panic fuzz the per-source decoders over a JSONL corpus DIR (on-demand;
+# not in preflight/CI — points at local or public real sessions, not committed
+# data). Auto-routes each line to the CC / Codex / hook decoder by its shape;
+# exits non-zero on any panic. Examples:
+#   just fuzz ~/.claude/projects     # your CC sessions (newest formats)
+#   just fuzz ~/.codex/sessions      # your Codex rollouts
+#   git clone https://github.com/daaain/claude-code-log /tmp/cc && just fuzz /tmp/cc/test_data/real_projects
+[group('check')]
+[doc('Never-panic fuzz the decoders over a JSONL corpus dir: just fuzz ~/.claude/projects')]
+fuzz dir:
+    cargo build --release --example decoder_fuzz -p pixtuoid-core
+    find {{ dir }} -name '*.jsonl' -print0 | xargs -0 cat | ./target/release/examples/decoder_fuzz
+
 # Fail if the current release_notes() arm still has the uncurated TODO marker.
 # A release-PR guard (#116) — deliberately NOT in preflight, since `just bump`
 # leaves the marker for the human to curate after the bump commit.

--- a/justfile
+++ b/justfile
@@ -116,7 +116,7 @@ coverage:
 [doc('Never-panic fuzz the decoders over a JSONL corpus dir: just fuzz ~/.claude/projects')]
 fuzz dir:
     cargo build --release --example decoder_fuzz -p pixtuoid-core
-    find {{ dir }} -name '*.jsonl' -print0 | xargs -0 cat | ./target/release/examples/decoder_fuzz
+    find "{{ dir }}" -name '*.jsonl' -print0 | xargs -0 cat | ./target/release/examples/decoder_fuzz
 
 # Fail if the current release_notes() arm still has the uncurated TODO marker.
 # A release-PR guard (#116) — deliberately NOT in preflight, since `just bump`


### PR DESCRIPTION
Turns the one-off corpus fuzz I used to mine the #177 (CC) and #178 (Codex) edge cases into a **committed, repeatable tool** — the concrete way to "leverage the open-source sessions" without vendoring any data.

**`examples/decoder_fuzz.rs`** reads JSONL on stdin, auto-routes each line to the right decoder by its shape — `decode_hook_payload` (has `hook_event_name`), `decode_codex_line` (`type` is `event_msg`/`response_item`/`session_meta`/`turn_context`), else `decode_cc_line` — runs it under `catch_unwind`, and **exits non-zero on any panic**. It prints only top-level key STRUCTURE on a panic, never line content.

**`just fuzz <dir>`** wires it up:
```
just fuzz ~/.claude/projects     # your CC sessions (newest formats)
just fuzz ~/.codex/sessions      # your Codex rollouts
git clone https://github.com/daaain/claude-code-log /tmp/cc && just fuzz /tmp/cc/test_data/real_projects   # a public real-world corpus
```

### Why on-demand, not committed data
This checks the never-panic contract (invariant #5) on **real** data, not just synthetic fixtures — but the sessions are a **target, not a dependency**: nothing is committed or redistributed, so there's no license / size / sanitization concern. Synthetic fixtures (like the ones #177/#178 added) stay the committed regression layer; this is the breadth layer you run after touching a decoder.

Verified locally: **291,763 CC lines + 1,787 Codex lines, 0 panics**. The example compiles under `just hack`'s feature-powerset and is built by the smoke job (`--examples`). Documented in the root CLAUDE.md build & test section. Preflight green, 1069/1069.

🤖 Generated with [Claude Code](https://claude.com/claude-code)