### PR TITLE
feat(npm): ship pixtuoid via `npm i -g pixtuoid` (optionalDependencies)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -390,6 +390,9 @@ jobs:
             fi
           done
 
+      - name: Test the package generator
+        run: node --test npm/generate.test.mjs
+
       - name: Generate npm packages
         run: node npm/generate.mjs --version "${GITHUB_REF_NAME#v}" --artifacts npm/dist
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -340,3 +340,82 @@ jobs:
           git add Formula/pixtuoid.rb
           git commit -m "pixtuoid ${VERSION}"
           git push
+
+  npm:
+    name: publish to npm
+    needs: build
+    # Never publish a pre-release to npm — like crates.io, an npm publish is
+    # effectively irreversible (no unpublish after 72h). Pre-release tags
+    # (v*-win.N / -rc) build artifacts only. Consumes the SAME build artifacts
+    # as the release/homebrew jobs — npm is a fourth downstream consumer of the
+    # one build matrix, not a parallel build.
+    if: ${{ !contains(github.ref_name, '-') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # npm provenance (`npm publish --provenance`)
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Extract binaries per target
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          for target in aarch64-apple-darwin x86_64-apple-darwin \
+                        x86_64-unknown-linux-musl aarch64-unknown-linux-gnu \
+                        x86_64-pc-windows-msvc aarch64-pc-windows-msvc; do
+            dest="npm/dist/${target}"
+            mkdir -p "$dest"
+            tgz="artifacts/pixtuoid-${TAG}-${target}.tar.gz"
+            zip="artifacts/pixtuoid-${TAG}-${target}.zip"
+            if [ -f "$tgz" ]; then
+              # tarball wraps everything in pixtuoid-<tag>-<target>/ — unwrap it
+              tar xzf "$tgz" -C "$dest" --strip-components=1
+            elif [ -f "$zip" ]; then
+              # windows zip is flat — exes at the root
+              unzip -o "$zip" -d "$dest"
+            else
+              echo "::error::missing artifact for ${target} (${tgz} / ${zip})"
+              exit 1
+            fi
+          done
+
+      - name: Generate npm packages
+        run: node npm/generate.mjs --version "${GITHUB_REF_NAME#v}" --artifacts npm/dist
+
+      - name: Publish (platform packages first, launcher last)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          # Idempotent: swallow "cannot publish over previously published" so a
+          # re-run of a partially-published tag is safe (mirrors the crates.io job).
+          publish_one() {
+            local dir="$1" name out
+            name=$(node -p "require('./${dir}/package.json').name")
+            if out=$(npm publish "$dir" --access public --provenance 2>&1); then
+              printf '%s\n' "$out"; echo "::notice::${name} published"; return 0
+            elif grep -qiE 'cannot publish over|previously published' <<<"$out"; then
+              # Match ONLY the over-publish phrase — never a bare 403, which npm
+              # also emits for auth/scope/2FA failures we must NOT swallow (the
+              # crates.io job's "every other failure fails loudly" discipline).
+              printf '%s\n' "$out"; echo "::warning::${name}@${VERSION} already on npm, skipping"; return 0
+            else
+              printf '%s\n' "$out"; echo "::error::${name} publish failed"; return 1
+            fi
+          }
+          # Platform packages first so the launcher's optionalDependencies always
+          # resolve to already-live versions; the launcher publishes last.
+          for dir in npm/@pixtuoid/cli-*; do publish_one "$dir"; done
+          publish_one npm/pixtuoid

--- a/npm/.gitignore
+++ b/npm/.gitignore
@@ -1,0 +1,4 @@
+dist/
+@pixtuoid/
+pixtuoid/node_modules/
+*.tgz

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,65 @@
+# npm distribution
+
+Ships pixtuoid's prebuilt binaries via `npm i -g pixtuoid`, using the
+**`optionalDependencies` + per-platform-packages** pattern (esbuild / Biome /
+git-cliff). No `postinstall`, no download-on-install, `--ignore-scripts`-safe.
+
+## How it works
+
+```
+npm i -g pixtuoid
+  └─ pixtuoid (launcher, pure JS — installs everywhere)
+       optionalDependencies (npm installs ONLY the one matching os/cpu/libc):
+         @pixtuoid/cli-darwin-arm64   os:darwin cpu:arm64
+         @pixtuoid/cli-darwin-x64     os:darwin cpu:x64
+         @pixtuoid/cli-linux-x64      os:linux  cpu:x64           (static musl, universal)
+         @pixtuoid/cli-linux-arm64    os:linux  cpu:arm64 libc:glibc
+         @pixtuoid/cli-win32-x64      os:win32  cpu:x64
+         @pixtuoid/cli-win32-arm64    os:win32  cpu:arm64
+```
+
+Each platform package is a **pure payload** (both native binaries, no `bin`).
+The launcher exposes the two commands; its shims resolve the installed platform
+package via `require.resolve` and exec the native binary:
+
+- **`bin/pixtuoid`** — the TUI launcher. May print an error + exit non-zero if no
+  prebuilt binary matches the host.
+- **`bin/pixtuoid-hook`** — the hook shim. **ALWAYS exits 0, never writes stderr,
+  never throws** (invariant #5: never block the agent). A Node hop adds ~tens of
+  ms; the zero-hop optimization (install-hooks targets the sibling native binary)
+  is a tracked follow-up.
+- **`bin/resolve.js`** — shared platform→package map + the `PIXTUOID_BINARY`
+  dev/CI override.
+
+## Files (committed)
+
+| File | Role |
+|---|---|
+| `pixtuoid/package.json` | launcher manifest (version + the 6 dep pins are `0.0.0` placeholders, stamped at publish) |
+| `pixtuoid/bin/{pixtuoid,pixtuoid-hook,resolve.js}` | the two shims + shared resolver |
+| `generate.mjs` | emits the 6 `@pixtuoid/cli-*` packages from prebuilt binaries + stamps the launcher |
+
+The per-platform packages are **generated, not committed** (see `.gitignore`).
+
+## Release flow (the `npm` job in `.github/workflows/release.yml`)
+
+On a stable `v*` tag (skipped for `-rc`/`-win` pre-releases, like crates.io +
+homebrew): download the `artifact-<target>` tarballs the build matrix already
+produced → extract both binaries per target → `node generate.mjs --version <tag>
+--artifacts <dir>` → `npm publish` the 6 platform packages first, the launcher
+last. The version is sourced from the git tag (single source of truth, same as
+the crates.io publish) — never a separate `package.json`.
+
+## Local dry-run (no publish)
+
+```bash
+just build --release                                  # produces target/release/{pixtuoid,pixtuoid-hook}
+mkdir -p /tmp/a/aarch64-apple-darwin
+cp target/release/pixtuoid target/release/pixtuoid-hook /tmp/a/aarch64-apple-darwin/
+node npm/generate.mjs --version 0.6.0 --artifacts /tmp/a   # (needs all 6 targets present; fake the others to test)
+# exercise the shim against a real binary without publishing:
+PIXTUOID_BINARY="$PWD/target/release" node npm/pixtuoid/bin/pixtuoid --version
+```
+
+For a full registry round-trip, publish the generated packages to a local
+[verdaccio](https://verdaccio.org/) and `npm i -g pixtuoid --registry http://localhost:4873`.

--- a/npm/generate.mjs
+++ b/npm/generate.mjs
@@ -10,9 +10,11 @@
 //   • re-stamps the launcher (npm/pixtuoid) version + its 6 optionalDependencies
 //     pins to <version>.
 //
-// Usage: node npm/generate.mjs --version X.Y.Z --artifacts <dir>
-// (always writes into the repo's npm/ tree in place — version + dep pins are
-//  stamped here; the per-platform @pixtuoid/cli-* dirs are gitignored.)
+// Usage: node npm/generate.mjs --version X.Y.Z --artifacts <dir> [--npm-dir <dir>]
+// Writes into the npm/ tree in place (default: this script's own dir) — version
+// + dep pins are stamped here; the per-platform @pixtuoid/cli-* dirs are
+// gitignored. --npm-dir overrides the target tree (used by the test to generate
+// into a temp copy instead of mutating the tracked launcher).
 //
 // Nothing per-platform is committed (git-cliff style) — the packages are
 // generated here at publish time and gitignored.
@@ -30,7 +32,6 @@ import {
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const NPM_DIR = dirname(fileURLToPath(import.meta.url)); // the repo's npm/ dir
 const SCOPE = "@pixtuoid";
 const BINS = ["pixtuoid", "pixtuoid-hook"];
 
@@ -55,6 +56,7 @@ function arg(name, def) {
 
 const version = arg("version");
 const artifacts = arg("artifacts");
+const NPM_DIR = arg("npm-dir", dirname(fileURLToPath(import.meta.url)));
 if (!version || !artifacts) {
   console.error("usage: node npm/generate.mjs --version X.Y.Z --artifacts <dir>");
   process.exit(1);

--- a/npm/generate.mjs
+++ b/npm/generate.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+// Generate the per-platform `@pixtuoid/cli-*` npm packages + stamp the launcher.
+//
+// Mirrors Biome's generate-packages.mjs, adapted for pixtuoid's TWO binaries
+// (pixtuoid + pixtuoid-hook) and ASYMMETRIC 6-target matrix. Reads the prebuilt
+// binaries from --artifacts (layout: <dir>/<rust-target>/{pixtuoid,pixtuoid-hook}
+// [.exe]) — the exact binaries release.yml already ships in its tarballs — and
+// writes, under npm/:
+//   • @pixtuoid/cli-<platform>-<arch>/  (per target: package.json + both binaries)
+//   • re-stamps the launcher (npm/pixtuoid) version + its 6 optionalDependencies
+//     pins to <version>.
+//
+// Usage: node npm/generate.mjs --version X.Y.Z --artifacts <dir>
+// (always writes into the repo's npm/ tree in place — version + dep pins are
+//  stamped here; the per-platform @pixtuoid/cli-* dirs are gitignored.)
+//
+// Nothing per-platform is committed (git-cliff style) — the packages are
+// generated here at publish time and gitignored.
+
+import {
+  existsSync,
+  mkdirSync,
+  copyFileSync,
+  chmodSync,
+  readFileSync,
+  writeFileSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const NPM_DIR = dirname(fileURLToPath(import.meta.url)); // the repo's npm/ dir
+const SCOPE = "@pixtuoid";
+const BINS = ["pixtuoid", "pixtuoid-hook"];
+
+// The asymmetric 6-row target table — mirrors release.yml's build matrix.
+//   linux-x64   → static musl build (portable to glibc too) → NO `libc` gate,
+//                 so npm installs it on every linux-x64 host.
+//   linux-arm64 → glibc build → `libc:["glibc"]` so npm SKIPS it on musl /
+//                 Alpine-arm64 (where it would crash) rather than mis-installing.
+const TARGETS = [
+  { rust: "aarch64-apple-darwin", pkg: "darwin-arm64", os: "darwin", cpu: "arm64" },
+  { rust: "x86_64-apple-darwin", pkg: "darwin-x64", os: "darwin", cpu: "x64" },
+  { rust: "x86_64-unknown-linux-musl", pkg: "linux-x64", os: "linux", cpu: "x64" },
+  { rust: "aarch64-unknown-linux-gnu", pkg: "linux-arm64", os: "linux", cpu: "arm64", libc: ["glibc"] },
+  { rust: "x86_64-pc-windows-msvc", pkg: "win32-x64", os: "win32", cpu: "x64" },
+  { rust: "aarch64-pc-windows-msvc", pkg: "win32-arm64", os: "win32", cpu: "arm64" },
+];
+
+function arg(name, def) {
+  const i = process.argv.indexOf("--" + name);
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : def;
+}
+
+const version = arg("version");
+const artifacts = arg("artifacts");
+if (!version || !artifacts) {
+  console.error("usage: node npm/generate.mjs --version X.Y.Z --artifacts <dir>");
+  process.exit(1);
+}
+if (!/^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/.test(version)) {
+  console.error(`refusing to stamp a non-semver version: ${version}`);
+  process.exit(1);
+}
+
+const launcherPath = join(NPM_DIR, "pixtuoid", "package.json");
+const launcher = JSON.parse(readFileSync(launcherPath, "utf8"));
+
+for (const t of TARGETS) {
+  const isWin = t.os === "win32";
+  const pkgName = `${SCOPE}/cli-${t.pkg}`;
+  const pkgDir = join(NPM_DIR, SCOPE, `cli-${t.pkg}`);
+  rmSync(pkgDir, { recursive: true, force: true });
+  mkdirSync(pkgDir, { recursive: true });
+
+  const files = [];
+  for (const bin of BINS) {
+    const exe = bin + (isWin ? ".exe" : "");
+    const src = join(artifacts, t.rust, exe);
+    if (!existsSync(src) || !statSync(src).isFile()) {
+      throw new Error(`missing prebuilt binary for ${t.rust}: ${src}`);
+    }
+    const dst = join(pkgDir, exe);
+    copyFileSync(src, dst);
+    // the upload/download-artifact round-trip strips the exec bit — restore it.
+    if (!isWin) chmodSync(dst, 0o755);
+    files.push(exe);
+  }
+
+  const pkg = {
+    name: pkgName,
+    version,
+    description: `pixtuoid prebuilt binaries for ${t.pkg}`,
+    license: launcher.license,
+    repository: launcher.repository,
+    homepage: launcher.homepage,
+    os: [t.os],
+    cpu: [t.cpu],
+    ...(t.libc ? { libc: t.libc } : {}),
+    files,
+  };
+  writeFileSync(join(pkgDir, "package.json"), JSON.stringify(pkg, null, 2) + "\n");
+  launcher.optionalDependencies[pkgName] = version; // re-pin to this version
+  console.log(`generated ${pkgName}@${version} (${files.join(", ")})`);
+}
+
+launcher.version = version;
+writeFileSync(launcherPath, JSON.stringify(launcher, null, 2) + "\n");
+console.log(`stamped launcher pixtuoid@${version} (${TARGETS.length} optionalDependencies)`);

--- a/npm/generate.test.mjs
+++ b/npm/generate.test.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+// Tests for generate.mjs — the per-platform package generator. Runs via the
+// zero-dep built-in runner: `node --test npm/generate.test.mjs` (also wired as a
+// pre-step of release.yml's npm job, so a broken generator fails the release
+// BEFORE anything is published).
+//
+// Strategy: spawn the real script against a throwaway --npm-dir + fake binaries,
+// then assert on what it wrote. No mocking — we exercise the actual semver guard,
+// the asymmetric libc gate, dep-pin stamping, and the missing-binary throw.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  rmSync,
+} from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), "generate.mjs");
+
+// The same 6-row matrix generate.mjs ships — kept here independently so the test
+// fails loudly if the production table is edited without updating the contract.
+const TARGETS = [
+  { rust: "aarch64-apple-darwin", pkg: "darwin-arm64", os: "darwin", cpu: "arm64", win: false },
+  { rust: "x86_64-apple-darwin", pkg: "darwin-x64", os: "darwin", cpu: "x64", win: false },
+  { rust: "x86_64-unknown-linux-musl", pkg: "linux-x64", os: "linux", cpu: "x64", win: false },
+  { rust: "aarch64-unknown-linux-gnu", pkg: "linux-arm64", os: "linux", cpu: "arm64", win: false, libc: ["glibc"] },
+  { rust: "x86_64-pc-windows-msvc", pkg: "win32-x64", os: "win32", cpu: "x64", win: true },
+  { rust: "aarch64-pc-windows-msvc", pkg: "win32-arm64", os: "win32", cpu: "arm64", win: true },
+];
+
+// Build a temp tree: a minimal launcher package.json + an artifacts dir holding
+// fake pixtuoid / pixtuoid-hook binaries for every (optionally all-but-one)
+// target. Returns { dir, npmDir, artifacts } and registers cleanup.
+function scaffold(t, { skip } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "pixtuoid-gen-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  const npmDir = join(dir, "npm");
+  mkdirSync(join(npmDir, "pixtuoid"), { recursive: true });
+  writeFileSync(
+    join(npmDir, "pixtuoid", "package.json"),
+    JSON.stringify(
+      {
+        name: "pixtuoid",
+        version: "0.0.0",
+        license: "MIT",
+        repository: { type: "git", url: "git+https://example/x.git" },
+        homepage: "https://example/x",
+        optionalDependencies: {},
+      },
+      null,
+      2,
+    ),
+  );
+
+  const artifacts = join(dir, "artifacts");
+  for (const tg of TARGETS) {
+    if (tg.rust === skip) continue;
+    const tdir = join(artifacts, tg.rust);
+    mkdirSync(tdir, { recursive: true });
+    const ext = tg.win ? ".exe" : "";
+    writeFileSync(join(tdir, "pixtuoid" + ext), "fake-tui");
+    writeFileSync(join(tdir, "pixtuoid-hook" + ext), "fake-hook");
+  }
+  return { dir, npmDir, artifacts };
+}
+
+function run(npmDir, artifacts, version) {
+  return spawnSync(
+    process.execPath,
+    [SCRIPT, "--version", version, "--artifacts", artifacts, "--npm-dir", npmDir],
+    { encoding: "utf8" },
+  );
+}
+
+test("stamps launcher + all 6 platform packages with the asymmetric libc gate", (t) => {
+  const { npmDir, artifacts } = scaffold(t);
+  const r = run(npmDir, artifacts, "1.2.3");
+  assert.equal(r.status, 0, r.stderr);
+
+  const launcher = JSON.parse(readFileSync(join(npmDir, "pixtuoid", "package.json"), "utf8"));
+  assert.equal(launcher.version, "1.2.3", "launcher version stamped");
+
+  for (const tg of TARGETS) {
+    const name = `@pixtuoid/cli-${tg.pkg}`;
+    assert.equal(launcher.optionalDependencies[name], "1.2.3", `${name} pinned in launcher`);
+
+    const pkgPath = join(npmDir, "@pixtuoid", `cli-${tg.pkg}`, "package.json");
+    assert.ok(existsSync(pkgPath), `${name} package.json written`);
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+    assert.equal(pkg.version, "1.2.3");
+    assert.deepEqual(pkg.os, [tg.os]);
+    assert.deepEqual(pkg.cpu, [tg.cpu]);
+
+    // The libc gate is the load-bearing asymmetry: ONLY linux-arm64 (glibc
+    // build) declares it; the static-musl linux-x64 and everything else omit it.
+    if (tg.libc) assert.deepEqual(pkg.libc, tg.libc, `${name} declares libc`);
+    else assert.equal("libc" in pkg, false, `${name} omits libc`);
+
+    // Each package ships BOTH binaries, with the .exe suffix only on win32.
+    const ext = tg.win ? ".exe" : "";
+    assert.deepEqual(pkg.files.sort(), ["pixtuoid" + ext, "pixtuoid-hook" + ext].sort());
+    for (const f of pkg.files) {
+      assert.ok(existsSync(join(npmDir, "@pixtuoid", `cli-${tg.pkg}`, f)), `${f} copied`);
+    }
+  }
+});
+
+test("accepts a prerelease semver", (t) => {
+  const { npmDir, artifacts } = scaffold(t);
+  assert.equal(run(npmDir, artifacts, "0.6.0-rc.1").status, 0);
+});
+
+test("rejects a non-semver version without writing", (t) => {
+  const { npmDir, artifacts } = scaffold(t);
+  const r = run(npmDir, artifacts, "1.2"); // not X.Y.Z
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /non-semver/);
+  // launcher must be untouched on a guard failure
+  const launcher = JSON.parse(readFileSync(join(npmDir, "pixtuoid", "package.json"), "utf8"));
+  assert.equal(launcher.version, "0.0.0");
+});
+
+test("throws when a target's prebuilt binary is missing", (t) => {
+  const { npmDir, artifacts } = scaffold(t, { skip: "x86_64-unknown-linux-musl" });
+  const r = run(npmDir, artifacts, "1.2.3");
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /missing prebuilt binary for x86_64-unknown-linux-musl/);
+});

--- a/npm/pixtuoid/bin/pixtuoid
+++ b/npm/pixtuoid/bin/pixtuoid
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+"use strict";
+
+// Launcher shim for the `pixtuoid` TUI. Resolves the native binary from the
+// platform package and execs it transparently. An interactive TUI has no
+// latency/exit-0 contract, so this may report an error and exit non-zero.
+
+const { binaryPath } = require("./resolve");
+
+const bin = binaryPath("pixtuoid");
+if (!bin) {
+  process.stderr.write(
+    "pixtuoid: no prebuilt binary for " +
+      process.platform +
+      "-" +
+      process.arch +
+      ".\n" +
+      "Install with `cargo install pixtuoid pixtuoid-hook`, or download a build:\n" +
+      "https://github.com/IvanWng97/pixtuoid/releases/latest\n"
+  );
+  process.exit(1);
+}
+
+const result = require("child_process").spawnSync(bin, process.argv.slice(2), {
+  stdio: "inherit",
+  shell: false,
+});
+if (result.error) {
+  process.stderr.write("pixtuoid: " + result.error.message + "\n");
+  process.exit(1);
+}
+process.exit(result.status == null ? 1 : result.status);

--- a/npm/pixtuoid/bin/pixtuoid-hook
+++ b/npm/pixtuoid/bin/pixtuoid-hook
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+"use strict";
+
+// Launcher shim for `pixtuoid-hook` — the shim CC/Codex/Reasonix invoke on every
+// hook event. INVARIANT #5 is sacred here: NEVER block the agent. So this shim
+// ALWAYS exits 0, NEVER writes to stderr, and NEVER throws — on any failure it
+// exits 0 silently (the visualizer just misses that event; the agent is never
+// blocked). It forwards the JSON payload (stdin) to the native shim, which
+// self-bounds to 200ms.
+//
+// NOTE: a Node hop adds ~tens of ms in front of the native shim. That stays well
+// within CC's hook tolerance, but the latency-optimal path is to have
+// `install-hooks` write the ABSOLUTE path of the sibling native pixtuoid-hook
+// (zero Node hop) — tracked as a follow-up. Until then, do not "optimize" this
+// shim into anything that could exit non-zero or print on error.
+
+try {
+  const { binaryPath } = require("./resolve");
+  const bin = binaryPath("pixtuoid-hook");
+  if (!bin) {
+    process.exit(0);
+  }
+  require("child_process").spawnSync(bin, process.argv.slice(2), {
+    stdio: "inherit",
+    shell: false,
+  });
+  // Exit 0 UNCONDITIONALLY. The hook's exit code is not consumed by the
+  // visualizer — only "never block the agent" matters — so invariant #5 holds
+  // STRUCTURALLY here, not by depending on the native binary always exiting 0.
+  process.exit(0);
+} catch (_e) {
+  process.exit(0);
+}

--- a/npm/pixtuoid/bin/resolve.js
+++ b/npm/pixtuoid/bin/resolve.js
@@ -1,0 +1,67 @@
+"use strict";
+
+// Shared platform → native-binary resolution for the two launcher shims.
+//
+// Mirrors the esbuild / Biome / git-cliff pattern: npm installs exactly the ONE
+// `@pixtuoid/cli-<platform>-<arch>` optionalDependency that matches the host
+// (filtered by each platform package's `os`/`cpu`/`libc`), and we
+// `require.resolve` the native binary out of it. No postinstall, no download.
+
+const fs = require("fs");
+const path = require("path");
+
+// pixtuoid's matrix is ASYMMETRIC — exactly one package per (platform, arch),
+// so there is no runtime gnu-vs-musl choice to make here:
+//   • linux-x64   ships a STATIC musl build (portable to glibc too) — the
+//     package declares no `libc`, so it installs on every linux-x64 host.
+//   • linux-arm64 ships a glibc build — its package declares `libc:["glibc"]`,
+//     so npm skips it on musl/Alpine-arm64 (where it would crash) rather than
+//     installing a broken binary.
+// The os/cpu/libc filtering happens at npm INSTALL time; here we just map.
+const PACKAGE = {
+  "darwin arm64": "@pixtuoid/cli-darwin-arm64",
+  "darwin x64": "@pixtuoid/cli-darwin-x64",
+  "linux x64": "@pixtuoid/cli-linux-x64",
+  "linux arm64": "@pixtuoid/cli-linux-arm64",
+  "win32 x64": "@pixtuoid/cli-win32-x64",
+  "win32 arm64": "@pixtuoid/cli-win32-arm64",
+};
+
+function exeName(bin) {
+  return bin + (process.platform === "win32" ? ".exe" : "");
+}
+
+// Resolve the absolute path to a named native binary ("pixtuoid" or
+// "pixtuoid-hook"). Returns null if this platform isn't shipped — callers
+// decide how to handle that (the TUI errors; the hook stays silent).
+function binaryPath(bin) {
+  // Dev / CI override: PIXTUOID_BINARY points at a directory holding the
+  // binaries (or at the pixtuoid binary itself). Lets a local debug build be
+  // driven through the npm shim without publishing; composes with the Rust-side
+  // PIXTUOID_HOOK override used by install-hooks.
+  const override = process.env.PIXTUOID_BINARY;
+  if (override) {
+    // One guarded statSync (not existsSync + statSync) — the two-syscall form
+    // can throw ENOENT on a delete-between-calls race, and binaryPath() must
+    // return null, never throw (the hook shim relies on it).
+    let st = null;
+    try {
+      st = fs.statSync(override);
+    } catch (_e) {
+      st = null;
+    }
+    const dir = st && st.isDirectory() ? override : path.dirname(override);
+    const p = path.join(dir, exeName(bin));
+    if (fs.existsSync(p)) return p;
+  }
+
+  const pkg = PACKAGE[process.platform + " " + process.arch];
+  if (!pkg) return null;
+  try {
+    return require.resolve(pkg + "/" + exeName(bin));
+  } catch (_e) {
+    return null;
+  }
+}
+
+module.exports = { binaryPath, exeName };

--- a/npm/pixtuoid/package.json
+++ b/npm/pixtuoid/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "pixtuoid",
+  "version": "0.0.0",
+  "description": "Terminal-native pixel-art visualizer for AI coding agents — watch Claude Code, Codex, Antigravity & Reasonix sessions as coworkers in an ASCII office.",
+  "keywords": [
+    "cli",
+    "tui",
+    "claude-code",
+    "codex",
+    "pixel-art",
+    "ai-agents",
+    "visualizer"
+  ],
+  "homepage": "https://github.com/IvanWng97/pixtuoid",
+  "bugs": {
+    "url": "https://github.com/IvanWng97/pixtuoid/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/IvanWng97/pixtuoid.git"
+  },
+  "license": "MIT",
+  "bin": {
+    "pixtuoid": "bin/pixtuoid",
+    "pixtuoid-hook": "bin/pixtuoid-hook"
+  },
+  "files": [
+    "bin/"
+  ],
+  "optionalDependencies": {
+    "@pixtuoid/cli-darwin-arm64": "0.0.0",
+    "@pixtuoid/cli-darwin-x64": "0.0.0",
+    "@pixtuoid/cli-linux-x64": "0.0.0",
+    "@pixtuoid/cli-linux-arm64": "0.0.0",
+    "@pixtuoid/cli-win32-x64": "0.0.0",
+    "@pixtuoid/cli-win32-arm64": "0.0.0"
+  }
+}


### PR DESCRIPTION
Adds the **npm** install channel — `npm i -g pixtuoid` — pulling **prebuilt** binaries (no Rust toolchain), the any-OS one-liner that closes the Windows gap and serves the CC/Codex audience who all have Node.

Modeled on the proven **esbuild / Biome / git-cliff** pattern: `optionalDependencies` + per-platform packages + a launcher shim. **No `postinstall`**, `--ignore-scripts`-safe. The publish job consumes the binaries `release.yml` **already ships in its tarballs** — no rebuild.

## How it works

`npm i -g pixtuoid` → launcher (pure JS) whose `optionalDependencies` let npm install **only** the one `@pixtuoid/cli-<platform>-<arch>` package matching the host (by `os`/`cpu`/`libc`); the launcher's shims `require.resolve` the native binary out of it and exec it.

```
npm/
├── pixtuoid/                       launcher: bin {pixtuoid, pixtuoid-hook} + resolve.js
│   └── bin/{pixtuoid,pixtuoid-hook,resolve.js}
├── generate.mjs                    emits the 6 platform packages + stamps versions
├── README.md  └── .gitignore       (generated @pixtuoid/cli-* are NOT committed)
```

## Four deltas from Biome (the design decisions)

1. **Two binaries** — each platform package carries both `pixtuoid` + `pixtuoid-hook`; the launcher exposes both commands.
2. **The hook shim honors invariant #5** — `bin/pixtuoid-hook` exits 0 **unconditionally**, never writes stderr, never throws (it can never block the agent). The TUI shim may error normally.
3. **Asymmetric 6-target matrix** (matches the build matrix): `linux-x64` is the static-musl/universal build (no `libc` gate), `linux-arm64` is glibc-gated (skips Alpine-arm64); the rest plain `os`/`cpu`.
4. **Version sourced from the git tag** (the generator stamps it), reusing the existing tag-triggered, pre-release-gated publish — no second version source.

## Verification

- **Locally validated** with the real release binaries: shim resolution + exec + arg passthrough, the `PIXTUOID_BINARY` override, the hook's exit-0 on every failure path, the generator's `os`/`cpu`/`libc` output, and the CI tarball-extraction path. YAML parses; `npm` job registered.
- **Multi-agent review** (shims / generator / release-pipeline, each finding adversarially verified): **4 confirmed (1 high + 3 low), ALL fixed in this PR**; 3 refuted.
  - *(high)* the idempotency grep matched bare `403` → would have silently swallowed an auth/scope/2FA failure on the irreversible first publish. Now matches only the over-publish phrase.
  - *(low)* hook shim now exits 0 *structurally*, not by forwarding the child status; *(low)* `PIXTUOID_BINARY` override TOCTOU hardened; *(low)* dropped the half-honored `--out` flag.
- **Cannot run end-to-end until the stable `v0.6.0` tag** — the job is pre-release-gated (like crates.io/homebrew) and `npm publish` is ~irreversible.

## ⚠️ Pre-merge / pre-tag checklist (operator)

- [ ] **Reserve `pixtuoid` + the `@pixtuoid` org/scope on npm** (or the publish job fails mid-release / a squatter grabs them)
- [ ] **Add the `NPM_TOKEN` repo secret** (automation/granular token with publish on `@pixtuoid` + `pixtuoid`)
- [ ] First real run is the **stable v0.6.0 tag** — pre-release tags (`-win.N`/`-rc`) skip it by design

## Follow-ups (separate PRs, not here)

- Zero-Node-hop hook path (have `install-hooks` target the sibling native binary's absolute path — eliminates the launcher hop for the hot path)
- The README / `install.json` **install-doc simplification** to the brew / npm / cargo / Releases matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)