### PR TITLE
chore(release): bump to 0.6.1 — complete the npm publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1388,7 +1388,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pixtuoid"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1414,7 +1414,7 @@ dependencies = [
 
 [[package]]
 name = "pixtuoid-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "filetime",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "pixtuoid-hook"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members  = [
 ]
 
 [workspace.package]
-version      = "0.6.0"
+version      = "0.6.1"
 edition      = "2021"
 rust-version = "1.78"
 license      = "MIT"

--- a/crates/pixtuoid/Cargo.toml
+++ b/crates/pixtuoid/Cargo.toml
@@ -16,7 +16,7 @@ name = "pixtuoid"
 path = "src/main.rs"
 
 [dependencies]
-pixtuoid-core  = { path = "../pixtuoid-core", version = "0.6.0" }
+pixtuoid-core  = { path = "../pixtuoid-core", version = "0.6.1" }
 tokio              = { workspace = true, features = ["rt-multi-thread", "macros", "signal", "sync", "time", "net", "fs", "io-util"] }
 ratatui            = { workspace = true }
 crossterm          = { workspace = true }

--- a/crates/pixtuoid/src/version.rs
+++ b/crates/pixtuoid/src/version.rs
@@ -58,6 +58,18 @@ pub fn release_notes(version: &str) -> Option<&'static [&'static str]> {
         // anchoring on a marker is whitespace-independent — matching the `match`
         // brace would silently break if the indentation ever shifted.
         // [bump-inject-here]
+        // 0.6.1 re-runs the 0.6.0 release with the npm-launcher publish fix
+        // (#186) — 0.6.0 shipped to crates.io/homebrew but the `pixtuoid` npm
+        // launcher failed, so 0.6.1 is the first fully-published version. Same
+        // highlights, since most users first land here.
+        "0.6.1" => Some(&[
+            "Windows support — native hook transport, installer, and release builds",
+            "Install via npm — `npm i -g pixtuoid` on macOS, Linux & Windows",
+            "Reasonix sessions now visualized — re-run `pixtuoid install-hooks` to wire it",
+            "Sharper agent activity — fewer ghost & duplicate sprites, and Codex stays active during web & tool search",
+            "Diagnostics you can see — source-death footer warnings, config warnings on stderr, an always-on log file",
+            "New project site — live demos, architecture & contributing docs, weather gallery",
+        ]),
         // LIVING DRAFT — 0.6.0 is the open breaking-dev window: the version is
         // bumped at window START so the CI semver gate admits the batched
         // breaking changes (#145, #131, …); the tag/publish only happens when


### PR DESCRIPTION
0.6.0 shipped to crates.io + homebrew + the 6 `@pixtuoid/cli-*` packages, but the `pixtuoid` npm launcher failed (npm parsed the `npm/pixtuoid` path as a GitHub shorthand; fixed in #186). **0.6.1 is a clean forward-fix re-release** — with the fixed workflow, the tag publishes all 7 npm packages + crates.io + homebrew.

- `cargo set-version 0.6.1` (workspace + path-dep + Cargo.lock)
- `release_notes("0.6.1")` carries 0.6.0's highlights (first fully-published version)

## Type of change
- [x] Release