### PR TITLE
refactor: GlobalDeskIndex / FloorLocalDeskIndex — compiler-enforced desk-index spaces

### DIFF
--- a/crates/pixtuoid-core/CLAUDE.md
+++ b/crates/pixtuoid-core/CLAUDE.md
@@ -26,7 +26,11 @@ src/
 │                       fatal source exit in the TUI footer, #157; plain data, invariant #1 holds)
 ├── state/              SceneState + Reducer (event coordinator: Transport-tagged dedup, the
 │                       cross-slot active_tasks/gated_before_waiting correlation, the sweeps) +
-│                       fsm.rs (Layer-A per-agent transitions) + scope.rs (Layer-B parent↔subagent tree)
+│                       fsm.rs (Layer-A per-agent transitions) + scope.rs (Layer-B parent↔subagent tree);
+│                       GlobalDeskIndex / FloorLocalDeskIndex newtypes encode the two desk-index
+│                       spaces (AgentSlot.desk_index is GLOBAL; the typed bridge to a floor's
+│                       home_desks is floor_local_desk(), or the documented single_floor_local()
+│                       identity for a single-floor scene)
 ├── sprite/             .sprite parser, pack.toml loader, half-block blitter, animator, Pack::merge_from
 ├── render/             Renderer trait + TestRenderer (feature = "test-renderer")
 ├── layout/             zone-based office geometry (terminal-agnostic):

--- a/crates/pixtuoid-core/src/layout/mod.rs
+++ b/crates/pixtuoid-core/src/layout/mod.rs
@@ -33,6 +33,7 @@ pub use mask::{WALL_THICK_H, WALL_THICK_V};
 pub use placement::{anchored_top_left, z_sort_row, Anchor};
 pub use reach::{ReachSet, REACH_CELL_SIZE, REACH_CELL_WALKABLE_MIN};
 
+use crate::state::FloorLocalDeskIndex;
 use crate::walkable::WalkableMask;
 
 /// Primitive rectangle. Same shape as `ratatui::layout::Rect` so the
@@ -241,6 +242,16 @@ impl SceneLayout {
 
     pub fn is_walkable(&self, x: u16, y: u16) -> bool {
         self.walkable.is_walkable(x, y)
+    }
+
+    /// Typed accessor for a floor's home-desk anchor. `home_desks` is a
+    /// FLOOR-LOCAL vector — index it through a `FloorLocalDeskIndex`
+    /// (from `SceneState::floor_local_desk`, or
+    /// `GlobalDeskIndex::single_floor_local` inside a single-floor
+    /// projected scene), never with an `AgentSlot.desk_index` directly.
+    /// Raw `home_desks[i]` with a loop/iteration `usize` stays fine.
+    pub fn home_desk(&self, i: FloorLocalDeskIndex) -> Option<Point> {
+        self.home_desks.get(i.0).copied()
     }
 }
 

--- a/crates/pixtuoid-core/src/layout/tests.rs
+++ b/crates/pixtuoid-core/src/layout/tests.rs
@@ -1,6 +1,24 @@
 use super::*;
 
 #[test]
