### PR TITLE
fix(watcher): register large transcripts on first-sight instead of waiting for their next write (#204)

### DIFF
--- a/crates/pixtuoid-core/src/source/jsonl.rs
+++ b/crates/pixtuoid-core/src/source/jsonl.rs
@@ -238,11 +238,13 @@ async fn walk_jsonl(path: &Path, decoders: SourceDecoders, ctx: &WatchCtx<'_>) {
         tx,
         window,
     } = *ctx;
+    // `derive_label` / `id_derive` are consumed inside `emit_first_sight` (off
+    // `decoders` directly); only the per-line decoder and the end-checker are
+    // used directly here.
     let SourceDecoders {
         decode_line,
-        derive_label,
         check_ended,
-        id_derive,
+        ..
     } = decoders;
     let meta = match tokio::fs::metadata(path).await {
         Ok(m) => m,
@@ -295,10 +297,23 @@ async fn walk_jsonl(path: &Path, decoders: SourceDecoders, ctx: &WatchCtx<'_>) {
     }
     if file_len - cursor_now > MAX_PENDING_BYTES {
         warn!(
-            "{} has > {} pending bytes with no newline; skipping to end",
+            "{} has > {} pending bytes; skipping backlog to end",
             path.display(),
             MAX_PENDING_BYTES
         );
+        // #204: on FIRST-sight of an oversized tail (a recent, not-yet-ended
+        // large session — stale/ended ones were already gated by
+        // should_seed_at_eof above), still REGISTER the agent before seeding the
+        // cursor to EOF. Otherwise a >1 MB transcript stays invisible until its
+        // next small append (a long session, or a delegating parent whose
+        // subagents then render as flat roots). The giant backlog is NOT
+        // replayed; cwd/label come from a BOUNDED head read (CC writes `cwd` on
+        // the first line), never the whole 7.4 MB file. A mid-session oversized
+        // append (`known`) is unchanged — skip to EOF, no re-registration.
+        if !known {
+            let head_cwd = read_head_cwd(path, MAX_PENDING_BYTES).await;
+            emit_first_sight(path, source, decoders, seen, tx, head_cwd).await;
+        }
         cursors.lock().await.insert(path.to_path_buf(), file_len);
         return;
     }
@@ -341,43 +356,7 @@ async fn walk_jsonl(path: &Path, decoders: SourceDecoders, ctx: &WatchCtx<'_>) {
     // Windows (caught by the PR #160 security review).
     let transcript_path_str = crate::source::decoder::normalize_path_key(&path.to_string_lossy());
 
-    // Take the `seen` lock ONLY to claim first-sight, then drop it before the
-    // awaited sends — holding it across `tx.send` would block on a slow consumer
-    // for no reason (the flag flip is the entire critical section). Mirrors the
-    // narrow `cursors` locking above.
-    let is_first = seen.lock().await.insert(path.to_path_buf(), true).is_none();
-    if is_first {
-        let id = AgentId::from_parts(source, &id_derive(path));
-        let session_id = path
-            .file_stem()
-            .map(|s| s.to_string_lossy().into_owned())
-            .unwrap_or_default();
-        let cwd = extract_cwd(new_bytes).unwrap_or_default();
-        let parent_id = detect_parent_id(path, source);
-        let _ = tx
-            .send((
-                Transport::Jsonl,
-                AgentEvent::SessionStart {
-                    agent_id: id,
-                    source: source.to_string(),
-                    session_id: session_id.clone(),
-                    cwd: cwd.clone(),
-                    parent_id,
-                },
-            ))
-            .await;
-
-        let label = derive_label(path, source, &cwd);
-        let _ = tx
-            .send((
-                Transport::Jsonl,
-                AgentEvent::Rename {
-                    agent_id: id,
-                    label,
-                },
-            ))
-            .await;
-    }
+    emit_first_sight(path, source, decoders, seen, tx, extract_cwd(new_bytes)).await;
 
     for line in new_bytes.split(|b| *b == b'\n') {
         if line.is_empty() {
@@ -408,6 +387,75 @@ async fn walk_jsonl(path: &Path, decoders: SourceDecoders, ctx: &WatchCtx<'_>) {
             Err(e) => warn!("decode error in {}: {e}", path.display()),
         }
     }
+}
+
+/// Claim first-sight for `path` and, if this is the first pass to see it, emit
+/// the synthesized `SessionStart` + `Rename` (the registration pair). Shared by
+/// the normal tail-read path and the #204 oversized-first-sight path so the two
+/// emit IDENTICAL events from one place. `cwd` is the source-derived working dir
+/// (from the tail in the normal path, from a bounded head read in the oversized
+/// path); `None`/empty falls back to the project-dir label in `derive_label`.
+///
+/// Takes the `seen` lock ONLY to claim first-sight, then drops it before the
+/// awaited sends — holding it across `tx.send` would block on a slow consumer
+/// for no reason (the flag flip is the entire critical section). Mirrors the
+/// narrow `cursors` locking in `walk_jsonl`.
+async fn emit_first_sight(
+    path: &Path,
+    source: &Arc<str>,
+    decoders: SourceDecoders,
+    seen: &Arc<Mutex<HashMap<PathBuf, bool>>>,
+    tx: &TaggedSender,
+    cwd: Option<PathBuf>,
+) {
+    let is_first = seen.lock().await.insert(path.to_path_buf(), true).is_none();
+    if !is_first {
+        return;
+    }
+    let id = AgentId::from_parts(source, &(decoders.id_derive)(path));
+    let session_id = path
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let cwd = cwd.unwrap_or_default();
+    let parent_id = detect_parent_id(path, source);
+    let _ = tx
+        .send((
+            Transport::Jsonl,
+            AgentEvent::SessionStart {
+                agent_id: id,
+                source: source.to_string(),
+                session_id,
+                cwd: cwd.clone(),
+                parent_id,
+            },
+        ))
+        .await;
+
+    let label = (decoders.derive_label)(path, source, &cwd);
+    let _ = tx
+        .send((
+            Transport::Jsonl,
+            AgentEvent::Rename {
+                agent_id: id,
+                label,
+            },
+        ))
+        .await;
+}
+
+/// Read at most `limit` bytes from the START of a file and extract `cwd` from
+/// the first complete JSONL line (CC writes `cwd` there). Used by the #204
+/// oversized-first-sight path so registration never reads the whole multi-MB
+/// file — the head is bounded by `MAX_PENDING_BYTES`. Returns `None` when the
+/// file can't be opened/read or has no `cwd` in its head (an empty-cwd
+/// SessionStart then falls back to the project-dir label).
+async fn read_head_cwd(path: &Path, limit: u64) -> Option<PathBuf> {
+    let mut file = tokio::fs::File::open(path).await.ok()?;
+    let mut head = vec![0u8; limit as usize];
+    let n = file.read(&mut head).await.ok()?;
+    head.truncate(n);
+    extract_cwd(&head)
 }
 
 /// Read the tail of a file and delegate to the source-specific checker.

--- a/crates/pixtuoid-core/src/source/jsonl.rs
+++ b/crates/pixtuoid-core/src/source/jsonl.rs
@@ -301,20 +301,27 @@ async fn walk_jsonl(path: &Path, decoders: SourceDecoders, ctx: &WatchCtx<'_>) {
             path.display(),
             MAX_PENDING_BYTES
         );
+        // Seed the cursor to EOF FIRST — before the awaited head-read +
+        // registration below — so a concurrent walk_jsonl on this path (250ms
+        // rescan / notify) sees `known` on its next read and won't re-enter this
+        // branch. Mirrors the normal tail-read path, which also advances the
+        // cursor before emitting. (`emit_first_sight` is idempotent via `seen`, so
+        // the window only ever cost a redundant head read, never a duplicate
+        // SessionStart — but matching the ordering closes it.)
+        cursors.lock().await.insert(path.to_path_buf(), file_len);
         // #204: on FIRST-sight of an oversized tail (a recent, not-yet-ended
         // large session — stale/ended ones were already gated by
-        // should_seed_at_eof above), still REGISTER the agent before seeding the
-        // cursor to EOF. Otherwise a >1 MB transcript stays invisible until its
-        // next small append (a long session, or a delegating parent whose
-        // subagents then render as flat roots). The giant backlog is NOT
-        // replayed; cwd/label come from a BOUNDED head read (CC writes `cwd` on
-        // the first line), never the whole 7.4 MB file. A mid-session oversized
-        // append (`known`) is unchanged — skip to EOF, no re-registration.
+        // should_seed_at_eof above), still REGISTER the agent. Otherwise a >1 MB
+        // transcript stays invisible until its next small append (a long session,
+        // or a delegating parent whose subagents then render as flat roots). The
+        // giant backlog is NOT replayed; cwd/label come from a BOUNDED head read
+        // (CC writes `cwd` on the first line), never the whole 7.4 MB file. A
+        // mid-session oversized append (`known`) just advances the cursor — no
+        // re-registration.
         if !known {
             let head_cwd = read_head_cwd(path, MAX_PENDING_BYTES).await;
             emit_first_sight(path, source, decoders, seen, tx, head_cwd).await;
         }
-        cursors.lock().await.insert(path.to_path_buf(), file_len);
         return;
     }
 

--- a/crates/pixtuoid-core/tests/watcher.rs
+++ b/crates/pixtuoid-core/tests/watcher.rs
@@ -941,8 +941,10 @@ async fn watcher_resets_cursor_on_truncation_below_cursor() {
     handle.abort();
 }
 
-// Cursor-safety guard: a > 1 MiB pending tail with no newline must be skipped to
-// EOF (not buffered), and a later newline-terminated valid line still decodes.
+// Cursor-safety guard: a > 1 MiB first-sight pending tail with no newline (no
+// recoverable cwd in its head) must skip its BACKLOG to EOF (not buffer it),
+// yet still REGISTER the agent (#204) — a SessionStart + a project-dir-fallback
+// Rename — and a later newline-terminated valid line still decodes.
 #[tokio::test]
 async fn watcher_skips_oversized_pending_tail() {
     let dir = TempDir::new().unwrap();
@@ -957,7 +959,8 @@ async fn watcher_skips_oversized_pending_tail() {
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     // Write > 1 MiB of junk with NO newline — file_len - cursor exceeds
-    // MAX_PENDING_BYTES, so the watcher seeks the cursor to EOF and skips it.
+    // MAX_PENDING_BYTES, so the watcher seeks the cursor to EOF (skipping the
+    // backlog) but still registers the agent on first-sight.
     let junk = vec![b'x'; (1 << 20) + 1024];
     let mut f = tokio::fs::OpenOptions::new()
         .create(true)
@@ -969,12 +972,47 @@ async fn watcher_skips_oversized_pending_tail() {
     f.flush().await.unwrap();
     drop(f);
 
-    // Give the watcher a scan to skip the junk.
-    tokio::time::sleep(Duration::from_millis(400)).await;
-    while tokio::time::timeout(Duration::from_millis(20), rx.recv())
-        .await
-        .is_ok()
-    {}
+    // Give the watcher a scan; collect the first-sight registration. The junk
+    // head has no complete line → no cwd → empty-cwd SessionStart, and the
+    // Rename falls back to the project-dir basename. No ActivityStart: a
+    // no-newline blob has no decodable line, and the backlog isn't replayed.
+    let mut got_start = false;
+    let mut got_rename = None;
+    let mut activity_before = 0usize;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while tokio::time::Instant::now() < deadline {
+        match tokio::time::timeout(Duration::from_millis(200), rx.recv()).await {
+            Ok(Some((_, AgentEvent::SessionStart { cwd, .. }))) => {
+                got_start = true;
+                assert_eq!(
+                    cwd,
+                    std::path::PathBuf::from(""),
+                    "a no-newline head yields an empty-cwd SessionStart"
+                );
+            }
+            Ok(Some((_, AgentEvent::Rename { label, .. }))) => got_rename = Some(label),
+            Ok(Some((_, AgentEvent::ActivityStart { .. }))) => activity_before += 1,
+            Ok(Some(_)) => {}
+            Ok(None) | Err(_) => {
+                if got_start && got_rename.is_some() {
+                    break;
+                }
+            }
+        }
+    }
+    assert!(
+        got_start,
+        "a first-sight oversized transcript must register an agent (#204), not stay invisible"
+    );
+    assert_eq!(
+        got_rename.as_deref(),
+        Some("cc·big"),
+        "empty-cwd Rename falls back to the project-dir basename"
+    );
+    assert_eq!(
+        activity_before, 0,
+        "the oversized backlog must not be replayed (got {activity_before} ActivityStart)"
+    );
 
     // Append a newline (closing the junk line) plus a valid line. The junk line
     // is past the EOF-seeked cursor, so only the valid line decodes.
@@ -1015,6 +1053,121 @@ async fn watcher_skips_oversized_pending_tail() {
     assert!(
         got_after,
         "the post-skip valid line must decode after the oversized tail is skipped"
+    );
+    handle.abort();
+}
+
+// #204: a RECENT, valid, multi-line transcript larger than MAX_PENDING_BYTES
+// (e.g. a 7.4 MB main session) must REGISTER its agent on first-sight — a
+// SessionStart + Rename derived from a bounded head read — instead of being
+// silently skipped to EOF and staying invisible until its next small append.
+// The giant backlog is still NOT replayed (no flood of historical events).
+#[tokio::test]
+async fn watcher_registers_large_transcript_on_first_sight() {
+    let dir = TempDir::new().unwrap();
+    let projects_root = dir.path().to_path_buf();
+    let project_dir = projects_root.join("-Users-me-bigrepo");
+    tokio::fs::create_dir_all(&project_dir).await.unwrap();
+    let transcript = project_dir.join("big-session.jsonl");
+
+    // Build a valid, newline-terminated transcript that exceeds 1 MiB. The
+    // FIRST line carries `cwd` (CC always writes it on the first line), so a
+    // bounded head read recovers it without touching the whole file. The rest
+    // are valid tool_use lines — the backlog that must NOT be replayed.
+    let first = serde_json::json!({
+        "type": "system",
+        "subtype": "session_start",
+        "sessionId": "big-session",
+        "cwd": "/Users/me/work/bigrepo"
+    });
+    let mut contents = format!("{first}\n");
+    let backlog_line = serde_json::json!({
+        "type": "assistant",
+        "sessionId": "big-session",
+        "cwd": "/Users/me/work/bigrepo",
+        "message": {
+            "role": "assistant",
+            "content": [
+                { "type": "tool_use", "id": "tu_backlog", "name": "Bash", "input": { "command": "ls" } }
+            ]
+        }
+    });
+    let backlog_line = format!("{backlog_line}\n");
+    while contents.len() <= (1usize << 20) + 4096 {
+        contents.push_str(&backlog_line);
+    }
+    assert!(
+        contents.len() > (1usize << 20),
+        "test transcript must exceed MAX_PENDING_BYTES"
+    );
+
+    // Write the whole file BEFORE the watcher first sees it, so the entire body
+    // is one oversized first-sight pending tail (cursor 0 → file_len > 1 MiB).
+    tokio::fs::write(&transcript, contents.as_bytes())
+        .await
+        .unwrap();
+    // Keep it inside the recency window (write() above already set a fresh
+    // mtime; assert it isn't gated as historical by should_seed_at_eof).
+
+    let (tx, mut rx) = mpsc::channel::<(Transport, AgentEvent)>(256);
+    let watcher = cc_watcher(projects_root.clone());
+    let handle = tokio::spawn(async move { watcher.run(tx).await });
+
+    let mut start_id = None;
+    let mut start_cwd = None;
+    let mut label = None;
+    let mut activity_count = 0usize;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    while tokio::time::Instant::now() < deadline {
+        match tokio::time::timeout(Duration::from_millis(200), rx.recv()).await {
+            Ok(Some((_, AgentEvent::SessionStart { agent_id, cwd, .. }))) => {
+                start_id = Some(agent_id);
+                start_cwd = Some(cwd);
+            }
+            Ok(Some((_, AgentEvent::Rename { label: l, .. }))) => {
+                label = Some(l);
+            }
+            Ok(Some((_, AgentEvent::ActivityStart { .. }))) => {
+                activity_count += 1;
+            }
+            Ok(Some(_)) => {}
+            Ok(None) | Err(_) => {}
+        }
+        // Once we have the registration pair, drain briefly to confirm the
+        // backlog isn't pouring in, then stop.
+        if start_id.is_some() && label.is_some() {
+            // Short settle: if the backlog were replayed we'd accumulate
+            // hundreds of ActivityStart here.
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            while let Ok(Some((_, ev))) =
+                tokio::time::timeout(Duration::from_millis(20), rx.recv()).await
+            {
+                if matches!(ev, AgentEvent::ActivityStart { .. }) {
+                    activity_count += 1;
+                }
+            }
+            break;
+        }
+    }
+
+    let _start_id = start_id.expect("expected SessionStart for the large first-sight transcript");
+    let start_cwd = start_cwd.expect("SessionStart should carry the head-derived cwd");
+    let label = label.expect("expected a Rename label for the large transcript");
+    assert_eq!(
+        start_cwd,
+        std::path::PathBuf::from("/Users/me/work/bigrepo"),
+        "cwd must come from the bounded head read of the first line"
+    );
+    assert_eq!(
+        label, "cc·bigrepo",
+        "label must derive from the head-read cwd basename"
+    );
+    // The backlog is skipped to EOF: registration fires, but the thousands of
+    // historical tool_use lines are NOT replayed. Allow a small margin (0) but
+    // assert it's nowhere near the backlog count (hundreds of lines).
+    assert!(
+        activity_count < 5,
+        "the giant backlog must not be replayed wholesale (got {activity_count} ActivityStart)"
     );
     handle.abort();
 }


### PR DESCRIPTION
## Summary

When `pixtuoid` attaches to a session whose transcript is already large (> 1 MB), that agent stays **invisible until the session writes its next line**. A delegating parent (large transcript) then has no slot, so its subagents render as **flat top-level roots** — the tree only forms once the parent next writes. Observed live while verifying #203: a ~7.4 MB main-session transcript didn't show on launch; its subagents scattered as roots; the parent + nesting appeared only when the main session became active again. Closes #204.

**Root cause** — `source/jsonl.rs::walk_jsonl`, the oversized-pending-tail guard:

```rust
if file_len - cursor_now > MAX_PENDING_BYTES {   // 1 MB
    cursors.insert(path, file_len);   // jump cursor to EOF
    return;                            // returned BEFORE the first-sight SessionStart block
}
```

On first-sight the whole file is a >1 MB pending tail, so it jumped to EOF and returned **before** registering the agent. (The check is size-only despite the old `"no newline"` wording — a valid multi-line 7.4 MB transcript was skipped like a corrupt blob.)

**Fix (approach A — register-on-skip):** on **first-sight** of an oversized tail, still emit the synthesized `SessionStart` + `Rename` (register the agent) before seeding the cursor to EOF. The giant backlog is **not** replayed; `cwd`/label come from a **bounded ≤1 MB head read** (CC writes `cwd` on the first line), never the whole file. The first-sight emission is extracted into one `emit_first_sight` helper shared by the normal and oversized paths, so they register identically. Unchanged: stale/ended files stay gated by `should_seed_at_eof` (runs first — no #85 regression); mid-session oversized appends still skip to EOF without re-registering.

Fixes large **solo** sessions too (not just parents), and "a live subagent's parent is shown" falls out for free. Independent of #203 (identity/cwd-split) — different code region, branched off `main`.

## Test Plan

- [x] `just preflight` green — **1150/1150** (lint → clippy → hack → test).
- [x] New RED→GREEN test `watcher_registers_large_transcript_on_first_sight`: a recent >1 MB multi-line transcript now emits a `SessionStart` (cwd/label from the head) and does **not** replay the backlog (`activity_count` stays low). Genuine RED on old code.
- [x] `watcher_skips_oversized_pending_tail` reconciled (strengthened): first-sight oversized now registers + skips backlog; the post-skip valid line still decodes.
- [x] Stale-gating preserved — `watcher_skips_session_start_for_stale_files_on_startup` + `…_recent_file_with_session_end_marker` + `stale_file_emits_session_start_when_written_to` all pass.
- [ ] **Live verify (`needs-human-verify`):** rebuild + relaunch `pixtuoid run` against a session with a >1 MB transcript (e.g. this one) — the main session agent should appear on attach, with its subagents nested, instead of staying invisible until the next write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)