### PR TITLE
fix: hardening batch — shim contract, CLI validation, falsifiable CI gate, script robustness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,9 +260,14 @@ jobs:
       - name: pixtuoid --help exits 0
         run: ./target/release/pixtuoid --help
       - name: pixtuoid-hook exits 0 with no socket
+        # Both halves of invariant #5's "always exit 0 SILENTLY", on the
+        # RELEASE profile (the test suite covers the debug build): the
+        # pipeline status is the shim's exit code (bash -e, no pipefail),
+        # and any output at all fails the emptiness check.
         run: |
-          echo '{}' | ./target/release/pixtuoid-hook || true
-          echo "hook shim exited (expected silent no-op)"
+          out=$(echo '{}' | ./target/release/pixtuoid-hook 2>&1)
+          test -z "$out"
+          echo "hook shim exited 0 silently (expected no-op with no socket)"
       - name: install-hooks round-trip
         run: |
           mkdir -p /tmp/smoke-test/.claude

--- a/crates/pixtuoid-core/src/physics.rs
+++ b/crates/pixtuoid-core/src/physics.rs
@@ -85,7 +85,9 @@ pub struct WalkProfile {
     pub path_len_octile: u32,
     /// Effective cruise speed after `speed_mult` applied.
     pub v_cruise: f32,
-    /// Acceleration constant (same as `WALK_ACCEL`; stored for walk_progress).
+    /// Acceleration constant for this leg's intent (`WALK_ACCEL`, or
+    /// `WALK_ACCEL_SNAPBACK` for SnapBack); stored so `walk_progress`
+    /// replays the same kinematics.
     pub accel: f32,
 }
 

--- a/crates/pixtuoid-core/src/source/hook/mod.rs
+++ b/crates/pixtuoid-core/src/source/hook/mod.rs
@@ -40,7 +40,9 @@ impl HookSocketListener {
     }
 }
 
-/// Per-connection byte ceiling: 2× the shim's 1MiB stdin cap. lines() buffers
+/// Per-connection byte ceiling: 2× the shim's ~1MiB stdin cap (the cap is
+/// `1MiB − STAMP_HEADROOM` since the pipe-quota fix, so 2MiB sits comfortably
+/// above any stamped line). lines() buffers
 /// until a newline, so without this an adversarial client could grow the
 /// buffer unboundedly for the whole CONN_TIMEOUT window × 128 slots —
 /// defense-in-depth behind the owner-only endpoint (Unix socket 0700, Windows

--- a/crates/pixtuoid-core/src/source/hook/windows.rs
+++ b/crates/pixtuoid-core/src/source/hook/windows.rs
@@ -16,9 +16,12 @@ use crate::source::TaggedSender;
 
 use super::{handle_conn, CONN_TIMEOUT, MAX_CONCURRENT_CONNS};
 
-/// In-buffer must cover the shim's 1MiB stdin cap (pixtuoid-hook main.rs
-/// `take(1 << 20)`) so one payload always fits the pipe quota and the shim's
-/// sync write can't stall behind a momentarily busy daemon task.
+/// In-buffer must cover the shim's stamped wire line: stdin is capped at
+/// `STDIN_CAP = 1MiB − 256B` and the stamps + newline fit the 256B
+/// `STAMP_HEADROOM` (both in pixtuoid-hook main.rs, where their sum is
+/// test-pinned to this 1MiB quota) — so one payload always fits the pipe
+/// quota and the shim's sync write can't stall behind a momentarily busy
+/// daemon task.
 const IN_BUFFER_SIZE: u32 = 1 << 20;
 
 /// Owner-only security descriptor via SDDL `D:P(A;;GA;;;OW)` — protected

--- a/crates/pixtuoid-hook/src/main.rs
+++ b/crates/pixtuoid-hook/src/main.rs
@@ -9,6 +9,21 @@ use paths::default_socket_path;
 
 mod transport;
 
+/// Headroom reserved below the daemon's 1MiB pipe quota for what the shim
+/// ADDS to stdin: the `_shim_ts_ms` stamp, the optional `_pixtuoid_source`
+/// stamp, and the trailing newline (≲100 B worst case — pinned by
+/// `stamp_headroom_covers_worst_case_stamps`). Without it, a payload within
+/// ~65 B of 1MiB re-serializes to a wire line that exceeds the quota, and the
+/// sync write can stall behind a momentarily busy daemon task until the
+/// watchdog fires (event dropped).
+const STAMP_HEADROOM: u64 = 256;
+
+/// Stdin cap. `STDIN_CAP + STAMP_HEADROOM` equals the daemon's Windows pipe
+/// in-buffer quota (`IN_BUFFER_SIZE = 1 << 20` in pixtuoid-core's
+/// source/hook/windows.rs), so one stamped payload always fits the pipe and
+/// the shim's sync write can't stall on quota.
+const STDIN_CAP: u64 = (1 << 20) - STAMP_HEADROOM;
+
 /// Explicit `u128 → u64` narrowing (`try_from`, not a truncating `as` cast):
 /// ms-since-epoch fits u64 for ~580M years, so the `unwrap_or(u64::MAX)` arm
 /// is unreachable in practice — it exists to make the narrowing visible and