+fn home_desk_typed_accessor_matches_raw_vec() {
+    let l = SceneLayout::compute(160, 200, 4).expect("layout fits");
+    assert!(!l.home_desks.is_empty());
+    for i in 0..l.home_desks.len() {
+        assert_eq!(
+            l.home_desk(FloorLocalDeskIndex(i)),
+            Some(l.home_desks[i]),
+            "typed accessor must agree with the raw vec at index {i}"
+        );
+    }
+    assert_eq!(
+        l.home_desk(FloorLocalDeskIndex(l.home_desks.len())),
+        None,
+        "out-of-range floor-local index returns None"
+    );
+}
+
+#[test]
 fn partial_bottom_row_caps_mid_fill_when_agents_run_out() {
     // Covers the partial-BOTTOM-ROW capacity break in `compute_pod_desks`
     // (compute.rs `'partial_y` loop): a layout whose fill needs the partial

--- a/crates/pixtuoid-core/src/lib.rs
+++ b/crates/pixtuoid-core/src/lib.rs
@@ -16,7 +16,7 @@ pub use render::Renderer;
 pub use source::{AgentEvent, Source, TaggedReceiver, TaggedSender, ToolDetail, Transport};
 pub use sprite::{Frame, Palette, Pixel, Rgb, RgbBuffer, Sprite};
 pub use state::reducer::Reducer;
-pub use state::{ActivityState, AgentSlot, SceneState};
+pub use state::{ActivityState, AgentSlot, FloorLocalDeskIndex, GlobalDeskIndex, SceneState};
 pub use walkable::{OccupancyOverlay, WalkableMask};
 
 /// Test-only mutex serializing tests that mutate process-global environment

--- a/crates/pixtuoid-core/src/pose/mod.rs
+++ b/crates/pixtuoid-core/src/pose/mod.rs
@@ -201,7 +201,7 @@ pub enum Pose {
 ///      SeatedIdle / Walking / AtWaypoint / AimlessAt based on the
 ///      wander state machine).
 pub fn derive(slot: &AgentSlot, now: SystemTime, layout: &SceneLayout) -> Option<Pose> {
-    let desk = *layout.home_desks.get(slot.desk_index)?;
+    let desk = layout.home_desk(slot.desk_index.single_floor_local())?;
 
     // Exit takes priority — once SessionEnd fires we always walk to the
     // door regardless of entry-window or normal state. Use door_threshold
@@ -303,7 +303,7 @@ fn state_driven_pose(
 ///
 /// Returns `None` when `slot.desk_index` is out of range for `layout`.
 pub fn derive_state_only(slot: &AgentSlot, now: SystemTime, layout: &SceneLayout) -> Option<Pose> {
-    let desk = *layout.home_desks.get(slot.desk_index)?;
+    let desk = layout.home_desk(slot.desk_index.single_floor_local())?;
     state_driven_pose(slot, desk, layout, now)
 }
 

--- a/crates/pixtuoid-core/src/pose/tests.rs
+++ b/crates/pixtuoid-core/src/pose/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::state::GlobalDeskIndex;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -21,7 +22,7 @@ fn slot(state: ActivityState, age_ms: u64) -> (AgentSlot, SystemTime) {
         last_event_at: created,
         exiting_at: None,
         pending_idle_at: None,
-        desk_index: 0,
+        desk_index: GlobalDeskIndex(0),
         floor_idx: 0,
         tool_call_count: 0,
         active_ms: 0,
@@ -350,7 +351,7 @@ fn entry_animation_overrides_normal_pose_for_first_4s() {
         last_event_at: now0,
         exiting_at: None,
         pending_idle_at: None,
-        desk_index: 0,
+        desk_index: GlobalDeskIndex(0),
         floor_idx: 0,
         tool_call_count: 0,
         active_ms: 0,
@@ -371,7 +372,7 @@ fn entry_animation_overrides_normal_pose_for_first_4s() {
 #[test]
 fn derive_returns_none_when_desk_index_out_of_range() {
     let (mut s, now) = slot(ActivityState::Idle, 0);
-    s.desk_index = 999;
+    s.desk_index = GlobalDeskIndex(999);
     assert!(derive(&s, now, &layout()).is_none());
 }
 
@@ -382,7 +383,7 @@ fn exit_override_walks_desk_to_door_within_window() {
     let (mut s, now) = slot(ActivityState::Idle, 0);
     s.exiting_at = Some(now - Duration::from_secs(1));
     let l = layout();
-    let desk = l.home_desks[s.desk_index];
+    let desk = l.home_desks[s.desk_index.0];
     match derive(&s, now, &l).expect("pose") {
         Pose::Walking { from, to, .. } => {
             assert_eq!(
@@ -592,7 +593,7 @@ fn entry_walk_does_not_carry_coffee() {
         last_event_at: now0,
         exiting_at: None,
         pending_idle_at: None,
-        desk_index: 0,
+        desk_index: GlobalDeskIndex(0),
         floor_idx: 0,
         tool_call_count: 0,
         active_ms: 0,
@@ -637,7 +638,7 @@ fn derive_state_only_skips_entry_override() {
         last_event_at: now0,
         exiting_at: None,
         pending_idle_at: None,
-        desk_index: 0,
+        desk_index: GlobalDeskIndex(0),
         floor_idx: 0,
         tool_call_count: 0,
         active_ms: 0,

--- a/crates/pixtuoid-core/src/state/fsm.rs
+++ b/crates/pixtuoid-core/src/state/fsm.rs
@@ -162,7 +162,7 @@ mod tests {
             created_at: started,
             exiting_at: None,
             pending_idle_at: None,
-            desk_index: 0,
+            desk_index: GlobalDeskIndex(0),
             floor_idx: 0,
             tool_call_count: 0,
             active_ms: 0,

--- a/crates/pixtuoid-core/src/state/fsm.rs
+++ b/crates/pixtuoid-core/src/state/fsm.rs
@@ -162,7 +162,7 @@ mod tests {
             created_at: started,
             exiting_at: None,
             pending_idle_at: None,
-            desk_index: GlobalDeskIndex(0),
+            desk_index: crate::state::GlobalDeskIndex(0),
             floor_idx: 0,
             tool_call_count: 0,
             active_ms: 0,

--- a/crates/pixtuoid-core/src/state/mod.rs
+++ b/crates/pixtuoid-core/src/state/mod.rs
@@ -11,6 +11,43 @@ mod scope;
 
 pub const MAX_FLOORS: usize = 10;
 
+/// Global desk index — the reducer's allocation space across ALL floors.
+///
+/// This is the space `AgentSlot.desk_index` lives in (allocated once by
+/// `SceneState::next_free_desk`, never mutated). It is NOT a valid index
+/// into a single floor's `SceneLayout::home_desks`; convert through
+/// `SceneState::floor_local_desk` (the one legal bridge) first.
+///
+/// The inner `usize` stays `pub` for construction in tests and for raw
+/// arithmetic at documented sites — the safety comes from this type being
+/// distinct from `FloorLocalDeskIndex`, not from hiding the integer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct GlobalDeskIndex(pub usize);
+
+/// Floor-local desk index — indexes a single floor's
+/// `SceneLayout::home_desks` (see `SceneLayout::home_desk`).
+///
+/// Produced by `SceneState::floor_local_desk` (the arithmetic bridge) or —
+/// inside a single-floor projected scene — by
+/// `GlobalDeskIndex::single_floor_local` (a documented identity).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct FloorLocalDeskIndex(pub usize);
+
+impl GlobalDeskIndex {
+    /// The floor-local view of this index **within a single-floor scene**.
+    ///
+    /// Valid only for slots in a per-floor projection (the output of
+    /// `build_floor_scene` / `project_floor_scene` in the tui, or any
+    /// `uniform(cap)` scene standing in for one floor): there the scene's
+    /// global space coincides with its floor-0 local space
+    /// (`floor_of(g) == 0`, `floor_local_desk(g).0 == g.0`), so this cast
+    /// is the identity by construction. For a multi-floor scene go through
+    /// `SceneState::floor_local_desk` — the arithmetic bridge — instead.
+    pub fn single_floor_local(self) -> FloorLocalDeskIndex {
+        FloorLocalDeskIndex(self.0)
+    }
+}
+
 /// `AgentSlot` strings (label, source, session_id) and paths (cwd) are
 /// stored as `Arc<str>` / `Arc<Path>` so `SceneState::clone()` is a series
 /// of pointer copies instead of heap allocations. At 30 fps with N agents
@@ -178,6 +215,15 @@ mod tests {
             unknown_cwd: false,
             parent_id: None,
         }
+    }
+
+    #[test]
+    fn single_floor_local_is_the_identity_cast() {
+        // The documented coincidence: in a uniform(cap) scene standing in for
+        // ONE floor, the global space == the floor-0 local space, so the
+        // typed identity cast agrees with the arithmetic bridge.
+        let g = GlobalDeskIndex(7);
+        assert_eq!(g.single_floor_local(), FloorLocalDeskIndex(7));
     }
 
     #[test]

--- a/crates/pixtuoid-core/src/state/mod.rs
+++ b/crates/pixtuoid-core/src/state/mod.rs
@@ -293,11 +293,26 @@ mod tests {
     #[test]
     fn floor_local_desk_variable() {
         let s = SceneState::new([4, 8, 6, 4, 2, 0, 0, 0, 0, 0]);
-        assert_eq!(s.floor_local_desk(GlobalDeskIndex(0)), FloorLocalDeskIndex(0));
-        assert_eq!(s.floor_local_desk(GlobalDeskIndex(3)), FloorLocalDeskIndex(3));
-        assert_eq!(s.floor_local_desk(GlobalDeskIndex(4)), FloorLocalDeskIndex(0)); // first desk on F1
-        assert_eq!(s.floor_local_desk(GlobalDeskIndex(11)), FloorLocalDeskIndex(7)); // last desk on F1
-        assert_eq!(s.floor_local_desk(GlobalDeskIndex(12)), FloorLocalDeskIndex(0)); // first desk on F2
+        assert_eq!(
+            s.floor_local_desk(GlobalDeskIndex(0)),
+            FloorLocalDeskIndex(0)
+        );
+        assert_eq!(
+            s.floor_local_desk(GlobalDeskIndex(3)),
+            FloorLocalDeskIndex(3)
+        );
+        assert_eq!(
+            s.floor_local_desk(GlobalDeskIndex(4)),
+            FloorLocalDeskIndex(0)
+        ); // first desk on F1
+        assert_eq!(
+            s.floor_local_desk(GlobalDeskIndex(11)),
+            FloorLocalDeskIndex(7)
+        ); // last desk on F1
+        assert_eq!(
+            s.floor_local_desk(GlobalDeskIndex(12)),
+            FloorLocalDeskIndex(0)
+        ); // first desk on F2
     }
 
     #[test]
@@ -347,7 +362,10 @@ mod tests {
         let s = SceneState::new([4, 0, 6, 0, 2, 0, 0, 0, 0, 0]);
         // Desk 4 is first desk of F2 (F1 has zero capacity)
         assert_eq!(s.floor_of(GlobalDeskIndex(4)), 2);
-        assert_eq!(s.floor_local_desk(GlobalDeskIndex(4)), FloorLocalDeskIndex(0));
+        assert_eq!(
+            s.floor_local_desk(GlobalDeskIndex(4)),
+            FloorLocalDeskIndex(0)
+        );
         assert_eq!(s.floor_of(GlobalDeskIndex(9)), 2);
         assert_eq!(s.floor_of(GlobalDeskIndex(10)), 4);
     }

--- a/crates/pixtuoid-core/src/state/mod.rs
+++ b/crates/pixtuoid-core/src/state/mod.rs
@@ -94,12 +94,11 @@ pub struct AgentSlot {
     /// state to Idle. Hides the per-tool-call Active flicker that rapid
     /// PreToolUse → PostToolUse chains produce in CC.
     pub pending_idle_at: Option<SystemTime>,
-    /// GLOBAL flat desk index across all floors (assigned once at `SessionStart`,
-    /// never mutated). NOT a floor-local index: `build_floor_scene` (tui/floor.rs)
-    /// remaps it to a floor-local index before any `layout.home_desks` lookup —
-    /// indexing `home_desks` with this raw value is a bug. `floor_idx` derives
-    /// from it via `floor_of()`.
-    pub desk_index: usize,
+    /// GLOBAL desk index (assigned once at `SessionStart`, never mutated).
+    /// The `GlobalDeskIndex` newtype encodes the index space — see its docs
+    /// for the bridge to a floor's `home_desks`. `floor_idx` derives from it
+    /// via `floor_of()`.
+    pub desk_index: GlobalDeskIndex,
     /// Floor assigned at desk allocation time. Immutable for the agent's
     /// lifetime so capacity growth never silently migrates agents between
     /// floors.
@@ -151,9 +150,13 @@ impl SceneState {
     }
 
     /// Which floor does `desk_index` belong to, given precomputed `offsets`?
-    fn floor_of_with_offsets(&self, desk_index: usize, offsets: &[usize; MAX_FLOORS]) -> usize {
+    fn floor_of_with_offsets(
+        &self,
+        desk_index: GlobalDeskIndex,
+        offsets: &[usize; MAX_FLOORS],
+    ) -> usize {
         for i in (0..MAX_FLOORS).rev() {
-            if self.floor_capacities[i] > 0 && desk_index >= offsets[i] {
+            if self.floor_capacities[i] > 0 && desk_index.0 >= offsets[i] {
                 return i;
             }
         }
@@ -161,19 +164,22 @@ impl SceneState {
     }
 
     /// Which floor does `desk_index` belong to?
-    pub fn floor_of(&self, desk_index: usize) -> usize {
+    pub fn floor_of(&self, desk_index: GlobalDeskIndex) -> usize {
         self.floor_of_with_offsets(desk_index, &self.cumulative_offsets())
     }
 
-    /// Local desk offset within the floor.
-    pub fn floor_local_desk(&self, desk_index: usize) -> usize {
+    /// Local desk offset within the floor — THE bridge from the reducer's
+    /// global allocation space to a floor's `home_desks` index space.
+    pub fn floor_local_desk(&self, desk_index: GlobalDeskIndex) -> FloorLocalDeskIndex {
         let offsets = self.cumulative_offsets();
         let floor = self.floor_of_with_offsets(desk_index, &offsets);
-        desk_index - offsets[floor]
+        FloorLocalDeskIndex(desk_index.0 - offsets[floor])
     }
 
     /// Global desk index range `[lo, hi)` for a given floor.
     /// Clamps `floor_idx` to `MAX_FLOORS - 1` to avoid panics.
+    /// Stays `Range<usize>` over raw global indices — a `Range` of newtypes
+    /// is painful (no `Step` impl) and the consumers only need the offsets.
     pub fn floor_range(&self, floor_idx: usize) -> std::ops::Range<usize> {
         let idx = floor_idx.min(MAX_FLOORS - 1);
         let offsets = self.cumulative_offsets();
@@ -183,10 +189,12 @@ impl SceneState {
     }
 
     /// Lowest free desk index, or `None` if all desks are occupied.
-    pub fn next_free_desk(&self) -> Option<usize> {
-        let occupied: std::collections::BTreeSet<usize> =
+    pub fn next_free_desk(&self) -> Option<GlobalDeskIndex> {
+        let occupied: std::collections::BTreeSet<GlobalDeskIndex> =
             self.agents.values().map(|a| a.desk_index).collect();
-        (0..self.total_capacity()).find(|i| !occupied.contains(i))
+        (0..self.total_capacity())
+            .map(GlobalDeskIndex)
+            .find(|i| !occupied.contains(i))
     }
 }
 
@@ -208,7 +216,7 @@ mod tests {
             last_event_at: now,
             exiting_at: None,
             pending_idle_at: None,
-            desk_index,
+            desk_index: GlobalDeskIndex(desk_index),
             floor_idx: 0,
             tool_call_count: 0,
             active_ms: 0,
@@ -229,7 +237,7 @@ mod tests {
     #[test]
     fn next_free_desk_starts_at_zero() {
         let s = SceneState::uniform(4);
-        assert_eq!(s.next_free_desk(), Some(0));
+        assert_eq!(s.next_free_desk(), Some(GlobalDeskIndex(0)));
     }
 
     #[test]
@@ -252,7 +260,7 @@ mod tests {
         }
         assert_eq!(
             s.next_free_desk(),
-            Some(4),
+            Some(GlobalDeskIndex(4)),
             "should overflow to desk 4 (floor 1)"
         );
     }
@@ -260,36 +268,36 @@ mod tests {
     #[test]
     fn floor_of_uniform() {
         let s = SceneState::uniform(8);
-        assert_eq!(s.floor_of(0), 0);
-        assert_eq!(s.floor_of(7), 0);
-        assert_eq!(s.floor_of(8), 1);
-        assert_eq!(s.floor_of(15), 1);
-        assert_eq!(s.floor_of(16), 2);
+        assert_eq!(s.floor_of(GlobalDeskIndex(0)), 0);
+        assert_eq!(s.floor_of(GlobalDeskIndex(7)), 0);
+        assert_eq!(s.floor_of(GlobalDeskIndex(8)), 1);
+        assert_eq!(s.floor_of(GlobalDeskIndex(15)), 1);
+        assert_eq!(s.floor_of(GlobalDeskIndex(16)), 2);
     }
 
     #[test]
     fn floor_of_variable_capacities() {
         let s = SceneState::new([4, 8, 6, 4, 2, 0, 0, 0, 0, 0]);
         // F0: 0..4, F1: 4..12, F2: 12..18, F3: 18..22, F4: 22..24
-        assert_eq!(s.floor_of(0), 0);
-        assert_eq!(s.floor_of(3), 0);
-        assert_eq!(s.floor_of(4), 1);
-        assert_eq!(s.floor_of(11), 1);
-        assert_eq!(s.floor_of(12), 2);
-        assert_eq!(s.floor_of(17), 2);
-        assert_eq!(s.floor_of(18), 3);
-        assert_eq!(s.floor_of(22), 4);
-        assert_eq!(s.floor_of(23), 4);
+        assert_eq!(s.floor_of(GlobalDeskIndex(0)), 0);
+        assert_eq!(s.floor_of(GlobalDeskIndex(3)), 0);
+        assert_eq!(s.floor_of(GlobalDeskIndex(4)), 1);
+        assert_eq!(s.floor_of(GlobalDeskIndex(11)), 1);
+        assert_eq!(s.floor_of(GlobalDeskIndex(12)), 2);
+        assert_eq!(s.floor_of(GlobalDeskIndex(17)), 2);
+        assert_eq!(s.floor_of(GlobalDeskIndex(18)), 3);
+        assert_eq!(s.floor_of(GlobalDeskIndex(22)), 4);
+        assert_eq!(s.floor_of(GlobalDeskIndex(23)), 4);
     }
 
     #[test]
     fn floor_local_desk_variable() {
         let s = SceneState::new([4, 8, 6, 4, 2, 0, 0, 0, 0, 0]);
-        assert_eq!(s.floor_local_desk(0), 0);
-        assert_eq!(s.floor_local_desk(3), 3);
-        assert_eq!(s.floor_local_desk(4), 0); // first desk on F1
-        assert_eq!(s.floor_local_desk(11), 7); // last desk on F1
-        assert_eq!(s.floor_local_desk(12), 0); // first desk on F2
+        assert_eq!(s.floor_local_desk(GlobalDeskIndex(0)), FloorLocalDeskIndex(0));
+        assert_eq!(s.floor_local_desk(GlobalDeskIndex(3)), FloorLocalDeskIndex(3));
+        assert_eq!(s.floor_local_desk(GlobalDeskIndex(4)), FloorLocalDeskIndex(0)); // first desk on F1
+        assert_eq!(s.floor_local_desk(GlobalDeskIndex(11)), FloorLocalDeskIndex(7)); // last desk on F1
+        assert_eq!(s.floor_local_desk(GlobalDeskIndex(12)), FloorLocalDeskIndex(0)); // first desk on F2
     }
 
     #[test]
@@ -320,7 +328,7 @@ mod tests {
             s.agents.insert(id, make_slot(id, i));
         }
         // Next free should be desk 4 (first desk on F1)
-        assert_eq!(s.next_free_desk(), Some(4));
+        assert_eq!(s.next_free_desk(), Some(GlobalDeskIndex(4)));
     }
 
     #[test]
@@ -331,26 +339,26 @@ mod tests {
         assert_eq!(s.floor_range(0), 0..4);
         assert_eq!(s.floor_range(1), 4..4);
         assert_eq!(s.floor_range(2), 4..10);
-        assert_eq!(s.next_free_desk(), Some(0));
+        assert_eq!(s.next_free_desk(), Some(GlobalDeskIndex(0)));
     }
 
     #[test]
     fn floor_of_skips_zero_capacity_floors() {
         let s = SceneState::new([4, 0, 6, 0, 2, 0, 0, 0, 0, 0]);
         // Desk 4 is first desk of F2 (F1 has zero capacity)
-        assert_eq!(s.floor_of(4), 2);
-        assert_eq!(s.floor_local_desk(4), 0);
-        assert_eq!(s.floor_of(9), 2);
-        assert_eq!(s.floor_of(10), 4);
+        assert_eq!(s.floor_of(GlobalDeskIndex(4)), 2);
+        assert_eq!(s.floor_local_desk(GlobalDeskIndex(4)), FloorLocalDeskIndex(0));
+        assert_eq!(s.floor_of(GlobalDeskIndex(9)), 2);
+        assert_eq!(s.floor_of(GlobalDeskIndex(10)), 4);
     }
 
     #[test]
     fn floor_of_leading_zero_capacity_floors() {
         let s = SceneState::new([0, 0, 6, 4, 2, 0, 0, 0, 0, 0]);
         // F0 and F1 have zero capacity, desk 0 belongs to F2
-        assert_eq!(s.floor_of(0), 2);
-        assert_eq!(s.floor_of(5), 2);
-        assert_eq!(s.floor_of(6), 3);
+        assert_eq!(s.floor_of(GlobalDeskIndex(0)), 2);
+        assert_eq!(s.floor_of(GlobalDeskIndex(5)), 2);
+        assert_eq!(s.floor_of(GlobalDeskIndex(6)), 3);
     }
 
     #[test]
@@ -369,11 +377,11 @@ mod tests {
                                         // desk_index 100 is beyond capacity — floor_of returns the last
                                         // floor with nonzero capacity (floor 4, offset 22).
         let oob = total + 76; // 100
-        let floor = s.floor_of(oob);
+        let floor = s.floor_of(GlobalDeskIndex(oob));
         assert_eq!(floor, 4, "OOB desk lands on last nonempty floor");
-        let local = s.floor_local_desk(oob);
+        let local = s.floor_local_desk(GlobalDeskIndex(oob));
         // offsets[4] = 22, so local = 100 - 22 = 78
-        assert_eq!(local, oob - 22);
+        assert_eq!(local, FloorLocalDeskIndex(oob - 22));
     }
 
     #[test]
@@ -385,10 +393,10 @@ mod tests {
         assert_eq!(s.floor_capacities.len(), 10, "office spans ten floors");
         assert_eq!(s.total_capacity(), 20, "ten floors × 2 desks");
         assert_eq!(
-            s.floor_of(18),
+            s.floor_of(GlobalDeskIndex(18)),
             9,
             "desk 18 is the first seat on the tenth floor"
         );
-        assert_eq!(s.floor_of(19), 9);
+        assert_eq!(s.floor_of(GlobalDeskIndex(19)), 9);
     }
 }

--- a/crates/pixtuoid-core/src/state/scope.rs
+++ b/crates/pixtuoid-core/src/state/scope.rs
@@ -139,7 +139,7 @@ mod tests {
             created_at: now,
             exiting_at: None,
             pending_idle_at: None,
-            desk_index: GlobalDeskIndex(0),
+            desk_index: crate::state::GlobalDeskIndex(0),
             floor_idx: 0,
             tool_call_count: 0,
             active_ms: 0,

--- a/crates/pixtuoid-core/src/state/scope.rs
+++ b/crates/pixtuoid-core/src/state/scope.rs
@@ -139,7 +139,7 @@ mod tests {
             created_at: now,
             exiting_at: None,
             pending_idle_at: None,
-            desk_index: 0,
+            desk_index: GlobalDeskIndex(0),
             floor_idx: 0,
             tool_call_count: 0,
             active_ms: 0,

--- a/crates/pixtuoid-core/tests/reducer.rs
+++ b/crates/pixtuoid-core/tests/reducer.rs
@@ -5,7 +5,7 @@ use pixtuoid_core::source::{AgentEvent, Transport};
 use pixtuoid_core::state::reducer::{
     Reducer, ACTIVE_GRACE_WINDOW, B1_CASCADE_GRACE, HOOK_WINS_WINDOW,
 };
-use pixtuoid_core::state::{ActivityState, SceneState};
+use pixtuoid_core::state::{ActivityState, GlobalDeskIndex, SceneState};
 use pixtuoid_core::AgentId;
 
 fn start(reducer: &mut Reducer, scene: &mut SceneState, id: AgentId) {
@@ -93,7 +93,7 @@ fn session_start_creates_idle_slot_at_first_free_desk() {
     );
 
     let slot = scene.agents.get(&id).expect("agent inserted");
-    assert_eq!(slot.desk_index, 0);
+    assert_eq!(slot.desk_index, GlobalDeskIndex(0));
     assert_eq!(
         &*slot.label, "cc·repo",
         "label = source prefix + cwd basename"
@@ -288,7 +288,7 @@ fn session_end_marks_slot_exiting_then_tick_removes_it_after_grace() {
         !scene.agents.contains_key(&a),
         "tick should sweep expired exit"
     );
-    assert_eq!(scene.next_free_desk(), Some(0));
+    assert_eq!(scene.next_free_desk(), Some(GlobalDeskIndex(0)));
 }
 
 #[test]
@@ -3049,14 +3049,14 @@ fn session_start_overflows_to_floor1_with_heterogeneous_capacity() {
         );
     }
     assert_eq!(scene.agents.len(), 3);
-    let desks: Vec<usize> = scene.agents.values().map(|a| a.desk_index).collect();
+    let desks: Vec<usize> = scene.agents.values().map(|a| a.desk_index.0).collect();
     assert!(desks.contains(&0));
     assert!(desks.contains(&1));
     assert!(
         desks.contains(&2),
         "third agent should get desk 2 (floor 1)"
     );
-    assert_eq!(scene.floor_of(2), 1);
+    assert_eq!(scene.floor_of(GlobalDeskIndex(2)), 1);
 }
 
 #[test]

--- a/crates/pixtuoid/examples/snapshot.rs
+++ b/crates/pixtuoid/examples/snapshot.rs
@@ -18,7 +18,7 @@ use pixtuoid_core::source::jsonl::JsonlWatcher;
 use pixtuoid_core::source::AgentEvent;
 use pixtuoid_core::sprite::{Rgb, RgbBuffer};
 use pixtuoid_core::state::ActivityState;
-use pixtuoid_core::{AgentId, AgentSlot, Reducer, SceneState, Transport};
+use pixtuoid_core::{AgentId, AgentSlot, GlobalDeskIndex, Reducer, SceneState, Transport};
 use ratatui::backend::TestBackend;
 use ratatui::style::Color;
 use ratatui::Terminal;
@@ -668,7 +668,7 @@ async fn capture_live_scene(projects_root: &str, listen_secs: u64) -> Result<Sce
     for (id, slot) in &snapshot.agents {
         println!(
             "  {} ({}) at desk {}: {:?}",
-            slot.label, id, slot.desk_index, slot.state
+            slot.label, id, slot.desk_index.0, slot.state
         );
     }
     watcher_handle.abort();
@@ -758,10 +758,10 @@ fn sample_scene(now: SystemTime, max_desks: usize, n_agents: usize) -> SceneStat
                 exiting_at: None,
                 pending_idle_at: None,
 
-                desk_index: i,
+                desk_index: GlobalDeskIndex(i),
                 // floor_of maps the global desk_index to the correct floor based on
                 // per-floor capacities; hardcoding 0 would leave overflow agents invisible.
-                floor_idx: s.floor_of(i),
+                floor_idx: s.floor_of(GlobalDeskIndex(i)),
                 tool_call_count: 0,
                 active_ms: 0,
                 unknown_cwd: false,
@@ -864,8 +864,8 @@ fn dashboard_scene(now: SystemTime) -> SceneState {
                 last_event_at: now,
                 exiting_at: None,
                 pending_idle_at: None,
-                desk_index: *desk_index,
-                floor_idx: s.floor_of(*desk_index),
+                desk_index: GlobalDeskIndex(*desk_index),
+                floor_idx: s.floor_of(GlobalDeskIndex(*desk_index)),
                 tool_call_count: 0,
                 active_ms: 0,
                 unknown_cwd: false,
@@ -993,7 +993,7 @@ fn anim_scene(
             last_event_at: now,
             exiting_at: None,
             pending_idle_at: None,
-            desk_index: 0,
+            desk_index: GlobalDeskIndex(0),
             floor_idx: 0,
             tool_call_count: 0,
             active_ms: 0,

--- a/crates/pixtuoid/src/runtime/mod.rs
+++ b/crates/pixtuoid/src/runtime/mod.rs
@@ -116,7 +116,7 @@ fn summarize(scene: &SceneState) -> String {
                     format!("waiting({})", sanitize_line(reason))
                 }
             };
-            format!("{}@{}:{}", sanitize_line(&a.label), a.desk_index, state)
+            format!("{}@{}:{}", sanitize_line(&a.label), a.desk_index.0, state)
         })
         .collect();
     format!("agents=[{}]", agents.join(", "))

--- a/crates/pixtuoid/src/tui/CLAUDE.md
+++ b/crates/pixtuoid/src/tui/CLAUDE.md
@@ -56,6 +56,10 @@ tui/
 │                   sprite::format::load_pack_from_strings; --pack-dir merges OPTIONAL_FURNITURE over it
 ├── layout.rs       thin façade re-exporting core::layout::SceneLayout as tui::layout::Layout (renderer's geometry entry)
 ├── floor.rs        FloorCtx (per-floor render state), FloorTransition, LightingState, build_floor_scene
+│                   (projects one floor's agents into a self-contained uniform scene; the desk_index
+│                   remap stays typed — it re-wraps as a GlobalDeskIndex valid FOR THAT smaller scene,
+│                   so single_floor_local identity reads stay honest; see its doc comment + core's
+│                   GlobalDeskIndex/FloorLocalDeskIndex docs in state/mod.rs)
 ├── pet.rs          PetKind (Cat, Dog) + per-kind static data; Pet{kind,name} (a configured office pet) + Pet::defaulted; select_pet_for_floor(u64,&[Pet])->Option<&Pet>; PetState (heart-anim interaction)
 ├── chitchat.rs     venue-keyed group/solo speech bubbles (VenueKey::Room vs ::Waypoint)
 ├── dashboard/      agent-dashboard PURE model (no ratatui): mod.rs (DashboardUi / DashboardRow /

--- a/crates/pixtuoid/src/tui/dashboard/tests.rs
+++ b/crates/pixtuoid/src/tui/dashboard/tests.rs
@@ -3,7 +3,7 @@ use super::*;
 use std::path::Path;
 use std::time::SystemTime;
 
-use pixtuoid_core::state::{ActivityState, AgentSlot};
+use pixtuoid_core::state::{ActivityState, AgentSlot, GlobalDeskIndex};
 use pixtuoid_core::AgentId;
 
 /// Build a slot with the fields the dashboard reads; the rest are inert.
@@ -28,7 +28,7 @@ fn mk_slot(
         last_event_at: now,
         exiting_at: None,
         pending_idle_at: None,
-        desk_index,
+        desk_index: GlobalDeskIndex(desk_index),
         floor_idx,
         tool_call_count: 0,
         active_ms: 0,

--- a/crates/pixtuoid/src/tui/floor.rs
+++ b/crates/pixtuoid/src/tui/floor.rs
@@ -420,10 +420,22 @@ mod tests {
     #[test]
     fn floor_local_desk_remaps_to_floor_range() {
         let s = SceneState::uniform(16);
-        assert_eq!(s.floor_local_desk(GlobalDeskIndex(0)), FloorLocalDeskIndex(0));
-        assert_eq!(s.floor_local_desk(GlobalDeskIndex(16)), FloorLocalDeskIndex(0));
-        assert_eq!(s.floor_local_desk(GlobalDeskIndex(17)), FloorLocalDeskIndex(1));
-        assert_eq!(s.floor_local_desk(GlobalDeskIndex(31)), FloorLocalDeskIndex(15));
+        assert_eq!(
+            s.floor_local_desk(GlobalDeskIndex(0)),
+            FloorLocalDeskIndex(0)
+        );
+        assert_eq!(
+            s.floor_local_desk(GlobalDeskIndex(16)),
+            FloorLocalDeskIndex(0)
+        );
+        assert_eq!(
+            s.floor_local_desk(GlobalDeskIndex(17)),
+            FloorLocalDeskIndex(1)
+        );
+        assert_eq!(
+            s.floor_local_desk(GlobalDeskIndex(31)),
+            FloorLocalDeskIndex(15)
+        );
     }
 
     #[test]

--- a/crates/pixtuoid/src/tui/floor.rs
+++ b/crates/pixtuoid/src/tui/floor.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::time::{Duration, SystemTime};
 
 use pixtuoid_core::physics::{walk_arrived, WalkProfile};
-use pixtuoid_core::state::{AgentSlot, SceneState};
+use pixtuoid_core::state::{AgentSlot, GlobalDeskIndex, SceneState};
 use pixtuoid_core::walkable::OccupancyOverlay;
 use pixtuoid_core::AgentId;
 
@@ -261,6 +261,15 @@ pub fn num_floors(scene: &SceneState) -> usize {
 /// into the `[0..capacity)` range so the layout engine sees a
 /// self-contained floor. Uses the stored `floor_idx` on each slot so
 /// capacity growth never migrates agents between floors.
+///
+/// The remap is a RE-PROJECTION, not a space mix-up: the projected slots
+/// live in a `uniform(cap)` single-floor scene (`project_floor_scene`)
+/// whose own global desk space coincides with its floor-0 local space by
+/// construction (`floor_of(g) == 0`, `floor_local_desk(g).0 == g.0` —
+/// pinned by `build_floor_scene_remap_is_local_global_coincident` below).
+/// So the remapped value is a genuinely valid `GlobalDeskIndex` FOR THAT
+/// SMALLER SCENE, and the render path's
+/// `GlobalDeskIndex::single_floor_local` identity reads stay honest.
 pub fn build_floor_scene(scene: &SceneState, floor_idx: usize) -> Vec<AgentSlot> {
     let offset = scene.floor_range(floor_idx).start;
     scene
@@ -268,11 +277,11 @@ pub fn build_floor_scene(scene: &SceneState, floor_idx: usize) -> Vec<AgentSlot>
         .values()
         .filter(|a| a.floor_idx == floor_idx)
         .filter_map(|a| {
-            if a.desk_index < offset {
+            if a.desk_index.0 < offset {
                 return None;
             }
             let mut slot = a.clone();
-            slot.desk_index = a.desk_index - offset;
+            slot.desk_index = GlobalDeskIndex(a.desk_index.0 - offset);
             Some(slot)
         })
         .collect()
@@ -294,7 +303,7 @@ pub fn project_floor_scene(scene: &SceneState, floor_idx: usize) -> SceneState {
 mod tests {
     use super::*;
     use pixtuoid_core::id::AgentId;
-    use pixtuoid_core::state::ActivityState;
+    use pixtuoid_core::state::{ActivityState, FloorLocalDeskIndex};
     use std::path::Path;
     use std::sync::Arc;
     use std::time::Duration;
@@ -370,7 +379,7 @@ mod tests {
         let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
         for i in 0..n {
             let id = AgentId::from_transcript_path(&format!("/p/{i}.jsonl"));
-            let floor_idx = s.floor_of(i);
+            let floor_idx = s.floor_of(GlobalDeskIndex(i));
             s.agents.insert(
                 id,
                 AgentSlot {
@@ -386,7 +395,7 @@ mod tests {
                     exiting_at: None,
                     pending_idle_at: None,
 
-                    desk_index: i,
+                    desk_index: GlobalDeskIndex(i),
                     floor_idx,
                     tool_call_count: 0,
                     active_ms: 0,
@@ -401,20 +410,20 @@ mod tests {
     #[test]
     fn floor_of_maps_desk_to_floor() {
         let s = SceneState::uniform(16);
-        assert_eq!(s.floor_of(0), 0);
-        assert_eq!(s.floor_of(15), 0);
-        assert_eq!(s.floor_of(16), 1);
-        assert_eq!(s.floor_of(31), 1);
-        assert_eq!(s.floor_of(32), 2);
+        assert_eq!(s.floor_of(GlobalDeskIndex(0)), 0);
+        assert_eq!(s.floor_of(GlobalDeskIndex(15)), 0);
+        assert_eq!(s.floor_of(GlobalDeskIndex(16)), 1);
+        assert_eq!(s.floor_of(GlobalDeskIndex(31)), 1);
+        assert_eq!(s.floor_of(GlobalDeskIndex(32)), 2);
     }
 
     #[test]
     fn floor_local_desk_remaps_to_floor_range() {
         let s = SceneState::uniform(16);
-        assert_eq!(s.floor_local_desk(0), 0);
-        assert_eq!(s.floor_local_desk(16), 0);
-        assert_eq!(s.floor_local_desk(17), 1);
-        assert_eq!(s.floor_local_desk(31), 15);
+        assert_eq!(s.floor_local_desk(GlobalDeskIndex(0)), FloorLocalDeskIndex(0));
+        assert_eq!(s.floor_local_desk(GlobalDeskIndex(16)), FloorLocalDeskIndex(0));
+        assert_eq!(s.floor_local_desk(GlobalDeskIndex(17)), FloorLocalDeskIndex(1));
+        assert_eq!(s.floor_local_desk(GlobalDeskIndex(31)), FloorLocalDeskIndex(15));
     }
 
     #[test]
@@ -443,17 +452,44 @@ mod tests {
         assert_eq!(floor0.len(), 16);
         for a in &floor0 {
             assert!(
-                a.desk_index < 16,
+                a.desk_index.0 < 16,
                 "desk_index {} out of range",
-                a.desk_index
+                a.desk_index.0
             );
         }
 
         let floor1 = build_floor_scene(&scene, 1);
         assert_eq!(floor1.len(), 4);
-        let mut indices: Vec<usize> = floor1.iter().map(|a| a.desk_index).collect();
+        let mut indices: Vec<usize> = floor1.iter().map(|a| a.desk_index.0).collect();
         indices.sort();
         assert_eq!(indices, vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn build_floor_scene_remap_is_local_global_coincident() {
+        // The doc-comment-backed property on `build_floor_scene`: within a
+        // projected `uniform(cap)` scene the global desk space coincides with
+        // its (only) floor's local space, so the remapped `GlobalDeskIndex`
+        // is simultaneously a valid global index for the smaller scene AND —
+        // through the typed bridge — the floor-local index the render path
+        // needs. This is what makes `single_floor_local` an identity there.
+        let scene = make_scene(20, 16);
+        for floor_idx in 0..num_floors(&scene) {
+            let projected = project_floor_scene(&scene, floor_idx);
+            for slot in projected.agents.values() {
+                assert_eq!(projected.floor_of(slot.desk_index), 0);
+                assert_eq!(
+                    projected.floor_local_desk(slot.desk_index).0,
+                    slot.desk_index.0,
+                    "projected scene: bridge must be the identity"
+                );
+                assert_eq!(
+                    projected.floor_local_desk(slot.desk_index),
+                    slot.desk_index.single_floor_local(),
+                    "typed bridge and identity cast must agree in a projection"
+                );
+            }
+        }
     }
 
     #[test]
@@ -478,7 +514,7 @@ mod tests {
                 last_event_at: now,
                 exiting_at: None,
                 pending_idle_at: None,
-                desk_index: 5,
+                desk_index: GlobalDeskIndex(5),
                 floor_idx: 1,
                 tool_call_count: 0,
                 active_ms: 0,
@@ -502,7 +538,7 @@ mod tests {
         let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
         for i in 0..6 {
             let id = AgentId::from_transcript_path(&format!("/p/{i}.jsonl"));
-            let floor_idx = s.floor_of(i);
+            let floor_idx = s.floor_of(GlobalDeskIndex(i));
             s.agents.insert(
                 id,
                 AgentSlot {
@@ -517,7 +553,7 @@ mod tests {
                     last_event_at: now,
                     exiting_at: None,
                     pending_idle_at: None,
-                    desk_index: i,
+                    desk_index: GlobalDeskIndex(i),
                     floor_idx,
                     tool_call_count: 0,
                     active_ms: 0,

--- a/crates/pixtuoid/src/tui/hit_test.rs
+++ b/crates/pixtuoid/src/tui/hit_test.rs
@@ -61,7 +61,13 @@ pub fn hit_test_from_tui(scene: &SceneState, layout: &Layout, mx: u16, my: u16) 
     const SPRITE_W: u16 = 8;
     const SPRITE_H_CELLS: u16 = 6;
     for agent in scene.agents.values() {
-        let Some(desk) = layout.home_desk(scene.floor_local_desk(agent.desk_index)) else {
+        // `single_floor_local()` (the projected-scene identity), NOT the
+        // arithmetic bridge: on an out-of-range desk the bridge would wrap onto
+        // a synthetic later floor of the uniform projection and could land back
+        // in `[0..len)` — hit-testable while invisible to the renderer. The
+        // identity keeps the OOB index OOB, so `home_desk` skips it like the
+        // render path does.
+        let Some(desk) = layout.home_desk(agent.desk_index.single_floor_local()) else {
             continue;
         };
         let ax = desk.x + 1;
@@ -523,6 +529,33 @@ mod tests {
         // No agent occupies any cell — scan a few and confirm None everywhere.
         for &(mx, my) in &[(0u16, 0u16), (40, 20), (80, 40)] {
             assert_eq!(hit_test_from_tui(&scene, &layout, mx, my), None);
+        }
+    }
+
+    // Regression for the bridge-choice bug: with the ARITHMETIC bridge
+    // (`scene.floor_local_desk`), an OOB desk equal to the uniform scene's cap
+    // wraps onto a synthetic floor 1 and lands back at local 0 — hit-testable
+    // at desk 0 while the renderer skips it. The identity cast must keep it
+    // OOB everywhere.
+    #[test]
+    fn from_tui_oob_desk_at_capacity_boundary_does_not_wrap_to_desk_zero() {
+        use pixtuoid_core::state::GlobalDeskIndex;
+        let layout = Layout::compute(160, 200, 4).expect("layout");
+        let (mut scene, id) = scene_with_agent_at_desk(0);
+        let cap = scene.floor_capacities[0];
+        // Re-seat the agent at exactly `cap` — the wrap-prone value.
+        scene.agents.get_mut(&id).expect("slot").desk_index = GlobalDeskIndex(cap);
+        // Scan desk 0's whole sprite box — the wrapped bridge would hit here.
+        let desk0 = layout.home_desks[0];
+        let (ax, ay) = (desk0.x + 1, desk0.y.saturating_sub(4) / 2);
+        for dx in 0..8u16 {
+            for dy in 0..6u16 {
+                assert_eq!(
+                    hit_test_from_tui(&scene, &layout, ax + dx, ay + dy),
+                    None,
+                    "an OOB desk at the capacity boundary must never hit-test"
+                );
+            }
         }
     }
 

--- a/crates/pixtuoid/src/tui/hit_test.rs
+++ b/crates/pixtuoid/src/tui/hit_test.rs
@@ -49,14 +49,21 @@ pub(crate) fn hit_test_agent(
 
 /// Lightweight hit-test for click-to-pin without needing router/overlay state.
 /// Uses home desk positions only (no walking agents).
+///
+/// `scene` must be a SINGLE-FLOOR scene matching `layout` — the caller
+/// projects the live scene via `project_floor_scene(scene, current_floor)`
+/// first, so only the visible floor's agents are tested, with their
+/// re-projected desk indices. (Indexing `layout.home_desks` with a raw
+/// multi-floor `desk_index` was exactly the global/local confusion the
+/// `GlobalDeskIndex` newtype exists to prevent: while viewing floor ≥ 1 it
+/// could pin an invisible agent from another floor.)
 pub fn hit_test_from_tui(scene: &SceneState, layout: &Layout, mx: u16, my: u16) -> Option<AgentId> {
     const SPRITE_W: u16 = 8;
     const SPRITE_H_CELLS: u16 = 6;
     for agent in scene.agents.values() {
-        if agent.desk_index >= layout.home_desks.len() {
+        let Some(desk) = layout.home_desk(scene.floor_local_desk(agent.desk_index)) else {
             continue;
-        }
-        let desk = &layout.home_desks[agent.desk_index];
+        };
         let ax = desk.x + 1;
         let ay = desk.y.saturating_sub(4);
         let cell_x = ax;

--- a/crates/pixtuoid/src/tui/hit_test.rs
+++ b/crates/pixtuoid/src/tui/hit_test.rs
@@ -469,7 +469,7 @@ mod tests {
     // --- hit_test_from_tui (click-to-pin, home-desk-only) -----------------
 
     fn scene_with_agent_at_desk(desk_index: usize) -> (SceneState, AgentId) {
-        use pixtuoid_core::state::{ActivityState, AgentSlot};
+        use pixtuoid_core::state::{ActivityState, AgentSlot, GlobalDeskIndex};
         use std::path::Path;
         use std::sync::Arc;
         let id = AgentId::from_transcript_path("/pin/0.jsonl");
@@ -485,7 +485,7 @@ mod tests {
             last_event_at: SystemTime::UNIX_EPOCH,
             exiting_at: None,
             pending_idle_at: None,
-            desk_index,
+            desk_index: GlobalDeskIndex(desk_index),
             floor_idx: 0,
             tool_call_count: 0,
             active_ms: 0,

--- a/crates/pixtuoid/src/tui/mod.rs
+++ b/crates/pixtuoid/src/tui/mod.rs
@@ -110,9 +110,14 @@ fn toggle_pin<B: ratatui::backend::Backend<Error: Send + Sync + 'static>>(
         renderer.set_pinned_agent(None);
     } else {
         let snap = scene_rx.borrow().clone();
+        // Project to the VISIBLE floor first: `hit_test_from_tui` requires a
+        // single-floor scene matching `cached_layout` (a raw multi-floor
+        // snapshot would test other floors' agents against this floor's
+        // desks — the global/local desk-index confusion, see its doc).
+        let floor_scene = floor::project_floor_scene(&snap, renderer.current_floor());
         let hit = renderer
             .cached_layout()
-            .and_then(|layout| renderer::hit_test_from_tui(&snap, layout, col, row));
+            .and_then(|layout| renderer::hit_test_from_tui(&floor_scene, layout, col, row));
         renderer.set_pinned_agent(hit);
     }
 }

--- a/crates/pixtuoid/src/tui/motion/mod.rs
+++ b/crates/pixtuoid/src/tui/motion/mod.rs
@@ -281,7 +281,7 @@ pub fn advance_wander(
                     // Resolve the stand cell off the agent's home desk (the
                     // origin must match core::idle_pose's `desk` so the
                     // stateless/stateful destinations stay in lockstep).
-                    let desk_pt = layout.home_desks.get(slot.desk_index).copied();
+                    let desk_pt = layout.home_desk(slot.desk_index.single_floor_local());
                     let origin = desk_pt.unwrap_or(Point { x: 0, y: 0 });
                     let (dest, dest_kind, wp_idx, seat) =
                         pick_wander_dest(id, ms.wander_cycle_n, layout, origin);
@@ -481,9 +481,7 @@ fn snapshot_back_profile(
     overlay: &OccupancyOverlay,
 ) -> WalkProfile {
     let desk = layout
-        .home_desks
-        .get(slot.desk_index)
-        .copied()
+        .home_desk(slot.desk_index.single_floor_local())
         .unwrap_or(ms.wander_dest);
     // Arrive via the desk approach cell (glide onto the chair), mirroring pose's
     // WalkingBack leg; add the chair-glide so the profile covers the full

--- a/crates/pixtuoid/src/tui/motion/tests.rs
+++ b/crates/pixtuoid/src/tui/motion/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use pixtuoid_core::AgentId;
+use pixtuoid_core::{AgentId, GlobalDeskIndex};
 
 fn id() -> AgentId {
     AgentId::from_parts("test", "motion-test-agent")
@@ -145,7 +145,7 @@ fn idle_slot(path: &str, state_started: SystemTime) -> AgentSlot {
             .unwrap_or(state_started),
         exiting_at: None,
         pending_idle_at: None,
-        desk_index: 0,
+        desk_index: GlobalDeskIndex(0),
         floor_idx: 0,
         tool_call_count: 0,
         active_ms: 0,

--- a/crates/pixtuoid/src/tui/pixel_painter/ambient.rs
+++ b/crates/pixtuoid/src/tui/pixel_painter/ambient.rs
@@ -8,6 +8,7 @@
 use std::time::{Duration, SystemTime};
 
 use pixtuoid_core::sprite::{Rgb, RgbBuffer};
+use pixtuoid_core::state::FloorLocalDeskIndex;
 
 use crate::tui::layout::Layout;
 use crate::tui::pixel_painter::background::{
@@ -85,7 +86,7 @@ pub(super) fn dust_mote_positions(
 
 pub(super) fn paint_ambient(
     ctx: &mut PixelCtx<'_>,
-    seated_agents: &std::collections::HashMap<usize, bool>,
+    seated_agents: &std::collections::HashMap<FloorLocalDeskIndex, bool>,
 ) {
     paint_sun_spot(ctx.buf, ctx.theme, ctx.layout, ctx.now);
     paint_dust_motes(
@@ -140,7 +141,7 @@ pub(super) fn paint_ceiling_halos(buf: &mut RgbBuffer, theme: &Theme, halos: &[C
 /// rather than on the monitor frame itself.
 fn collect_ceiling_halos(
     ctx: &PixelCtx<'_>,
-    seated_agents: &std::collections::HashMap<usize, bool>,
+    seated_agents: &std::collections::HashMap<FloorLocalDeskIndex, bool>,
 ) -> Vec<CeilingHalo> {
     use pixtuoid_core::state::ActivityState;
     let mut halos = Vec::new();
@@ -164,13 +165,13 @@ fn collect_ceiling_halos(
         // mid-walk (entry / snap-back) during the Active grace window. Mirrors
         // the desk-cubicle screen-glow gate so the two never disagree.
         if !seated_agents
-            .get(&agent.desk_index)
+            .get(&agent.desk_index.single_floor_local())
             .copied()
             .unwrap_or(false)
         {
             continue;
         }
-        let Some(desk) = ctx.layout.home_desks.get(agent.desk_index) else {
+        let Some(desk) = ctx.layout.home_desk(agent.desk_index.single_floor_local()) else {
             continue;
         };
         // `tool_glow_tint` only returns None for a non-Active state, but the

--- a/crates/pixtuoid/src/tui/pixel_painter/anchors.rs
+++ b/crates/pixtuoid/src/tui/pixel_painter/anchors.rs
@@ -133,7 +133,7 @@ pub(in crate::tui) fn character_anchor(
     now: SystemTime,
     rctx: &mut pose::RouteCtx<'_>,
 ) -> Option<Point> {
-    let desk = *layout.home_desks.get(agent.desk_index)?;
+    let desk = layout.home_desk(agent.desk_index.single_floor_local())?;
     let pose = pose::derive_with_routing(agent, now, layout, rctx)?;
     // Labels anchor off the DEFAULT character width — a custom pack's true
     // width isn't threaded here and ±1px doesn't matter for a text label.

--- a/crates/pixtuoid/src/tui/pixel_painter/debug_overlay.rs
+++ b/crates/pixtuoid/src/tui/pixel_painter/debug_overlay.rs
@@ -342,7 +342,7 @@ mod tests {
     }
 
     fn slot(id: AgentId) -> pixtuoid_core::AgentSlot {
-        use pixtuoid_core::state::ActivityState;
+        use pixtuoid_core::state::{ActivityState, GlobalDeskIndex};
         use std::path::PathBuf;
         use std::sync::Arc;
         use std::time::SystemTime;
@@ -359,7 +359,7 @@ mod tests {
             last_event_at: now,
             exiting_at: None,
             pending_idle_at: None,
-            desk_index: 0,
+            desk_index: GlobalDeskIndex(0),
             floor_idx: 0,
             tool_call_count: 0,
             active_ms: 0,

--- a/crates/pixtuoid/src/tui/pixel_painter/drawable.rs
+++ b/crates/pixtuoid/src/tui/pixel_painter/drawable.rs
@@ -20,6 +20,7 @@ use std::time::SystemTime;
 use pixtuoid_core::sprite::blit::blit_frame;
 use pixtuoid_core::sprite::format::Pack;
 use pixtuoid_core::sprite::{Rgb, RgbBuffer};
+use pixtuoid_core::state::FloorLocalDeskIndex;
 use pixtuoid_core::AgentSlot;
 
 use super::effects::{
@@ -175,7 +176,7 @@ pub(super) fn pet_position(
     layout: &Layout,
     pack: &Pack,
     now: SystemTime,
-    idle_desk_indices: &[usize],
+    idle_desk_indices: &[FloorLocalDeskIndex],
     all_idle: bool,
     pet_seed: u64,
 ) -> Option<(Point, bool, &'static str, usize)> {
@@ -196,7 +197,7 @@ pub(super) fn pet_position(
                 x: desk.x + DESK_W + 1,
                 y: desk.y + DESK_H + 2,
             },
-            idle_desk_indices.contains(&i),
+            idle_desk_indices.contains(&FloorLocalDeskIndex(i)),
         ));
     }
     if let Some(wp) = layout

--- a/crates/pixtuoid/src/tui/pixel_painter/mod.rs
+++ b/crates/pixtuoid/src/tui/pixel_painter/mod.rs
@@ -16,7 +16,7 @@ use pixtuoid_core::layout::WALKING_Y_OFF;
 use pixtuoid_core::sprite::blit::blit_frame;
 use pixtuoid_core::sprite::format::Pack;
 use pixtuoid_core::sprite::{Rgb, RgbBuffer};
-use pixtuoid_core::state::ActivityState;
+use pixtuoid_core::state::{ActivityState, FloorLocalDeskIndex};
 use pixtuoid_core::walkable::OccupancyOverlay;
 use pixtuoid_core::{AgentSlot, SceneState};
 
@@ -477,9 +477,14 @@ pub fn render_to_rgb_buffer(ctx: &mut PixelCtx<'_>) -> PixelPassResult {
     // (before the ambient pass) and reused by the desk-cubicle screen glow
     // below — so the ceiling halo and the screen glow share one gate and one
     // pose derivation (no double A*).
-    let seated_agents: HashMap<usize, bool> = agents
+    let seated_agents: HashMap<FloorLocalDeskIndex, bool> = agents
         .iter()
-        .filter(|a| a.desk_index < ctx.layout.home_desks.len() && a.exiting_at.is_none())
+        .filter(|a| {
+            ctx.layout
+                .home_desk(a.desk_index.single_floor_local())
+                .is_some()
+                && a.exiting_at.is_none()
+        })
         .map(|a| {
             let p = pose::derive_with_routing(
                 a,
@@ -493,7 +498,7 @@ pub fn render_to_rgb_buffer(ctx: &mut PixelCtx<'_>) -> PixelPassResult {
                 },
             );
             let seated = matches!(p, Some(Pose::SeatedTyping { .. } | Pose::SeatedThinking));
-            (a.desk_index, seated)
+            (a.desk_index.single_floor_local(), seated)
         })
         .collect();
 
@@ -522,9 +527,7 @@ pub fn render_to_rgb_buffer(ctx: &mut PixelCtx<'_>) -> PixelPassResult {
                 // `desk` origin as every other stand_point caller.
                 let origin = ctx
                     .layout
-                    .home_desks
-                    .get(agent.desk_index)
-                    .copied()
+                    .home_desk(agent.desk_index.single_floor_local())
                     .unwrap_or(w.pos);
                 let stand = pixtuoid_core::layout::stand_point(
                     w.kind,
@@ -640,7 +643,7 @@ fn enqueue_characters<'a>(
         .and_then(|a| a.frames.first())
         .map_or(CHARACTER_SPRITE_W, |f| f.width);
     for agent in agents {
-        let Some(desk) = ctx.layout.home_desks.get(agent.desk_index).copied() else {
+        let Some(desk) = ctx.layout.home_desk(agent.desk_index.single_floor_local()) else {
             continue;
         };
         let Some(p) = pose::derive_with_routing(
@@ -971,10 +974,11 @@ fn enqueue_room_walls_h<'a>(layout: &'a Layout, drawables: &mut Vec<Drawable<'a>
 fn enqueue_desk_cubicles<'a>(
     ctx: &PixelCtx<'_>,
     agents: &[AgentSlot],
-    seated_agents: &HashMap<usize, bool>,
+    seated_agents: &HashMap<FloorLocalDeskIndex, bool>,
     drawables: &mut Vec<Drawable<'a>>,
 ) {
     for (i, &desk) in ctx.layout.home_desks.iter().enumerate() {
+        let local = FloorLocalDeskIndex(i);
         let Size {
             w: desk_fp_w,
             h: desk_fp_h,
@@ -988,9 +992,9 @@ fn enqueue_desk_cubicles<'a>(
             >= ctx.layout.cubicle_band.x + ctx.layout.cubicle_band.width;
         let occupant = agents
             .iter()
-            .find(|a| a.desk_index == i && a.exiting_at.is_none());
+            .find(|a| a.desk_index.single_floor_local() == local && a.exiting_at.is_none());
         let screen_glow = occupant
-            .filter(|_| seated_agents.get(&i).copied().unwrap_or(false))
+            .filter(|_| seated_agents.get(&local).copied().unwrap_or(false))
             .and_then(|a| palette::tool_glow_tint(a, &ctx.theme.tool_glow));
         let has_coffee = occupant.is_some_and(|a| ctx.coffee_holders.contains(&a.agent_id));
         let coffee_steam = has_coffee
@@ -1026,14 +1030,17 @@ fn enqueue_pet<'a>(
     drawables: &mut Vec<Drawable<'a>>,
 ) -> Option<PetFrame> {
     let kind = ctx.floor_pet.map(|p| p.kind)?;
-    let idle_desk_indices: Vec<usize> = agents
+    let idle_desk_indices: Vec<FloorLocalDeskIndex> = agents
         .iter()
         .filter(|a| {
             matches!(a.state, ActivityState::Idle)
-                && a.desk_index < ctx.layout.home_desks.len()
+                && ctx
+                    .layout
+                    .home_desk(a.desk_index.single_floor_local())
+                    .is_some()
                 && a.exiting_at.is_none()
         })
-        .map(|a| a.desk_index)
+        .map(|a| a.desk_index.single_floor_local())
         .collect();
     let all_idle = agents
         .iter()

--- a/crates/pixtuoid/src/tui/pixel_painter/tests.rs
+++ b/crates/pixtuoid/src/tui/pixel_painter/tests.rs
@@ -1,6 +1,7 @@
 use super::seat::DESK_SEAT_Z_OFF;
 use super::*;
 use pixtuoid_core::sprite::{Frame, Palette};
+use pixtuoid_core::state::GlobalDeskIndex;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -156,7 +157,7 @@ fn make_slot(id: pixtuoid_core::AgentId, state: ActivityState) -> AgentSlot {
         exiting_at: None,
         pending_idle_at: None,
 
-        desk_index: 0,
+        desk_index: GlobalDeskIndex(0),
         floor_idx: 0,
         tool_call_count: 0,
         active_ms: 0,

--- a/crates/pixtuoid/src/tui/pose/mod.rs
+++ b/crates/pixtuoid/src/tui/pose/mod.rs
@@ -177,7 +177,7 @@ pub fn derive_with_routing(
     let overlay = rctx.overlay;
     let history = &mut *rctx.history;
     let motion = &mut *rctx.motion;
-    let desk = *layout.home_desks.get(slot.desk_index)?;
+    let desk = layout.home_desk(slot.desk_index.single_floor_local())?;
 
     // ---- EXIT branch -------------------------------------------------------
     // Takes priority over entry and state-driven poses.
@@ -407,7 +407,7 @@ pub fn derive_with_routing(
         match wander_phase {
             WanderPhase::WalkingOut => {
                 let ms = motion.get(&slot.agent_id)?;
-                let desk_point = *layout.home_desks.get(slot.desk_index)?;
+                let desk_point = layout.home_desk(slot.desk_index.single_floor_local())?;
                 let dest = ms.wander_dest;
                 let seat = ms.wander_seat;
                 // Leave the desk via the approach cell (a reachable N/E/W side),
@@ -469,7 +469,7 @@ pub fn derive_with_routing(
             }
             WanderPhase::WalkingBack => {
                 let ms = motion.get(&slot.agent_id)?;
-                let desk_point = *layout.home_desks.get(slot.desk_index)?;
+                let desk_point = layout.home_desk(slot.desk_index.single_floor_local())?;
                 // Copy the fields off `ms` so the immutable `motion` borrow ends
                 // before `route_walking_pose` takes `&mut motion`.
                 let wander_dest = ms.wander_dest;

--- a/crates/pixtuoid/src/tui/pose/tests.rs
+++ b/crates/pixtuoid/src/tui/pose/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use pixtuoid_core::state::ActivityState;
+use pixtuoid_core::state::{ActivityState, GlobalDeskIndex};
 use pixtuoid_core::walkable::WalkableMask;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -180,7 +180,7 @@ fn active_slot(state_started_at: SystemTime, created_at: SystemTime) -> AgentSlo
         exiting_at: None,
         pending_idle_at: None,
 
-        desk_index: 0,
+        desk_index: GlobalDeskIndex(0),
         floor_idx: 0,
         tool_call_count: 0,
         active_ms: 0,
@@ -628,7 +628,7 @@ fn snap_back_routes_via_the_approach_cell_then_settles_onto_the_chair() {
     let approach = desk_approach_cell(desk, &l).expect("approach cell");
 
     let mut slot = active_slot(now, now - Duration::from_secs(60));
-    slot.desk_index = desk_index;
+    slot.desk_index = GlobalDeskIndex(desk_index);
     slot.agent_id = AgentId::from_transcript_path("/snapapproach/slot.jsonl");
     // Far from the chair (≥ SNAP_BACK_MIN_DIST) so the snap-back arms.
     let prev = Point {
@@ -845,7 +845,7 @@ fn at_waypoint_pose_records_position_to_history() {
         exiting_at: None,
         pending_idle_at: None,
 
-        desk_index: 0,
+        desk_index: GlobalDeskIndex(0),
         floor_idx: 0,
         tool_call_count: 0,
         active_ms: 0,
@@ -879,7 +879,7 @@ fn delegates_to_derive_for_oob_desk() {
     let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
     let l = layout();
     let mut slot = active_slot(now, now - Duration::from_secs(60));
-    slot.desk_index = 999;
+    slot.desk_index = GlobalDeskIndex(999);
     let mut history = PoseHistory::new();
     let overlay = pixtuoid_core::walkable::OccupancyOverlay::new();
     let mut router = StubRouter::straight();
@@ -1163,14 +1163,14 @@ fn snap_back_rearms_on_new_state_transition() {
 fn entry_slot_near(created_at: SystemTime) -> AgentSlot {
     let mut s = active_slot(created_at, created_at);
     s.state = pixtuoid_core::state::ActivityState::Idle;
-    s.desk_index = 0;
+    s.desk_index = GlobalDeskIndex(0);
     s
 }
 
 /// Build an entry slot for a far desk index.
 fn entry_slot_far(created_at: SystemTime, desk_index: usize) -> AgentSlot {
     let mut s = entry_slot_near(created_at);
-    s.desk_index = desk_index;
+    s.desk_index = GlobalDeskIndex(desk_index);
     // Give each far slot a distinct agent_id so speed_mult differs.
     s.agent_id = AgentId::from_transcript_path(&format!("/far/{desk_index}.jsonl"));
     s
@@ -1849,7 +1849,7 @@ fn wander_legs_approach_the_desk_via_an_allowed_side_not_through_the_front() {
     let old = now - Duration::from_secs(120);
     let mut slot = entry_slot(old);
     slot.agent_id = trip_id;
-    slot.desk_index = desk_index;
+    slot.desk_index = GlobalDeskIndex(desk_index);
     slot.last_event_at = old;
 
     let mut router = AStarRouter::new();
@@ -1951,7 +1951,7 @@ fn exit_from_desk_rises_off_the_chair_via_the_approach_cell() {
     let approach = desk_approach_cell(desk, &l).expect("approach cell");
 
     let mut slot = exiting_slot(now, now - Duration::from_secs(300));
-    slot.desk_index = desk_index;
+    slot.desk_index = GlobalDeskIndex(desk_index);
     slot.agent_id = AgentId::from_transcript_path("/exitdesk/slot.jsonl");
 
     let overlay = pixtuoid_core::walkable::OccupancyOverlay::new();
@@ -2383,7 +2383,7 @@ fn wander_continuous_across_layouts_and_agents() {
             let old = now - Duration::from_secs(120);
             let mut slot = entry_slot(old);
             slot.agent_id = id;
-            slot.desk_index = k;
+            slot.desk_index = GlobalDeskIndex(k);
             slot.last_event_at = old;
             // ~20 s ⇒ 2–3 full wander cycles per agent.
             let (max_step, _) = max_anchor_step(&slot, &l, now, 600, true);
@@ -2531,7 +2531,7 @@ fn multiple_agents_share_overlay_without_teleport() {
         .map(|k| {
             let mut s = entry_slot(old);
             s.agent_id = AgentId::from_transcript_path(&format!("/multi/{k}.jsonl"));
-            s.desk_index = k;
+            s.desk_index = GlobalDeskIndex(k);
             s.last_event_at = old;
             s
         })

--- a/crates/pixtuoid/src/tui/tui_renderer/harness.rs
+++ b/crates/pixtuoid/src/tui/tui_renderer/harness.rs
@@ -6,7 +6,7 @@
 use super::*;
 use crate::tui::layout::Point;
 use crate::tui::pet::PetKind;
-use pixtuoid_core::state::{ActivityState, AgentSlot, SceneState};
+use pixtuoid_core::state::{ActivityState, AgentSlot, GlobalDeskIndex, SceneState};
 use pixtuoid_core::AgentId;
 use ratatui::backend::TestBackend;
 use ratatui::Terminal;
@@ -27,7 +27,7 @@ fn slot(id: AgentId, floor_idx: usize, desk_index: usize, started: SystemTime) -
         last_event_at: started,
         exiting_at: None,
         pending_idle_at: None,
-        desk_index,
+        desk_index: GlobalDeskIndex(desk_index),
         floor_idx,
         tool_call_count: 0,
         active_ms: 0,

--- a/crates/pixtuoid/src/tui/widgets/hud.rs
+++ b/crates/pixtuoid/src/tui/widgets/hud.rs
@@ -778,7 +778,7 @@ mod hud_tests {
     // empty (leading non-alphanumeric) must be SKIPPED, not counted as a tool.
     #[test]
     fn status_segments_skips_empty_leading_token() {
-        use pixtuoid_core::{AgentId, AgentSlot};
+        use pixtuoid_core::{AgentId, AgentSlot, GlobalDeskIndex};
         use std::path::PathBuf;
         use std::sync::Arc;
         let slot = AgentSlot {
@@ -797,7 +797,7 @@ mod hud_tests {
             last_event_at: SystemTime::UNIX_EPOCH,
             exiting_at: None,
             pending_idle_at: None,
-            desk_index: 0,
+            desk_index: GlobalDeskIndex(0),
             floor_idx: 0,
             tool_call_count: 0,
             active_ms: 0,
@@ -824,7 +824,7 @@ mod hud_tests {
     // measure over-counts width and short-pads the row below the terminal width.
     #[test]
     fn status_segments_pads_to_full_column_width_with_multibyte_glyphs() {
-        use pixtuoid_core::{AgentId, AgentSlot};
+        use pixtuoid_core::{AgentId, AgentSlot, GlobalDeskIndex};
         use std::path::PathBuf;
         use std::sync::Arc;
         let slot = AgentSlot {
@@ -844,7 +844,7 @@ mod hud_tests {
             last_event_at: SystemTime::UNIX_EPOCH,
             exiting_at: None,
             pending_idle_at: None,
-            desk_index: 0,
+            desk_index: GlobalDeskIndex(0),
             floor_idx: 0,
             tool_call_count: 0,
             active_ms: 0,

--- a/crates/pixtuoid/src/tui/widgets/mod.rs
+++ b/crates/pixtuoid/src/tui/widgets/mod.rs
@@ -135,7 +135,7 @@ impl TickerQueue {
 mod tests {
     use super::*;
     use hud::{build_status_spans, build_status_summary};
-    use pixtuoid_core::{AgentId, AgentSlot};
+    use pixtuoid_core::{AgentId, AgentSlot, GlobalDeskIndex};
     use std::path::PathBuf;
     use std::sync::Arc;
     use tooltip::truncate_label;
@@ -225,7 +225,7 @@ mod tests {
             exiting_at: None,
             pending_idle_at: None,
 
-            desk_index: 0,
+            desk_index: GlobalDeskIndex(0),
             floor_idx: 0,
             tool_call_count: 0,
             active_ms: 0,

--- a/crates/pixtuoid/tests/frame_cache.rs
+++ b/crates/pixtuoid/tests/frame_cache.rs
@@ -11,7 +11,7 @@ use std::time::SystemTime;
 use pixtuoid::tui::frame_cache::{FrameCache, FrameKey};
 use pixtuoid_core::sprite::{Frame, Rgb};
 use pixtuoid_core::state::ActivityState;
-use pixtuoid_core::{AgentId, AgentSlot, SceneState};
+use pixtuoid_core::{AgentId, AgentSlot, GlobalDeskIndex, SceneState};
 
 /// Build a glow-less frame key (no test here varies glow_tint).
 fn key(id: AgentId, anim_name: &'static str, frame_idx: usize, flip_x: bool) -> FrameKey {
@@ -51,7 +51,7 @@ fn make_slot(id: AgentId) -> AgentSlot {
         exiting_at: None,
         pending_idle_at: None,
 
-        desk_index: 0,
+        desk_index: GlobalDeskIndex(0),
         floor_idx: 0,
         tool_call_count: 0,
         active_ms: 0,

--- a/crates/pixtuoid/tests/golden_image.rs
+++ b/crates/pixtuoid/tests/golden_image.rs
@@ -16,7 +16,7 @@ use pixtuoid::tui::embedded_pack::load_sprite_pack;
 use pixtuoid::tui::renderer::draw_scene;
 use pixtuoid::tui::theme;
 use pixtuoid_core::state::ActivityState;
-use pixtuoid_core::{AgentId, AgentSlot, SceneState};
+use pixtuoid_core::{AgentId, AgentSlot, GlobalDeskIndex, SceneState};
 use ratatui::backend::TestBackend;
 use ratatui::Terminal;
 
@@ -56,7 +56,7 @@ fn populated_scene(now: SystemTime) -> SceneState {
                 session_id: format!("sess-{i}").into(),
                 cwd: std::path::PathBuf::from(format!("/tmp/test/{label}")).into(),
                 label: (*label).into(),
-                desk_index: i,
+                desk_index: GlobalDeskIndex(i),
                 floor_idx: 0,
                 state,
                 created_at: now - age_offset,

--- a/crates/pixtuoid/tests/pixel_regression.rs
+++ b/crates/pixtuoid/tests/pixel_regression.rs
@@ -18,7 +18,7 @@ use pixtuoid::tui::floor::FloorMeta;
 use pixtuoid::tui::renderer::draw_scene;
 use pixtuoid::tui::theme::{self, Theme};
 use pixtuoid_core::state::ActivityState;
-use pixtuoid_core::{AgentId, AgentSlot, SceneState};
+use pixtuoid_core::{AgentId, AgentSlot, GlobalDeskIndex, SceneState};
 use ratatui::backend::TestBackend;
 use ratatui::Terminal;
 
@@ -60,7 +60,7 @@ fn fixture_scene(now: SystemTime) -> SceneState {
                 exiting_at: None,
                 pending_idle_at: None,
 
-                desk_index: i,
+                desk_index: GlobalDeskIndex(i),
                 floor_idx: 0,
                 tool_call_count: 0,
                 active_ms: 0,

--- a/crates/pixtuoid/tests/snapshot_regression.rs
+++ b/crates/pixtuoid/tests/snapshot_regression.rs
@@ -21,7 +21,7 @@ use std::time::{Duration, SystemTime};
 use pixtuoid::tui::embedded_pack::load_sprite_pack;
 use pixtuoid::tui::renderer::draw_scene;
 use pixtuoid_core::state::ActivityState;
-use pixtuoid_core::{AgentId, AgentSlot, SceneState};
+use pixtuoid_core::{AgentId, AgentSlot, GlobalDeskIndex, SceneState};
 use ratatui::backend::TestBackend;
 use ratatui::Terminal;
 
@@ -63,7 +63,7 @@ fn fixture_scene(now: SystemTime) -> SceneState {
                 exiting_at: None,
                 pending_idle_at: None,
 
-                desk_index: i,
+                desk_index: GlobalDeskIndex(i),
                 floor_idx: 0,
                 tool_call_count: 0,
                 active_ms: 0,

--- a/crates/pixtuoid/tests/tui_renderer.rs
+++ b/crates/pixtuoid/tests/tui_renderer.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, SystemTime};
 use pixtuoid::tui::embedded_pack::load_sprite_pack;
 use pixtuoid::tui::tui_renderer::TuiRenderer;
 use pixtuoid_core::state::ActivityState;
-use pixtuoid_core::{AgentId, AgentSlot, Renderer, SceneState};
+use pixtuoid_core::{AgentId, AgentSlot, GlobalDeskIndex, Renderer, SceneState};
 use ratatui::backend::TestBackend;
 use ratatui::Terminal;
 
@@ -36,7 +36,7 @@ fn tui_renderer_render_paints_a_full_frame() {
             exiting_at: None,
             pending_idle_at: None,
 
-            desk_index: 0,
+            desk_index: GlobalDeskIndex(0),
             floor_idx: 0,
             tool_call_count: 0,
             active_ms: 0,
@@ -113,7 +113,7 @@ fn tui_renderer_transition_paints_pets_and_coffee() {
                 last_event_at: now - Duration::from_secs(60),
                 exiting_at: None,
                 pending_idle_at: None,
-                desk_index: i * 8,
+                desk_index: GlobalDeskIndex(i * 8),
                 floor_idx: i,
                 tool_call_count: 0,
                 active_ms: 0,
@@ -352,7 +352,7 @@ fn cancel_transition_lands_on_destination_floor() {
                 last_event_at: now - Duration::from_secs(60),
                 exiting_at: None,
                 pending_idle_at: None,
-                desk_index: i * 8,
+                desk_index: GlobalDeskIndex(i * 8),
                 floor_idx: i,
                 tool_call_count: 0,
                 active_ms: 0,

--- a/crates/pixtuoid/tests/widget_cells.rs
+++ b/crates/pixtuoid/tests/widget_cells.rs
@@ -14,7 +14,7 @@ use pixtuoid::tui::embedded_pack::load_sprite_pack;
 use pixtuoid::tui::renderer::draw_scene;
 use pixtuoid::tui::theme;
 use pixtuoid_core::state::ActivityState;
-use pixtuoid_core::{AgentId, AgentSlot, SceneState};
+use pixtuoid_core::{AgentId, AgentSlot, GlobalDeskIndex, SceneState};
 use ratatui::backend::TestBackend;
 use ratatui::buffer::Buffer;
 use ratatui::Terminal;
@@ -64,7 +64,7 @@ fn fixture_scene(now: SystemTime) -> SceneState {
                 exiting_at: None,
                 pending_idle_at: None,
 
-                desk_index: i,
+                desk_index: GlobalDeskIndex(i),
                 floor_idx: 0,
                 tool_call_count: 0,
                 active_ms: 0,


### PR DESCRIPTION
Closes #209. Lands inside the open 0.7.0 breaking window (#218), so `semver-checks` stays green despite the `AgentSlot.desk_index` type change.

## What
The two desk-index spaces — the reducer's **global** allocation space vs a floor's **local** `home_desks` indexing — were enforced by prose only (a 5-line doc warning). Now they're types:

- `GlobalDeskIndex(usize)` / `FloorLocalDeskIndex(usize)` in `pixtuoid-core::state`; `AgentSlot.desk_index: GlobalDeskIndex` is **always global**.
- `SceneState::floor_local_desk(GlobalDeskIndex) -> FloorLocalDeskIndex` is the arithmetic bridge; `SceneLayout::home_desk(FloorLocalDeskIndex)` is the typed accessor. **You can no longer index `home_desks` with a slot's desk_index** — no `Index<GlobalDeskIndex>` exists.
- `build_floor_scene`'s remap re-wraps as `GlobalDeskIndex(global − offset)`: a projected `uniform(cap)` single-floor scene's own global space **coincides** with its floor-0 local space by construction (`floor_of()==0`), so the value is genuinely a valid global index *for that scene* — documented at the remap + pinned by a new coincidence test. Render-path reads use the documented `single_floor_local()` identity cast.

## Real bugs the types surfaced (both fixed here)
1. **`toggle_pin` cross-floor mis-pin** (`tui/mod.rs`): clicking while viewing floor ≥ 1 hit-tested the raw multi-floor scene against the visible floor's layout — a floor-0 agent with a low global index could be pinned invisibly. Now projects via `project_floor_scene` first.
2. **OOB wrap in `hit_test_from_tui`** (adversarial-review finding, fail-first test): the arithmetic bridge on an out-of-range desk wraps onto a synthetic floor and can land back in range — hit-testable while invisible. Switched to the identity cast; OOB stays OOB.

## Scope
36 files, +349/−171 across both crates. `floor_idx` / `active_ms` / `tool_call_count` deliberately stay raw (out of scope per the issue). Docs updated in the nested CLAUDE.md guides.

## Verification
- 1200/1200 tests (4 new: typed-accessor ⇔ raw-vec, remap coincidence, identity-cast contract, the OOB capacity-boundary wrap — watched fail-first).
- fmt + clippy (-D warnings) clean.
- 2-agent review: correctness **APPROVE** (0 findings) + adversarial (6/7 vectors refuted with structural proofs — incl. capacities-only-grow in-range proof, serde non-issue, Ord preservation; its 1 LOW finding is fixed above).

AI-authored — `needs-human-verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)