### PR TITLE
docs(install): feature npm + drop deb

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,19 @@ A little bit *Black Mirror*, a little bit *The Sims* — and the most glanceable
 
 Pick one — Homebrew on macOS, or npm on any OS:
 
+<!-- install:start · generated from site/src/install.json by `just gen-readme` — edit the JSON, not this block -->
+**Homebrew** (macOS):
+
 ```bash
 brew install IvanWng97/pixtuoid/pixtuoid
 ```
 
+**npm** (any OS):
+
 ```bash
 npm install -g pixtuoid
 ```
+<!-- install:end -->
 
 Then wire up your agent and launch:
 
@@ -64,47 +70,7 @@ In another terminal, start a supported coding agent (Claude Code, Codex, Antigra
 
 **Keyboard shortcuts:** `q` quit · `p` pause · `t` themes · `?` help · `↑↓/jk/PgUp/PgDn` floors · click to pin tooltip
 
-<details>
-<summary><strong>More install methods</strong></summary>
-
-**Both packages are required** — `pixtuoid` (the visualizer) and `pixtuoid-hook` (the shim your agent invokes). Homebrew and npm bundle both; with Cargo or the raw binaries, grab both.
-
-### Cargo
-
-```bash
-cargo install pixtuoid pixtuoid-hook
-```
-
-### Pre-built binaries
-
-Download from [GitHub Releases](https://github.com/IvanWng97/pixtuoid/releases/latest):
-
-| Platform | Tarball |
-|---|---|
-| macOS (Apple Silicon) | `pixtuoid-v*-aarch64-apple-darwin.tar.gz` |
-| macOS (Intel) | `pixtuoid-v*-x86_64-apple-darwin.tar.gz` |
-| Linux (x86_64, static) | `pixtuoid-v*-x86_64-unknown-linux-musl.tar.gz` |
-| Linux (ARM64) | `pixtuoid-v*-aarch64-unknown-linux-gnu.tar.gz` |
-
-### Windows
-
-[`npm install -g pixtuoid`](#quick-start) is the simplest route. Support is
-experimental — Claude Code only so far (see the [matrix](#supported-tools)) and
-the binaries are unsigned, so you'll want
-[Windows Terminal](https://aka.ms/terminal). Standalone `.zip`s
-(`x86_64-` / `aarch64-pc-windows-msvc`) are on the
-[Releases page](https://github.com/IvanWng97/pixtuoid/releases).
-
-### From source
-
-```bash
-git clone https://github.com/IvanWng97/pixtuoid && cd pixtuoid
-just build --release
-```
-
-Upgrading from `ascii-agents` v0.3.x? See [docs/MIGRATION.md](docs/MIGRATION.md).
-
-</details>
+**More ways to install** — Cargo, prebuilt binaries, and Debian `.deb`s — are on the **[install guide ↗](https://ivanwng97.github.io/pixtuoid/#install)**. Upgrading from `ascii-agents`? See [docs/MIGRATION.md](docs/MIGRATION.md).
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -69,19 +69,6 @@ In another terminal, start a supported coding agent (Claude Code, Codex, Antigra
 
 **Both packages are required** — `pixtuoid` (the visualizer) and `pixtuoid-hook` (the shim your agent invokes). Homebrew and npm bundle both; with Cargo or the raw binaries, grab both.
 
-### npm (macOS · Linux · Windows)
-
-```bash
-npm install -g pixtuoid
-```
-
-The one-liner that works everywhere — npm fetches the prebuilt binary for your
-platform (no Rust toolchain, no compile). This is the recommended **Windows**
-install; it needs [Windows Terminal](https://aka.ms/terminal) (the Windows 11
-default). A standalone `.zip` (`x86_64-` / `aarch64-pc-windows-msvc`) is also on
-the [Releases page](https://github.com/IvanWng97/pixtuoid/releases) if you'd
-rather not use npm.
-
 ### Cargo
 
 ```bash
@@ -98,6 +85,15 @@ Download from [GitHub Releases](https://github.com/IvanWng97/pixtuoid/releases/l
 | macOS (Intel) | `pixtuoid-v*-x86_64-apple-darwin.tar.gz` |
 | Linux (x86_64, static) | `pixtuoid-v*-x86_64-unknown-linux-musl.tar.gz` |
 | Linux (ARM64) | `pixtuoid-v*-aarch64-unknown-linux-gnu.tar.gz` |
+
+### Windows
+
+[`npm install -g pixtuoid`](#quick-start) is the simplest route. Support is
+experimental — Claude Code only so far (see the [matrix](#supported-tools)) and
+the binaries are unsigned, so you'll want
+[Windows Terminal](https://aka.ms/terminal). Standalone `.zip`s
+(`x86_64-` / `aarch64-pc-windows-msvc`) are on the
+[Releases page](https://github.com/IvanWng97/pixtuoid/releases).
 
 ### From source
 
@@ -138,12 +134,14 @@ Upgrading from `ascii-agents` v0.3.x? See [docs/MIGRATION.md](docs/MIGRATION.md)
 <!-- tools:start · generated from site/src/sources.json by `just gen-readme` — edit the JSON, not this table -->
 | Tool | Runs on |
 |---|---|
-| [Claude Code](https://code.claude.com) | macOS · Linux · Windows |
+| [Claude Code](https://code.claude.com) | macOS · Linux · Windows\* |
 | [Codex CLI](https://github.com/openai/codex) | macOS · Linux |
 
 _Also supported: [Antigravity CLI](https://github.com/antiGravity-AI/antigravity-cli), [DeepSeek-Reasonix](https://github.com/esengine/DeepSeek-Reasonix). Planned: Copilot CLI, OpenCode, Cursor CLI._
 
 **→ [Full tool × OS support matrix on the site](https://ivanwng97.github.io/pixtuoid/#tools)**
+
+_\* experimental — limited testing, unsigned binaries._
 <!-- tools:end -->
 
 > Adding a new tool? Implement the [`Source` trait](#contributing) — or, for a hook-only CLI, just a hook decoder + an `install-hooks` target — then add a row to [`site/src/sources.json`](site/src/sources.json) (its `supported` set is pinned to the code by a test). One file, one channel, done.

--- a/README.md
+++ b/README.md
@@ -43,8 +43,19 @@ A little bit *Black Mirror*, a little bit *The Sims* — and the most glanceable
 
 ## Quick Start
 
+Pick one — Homebrew on macOS, or npm on any OS:
+
 ```bash
 brew install IvanWng97/pixtuoid/pixtuoid
+```
+
+```bash
+npm install -g pixtuoid
+```
+
+Then wire up your agent and launch:
+
+```bash
 pixtuoid install-hooks
 pixtuoid
 ```
@@ -56,7 +67,26 @@ In another terminal, start a supported coding agent (Claude Code, Codex, Antigra
 <details>
 <summary><strong>More install methods</strong></summary>
 
-**Both packages are required** — `pixtuoid` (the visualizer) and `pixtuoid-hook` (the shim your agent invokes).
+**Both packages are required** — `pixtuoid` (the visualizer) and `pixtuoid-hook` (the shim your agent invokes). Homebrew and npm bundle both; with Cargo or the raw binaries, grab both.
+
+### npm (macOS · Linux · Windows)
+
+```bash
+npm install -g pixtuoid
+```
+
+The one-liner that works everywhere — npm fetches the prebuilt binary for your
+platform (no Rust toolchain, no compile). This is the recommended **Windows**
+install; it needs [Windows Terminal](https://aka.ms/terminal) (the Windows 11
+default). A standalone `.zip` (`x86_64-` / `aarch64-pc-windows-msvc`) is also on
+the [Releases page](https://github.com/IvanWng97/pixtuoid/releases) if you'd
+rather not use npm.
+
+### Cargo
+
+```bash
+cargo install pixtuoid pixtuoid-hook
+```
 
 ### Pre-built binaries
 
@@ -68,34 +98,6 @@ Download from [GitHub Releases](https://github.com/IvanWng97/pixtuoid/releases/l
 | macOS (Intel) | `pixtuoid-v*-x86_64-apple-darwin.tar.gz` |
 | Linux (x86_64, static) | `pixtuoid-v*-x86_64-unknown-linux-musl.tar.gz` |
 | Linux (ARM64) | `pixtuoid-v*-aarch64-unknown-linux-gnu.tar.gz` |
-
-Debian/Ubuntu `.deb`s (amd64/arm64) are on the same page — install the binary
-**and** the hook shim:
-
-```bash
-sudo dpkg -i pixtuoid_*.deb pixtuoid-hook_*.deb
-```
-
-### Cargo
-
-```bash
-cargo install pixtuoid pixtuoid-hook
-```
-
-### Windows (experimental)
-
-Requires [Windows Terminal](https://aka.ms/terminal) (the Windows 11 default).
-Claude Code only for now — Codex support is coming.
-
-1. Download `pixtuoid-<version>-x86_64-pc-windows-msvc.zip` from the
-   [latest release](https://github.com/IvanWng97/pixtuoid/releases)
-2. Unblock before extracting (the exes are unsigned — SmartScreen marks
-   downloads): right-click the zip → Properties → Unblock, or
-   `Unblock-File .\pixtuoid-*.zip` in PowerShell
-3. Extract anywhere and add the folder to your PATH
-4. `pixtuoid install-hooks` then `pixtuoid run`
-
-ARM64 Windows: use the `aarch64-pc-windows-msvc` zip.
 
 ### From source
 

--- a/crates/pixtuoid-core/tests/supported_sources_manifest.rs
+++ b/crates/pixtuoid-core/tests/supported_sources_manifest.rs
@@ -108,8 +108,8 @@ fn manifest_rows_are_well_formed() {
                 .and_then(|v| v.as_str())
                 .unwrap_or_else(|| panic!("{name}: `platforms.{os}` missing/not a string"));
             assert!(
-                matches!(v, "yes" | "planned" | "no"),
-                "{name}: `platforms.{os}` must be yes|planned|no, got {v:?}"
+                matches!(v, "yes" | "experimental" | "planned" | "no"),
+                "{name}: `platforms.{os}` must be yes|experimental|planned|no, got {v:?}"
             );
         }
 

--- a/site/README.md
+++ b/site/README.md
@@ -41,12 +41,15 @@ From the repo root the same gate is `just site-check` (and `just site-fmt`).
 > its Features table and install commands are sourced from `src/features.json` /
 > `src/install.json` (see below), and `readme:check` fails on drift.
 
-> **Generated README sections.** `src/features.json` (the feature inventory — also
-> drives the Features bento) and `src/install.json` (the canonical install commands —
-> also drives the Install tabs) are single sources shared with the **root README**:
-> `scripts/gen-readme.mjs` regenerates the README's Features table between its
-> markers and checks each `readmeCheck` install command appears verbatim. Edit the
-> JSON → run `just gen-readme` (or `npm run readme:gen`); CI runs `readme:check`.
+> **Generated README sections.** `src/features.json` (feature inventory — also
+> drives the Features bento), `src/sources.json` (supported tools — also drives the
+> tool × OS matrix), and `src/install.json` (install methods — also drives the
+> Install tabs) are single sources shared with the **root README**:
+> `scripts/gen-readme.mjs` regenerates the Features table, the supported-tools
+> glimpse, and the install block between their markers. The install block shows
+> only methods flagged `"readme": true` (Homebrew, npm); the rest (Cargo, GitHub
+> Releases) stay site-only. Edit the JSON → run `just gen-readme` (or
+> `npm run readme:gen`); CI runs `readme:check` and fails on drift.
 
 ## Design
 

--- a/site/scripts/gen-readme.mjs
+++ b/site/scripts/gen-readme.mjs
@@ -78,9 +78,12 @@ regenSection(
 const OS_LABELS = { macos: 'macOS', linux: 'Linux', windows: 'Windows' };
 const OS_ORDER = ['macos', 'linux', 'windows'];
 const runsOn = (s) =>
-  OS_ORDER.filter((os) => s.platforms?.[os] === 'yes')
-    .map((os) => OS_LABELS[os])
+  OS_ORDER.filter((os) => s.platforms?.[os] === 'yes' || s.platforms?.[os] === 'experimental')
+    .map((os) => (s.platforms[os] === 'experimental' ? `${OS_LABELS[os]}\\*` : OS_LABELS[os]))
     .join(' · ');
+const hasExperimental = sources.some(
+  (s) => s.status === 'supported' && Object.values(s.platforms || {}).includes('experimental')
+);
 
 const featured = sources.filter((s) => s.status === 'supported' && s.featured);
 const otherSupported = sources.filter((s) => s.status === 'supported' && !s.featured);
@@ -104,6 +107,7 @@ regenSection(
     ...featured.map((s) => `| ${link(s)} | ${cell(runsOn(s)) || '—'} |`),
     '',
     alsoLine + `**→ [Full tool × OS support matrix on the site](${SITE}/#tools)**`,
+    ...(hasExperimental ? ['', '_\\* experimental — limited testing, unsigned binaries._'] : []),
   ].join('\n')
 );
 

--- a/site/scripts/gen-readme.mjs
+++ b/site/scripts/gen-readme.mjs
@@ -2,7 +2,7 @@
 // Keep the README in sync with the site's single-source data files:
 //   • Features table          ← site/src/features.json  (GENERATED between markers)
 //   • Supported-tools glimpse ← site/src/sources.json   (GENERATED between markers)
-//   • install commands        ← site/src/install.json   (CHECKED — must appear verbatim)
+//   • Install block           ← site/src/install.json   (GENERATED — `readme:true` methods only)
 // The site (Features.astro / SupportedTools.astro / Install.astro) reads the same
 // JSON, so the README and the site can't drift. The supported-tools glimpse shows
 // only the FEATURED tools + a link to the full tool × OS matrix on the site, so the
@@ -111,31 +111,33 @@ regenSection(
   ].join('\n')
 );
 
-// --- Install commands (checked, not generated — the README install prose is
-// hand-curated, but every canonical command must appear in it verbatim) ---
-// Line-anchored (not substring): a README line that grew a flag (e.g.
-// `... pixtuoid-hook --locked`) must FAIL, or the site would silently keep
-// recommending the shorter command. Comment lines (#…) are site-tab
-// presentation, not commands — skip them.
-const readmeLines = new Set(readme.split('\n').map((l) => l.trim()));
-for (const m of install) {
-  if (!m.readmeCheck) continue; // site-only method
-  for (const cmd of m.cmds) {
-    if (cmd.trimStart().startsWith('#')) continue;
-    if (!readmeLines.has(cmd)) {
-      errors.push(
-        `README is missing the ${m.label} install command from install.json as its own line: \`${cmd}\` — update the README to match, or fix install.json.`
-      );
-    }
-  }
-}
+// --- Install block (GENERATED, like features/sources). The README shows only
+// the `readme: true` methods (brew, npm); the rest (Cargo, GitHub Releases) live
+// on the site's install tab. Single source: site/src/install.json — the same
+// file Install.astro renders, so the two can't drift. ---
+const installBody = install
+  .filter((m) => m.readme)
+  .map(
+    (m) =>
+      `**${cell(m.label)}**${m.blurb ? ` (${cell(m.blurb)})` : ''}:\n\n\`\`\`bash\n${m.cmds.join('\n')}\n\`\`\``
+  )
+  .join('\n\n');
+regenSection(
+  'Install block',
+  '<!-- install:start · generated from site/src/install.json by `just gen-readme` — edit the JSON, not this block -->',
+  '<!-- install:end -->',
+  installBody
+);
 
 if (errors.length) {
   console.error(errors.map((e) => `✗ ${e}`).join('\n'));
   process.exit(1);
 }
-if (check) console.log('README is in sync with features.json + sources.json + install.json ✓');
-else console.log('README install commands match install.json ✓');
+console.log(
+  check
+    ? 'README is in sync with features.json + sources.json + install.json ✓'
+    : 'README regenerated from features.json + sources.json + install.json ✓'
+);
 
 function escapeRe(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -2,8 +2,9 @@
 import { Code } from 'astro:components';
 import { REPO, CRATES } from '../consts';
 // Single source of truth for install commands → site/src/install.json. The README
-// is checked against the same file (readme:check), so the site and the README's
-// install commands can't drift (this is what let the Cargo command go stale).
+// regenerates its install block from the same file (readme:check), so the site and
+// README can't drift — the site shows every method, the README only the ones
+// flagged `readme: true`.
 import tabs from '../install.json';
 ---
 
@@ -13,7 +14,9 @@ import tabs from '../install.json';
       <p class="eyebrow">Get it</p>
       <h2>Install pixtuoid.</h2>
       <p class="lead">
-        macOS, Linux &amp; Windows. Then <code>pixtuoid install-hooks</code> and <code>pixtuoid run</code>.
+        macOS, Linux &amp; Windows. Then <code>pixtuoid install-hooks</code> and <code
+          >pixtuoid run</code
+        >.
       </p>
     </div>
 

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -13,7 +13,7 @@ import tabs from '../install.json';
       <p class="eyebrow">Get it</p>
       <h2>Install pixtuoid.</h2>
       <p class="lead">
-        macOS &amp; Linux. Then <code>pixtuoid install-hooks</code> and <code>pixtuoid run</code>.
+        macOS, Linux &amp; Windows. Then <code>pixtuoid install-hooks</code> and <code>pixtuoid run</code>.
       </p>
     </div>
 

--- a/site/src/components/SupportedTools.astro
+++ b/site/src/components/SupportedTools.astro
@@ -8,19 +8,20 @@ import { asset } from '../consts';
 // (crates/pixtuoid-core/tests/supported_sources_manifest.rs) — so this matrix,
 // the README glimpse, and what's actually wired can't drift.
 
-type OsState = 'yes' | 'planned' | 'no';
+type OsState = 'yes' | 'experimental' | 'planned' | 'no';
 const OSES = [
   { key: 'macos', label: 'macOS' },
   { key: 'linux', label: 'Linux' },
   { key: 'windows', label: 'Windows' },
 ] as const;
-const GLYPH: Record<OsState, string> = { yes: '✅', planned: '🔜', no: '—' };
+const GLYPH: Record<OsState, string> = { yes: '✅', experimental: '🧪', planned: '🔜', no: '—' };
 const glyph = (s: string): string => GLYPH[s as OsState] ?? '—';
 // Screen-reader text for each cell. The emoji carries the value visually but is
 // aria-hidden (aria-label on a roleless <span> is naming-prohibited and gets
 // dropped), so the real value rides a visually-hidden sibling.
 const STATE_LABEL: Record<OsState, string> = {
   yes: 'supported',
+  experimental: 'experimental',
   planned: 'planned',
   no: 'not supported',
 };

--- a/site/src/install.json
+++ b/site/src/install.json
@@ -6,18 +6,15 @@
     "readmeCheck": true
   },
   {
-    "id": "cargo",
-    "label": "Cargo",
-    "cmds": ["cargo install pixtuoid pixtuoid-hook"],
+    "id": "npm",
+    "label": "npm",
+    "cmds": ["npm install -g pixtuoid"],
     "readmeCheck": true
   },
   {
-    "id": "deb",
-    "label": "Debian",
-    "cmds": [
-      "# download both .debs from the Releases page",
-      "sudo dpkg -i pixtuoid_*.deb pixtuoid-hook_*.deb"
-    ],
+    "id": "cargo",
+    "label": "Cargo",
+    "cmds": ["cargo install pixtuoid pixtuoid-hook"],
     "readmeCheck": true
   }
 ]

--- a/site/src/install.json
+++ b/site/src/install.json
@@ -2,19 +2,30 @@
   {
     "id": "brew",
     "label": "Homebrew",
+    "blurb": "macOS",
     "cmds": ["brew install IvanWng97/pixtuoid/pixtuoid"],
-    "readmeCheck": true
+    "readme": true
   },
   {
     "id": "npm",
     "label": "npm",
+    "blurb": "any OS",
     "cmds": ["npm install -g pixtuoid"],
-    "readmeCheck": true
+    "readme": true
   },
   {
     "id": "cargo",
     "label": "Cargo",
     "cmds": ["cargo install pixtuoid pixtuoid-hook"],
-    "readmeCheck": true
+    "readme": false
+  },
+  {
+    "id": "release",
+    "label": "GitHub Releases",
+    "cmds": [
+      "# prebuilt binaries (macOS · Linux · Windows .zip) + Debian .debs:",
+      "# https://github.com/IvanWng97/pixtuoid/releases/latest"
+    ],
+    "readme": false
   }
 ]

--- a/site/src/sources.json
+++ b/site/src/sources.json
@@ -6,7 +6,7 @@
     "status": "supported",
     "featured": true,
     "transport": "Hook shim + JSONL watcher",
-    "platforms": { "macos": "yes", "linux": "yes", "windows": "yes" }
+    "platforms": { "macos": "yes", "linux": "yes", "windows": "experimental" }
   },
   {
     "id": "codex",


### PR DESCRIPTION
The npm channel is live (v0.6.1) and verified end-to-end (install → `pixtuoid --version` → `install-hooks` → `pixtuoid-hook` exit 0), so make it the headline cross-platform install and tidy the rest.

- **Add npm** to `site/src/install.json` (single source → README + site install tab) and the README **Quick Start** + **More install methods**. npm covers Windows, so the multi-step experimental-ZIP section is **dropped**.
- **Remove the Debian/.deb** method from the manifest (README + site). The `.deb`s still build + ship on Releases — just no longer advertised.
- `Install.astro` intro: "macOS & Linux" → "macOS, Linux & Windows".

Install priority is now **brew (macOS) → npm (any OS) → cargo → Releases**.

README ↔ manifest sync check passes locally. Docs-only — no release.