### PR TITLE
ci: gate the npm generator + README drift on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,35 @@ jobs:
       - uses: extractions/setup-just@v4
       - run: just notes-curated
 
+  npm-gen:
+    name: npm package generator
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      # No rust-toolchain: this only exercises the Node generator's unit test —
+      # the same `just npm-check` release.yml gates `npm publish` on, run here at
+      # PR time so a generate.mjs regression can't first surface at tag-push.
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - uses: extractions/setup-just@v4
+      - run: just npm-check
+
+  readme:
+    name: readme drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      # No rust-toolchain, no npm ci: gen-readme.mjs is pure node:builtins. It
+      # fails if the committed README drifted from site/src/*.json. Lives HERE
+      # (not the path-filtered `site` workflow) because ci.yml runs on every PR —
+      # so it's safe to mark required without deadlocking PRs that don't touch site/.
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - uses: extractions/setup-just@v4
+      - run: just gen-readme-check
+
   hack:
     name: feature combinations
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -360,6 +360,7 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
+      - uses: extractions/setup-just@v4
 
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -391,7 +392,7 @@ jobs:
           done
 
       - name: Test the package generator
-        run: node --test npm/generate.test.mjs
+        run: just npm-check
 
       - name: Generate npm packages
         run: node npm/generate.mjs --version "${GITHUB_REF_NAME#v}" --artifacts npm/dist

--- a/justfile
+++ b/justfile
@@ -132,6 +132,16 @@ notes-curated:
     fi
     echo "release notes curated ✓"
 
+# Unit-test the npm package generator (Node, no cargo). The ONLY validation of
+# npm/generate.mjs — release.yml runs this as a hard gate right before `npm
+# publish`, and ci.yml runs it on every PR so a generator regression is caught
+# at review time, not at the irreversible tag-push. NOT in preflight: a Rust
+# pre-push shouldn't require a Node toolchain. Needs Node ≥ 22.
+[group('check')]
+[doc('Test the npm package generator (Node; CI + release call it, not in preflight)')]
+npm-check:
+    node --test npm/generate.test.mjs
+
 # Install the dev tools every check + recipe relies on (idempotent). Prefers
 # cargo-binstall (prebuilt) and falls back to cargo install (compiles).
 [group('check')]
@@ -354,3 +364,12 @@ site-demos:
 [doc('Sync the README from site data: regen Features table (features.json) + check install commands (install.json)')]
 gen-readme:
     node site/scripts/gen-readme.mjs
+
+# Verify the committed README still matches site/src/{features,sources,install}.json
+# (exits non-zero on drift; `just gen-readme` regenerates). Pure node:builtins —
+# no npm ci. ci.yml runs this on every PR so README↔manifest drift is a hard gate
+# at REVIEW time, not just a (path-filtered, advisory) site-CI failure.
+[group('site')]
+[doc('Fail if the committed README drifted from site data (features/sources/install.json)')]
+gen-readme-check:
+    node site/scripts/gen-readme.mjs --check


### PR DESCRIPTION
## What

Two generated-artifact pipelines were validated at the wrong time. This wires both into the always-on `ci.yml` (no path filter → safe to mark **required**), behind `just` recipes so there's one definition.

| Gate | Before | After |
|---|---|---|
| **npm packages** (`npm/generate.mjs`) | `node --test` ran **only in release.yml** — first execution at the irreversible tag-push | new `npm-gen` job runs `just npm-check` on every PR; release.yml calls the same recipe (DRY) |
| **README drift** (committed README vs `site/src/*.json`) | only in the path-filtered, **advisory** `site` workflow | new `readme` job runs `just gen-readme-check` on every PR |

## Why it matters

- The npm generator's only validation was at tag-push, where `crates.io` + homebrew publish **in parallel and don't depend on it** — a broken generator → half-published release → forced forward-bump (exactly the v0.6.0→v0.6.1 story). Now a generator regression fails at PR time.
- `readme:check` lived only in `site.yml`, which is **path-filtered** — making *that* a required check would deadlock PRs that don't touch `site/`. `gen-readme.mjs` is pure `node:` builtins (no `npm ci`), so running it in `ci.yml` is cheap and requireable.

## Notes

- Neither recipe is in `just preflight` — a Rust pre-push shouldn't pull a Node toolchain. They sit with the other CI-only checks (semver/coverage).
- Touches `.github/workflows/`, so the security-review action's expected-401 check will go red (self-healing).
- Follow-up (not in this PR): add `npm package generator` + `readme drift` to `main`'s required status checks once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)