### PR TITLE
ci: run windows tests with nextest ci profile and upload JUnit to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,18 @@ jobs:
       - name: Install cargo-nextest
         uses: taiki-e/install-action@cargo-nextest
       - run: just test
+        env:
+          NEXTEST_PROFILE: ci
+      - name: Upload test results to Codecov
+        if: always()
+        uses: codecov/codecov-action@v6
+        with:
+          files: target/nextest/ci/junit.xml
+          report-type: test_results
+          flags: windows
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   semver:
     name: semver-checks


### PR DESCRIPTION
## Summary

The windows-test job now runs nextest with the `ci` profile (`NEXTEST_PROFILE: ci`) and uploads the resulting JUnit report to Codecov as test results, mirroring the linux unit-test job's existing Codecov step (with `flags: windows`). The `ci` profile in `.config/nextest.toml` already emits `target/nextest/ci/junit.xml`; the job just never activated it, so Windows test results were missing from Codecov.

## Related issue

Closes #214

## Type of change

- [x] Refactor / chore

## How I tested it

Workflow YAML parses cleanly; the new step is a copy of the linux job's working Codecov upload with the profile env var added to the test step, exactly as specified in the issue. `just preflight` could not complete locally (`cargo-deny` is not installed on this machine; `fmt` passed) — this is a CI-workflow-only change with no Rust code touched, so the workflow run on this PR is the real verification.

## Visual verification (required for sprite / rendering changes)

- [x] Not a visual change, or — screenshot/GIF attached below and it reads at half-block scale.

## Checklist

- [x] I read the relevant `CLAUDE.md` (root + the nested one for the crate I touched).
- [x] New behavior has a test (this repo is TDD-first). (N/A: CI workflow change only; the change itself activates test reporting.)
- [x] No `unwrap()` in non-test code; errors propagate via `anyhow`/`thiserror`. (N/A: no Rust code touched.)
- [x] No new `println!`/`eprintln!` on a production path (use `tracing`). (N/A: no Rust code touched.)
- [x] Docs updated in the same commit if I changed module structure, architecture, or public API (`CLAUDE.md` / `README.md`). (N/A: no structural change.)
- [ ] `just preflight` passes locally. (Could not run fully here: cargo-deny missing; fmt passed, no Rust code touched.)

## AI assistance

- [x] This PR was written/heavily-assisted by an AI agent.