@@ -24,7 +39,7 @@ fn main() -> Result<()> {
 
     let mut buf = String::new();
     if std::io::stdin()
-        .take(1 << 20)
+        .take(STDIN_CAP)
         .read_to_string(&mut buf)
         .is_err()
     {
@@ -41,7 +56,16 @@ fn main() -> Result<()> {
         // form — cmd.exe /C can't express a POSIX `VAR=value cmd` env-prefix) wins,
         // then the `PIXTUOID_SOURCE` env var (the Unix install form). Either way the
         // daemon only ever sees the resulting `_pixtuoid_source` stamp.
-        let args: Vec<String> = std::env::args().collect();
+        //
+        // `args_os` + lossy, NOT `args()`: `std::env::args()` PANICS on any
+        // non-Unicode argument (legal Unix argv), breaching invariant #5's
+        // silent exit-0. Lossy rather than filter_map: dropping a non-UTF-8
+        // arg would shift `--source <value>` pairing so the NEXT arg gets
+        // read as the value; lossy preserves arity, and a U+FFFD-mangled
+        // value simply fails the daemon's registry lookup downstream.
+        let args: Vec<String> = std::env::args_os()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
         let source = source_from_argv(&args).or_else(|| std::env::var("PIXTUOID_SOURCE").ok());
         enrich_payload(map, source, now_ms());
     }
@@ -81,10 +105,14 @@ fn source_from_argv(args: &[String]) -> Option<String> {
 /// payload already uses `source` for the start *reason* (startup/resume/clear/
 /// compact). Reading that as the CLI source namespaced the agent under
 /// "startup", splitting it from the claude-code-keyed tool/JSONL/SessionEnd
-/// events — an un-reapable ghost. The private key is shim-owned, so a plain
-/// insert is safe (nothing else writes it). Absent any source (bare `pixtuoid-hook`,
-/// i.e. CC), the decoder defaults to claude-code.
+/// events — an un-reapable ghost. The private key is shim-OWNED — the daemon
+/// trusts it exclusively for CLI attribution — so any inbound
+/// `_pixtuoid_source` (spoofed or replayed) is stripped unconditionally
+/// before stamping; the daemon never sees a value the shim didn't write.
+/// Absent any source (bare `pixtuoid-hook`, i.e. CC), no key is stamped and
+/// the decoder defaults to claude-code.
 fn enrich_payload(map: &mut serde_json::Map<String, Value>, source: Option<String>, ts_ms: u64) {
+    map.remove("_pixtuoid_source");
     map.insert("_shim_ts_ms".into(), Value::from(ts_ms));
     if let Some(src) = source {
         if !src.is_empty() {
@@ -97,6 +125,31 @@ fn enrich_payload(map: &mut serde_json::Map<String, Value>, source: Option<Strin
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn stdin_cap_plus_headroom_equals_the_pipe_quota() {
+        // The daemon's Windows pipe in-buffer (hook/windows.rs IN_BUFFER_SIZE)
+        // is 1 MiB; the wire line is capped stdin + stamps + newline. Pin the
+        // arithmetic the "one payload always fits the quota" claim rests on.
+        assert_eq!(STDIN_CAP + STAMP_HEADROOM, 1 << 20);
+    }
+
+    #[test]
+    fn stamp_headroom_covers_worst_case_stamps() {
+        let mut p = json!({});
+        let map = p.as_object_mut().unwrap();
+        // Worst realistic stamps: a 20-digit u64::MAX timestamp + a source
+        // name far longer than any registered CLI name (claude-code / codex /
+        // reasonix / antigravity are all ≤ 11 chars; allow 64 for custom ones).
+        enrich_payload(map, Some("x".repeat(64)), u64::MAX);
+        let stamped = serde_json::to_vec(&p).unwrap();
+        // minus the bare `{}` baseline, plus the trailing '\n' main appends.
+        let overhead = (stamped.len() - 2 + 1) as u64;
+        assert!(
+            overhead <= STAMP_HEADROOM,
+            "stamps ({overhead}B) must fit within STAMP_HEADROOM ({STAMP_HEADROOM}B)"
+        );
+    }
 
     #[test]
     fn now_ms_keeps_real_magnitude() {
@@ -125,10 +178,34 @@ mod tests {
 
     #[test]
     fn empty_source_env_is_ignored() {
-        let mut p = json!({});
+        // Seeded with a spoofed inbound key: the empty-source path must strip
+        // it too, not just decline to insert.
+        let mut p = json!({ "_pixtuoid_source": "codex" });
         let map = p.as_object_mut().unwrap();
         enrich_payload(map, Some(String::new()), 1);
         assert!(map.get("_pixtuoid_source").is_none());
+    }
+
+    #[test]
+    fn inbound_spoofed_private_key_is_stripped_when_no_source_resolves() {
+        // `_pixtuoid_source` is shim-OWNED: the daemon trusts it exclusively
+        // for CLI attribution (AgentId namespacing), so a spoofed/replayed
+        // inbound key must never pass through on the bare-CC (no source) path.
+        let mut p = json!({ "hook_event_name": "Stop", "_pixtuoid_source": "codex" });
+        let map = p.as_object_mut().unwrap();
+        enrich_payload(map, None, 1);
+        assert!(
+            map.get("_pixtuoid_source").is_none(),
+            "inbound spoofed key must be stripped, not passed through"
+        );
+    }
+
+    #[test]
+    fn inbound_spoofed_private_key_is_overwritten_when_source_resolves() {
+        let mut p = json!({ "_pixtuoid_source": "codex" });
+        let map = p.as_object_mut().unwrap();
+        enrich_payload(map, Some("reasonix".into()), 1);
+        assert_eq!(map["_pixtuoid_source"], json!("reasonix"));
     }
 
     fn argv(parts: &[&str]) -> Vec<String> {

--- a/crates/pixtuoid-hook/src/main.rs
+++ b/crates/pixtuoid-hook/src/main.rs
@@ -20,8 +20,12 @@ const STAMP_HEADROOM: u64 = 256;
 
 /// Stdin cap. `STDIN_CAP + STAMP_HEADROOM` equals the daemon's Windows pipe
 /// in-buffer quota (`IN_BUFFER_SIZE = 1 << 20` in pixtuoid-core's
-/// source/hook/windows.rs), so one stamped payload always fits the pipe and
-/// the shim's sync write can't stall on quota.
+/// source/hook/windows.rs), so a stamped payload fits the pipe and the shim's
+/// sync write can't stall on quota. The headroom covers what the SHIM adds;
+/// pathological number canonicalization can still expand the body itself
+/// (e.g. `1e9` re-serializes to `1000000000.0`) and an absurdly long
+/// `--source` value can exceed the stamp budget — both degrade to the
+/// pre-existing stall→watchdog→drop mode, never a block of CC.
 const STDIN_CAP: u64 = (1 << 20) - STAMP_HEADROOM;
 
 /// Explicit `u128 → u64` narrowing (`try_from`, not a truncating `as` cast):

--- a/crates/pixtuoid-hook/src/transport.rs
+++ b/crates/pixtuoid-hook/src/transport.rs
@@ -42,8 +42,9 @@ pub fn send_line(endpoint: &str, line: &[u8]) {
     // 200ms invariant is enforced by a watchdog thread that hard-exits the
     // process: after stdin is consumed this send is the shim's only job,
     // and exit(0)-on-timeout IS the contract (never block CC, spec §2).
-    // The daemon sizes its pipe in-buffer >= the shim's 1MiB stdin cap so a
-    // write that gets through open() never stalls on quota in practice.
+    // The daemon's 1MiB pipe in-buffer covers the shim's capped stdin
+    // (`STDIN_CAP = 1MiB − STAMP_HEADROOM` in main.rs) PLUS the stamps +
+    // newline, so a write that gets through open() never stalls on quota.
     // Builder::spawn (not thread::spawn) so OS thread exhaustion degrades to
     // dropping the event instead of an abort — and we must NOT enter the
     // retry loop watchdog-less, or the 231 retry becomes unbounded.

--- a/crates/pixtuoid-hook/tests/shim.rs
+++ b/crates/pixtuoid-hook/tests/shim.rs
@@ -23,11 +23,13 @@ fn sock_path(tag: &str) -> std::path::PathBuf {
 }
 
 /// Spawn the shim with the given socket path, optional source env, and extra
-/// argv, pipe `stdin` to it, and return its exit status (after closing stdin → EOF).
-fn run_shim_inner(
+/// argv, pipe `stdin` to it, and return its exit status (after closing stdin →
+/// EOF). Generic over the arg type so the non-UTF-8-argv test can pass raw
+/// `OsStr` bytes.
+fn run_shim_inner<S: AsRef<std::ffi::OsStr>>(
     socket: &std::path::Path,
     source: Option<&str>,
-    args: &[&str],
+    args: &[S],
     stdin: &[u8],
 ) -> std::process::ExitStatus {
     let mut cmd = Command::new(BIN);
@@ -61,7 +63,7 @@ fn run_shim(
     source: Option<&str>,
     stdin: &[u8],
 ) -> std::process::ExitStatus {
-    run_shim_inner(socket, source, &[], stdin)
+    run_shim_inner::<&str>(socket, source, &[], stdin)
 }
 
 /// Spawn the shim with extra argv and NO `PIXTUOID_SOURCE` env, so a `--source`
@@ -218,6 +220,31 @@ fn stalled_listener_shim_exits_zero_within_watchdog_bound() {
     drop(listener);
     drop(fillers);
     let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn non_utf8_argv_exits_zero() {
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+    // Non-UTF-8 bytes are legal in Unix argv (e.g. a binary installed under a
+    // non-UTF-8 path, or shell-expanded bytes in a settings.json hook
+    // command). `std::env::args()` PANICS while collecting such an argument —
+    // exit 101 + stderr, breaching invariant #5's silent exit-0 contract. The
+    // shim must collect argv panic-free and degrade gracefully instead.
+    let path = sock_path("nonutf8");
+    let status = run_shim_inner(
+        &path,
+        None,
+        &[
+            OsStr::from_bytes(b"--source"),
+            OsStr::from_bytes(b"\xff\xfe not utf8"),
+        ],
+        br#"{"hook_event_name":"Stop"}"#,
+    );
+    assert!(
+        status.success(),
+        "non-UTF-8 argv must not panic the shim; got {status:?}"
+    );
 }
 
 #[test]

--- a/crates/pixtuoid/src/cli.rs
+++ b/crates/pixtuoid/src/cli.rs
@@ -12,12 +12,13 @@ pub struct Cli {
     #[command(subcommand)]
     pub cmd: Option<Cmd>,
 
-    /// Log verbosity: error, warn, info, debug, trace. The TUI always logs
-    /// warn+ to a file (~/.cache/pixtuoid/log, or $PIXTUOID_LOG /
+    /// Log verbosity. The TUI always logs warn+ to a file
+    /// (~/.cache/pixtuoid/log, or $PIXTUOID_LOG /
     /// $XDG_STATE_HOME/pixtuoid/log); debug/trace raise the file's
     /// verbosity. Non-TUI commands log to stderr at this level.
-    #[arg(long, global = true, default_value = "info")]
-    pub log_level: String,
+    /// ($RUST_LOG remains the escape hatch for full directive syntax.)
+    #[arg(long, global = true, value_enum, default_value = "info")]
+    pub log_level: LogLevel,
 
     /// Color theme: normal, cyberpunk, dracula, tokyo-night, catppuccin, gruvbox.
     #[arg(long, global = true)]
@@ -38,11 +39,15 @@ pub enum Cmd {
         codex_sessions_root: Option<PathBuf>,
         #[arg(long)]
         pack_dir: Option<PathBuf>,
-        /// Cap desks per floor (auto-computed from terminal size if unset).
-        #[arg(long, hide = true)]
+        /// Cap desks per floor, ≥ 1 (auto-computed from terminal size if
+        /// unset). 0 is rejected: it would permanently zero every floor's
+        /// capacity and silently drop every agent (the boot atomics only
+        /// grow via fetch_max, gated on capacity > 0).
+        #[arg(long, hide = true, value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..))]
         max_desks: Option<usize>,
         /// Skip the TUI entirely — useful for CI / scripting.
-        /// Prints a JSON snapshot of SceneState every 200ms when it changes.
+        /// Prints a one-line `agents=[label@desk:state, ...]` summary every
+        /// 200ms when it changes.
         #[arg(long, default_value_t = false)]
         headless: bool,
     },
@@ -82,6 +87,35 @@ pub enum Cmd {
     },
 }
 
+/// `--log-level` values. A typed enum (not a free `String`) so a typo like
+/// `dbug` is a hard clap parse error instead of silently parsing as an
+/// `EnvFilter` TARGET directive (`dbug=trace`) that filters everything off —
+/// the #157 silent-diagnostics class. `$RUST_LOG` stays the escape hatch for
+/// full tracing directive syntax (targets, per-module levels).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub enum LogLevel {
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl LogLevel {
+    /// The tracing level token — exactly the strings the old free-form
+    /// `--log-level` accepted, so every `EnvFilter` built from it is
+    /// unchanged; the enum only moved typo rejection to the clap seam.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            LogLevel::Error => "error",
+            LogLevel::Warn => "warn",
+            LogLevel::Info => "info",
+            LogLevel::Debug => "debug",
+            LogLevel::Trace => "trace",
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
 pub enum TargetName {
     Claude,
@@ -102,7 +136,7 @@ impl TargetName {
 }
 
 impl Cli {
-    pub fn cmd_or_default(self) -> (String, Option<String>, Cmd) {
+    pub fn cmd_or_default(self) -> (LogLevel, Option<String>, Cmd) {
         let level = self.log_level;
         let theme = self.theme;
         let cmd = self.cmd.unwrap_or(Cmd::Run {
@@ -122,6 +156,58 @@ mod tests {
     use super::*;
 
     #[test]
+    fn log_level_typo_is_a_hard_parse_error() {
+        // A free String silently parsed a typo like `dbug` as an EnvFilter
+        // TARGET directive (everything filtered off — the #157 class); the
+        // ValueEnum makes it a loud clap error at the seam.
+        let err = Cli::try_parse_from(["pixtuoid", "--log-level", "dbug"]).unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::InvalidValue);
+    }
+
+    #[test]
+    fn max_desks_zero_is_a_hard_parse_error() {
+        // 0 would permanently zero every floor's capacity (the per-frame
+        // re-seed guards `> 0`, so the atomics never grow) — every agent
+        // silently dropped. Rejected at the clap seam.
+        let err = Cli::try_parse_from(["pixtuoid", "run", "--max-desks", "0"]).unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::ValueValidation);
+    }
+
+    #[test]
+    fn log_level_valid_values_map_to_the_same_filter_tokens_as_before() {
+        // The enum's as_str must be exactly the strings the old free-form
+        // --log-level accepted, and each must build a valid EnvFilter — the
+        // typed seam may not change any accepted filter.
+        for (raw, lvl) in [
+            ("error", LogLevel::Error),
+            ("warn", LogLevel::Warn),
+            ("info", LogLevel::Info),
+            ("debug", LogLevel::Debug),
+            ("trace", LogLevel::Trace),
+        ] {
+            let cli = Cli::try_parse_from(["pixtuoid", "--log-level", raw]).unwrap();
+            assert_eq!(cli.log_level, lvl);
+            assert_eq!(lvl.as_str(), raw, "filter token must be unchanged");
+            assert!(
+                tracing_subscriber::EnvFilter::try_new(lvl.as_str()).is_ok(),
+                "{raw} must parse as an EnvFilter level"
+            );
+        }
+    }
+
+    #[test]
+    fn max_desks_positive_parses() {
+        let cli = Cli::try_parse_from(["pixtuoid", "run", "--max-desks", "4"]).unwrap();
+        assert!(matches!(
+            cli.cmd,
+            Some(Cmd::Run {
+                max_desks: Some(4),
+                ..
+            })
+        ));
+    }
+
+    #[test]
     fn target_name_as_str_covers_all_arms() {
         assert_eq!(TargetName::Claude.as_str(), "claude");
         assert_eq!(TargetName::Codex.as_str(), "codex");
@@ -133,11 +219,11 @@ mod tests {
     fn cmd_or_default_returns_run_when_no_subcommand() {
         let cli = Cli {
             cmd: None,
-            log_level: "info".into(),
+            log_level: LogLevel::Info,
             theme: None,
         };
         let (level, theme, cmd) = cli.cmd_or_default();
-        assert_eq!(level, "info");
+        assert_eq!(level, LogLevel::Info);
         assert!(theme.is_none());
         assert!(matches!(
             cmd,
@@ -157,11 +243,11 @@ mod tests {
                 target: None,
                 yes: false,
             }),
-            log_level: "debug".into(),
+            log_level: LogLevel::Debug,
             theme: Some("cyberpunk".into()),
         };
         let (level, theme, cmd) = cli.cmd_or_default();
-        assert_eq!(level, "debug");
+        assert_eq!(level, LogLevel::Debug);
         assert_eq!(theme.as_deref(), Some("cyberpunk"));
         assert!(matches!(cmd, Cmd::UninstallHooks { .. }));
     }

--- a/crates/pixtuoid/src/config.rs
+++ b/crates/pixtuoid/src/config.rs
@@ -173,6 +173,28 @@ pub fn save_version(path: &Path, version: &str) -> Result<()> {
     })
 }
 
+/// Resolve the config `max-desks` into the runtime desk cap. `0` is treated
+/// as unset with a collected warning (#87 channel): the cap clamps every
+/// floor via `min`, and the per-frame capacity re-seed only grows atomics
+/// when `capacity > 0` — so an accepted 0 would permanently zero every floor
+/// and silently drop every SessionStart (a permanently empty office with no
+/// in-TUI signal). The hidden `--max-desks` CLI flag rejects 0 at the clap
+/// seam (`range(1..)`); this is the config file's twin of that guard.
+pub fn resolve_max_desks(config: &AppConfig, warnings: &mut Vec<String>) -> Option<usize> {
+    match config.max_desks {
+        Some(0) => {
+            tracing::warn!("max-desks = 0 in config would hide every agent — ignoring");
+            warnings.push(
+                "max-desks = 0 in config would hide every agent — ignoring it \
+                 (desk capacity stays auto-computed)"
+                    .into(),
+            );
+            None
+        }
+        other => other,
+    }
+}
+
 /// Resolve CLI + config into the one `&'static Theme` the runtime uses
 /// (CLI > config > `NORMAL`). The asymmetry is deliberate: a `--theme` typo is
 /// explicit user intent and hard-errors (listing valid names), while a config
@@ -556,8 +578,10 @@ mod tests {
         std::fs::write(&path, "max-desks = 8\n").unwrap();
         let cfg = load(&path, &mut Vec::new());
         let cli_max_desks: Option<usize> = None;
-        let desk_cap = cli_max_desks.or(cfg.max_desks);
+        let mut w = Vec::new();
+        let desk_cap = cli_max_desks.or(resolve_max_desks(&cfg, &mut w));
         assert_eq!(desk_cap, Some(8));
+        assert!(w.is_empty(), "a valid cap collects no warning: {w:?}");
     }
 
     #[test]
@@ -567,7 +591,7 @@ mod tests {
         std::fs::write(&path, "max-desks = 8\n").unwrap();
         let cfg = load(&path, &mut Vec::new());
         let cli_max_desks: Option<usize> = Some(4);
-        let desk_cap = cli_max_desks.or(cfg.max_desks);
+        let desk_cap = cli_max_desks.or(resolve_max_desks(&cfg, &mut Vec::new()));
         assert_eq!(desk_cap, Some(4));
     }
 
@@ -575,7 +599,7 @@ mod tests {
     fn max_desks_neither_set() {
         let cfg = AppConfig::default();
         let cli_max_desks: Option<usize> = None;
-        let desk_cap = cli_max_desks.or(cfg.max_desks);
+        let desk_cap = cli_max_desks.or(resolve_max_desks(&cfg, &mut Vec::new()));
         assert_eq!(desk_cap, None);
     }
 
@@ -583,8 +607,28 @@ mod tests {
     fn max_desks_no_config_file() {
         let cfg = load(Path::new("/nonexistent/path/config.toml"), &mut Vec::new());
         let cli_max_desks: Option<usize> = None;
-        let desk_cap = cli_max_desks.or(cfg.max_desks);
+        let desk_cap = cli_max_desks.or(resolve_max_desks(&cfg, &mut Vec::new()));
         assert_eq!(desk_cap, None);
+    }
+
+    #[test]
+    fn max_desks_zero_in_config_is_ignored_with_warning() {
+        // 0 would permanently zero every floor (the per-frame re-seed guards
+        // `capacity > 0`, so the boot atomics never grow) — every agent
+        // silently dropped. The config seam must degrade to auto capacity
+        // and say so on the #87 warning channel.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "max-desks = 0\n").unwrap();
+        let cfg = load(&path, &mut Vec::new());
+        assert_eq!(cfg.max_desks, Some(0), "the raw key still deserializes");
+        let mut w = Vec::new();
+        assert_eq!(resolve_max_desks(&cfg, &mut w), None, "0 resolves to unset");
+        assert_eq!(w.len(), 1);
+        assert!(
+            w[0].contains("max-desks = 0"),
+            "the warning names the bad key: {w:?}"
+        );
     }
 
     #[test]

--- a/crates/pixtuoid/src/config.rs
+++ b/crates/pixtuoid/src/config.rs
@@ -186,7 +186,7 @@ pub fn resolve_max_desks(config: &AppConfig, warnings: &mut Vec<String>) -> Opti
             tracing::warn!("max-desks = 0 in config would hide every agent — ignoring");
             warnings.push(
                 "max-desks = 0 in config would hide every agent — ignoring it \
-                 (desk capacity stays auto-computed)"
+                 (the --max-desks flag or auto-computed capacity applies)"
                     .into(),
             );
             None

--- a/crates/pixtuoid/src/main.rs
+++ b/crates/pixtuoid/src/main.rs
@@ -11,6 +11,11 @@ use tracing_subscriber::EnvFilter;
 fn main() -> Result<()> {
     install_crash_hook();
     let (log_level, cli_theme, cmd) = Cli::parse().cmd_or_default();
+    // The typed LogLevel's as_str is exactly the old free-string levels, so
+    // every filter built below is unchanged — the enum only moved typo
+    // rejection to the clap seam (a typo used to parse as a bogus EnvFilter
+    // TARGET directive that silently filtered everything off, #157 class).
+    let log_level: &'static str = log_level.as_str();
     // RUST_LOG wins only when set to a NON-EMPTY value; an empty RUST_LOG
     // parses as Ok(zero directives) = everything OFF, which would silently
     // defeat logging on the verbose / $PIXTUOID_LOG / --headless paths that
@@ -18,8 +23,8 @@ fn main() -> Result<()> {
     // empty=unset normalization is pinned by `filter_directives` + its test.
     let rust_log = std::env::var("RUST_LOG").ok();
     let make_filter = || {
-        EnvFilter::try_new(filter_directives(rust_log.as_deref(), &log_level))
-            .unwrap_or_else(|_| EnvFilter::new(&log_level))
+        EnvFilter::try_new(filter_directives(rust_log.as_deref(), log_level))
+            .unwrap_or_else(|_| EnvFilter::new(log_level))
     };
 
     // Log routing:
@@ -30,7 +35,7 @@ fn main() -> Result<()> {
     //     Crash reporting is handled separately by the panic hook.
     //   Non-TUI (install-hooks, uninstall-hooks, --headless): stderr.
     let tui_active = matches!(&cmd, Cmd::Run { headless, .. } if !*headless);
-    let wants_verbose = matches!(log_level.as_str(), "debug" | "trace");
+    let wants_verbose = matches!(log_level, "debug" | "trace");
     // The env var's VALUE is the log file path — an empty value would
     // "enable" file mode with an unopenable path; treat it as unset.
     let explicit_log_file = std::env::var("PIXTUOID_LOG").is_ok_and(|v| !v.is_empty());
@@ -53,7 +58,7 @@ fn main() -> Result<()> {
             EnvFilter::try_new(filter_directives(rust_log.as_deref(), "warn"))
                 .unwrap_or_else(|_| EnvFilter::new("warn"))
         } else {
-            EnvFilter::new(match log_level.as_str() {
+            EnvFilter::new(match log_level {
                 lvl @ ("warn" | "error") => lvl,
                 _ => "warn",
             })
@@ -102,7 +107,11 @@ fn main() -> Result<()> {
             let mut cfg_warnings = Vec::new();
             let cfg = config::load(&cfg_path, &mut cfg_warnings);
             let theme = config::resolve_theme(&cfg, cli_theme.as_deref(), &mut cfg_warnings)?;
-            let desk_cap = cli_max_desks.or(cfg.max_desks);
+            // The config seam's twin of the clap range(1..) guard: a config
+            // max-desks = 0 is ignored with a collected warning (eager `.or`
+            // argument on purpose — the warning must fire even when the CLI
+            // flag overrides, same as the stale-config-theme warn above).
+            let desk_cap = cli_max_desks.or(config::resolve_max_desks(&cfg, &mut cfg_warnings));
             let pack_dir = config::resolve_pack_dir(&cfg, pack_dir);
             let pets = config::resolve_pets(&cfg, &mut cfg_warnings);
             // Config problems must reach the user's eyes, not only the log

--- a/crates/pixtuoid/src/runtime/driver.rs
+++ b/crates/pixtuoid/src/runtime/driver.rs
@@ -151,6 +151,17 @@ async fn reducer_task(
 
 async fn headless_loop(mut scene_rx: SceneRx) -> Result<()> {
     tracing::info!("pixtuoid headless mode — Ctrl-C to quit");
+    // ONE SIGINT listener for the loop's lifetime. A fresh `ctrl_c()` per
+    // select! iteration drops the old listener while the sleep arm runs, and
+    // tokio's process-global handler (installed once) suppresses default
+    // termination — so a SIGINT landing in that gap notifies zero listeners
+    // and is silently lost (the user must Ctrl-C twice). Pinned outside the
+    // loop the subscription is continuous; the arm returns on completion, so
+    // the future is never polled again after it resolves. No test: driver.rs
+    // is the documented untestable async glue (#103) and a real-signal test
+    // would race the whole test binary.
+    let ctrl_c = tokio::signal::ctrl_c();
+    tokio::pin!(ctrl_c);
     let mut prev_summary = String::new();
     loop {
         tokio::select! {
@@ -162,7 +173,7 @@ async fn headless_loop(mut scene_rx: SceneRx) -> Result<()> {
                     prev_summary = summary;
                 }
             }
-            _ = tokio::signal::ctrl_c() => {
+            _ = &mut ctrl_c => {
                 tracing::info!("shutting down");
                 return Ok(());
             }

--- a/crates/pixtuoid/src/tui/pathfind.rs
+++ b/crates/pixtuoid/src/tui/pathfind.rs
@@ -7,7 +7,8 @@
 //! `renderer.rs`.
 //!
 //! `AStarRouter` is the concrete impl: A* on a coarsened 4×4 cell grid
-//! with a permissive cell-walkability threshold (≥12/16 px walkable).
+//! with a permissive cell-walkability threshold (≥8/16 px walkable, 50% —
+//! see `CELL_WALKABLE_MIN` for why tighter thresholds were rejected).
 //! Memoizes results in a per-(from, to) cache; auto-invalidates when
 //! the overlay signature changes so per-frame agent movement still routes
 //! around live agents.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -28,7 +28,7 @@ kind = "dog"        # name omitted → "Office Dog"
 | Key | Default | Description |
 |-----|---------|-------------|
 | `theme` | `"normal"` | Color theme — `normal`, `cyberpunk`, `dracula`, `tokyo-night`, `catppuccin`, `gruvbox`. |
-| `max-desks` | auto | Cap desks per floor. If unset, auto-computed from terminal size. Excess agents overflow to additional floors. |
+| `max-desks` | auto | Cap desks per floor (≥ 1; `0` is ignored with a warning). If unset, auto-computed from terminal size. Excess agents overflow to additional floors. |
 | `pack-dir` | — | Custom sprite pack directory. Supports `~` expansion. See [Custom sprite packs](#custom-sprite-packs). |
 | `[[pets]]` | all kinds, default names | One stanza per pet. `kind` (`"cat"`/`"dog"`) is required; `name` is optional (the hover-tooltip label, default `Office Cat`/`Office Dog`). Omit the section for all pets; `pets = []` for none; an unknown `kind` is skipped without affecting other settings. Keep it last (it's a table section). |
 

--- a/justfile
+++ b/justfile
@@ -139,8 +139,17 @@ coverage:
 [group('rust')]
 [doc('Never-panic fuzz the decoders over a JSONL corpus dir: just fuzz ~/.claude/projects')]
 fuzz dir:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    dir="{{ dir }}"
+    # Guard the corpus BEFORE fuzzing: under the default no-pipefail shell a
+    # typo'd dir made `find` fail while the pipeline status stayed the
+    # fuzzer's — which fuzzes zero lines and exits 0, reporting the
+    # never-panic contract verified having tested nothing.
+    [ -d "$dir" ] || { echo "error: corpus dir '$dir' does not exist" >&2; exit 1; }
+    [ -n "$(find "$dir" -name '*.jsonl' -print -quit)" ] || { echo "error: no .jsonl files under '$dir' — nothing to fuzz" >&2; exit 1; }
     cargo build --release --example decoder_fuzz -p pixtuoid-core
-    find "{{ dir }}" -name '*.jsonl' -print0 | xargs -0 cat | ./target/release/examples/decoder_fuzz
+    find "$dir" -name '*.jsonl' -print0 | xargs -0 cat | ./target/release/examples/decoder_fuzz
 
 # Compile the workspace; extra args are forwarded:
 #   just build                                # debug

--- a/scripts/check_upstream_drift.py
+++ b/scripts/check_upstream_drift.py
@@ -30,11 +30,22 @@ See crates/pixtuoid-core/CLAUDE.md "Keeping the decode mapping current".
 
 from __future__ import annotations
 
+import http.client
 import pathlib
 import re
 import sys
+import traceback
 import urllib.error
 import urllib.request
+
+# What a fetch can raise transiently. URLError covers connect-phase failures
+# (urllib wraps OSErrors only during do_open) and HTTP 4xx/5xx (HTTPError
+# subclasses it), but the READ phase inside fetch() raises raw
+# socket.timeout / ConnectionResetError (OSError subclasses, NOT URLError)
+# and http.client.IncompleteRead (HTTPException) — left uncaught they exit 1
+# and the workflow files a junk "confirmed drift" issue from an empty report.
+# URLError is itself an OSError subclass; kept explicit to document intent.
+FETCH_ERRORS = (urllib.error.URLError, OSError, http.client.HTTPException)
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
 
@@ -137,34 +148,25 @@ def upstream_reasonix_hooks(text: str) -> set[str] | None:
     return found or None
 
 
-def main() -> int:
-    breaking: list[str] = []
-    review: list[str] = []
-    errors: list[str] = []
-
-    # Read what WE depend on from our OWN source first. A failure here means the
-    # monitor itself is broken (decoder.rs / install/codex.rs refactored away from
-    # what the parsers expect) — that is a LOUD breaking signal, never a transient
-    # one, or drift monitoring would silently stop with zero alarm.
-    codex_ours = None
-    dispatch_names = None
-    reasonix_ours = None
-    try:
-        codex_ours = read_codex_events()
-        dispatch_names = read_dispatch_names()
-        reasonix_ours = read_reasonix_events()
-    except Exception as e:  # noqa: BLE001
-        breaking.append(
-            f"drift-watch cannot read our own source ({e}) — the parsers in "
-            f"check_upstream_drift.py are stale (decoder.rs / install refactored?). "
-            f"The monitor is blind until the script is fixed."
-        )
-
+def run_checks(
+    codex_ours: set[str] | None,
+    dispatch_names: set[str] | None,
+    reasonix_ours: set[str] | None,
+    breaking: list[str],
+    review: list[str],
+    errors: list[str],
+) -> None:
+    """The upstream comparisons. Split from main() so an UNEXPECTED exception
+    here (a script bug, an exotic network failure outside FETCH_ERRORS) can be
+    routed to the transient bucket with the partial report intact — without it
+    the interpreter exits 1 and the workflow files a junk "confirmed drift"
+    issue from an empty report. The deliberate read-our-own-source LOUD path
+    stays inside main(), before this is called, and still exits 1."""
     # --- Codex hook events (only the FETCH is transient) -------------------
     if codex_ours is not None:
         try:
             text = fetch(CODEX_PROTOCOL_URL)
-        except urllib.error.URLError as e:
+        except FETCH_ERRORS as e:
             errors.append(f"Codex source fetch failed (transient?): {e}")
             text = None
         if text is not None:
@@ -194,7 +196,7 @@ def main() -> int:
     if reasonix_ours is not None:
         try:
             text = fetch(REASONIX_HOOK_URL)
-        except urllib.error.URLError as e:
+        except FETCH_ERRORS as e:
             errors.append(f"Reasonix source fetch failed (transient?): {e}")
             text = None
         if text is not None:
@@ -231,7 +233,7 @@ def main() -> int:
     if dispatch_names is not None:
         try:
             tools = fetch(CC_TOOLS_URL)
-        except urllib.error.URLError as e:
+        except FETCH_ERRORS as e:
             errors.append(f"CC tools-reference fetch failed (transient?): {e}")
             tools = None
         if tools is not None:
@@ -253,7 +255,7 @@ def main() -> int:
     # CC_LIFECYCLE_SURFACE_MARKERS).
     try:
         hooks_doc = fetch(CC_HOOKS_URL)
-    except urllib.error.URLError as e:
+    except FETCH_ERRORS as e:
         errors.append(f"CC hooks doc fetch failed (transient?): {e}")
         hooks_doc = None
     if hooks_doc is not None:
@@ -265,6 +267,41 @@ def main() -> int:
                     f"JSONL transport / the liveness-probe registry) and "
                     f"update this watch."
                 )
+
+
+
+def main() -> int:
+    breaking: list[str] = []
+    review: list[str] = []
+    errors: list[str] = []
+
+    # Read what WE depend on from our OWN source first. A failure here means the
+    # monitor itself is broken (decoder.rs / install/codex.rs refactored away from
+    # what the parsers expect) — that is a LOUD breaking signal, never a transient
+    # one, or drift monitoring would silently stop with zero alarm.
+    codex_ours = None
+    dispatch_names = None
+    reasonix_ours = None
+    try:
+        codex_ours = read_codex_events()
+        dispatch_names = read_dispatch_names()
+        reasonix_ours = read_reasonix_events()
+    except Exception as e:  # noqa: BLE001
+        breaking.append(
+            f"drift-watch cannot read our own source ({e}) — the parsers in "
+            f"check_upstream_drift.py are stale (decoder.rs / install refactored?). "
+            f"The monitor is blind until the script is fixed."
+        )
+
+    try:
+        run_checks(codex_ours, dispatch_names, reasonix_ours, breaking, review, errors)
+    except Exception as e:  # noqa: BLE001
+        traceback.print_exc()
+        errors.append(
+            f"unexpected error during the upstream checks "
+            f"({type(e).__name__}: {e}) — treating as transient; the report "
+            f"covers only the checks that completed (traceback on stderr)"
+        )
 
     # --- report ------------------------------------------------------------
     out = ["# pixtuoid upstream wire-format drift report", ""]

--- a/scripts/gen-media.py
+++ b/scripts/gen-media.py
@@ -316,6 +316,13 @@ def main():
     ap.add_argument("--jobs", help="comma-separated job ids to run (default: all)")
     args = ap.parse_args()
 
+    # run_check walks the FULL committed tree, so every still owned by a
+    # filtered-out job would report "NOT REGENERATED" — spurious failures.
+    # Rejecting the combination is the honest contract (CI never passes --jobs).
+    if args.check and args.jobs:
+        ap.error("--check renders everything and walks the full committed tree; "
+                 "--jobs cannot be combined with it (run --check without --jobs)")
+
     # Pin TZ=UTC for EVERY render so the office's epoch-derived weather slot +
     # lighting/twinkle phase (snapshot reads --now-hour as a chrono::Local wall
     # time) are machine-independent — without this a dev box and the UTC CI runner
@@ -326,8 +333,19 @@ def main():
 
     only_jobs = set(args.jobs.split(",")) if args.jobs else None
 
-    build_once()
+    # Validate --jobs against the manifest BEFORE the release build: an unknown
+    # id used to be a silent no-op that still printed "wrote media → …".
     manifest = json.loads(MANIFEST.read_text())
+    if only_jobs:
+        known = {j["id"] for j in manifest}
+        unknown = sorted(only_jobs - known)
+        if unknown:
+            sys.exit(
+                f"gen-media: unknown job id(s): {', '.join(unknown)}\n"
+                f"available: {', '.join(sorted(known))}"
+            )
+
+    build_once()
     work = Path(tempfile.mkdtemp(prefix="gen-media-"))
 
     if args.check:


### PR DESCRIPTION
Third of five PRs from the external whole-codebase review triage — findings #5, #10, #14, #18, #26, #27, #28, #29, #30, #34, #35, #36.

## Shim (invariant #5 — always exit 0 silently)
- **Non-UTF-8 argv no longer panics** (`args_os` + lossy conversion, preserving `--source` pairing arity) — was exit 101 with stderr, visible to CC as a failing hook. Child-process pinned.
- **Stamped lines always fit the Windows pipe quota**: stdin cap gains `STAMP_HEADROOM = 256` (was: a payload within ~55B of 1MiB could stall the sync write until the watchdog, silently dropping the event). All three stale comments tied to the old arithmetic fixed.
- **`_pixtuoid_source` is stripped from inbound payloads unconditionally** — the "shim-owned key" contract is now structurally true; a spoofed inbound key could previously mis-namespace an AgentId on the no-source path.

## CLI/runtime
- `--max-desks 0` is a parse error; config `max-desks = 0` is ignored with a pre-altscreen warning (was: a permanently empty office with no in-TUI signal).
- `headless_loop`'s `ctrl_c` future is pinned outside the `select!` loop (a SIGINT landing in the per-iteration recreate gap was swallowed — press-twice symptom).
- `--headless` help now describes the real one-line summary output (claimed JSON).
- `--log-level` is a `ValueEnum`: a typo (`dbug`) is a hard parse error instead of silently disabling all non-TUI logging. `RUST_LOG` remains the full-directive escape hatch (note: full directives via `--log-level` itself — undocumented — no longer parse).

## CI/scripts/docs
- The smoke job's hook-shim step drops `|| true` and asserts silence — the invariant-#5 gate is **falsifiable** again. (Expected PR noise: security-review goes red with the documented anti-tamper 401 on any workflow edit — self-healing.)
- `check_upstream_drift.py`: read-phase network errors (socket timeout, ConnectionReset, IncompleteRead — none are `URLError` subclasses) route to the transient bucket instead of auto-filing a junk "confirmed drift" issue; unexpected exceptions exit 2 with the partial report; the own-source-read failure stays LOUD.
- `physics.rs` accel doc + `pathfind.rs` threshold doc corrected (both handed a reader exactly the documented failure mode).
- `just fuzz` fails loudly on a missing/empty corpus (was: "verified" the never-panic contract on zero lines).
- `gen-media --jobs` validates job ids before the expensive release build; `--check --jobs` is rejected as unsupported.

## Review
Adversarial review: 0 critical/high/medium; 3 LOW (warning wording, comment over-claim, third stale comment) fixed in the follow-up commit. One deliberate trade-off worth knowing: the cap shrink means payloads in `(1MiB−256B, 1MiB]` now drop on Unix too (previously forwarded fine there) — chosen to keep the shim/daemon constants decoupled; hook payloads near 1MiB are not a real-world shape.

10 new tests, red-first where expressible; `just test` 1312/1312, clippy `-D warnings`, check-windows, both Python scripts compile + live-exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)