### PR TITLE
docs(release): curate release_notes("0.6.0") — npm + Reasonix headliners

### DIFF
--- a/crates/pixtuoid/src/version.rs
+++ b/crates/pixtuoid/src/version.rs
@@ -65,8 +65,10 @@ pub fn release_notes(version: &str) -> Option<&'static [&'static str]> {
         // tagging.
         "0.6.0" => Some(&[
             "Windows support — native hook transport, installer, and release builds",
+            "Install via npm — `npm i -g pixtuoid` now works on macOS, Linux & Windows",
+            "Reasonix sessions now visualized — re-run `pixtuoid install-hooks` to wire it",
+            "Sharper agent activity — fewer ghost & duplicate sprites, and Codex stays active during web & tool search",
             "Diagnostics you can see — source-death footer warnings, config warnings on stderr, an always-on log file",
-            "Sharper agent activity — fewer ghost & duplicate sprites (hook/JSONL dedup, subagent completion-cascade, permission-gate race fixes), and Codex stays active during web & tool search",
             "New project site — live demos, architecture & contributing docs, weather gallery",
         ]),
         "0.4.0" => Some(&[


### PR DESCRIPTION
## Summary

Re-curates the in-app `release_notes("0.6.0")` living draft before the v0.6.0 tag, per the "re-curate from `git log v0.5.0..HEAD` before tagging" note in `version.rs`.

- **Adds** the two headliners that landed after the draft was written: the npm install channel (#183) and Reasonix support (#181).
- **Reorders** by user impact (Windows → npm → Reasonix → activity → diagnostics → site).
- **Trims** the internal parenthetical from the agent-activity bullet.

Six highlights total. Strings-only; the `current_version_has_release_notes` / `release_notes_known_version` tests pass.

## Type of change
- [x] Docs / release prep (user-facing copy)