### PR TITLE
release: bump 0.7.0 + Transport #[non_exhaustive] (#212) — opens the 0.7.0 breaking window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1389,7 +1389,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pixtuoid"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1415,7 +1415,7 @@ dependencies = [
 
 [[package]]
 name = "pixtuoid-core"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "filetime",
@@ -1433,7 +1433,7 @@ dependencies = [
 
 [[package]]
 name = "pixtuoid-hook"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members  = [
 ]
 
 [workspace.package]
-version      = "0.6.1"
+version      = "0.7.0"
 edition      = "2021"
 rust-version = "1.89"
 license      = "MIT"

--- a/crates/pixtuoid-core/src/source/mod.rs
+++ b/crates/pixtuoid-core/src/source/mod.rs
@@ -57,7 +57,16 @@ mod registry_bridge_tests {
 /// Which transport produced an event — used by the reducer for hook-wins
 /// dedup. Lives on the source side because every `Source` implementor must
 /// tag its own events; the reducer is downstream.
+///
+/// `#[non_exhaustive]`: this is the tag on the workspace-wide event channel and
+/// a published-crate type, and the docs anticipate transport growth (a v2
+/// daemon split). Marking it non-exhaustive keeps adding a transport a
+/// non-breaking change, matching its channel siblings (`AgentEvent`,
+/// `ToolDetail`, `SourceDeath`). All in-crate uses are `==` comparisons, not
+/// exhaustive matches, so this is purely a forward-compat guard. (#212 — lands
+/// with the 0.7.0 bump so the one-time break rides the version boundary.)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Transport {
     Hook,
     Jsonl,

--- a/crates/pixtuoid/Cargo.toml
+++ b/crates/pixtuoid/Cargo.toml
@@ -16,7 +16,7 @@ name = "pixtuoid"
 path = "src/main.rs"
 
 [dependencies]
-pixtuoid-core  = { path = "../pixtuoid-core", version = "0.6.1" }
+pixtuoid-core  = { path = "../pixtuoid-core", version = "0.7.0" }
 tokio              = { workspace = true, features = ["rt-multi-thread", "macros", "signal", "sync", "time", "net", "fs", "io-util"] }
 ratatui            = { workspace = true }
 crossterm          = { workspace = true }

--- a/crates/pixtuoid/src/version.rs
+++ b/crates/pixtuoid/src/version.rs
@@ -58,6 +58,26 @@ pub fn release_notes(version: &str) -> Option<&'static [&'static str]> {
         // anchoring on a marker is whitespace-independent — matching the `match`
         // brace would silently break if the indentation ever shifted.
         // [bump-inject-here]
+        "0.7.0" => Some(&[
+            // TODO: curate into ~6 user-facing highlights (drafted from `git log v0.6.1..HEAD`)
+            "pipeline hygiene from the verified CI audit (#213)",
+            "review-followups — 12 confirmed findings from the whole-codebase review (#210)",
+            "honest MSRV (1.78→1.89) + drop fs4 for std-native locks (closes #194) (#208)",
+            "per-CLI badge, activity-tinted names, wider popup, overflow cue (#207)",
+            "consolidate cross-platform logic — one hook-command seam + one home/config resolver (#206)",
+            "register large transcripts on first-sight instead of waiting for their next write (#205)",
+            "derive agent identity from the session UUID so subagent→parent links survive a worktree cwd-split (#203)",
+            "strip Windows \\?\\ verbatim prefix in normalize_path_key (#202)",
+            "DOS 8.3 short-path for cmd-unsafe Windows hook paths (#201)",
+            "Windows support for Codex + Reasonix hooks + Antigravity watcher (#198)",
+            "agent dashboard (Tab) + raise MAX_FLOORS 5→10 (#199)",
+            "CLAUDE.md audit — 6 verified accuracy fixes (no restructuring) (#193)",
+            "build/test hygiene — drop a stray test binary, dedupe rustix, refresh lockfile (#192)",
+            "reorganize pixtuoid-core integration tests by capability/layer (15 → 8 binaries) (#191)",
+            "unify docs+site image pipelines behind one driver + manifest (#190)",
+            "gate the npm generator + README drift on every PR (#189)",
+            "feature npm + single-source install methods + Windows-experimental matrix (#188)",
+        ]),
         // 0.6.1 re-runs the 0.6.0 release with the npm-launcher publish fix
         // (#186) — 0.6.0 shipped to crates.io/homebrew but the `pixtuoid` npm
         // launcher failed, so 0.6.1 is the first fully-published version. Same

--- a/crates/pixtuoid/src/version.rs
+++ b/crates/pixtuoid/src/version.rs
@@ -59,24 +59,12 @@ pub fn release_notes(version: &str) -> Option<&'static [&'static str]> {
         // brace would silently break if the indentation ever shifted.
         // [bump-inject-here]
         "0.7.0" => Some(&[
-            // TODO: curate into ~6 user-facing highlights (drafted from `git log v0.6.1..HEAD`)
-            "pipeline hygiene from the verified CI audit (#213)",
-            "review-followups — 12 confirmed findings from the whole-codebase review (#210)",
-            "honest MSRV (1.78→1.89) + drop fs4 for std-native locks (closes #194) (#208)",
-            "per-CLI badge, activity-tinted names, wider popup, overflow cue (#207)",
-            "consolidate cross-platform logic — one hook-command seam + one home/config resolver (#206)",
-            "register large transcripts on first-sight instead of waiting for their next write (#205)",
-            "derive agent identity from the session UUID so subagent→parent links survive a worktree cwd-split (#203)",
-            "strip Windows \\?\\ verbatim prefix in normalize_path_key (#202)",
-            "DOS 8.3 short-path for cmd-unsafe Windows hook paths (#201)",
-            "Windows support for Codex + Reasonix hooks + Antigravity watcher (#198)",
-            "agent dashboard (Tab) + raise MAX_FLOORS 5→10 (#199)",
-            "CLAUDE.md audit — 6 verified accuracy fixes (no restructuring) (#193)",
-            "build/test hygiene — drop a stray test binary, dedupe rustix, refresh lockfile (#192)",
-            "reorganize pixtuoid-core integration tests by capability/layer (15 → 8 binaries) (#191)",
-            "unify docs+site image pipelines behind one driver + manifest (#190)",
-            "gate the npm generator + README drift on every PR (#189)",
-            "feature npm + single-source install methods + Windows-experimental matrix (#188)",
+            "Agent dashboard: Tab opens a foldable agent tree with per-CLI badges; Enter jumps floors",
+            "Offices now stack up to 10 floors (was 5)",
+            "Windows: Codex + Reasonix hooks and the Antigravity watcher work end-to-end",
+            "Subagent links survive git-worktree cwd splits (CC agents key on the session UUID)",
+            "Big transcripts appear on first sight instead of after their next write",
+            "Fixed a render crash on non-ASCII project paths; headless output is escape-sanitized",
         ]),
         // 0.6.1 re-runs the 0.6.0 release with the npm-launcher publish fix
         // (#186) — 0.6.0 shipped to crates.io/homebrew but the `pixtuoid` npm


### PR DESCRIPTION
**No release happens here** — `just bump` stops before the tag; only a later human `git tag v0.7.0 && git push origin v0.7.0` triggers release.yml (crates.io/homebrew/npm).

## What
- `just bump 0.7.0`: the 4 coordinated version edits (workspace version, path-dep req, release_notes arm, Cargo.lock) + preflight.
- Release notes curated to 6 user-facing highlights (dashboard, 10 floors, Windows arc, worktree-safe subagent links, first-sight transcripts, panic/escape fixes).
- **#212**: `Transport` is now `#[non_exhaustive]`, matching its channel siblings (`AgentEvent`/`ToolDetail`/`SourceDeath`). This is the one-time break parked at PR #210 — landing it WITH the bump means `semver-checks` stays green (0.6.1→0.7.0 permits breaks for a 0.x crate). Closes #212.

## Why now
This opens the **0.7.0 breaking window**: until v0.7.0 is actually tagged+published, `cargo-semver-checks` baselines crates.io 0.6.1 against local 0.7.0, so intentional API breaks (next up: the #209 desk-index newtype refactor) land green instead of holding a red gate.

## Verification
`just bump` ran full preflight (1196 tests green); notes-curated check passes; workspace + all-targets compile with the non_exhaustive Transport.

AI-authored — `needs-human-verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)