### PR TITLE
release: re-curate the 0.7.0 in-app notes for the full window

### DIFF
--- a/crates/pixtuoid/src/version.rs
+++ b/crates/pixtuoid/src/version.rs
@@ -59,12 +59,12 @@ pub fn release_notes(version: &str) -> Option<&'static [&'static str]> {
         // brace would silently break if the indentation ever shifted.
         // [bump-inject-here]
         "0.7.0" => Some(&[
-            "Agent dashboard: Tab opens a foldable agent tree with per-CLI badges; Enter jumps floors",
-            "Offices now stack up to 10 floors (was 5)",
+            "Agents leave the moment they finish — instant exit detection (process watch + SubagentStop hooks); re-run `pixtuoid install-hooks` once to enable",
+            "Workflow fleets render right: instant seats on arrival, desks free in seconds, parent links survive worktree splits and revivals",
+            "Attach mid-session and every live agent appears immediately — even idle or permission-parked ones",
+            "Agent dashboard: Tab opens a foldable agent tree with per-CLI badges; Enter jumps floors (now up to 10)",
             "Windows: Codex + Reasonix hooks and the Antigravity watcher work end-to-end",
-            "Subagent links survive git-worktree cwd splits (CC agents key on the session UUID)",
-            "Big transcripts appear on first sight instead of after their next write",
-            "Fixed a render crash on non-ASCII project paths; headless output is escape-sanitized",
+            "Your config is never wiped: installs and saves preserve comments & permissions under one atomic locked round",
         ]),
         // 0.6.1 re-runs the 0.6.0 release with the npm-launcher publish fix
         // (#186) — 0.6.0 shipped to crates.io/homebrew but the `pixtuoid` npm


### PR DESCRIPTION
## What

The 0.7.0 `release_notes()` arm was drafted at bump time (June 9) and 40+ merges landed since — the liveness ladder, 52 review fixes, and the complete subagent-lifecycle arc (#243/#245/#248/#249/#250). Re-curated to six user-facing highlights, led by the headline (instant exits) and the one operational note existing users need (**re-run `pixtuoid install-hooks` once**).

Notes-only change; `current_version_has_release_notes` + version tests green.

After this merges, v0.7.0 is tag-ready (tag push = maintainer-only, fires crates.io + npm + homebrew).

🤖 Generated with [Claude Code](https://claude.com/claude-code)