### PR TITLE
docs(release): fold Codex web/tool-search visibility into 0.6.0 notes

### DIFF
--- a/crates/pixtuoid/src/version.rs
+++ b/crates/pixtuoid/src/version.rs
@@ -66,7 +66,7 @@ pub fn release_notes(version: &str) -> Option<&'static [&'static str]> {
         "0.6.0" => Some(&[
             "Windows support — native hook transport, installer, and release builds",
             "Diagnostics you can see — source-death footer warnings, config warnings on stderr, an always-on log file",
-            "Fewer ghost & duplicate sprites — hook/JSONL dedup + subagent completion-cascade + permission-gate race fixes",
+            "Sharper agent activity — fewer ghost & duplicate sprites (hook/JSONL dedup, subagent completion-cascade, permission-gate race fixes), and Codex stays active during web & tool search",
             "New project site — live demos, architecture & contributing docs, weather gallery",
         ]),
         "0.4.0" => Some(&[


### PR DESCRIPTION
## What

Reframes the third 0.6.0 release-notes bullet so the in-app upgrade popup advertises the Codex web/tool-search activity fix shipped in #178.

Before:
> Fewer ghost & duplicate sprites — hook/JSONL dedup + subagent completion-cascade + permission-gate race fixes

After:
> Sharper agent activity — fewer ghost & duplicate sprites (hook/JSONL dedup, subagent completion-cascade, permission-gate race fixes), and Codex stays active during web & tool search

## Why

#178 made Codex stay `Active` during `web_search_*` / `tool_search_*` turns instead of flickering `Idle`. It's a user-visible behavior change merged into the 0.6.0 dev window, so it belongs in the popup highlights. The `LIVING DRAFT` comment block stays — the notes get re-curated from `git log v0.5.0..HEAD` right before tagging.

## Verification

- `just notes-curated` ✓ (no `TODO: curate` marker)
- `cargo test -p pixtuoid --lib version::` — 20 passed (incl. `current_version_has_release_notes`)
- `just preflight` — green, 1070/1070

🤖 Generated with [Claude Code](https://claude.com/claude-code)