### PR TITLE
ci(release): per-job least-privilege + tag-on-main ancestry check; OIDC prep (closes #215)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,12 @@ on:
   push:
     tags: ["v*"]
 
+# Least-privilege (#215): jobs inherit read-only; the `release` job alone
+# carries write + attestation scopes (it creates the GH release and attests
+# provenance), and `publish`/`npm` carry id-token for OIDC publishing. A
+# compromised action in any other job gets no repo-write.
 permissions:
-  contents: write
-  id-token: write
-  attestations: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -19,12 +21,26 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Full history for the tag-on-main ancestry check below.
+          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@cargo-nextest
       - uses: extractions/setup-just@v4
+      - name: Validate tag commit is on main
+        # A release tag pushed at an arbitrary (unreviewed) commit must not
+        # build + publish (#215). Pre-release tester tags (v*-win.N / -rc.N)
+        # are deliberately exempt — they exist to test commits BEFORE merge.
+        if: ${{ !contains(github.ref_name, '-') }}
+        run: |
+          git fetch origin main --quiet
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::Tag ${GITHUB_REF_NAME} points at ${GITHUB_SHA}, which is not an ancestor of origin/main — release tags must be cut from main"
+            exit 1
+          fi
       - name: Validate tag matches Cargo.toml version
         run: |
           # Pre-release suffixes (-win.1, -rc.1) validate against the base version —
@@ -175,6 +191,10 @@ jobs:
     needs: [build, deb]
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: write # creates the GitHub release
+      id-token: write # provenance attestation (OIDC)
+      attestations: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -226,6 +246,12 @@ jobs:
     if: ${{ !contains(github.ref_name, '-') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      # OIDC prep for crates.io Trusted Publishing (#216): unused until the
+      # Trusted Publisher is configured on crates.io, then the
+      # CARGO_REGISTRY_TOKEN secret can be dropped.
+      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -367,6 +393,12 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
+      # OIDC prep for npm Trusted Publishing (#216): node 22 bundles npm 10.x,
+      # but OIDC publishing needs npm >= 11.5.1 — without this, trusted
+      # publishing would silently not engage and fall back to the token.
+      # Harmless while NODE_AUTH_TOKEN is still configured; required once the
+      # per-package Trusted Publishers exist and the token is dropped.
+      - run: npm install -g npm@11
       - uses: extractions/setup-just@v4
 
       - name: Download build artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -398,7 +398,10 @@ jobs:
       # publishing would silently not engage and fall back to the token.
       # Harmless while NODE_AUTH_TOKEN is still configured; required once the
       # per-package Trusted Publishers exist and the token is dropped.
-      - run: npm install -g npm@11
+      # Pinned EXACTLY (not @11): the publish path is irreversible, so what
+      # runs must not float with the registry at release time; bump
+      # deliberately (and drop this line once node's bundled npm >= 11.5.1).
+      - run: npm install -g npm@11.5.1
       - uses: extractions/setup-just@v4
 
       - name: Download build artifacts


### PR DESCRIPTION
Implements both halves of #215 and the workflow-side prep for #216.

## #215 — least-privilege + ancestry
- Top-level `permissions` drop to `contents: read`. Only the `release` job carries `contents: write` + `id-token` + `attestations` (it creates the GH release and attests provenance); `publish`/`npm` carry `id-token: write`. A compromised action in `check`/`build`/`deb`/`homebrew` no longer has repo-write.
- The `check` job asserts the tagged commit is an ancestor of `origin/main` (`fetch-depth: 0` + `git merge-base --is-ancestor`) — a release tag pushed at an arbitrary unreviewed commit fails before anything builds or publishes. **Pre-release tester tags (`v*-win.N` / `-rc.N`) are exempt by design** — they exist to test commits before merge.

## #216 — OIDC prep only (tokens deliberately stay)
- `publish` gains `id-token: write` for crates.io Trusted Publishing.
- `npm` job bumps to `npm@11` (node 22 bundles npm 10.x; OIDC needs ≥ 11.5.1 or trusted publishing silently doesn't engage).
- Both are inert until the Trusted Publishers are configured on crates.io and npmjs.com (human dashboard step — that's the remaining scope of #216); `CARGO_REGISTRY_TOKEN` / `NODE_AUTH_TOKEN` remain until then.

## Verify
YAML parse-validated; per-job permissions confirmed job-by-job. **Cannot be exercised pre-merge** (a `pull_request` run executes the BASE branch's workflow definitions) — per the issue, this wants a human eye on the next release run. Expected PR noise: the security-review check goes red with a 401 on any `.github/workflows` edit (documented anti-tamper, self-healing).

Closes #215.

🤖 Generated with [Claude Code](https://claude.com/claude-code)