### PR TITLE
fix(release): publish npm dirs via ./ (launcher shorthand bug)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -420,5 +420,8 @@ jobs:
           }
           # Platform packages first so the launcher's optionalDependencies always
           # resolve to already-live versions; the launcher publishes last.
-          for dir in npm/@pixtuoid/cli-*; do publish_one "$dir"; done
-          publish_one npm/pixtuoid
+          # The `./` prefix is load-bearing: `npm publish npm/pixtuoid` parses the
+          # path as a GitHub `owner/repo` shorthand (npm/pixtuoid) and tries to
+          # `git ls-remote` it; `./npm/pixtuoid` forces folder interpretation.
+          for dir in ./npm/@pixtuoid/cli-*; do publish_one "$dir"; done
+          publish_one ./npm/pixtuoid


### PR DESCRIPTION
## Summary

The v0.6.0 release published all 6 `@pixtuoid/cli-*` packages but the **launcher `pixtuoid` failed**: `npm publish npm/pixtuoid` makes npm parse the path `npm/pixtuoid` as a GitHub `owner/repo` shorthand and run `git ls-remote ssh://git@github.com/npm/pixtuoid.git` (code 128). The scoped dirs dodge it (the `@`/extra segment breaks the shorthand).

Fix: prefix every publish dir with `./` so npm reads it as a folder, not a git spec.

Surfaced only on the first real publish (the npm job never ran before the tag). Once merged, re-tagging v0.6.0 re-runs the release; crates.io + the 6 platform packages skip idempotently and the launcher publishes (with provenance).

## Type of change
- [x] Bug fix (release pipeline)