### PR TITLE
fix: deterministic duplicate-id pid binding (CC registry + codex rollout) + unknown_cwd twin consolidation

### DIFF
--- a/crates/pixtuoid-core/src/source/cc_probe.rs
+++ b/crates/pixtuoid-core/src/source/cc_probe.rs
@@ -122,7 +122,7 @@ pub fn live_cc_session_ids(sessions_dir: &Path) -> Option<ProbeSnapshot> {
                             session_id = %reg.session_id,
                             pids = ?(slot.get().pid, reg.pid),
                             "two live CC registry entries claim the same sessionId — \
-                             keeping the most recently started"
+                             keeping a deterministic winner"
                         );
                     });
                     if prefer_candidate(slot.get(), &reg) {
@@ -155,9 +155,9 @@ pub fn live_cc_session_ids(sessions_dir: &Path) -> Option<ProbeSnapshot> {
 /// unspecified and may differ between refreshes, and the binding must not
 /// flap. Newest `startedAt` wins (the genuinely newer CC owns a reused id);
 /// a `startedAt`-carrying entry beats one without (it also passed the pid
-/// identity check, so it's the better-attested binding); both absent → larger
-/// pid — arbitrary, but stable for live processes, which is all stability
-/// needs.
+/// identity check, so it's the better-attested binding); both absent or equal
+/// → larger pid — arbitrary, but stable for live processes, which is all
+/// stability needs.
 #[cfg(unix)]
 fn prefer_candidate(incumbent: &RegistryEntry, candidate: &RegistryEntry) -> bool {
     match (candidate.started_at_ms, incumbent.started_at_ms) {
@@ -762,7 +762,10 @@ mod liveness_tests {
         // Newest startedAt wins, in BOTH presentation orders (the symmetry IS
         // the scan-order independence).
         assert!(prefer_candidate(&entry(1, Some(100)), &entry(2, Some(200))));
-        assert!(!prefer_candidate(&entry(2, Some(200)), &entry(1, Some(100))));
+        assert!(!prefer_candidate(
+            &entry(2, Some(200)),
+            &entry(1, Some(100))
+        ));
         // A startedAt-carrying entry beats one without, both orders.
         assert!(prefer_candidate(&entry(9, None), &entry(1, Some(100))));
         assert!(!prefer_candidate(&entry(1, Some(100)), &entry(9, None)));
@@ -770,7 +773,10 @@ mod liveness_tests {
         assert!(prefer_candidate(&entry(1, None), &entry(2, None)));
         assert!(!prefer_candidate(&entry(2, None), &entry(1, None)));
         assert!(prefer_candidate(&entry(1, Some(100)), &entry(2, Some(100))));
-        assert!(!prefer_candidate(&entry(2, Some(100)), &entry(1, Some(100))));
+        assert!(!prefer_candidate(
+            &entry(2, Some(100)),
+            &entry(1, Some(100))
+        ));
     }
 
     #[cfg(unix)]
@@ -781,23 +787,26 @@ mod liveness_tests {
         // is presented under file names sorting in OPPOSITE orders; whatever
         // order read_dir yields, the binding must come out identical — the
         // flap in #252 was exactly this binding following dir order.
-        let mut child_a = std::process::Command::new("sleep").arg("30").spawn().unwrap();
-        let mut child_b = std::process::Command::new("sleep").arg("30").spawn().unwrap();
+        let mut child_a = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .unwrap();
+        let mut child_b = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .unwrap();
         let (pid_a, pid_b) = (child_a.id() as i64, child_b.id() as i64);
         let expected = pid_a.max(pid_b) as i32;
 
-        let mut bindings = Vec::new();
+        // Probe inside the loop, assert only after the children are reaped —
+        // a panicking assert here would leak two sleep-30s (the sibling
+        // pid_start_time test's kill-before-assert discipline).
+        let mut snapshots = Vec::new();
         for (first, second) in [(pid_a, pid_b), (pid_b, pid_a)] {
             let dir = tempfile::tempdir().unwrap();
             write_entry(dir.path(), "aaa.json", first, "dup");
             write_entry(dir.path(), "zzz.json", second, "dup");
-            let live = live_cc_session_ids(dir.path()).expect("readable dir is a healthy probe");
-            assert_eq!(
-                live.ids,
-                HashSet::from(["dup".to_string()]),
-                "a duplicate id must yield ONE vouch, not two"
-            );
-            bindings.push(*live.pid_of.get("dup").unwrap());
+            snapshots.push(live_cc_session_ids(dir.path()));
         }
 
         let _ = child_a.kill();
@@ -805,11 +814,19 @@ mod liveness_tests {
         let _ = child_b.kill();
         let _ = child_b.wait();
 
-        assert_eq!(
-            bindings,
-            vec![expected, expected],
-            "the winning pid must be the deterministic tiebreak winner in both name orders"
-        );
+        for snapshot in snapshots {
+            let live = snapshot.expect("readable dir is a healthy probe");
+            assert_eq!(
+                live.ids,
+                HashSet::from(["dup".to_string()]),
+                "a duplicate id must yield ONE vouch, not two"
+            );
+            assert_eq!(
+                live.pid_of.get("dup"),
+                Some(&expected),
+                "the winning pid must be the deterministic tiebreak winner in both name orders"
+            );
+        }
     }
 
     #[test]

--- a/crates/pixtuoid-core/src/source/cc_probe.rs
+++ b/crates/pixtuoid-core/src/source/cc_probe.rs
@@ -35,7 +35,14 @@ use crate::source::jsonl::ProbeSnapshot;
 pub fn live_cc_session_ids(sessions_dir: &Path) -> Option<ProbeSnapshot> {
     #[cfg(unix)]
     {
-        let mut live = ProbeSnapshot::default();
+        // session_id → winning entry. The fold (not direct inserts) exists for
+        // the pathological duplicate-id case (#252): two live entries claiming
+        // one sessionId would otherwise bind id→pid by unspecified read_dir
+        // order, flapping across refreshes — each flap churns the exit-watch
+        // rebind, and the losing pid dying first emits a spurious SessionEnd
+        // for the live session.
+        let mut winners: std::collections::HashMap<String, RegistryEntry> =
+            std::collections::HashMap::new();
         let Ok(entries) = std::fs::read_dir(sessions_dir) else {
             tracing::debug!(
                 "CC session registry {} unreadable or missing; probe pass failed",
@@ -100,8 +107,34 @@ pub fn live_cc_session_ids(sessions_dir: &Path) -> Option<ProbeSnapshot> {
                     continue;
                 }
             }
-            live.pid_of.insert(reg.session_id.clone(), reg.pid);
-            live.ids.insert(reg.session_id);
+            match winners.entry(reg.session_id.clone()) {
+                std::collections::hash_map::Entry::Vacant(slot) => {
+                    slot.insert(reg);
+                }
+                std::collections::hash_map::Entry::Occupied(mut slot) => {
+                    // Real registries are one-file-per-pid with unique ids —
+                    // a duplicate is upstream junk worth ONE breadcrumb per
+                    // process run (SHAPE_DRIFT_WARNED spirit), not a per-scan
+                    // log storm.
+                    static DUPLICATE_ID_WARNED: std::sync::Once = std::sync::Once::new();
+                    DUPLICATE_ID_WARNED.call_once(|| {
+                        tracing::warn!(
+                            session_id = %reg.session_id,
+                            pids = ?(slot.get().pid, reg.pid),
+                            "two live CC registry entries claim the same sessionId — \
+                             keeping the most recently started"
+                        );
+                    });
+                    if prefer_candidate(slot.get(), &reg) {
+                        slot.insert(reg);
+                    }
+                }
+            }
+        }
+        let mut live = ProbeSnapshot::default();
+        for (session_id, entry) in winners {
+            live.pid_of.insert(session_id.clone(), entry.pid);
+            live.ids.insert(session_id);
         }
         Some(live)
     }
@@ -114,6 +147,24 @@ pub fn live_cc_session_ids(sessions_dir: &Path) -> Option<ProbeSnapshot> {
         // the negative vouch never arms.
         let _ = sessions_dir;
         None
+    }
+}
+
+/// Deterministic winner between two LIVE entries claiming one sessionId
+/// (#252). Scan-order independence is the whole point — read_dir order is
+/// unspecified and may differ between refreshes, and the binding must not
+/// flap. Newest `startedAt` wins (the genuinely newer CC owns a reused id);
+/// a `startedAt`-carrying entry beats one without (it also passed the pid
+/// identity check, so it's the better-attested binding); both absent → larger
+/// pid — arbitrary, but stable for live processes, which is all stability
+/// needs.
+#[cfg(unix)]
+fn prefer_candidate(incumbent: &RegistryEntry, candidate: &RegistryEntry) -> bool {
+    match (candidate.started_at_ms, incumbent.started_at_ms) {
+        (Some(c), Some(i)) if c != i => c > i,
+        (Some(_), None) => true,
+        (None, Some(_)) => false,
+        _ => candidate.pid > incumbent.pid,
     }
 }
 
@@ -692,6 +743,73 @@ mod liveness_tests {
             .expect("readable dir is a healthy probe")
             .ids
             .contains("legacy-session"));
+    }
+
+    // --- duplicate sessionId across live entries (#252) ---------------------
+
+    #[cfg(unix)]
+    fn entry(pid: i32, started_at_ms: Option<u64>) -> RegistryEntry {
+        RegistryEntry {
+            pid,
+            session_id: "dup".into(),
+            started_at_ms,
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn duplicate_winner_rule_is_symmetric_and_total() {
+        // Newest startedAt wins, in BOTH presentation orders (the symmetry IS
+        // the scan-order independence).
+        assert!(prefer_candidate(&entry(1, Some(100)), &entry(2, Some(200))));
+        assert!(!prefer_candidate(&entry(2, Some(200)), &entry(1, Some(100))));
+        // A startedAt-carrying entry beats one without, both orders.
+        assert!(prefer_candidate(&entry(9, None), &entry(1, Some(100))));
+        assert!(!prefer_candidate(&entry(1, Some(100)), &entry(9, None)));
+        // Both absent (or equal): larger pid wins, both orders.
+        assert!(prefer_candidate(&entry(1, None), &entry(2, None)));
+        assert!(!prefer_candidate(&entry(2, None), &entry(1, None)));
+        assert!(prefer_candidate(&entry(1, Some(100)), &entry(2, Some(100))));
+        assert!(!prefer_candidate(&entry(2, Some(100)), &entry(1, Some(100))));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn duplicate_session_id_binds_a_stable_pid_regardless_of_scan_order() {
+        // Two LIVE pids claiming one sessionId (no startedAt → no identity
+        // check on either platform → the pid tiebreak decides). The same pair
+        // is presented under file names sorting in OPPOSITE orders; whatever
+        // order read_dir yields, the binding must come out identical — the
+        // flap in #252 was exactly this binding following dir order.
+        let mut child_a = std::process::Command::new("sleep").arg("30").spawn().unwrap();
+        let mut child_b = std::process::Command::new("sleep").arg("30").spawn().unwrap();
+        let (pid_a, pid_b) = (child_a.id() as i64, child_b.id() as i64);
+        let expected = pid_a.max(pid_b) as i32;
+
+        let mut bindings = Vec::new();
+        for (first, second) in [(pid_a, pid_b), (pid_b, pid_a)] {
+            let dir = tempfile::tempdir().unwrap();
+            write_entry(dir.path(), "aaa.json", first, "dup");
+            write_entry(dir.path(), "zzz.json", second, "dup");
+            let live = live_cc_session_ids(dir.path()).expect("readable dir is a healthy probe");
+            assert_eq!(
+                live.ids,
+                HashSet::from(["dup".to_string()]),
+                "a duplicate id must yield ONE vouch, not two"
+            );
+            bindings.push(*live.pid_of.get("dup").unwrap());
+        }
+
+        let _ = child_a.kill();
+        let _ = child_a.wait();
+        let _ = child_b.kill();
+        let _ = child_b.wait();
+
+        assert_eq!(
+            bindings,
+            vec![expected, expected],
+            "the winning pid must be the deterministic tiebreak winner in both name orders"
+        );
     }
 
     #[test]

--- a/crates/pixtuoid-core/src/source/codex.rs
+++ b/crates/pixtuoid-core/src/source/codex.rs
@@ -278,7 +278,14 @@ fn rollout_ids_from_paths(
         }
         tracing::debug!("codex probe: pid {pid} holds {} open", path.display());
         let id = codex_id_from_path(&path);
-        snap.pid_of.insert(id.clone(), pid);
+        // Two live processes holding ONE rollout open (a resume overlap) must
+        // not bind id→pid by proc-enumeration order — the same determinism
+        // rule as the CC registry fold's no-startedAt arm (#252): larger pid
+        // wins, arbitrary but stable for live processes.
+        let bound = snap.pid_of.entry(id.clone()).or_insert(pid);
+        if pid > *bound {
+            *bound = pid;
+        }
         snap.ids.insert(id);
     }
     snap
@@ -647,6 +654,26 @@ mod tests {
         // #223: the snapshot binds each id to the OWNING pid (the exit-watch
         // half) — the (42, path) pair above must survive the join intact.
         assert_eq!(got.pid_of.get(UUID), Some(&42));
+    }
+
+    #[test]
+    fn shared_rollout_binds_the_larger_pid_regardless_of_enumeration_order() {
+        // Two live processes holding ONE rollout (a resume overlap, #252's
+        // codex sibling): the binding must be the deterministic tiebreak
+        // winner in BOTH presentation orders, never last-writer-wins.
+        let root = Path::new("/home/u/.codex/sessions");
+        let path = root.join(format!(
+            "2026/06/10/rollout-2026-06-10T08-00-00-{UUID}.jsonl"
+        ));
+        for pids in [[100, 200], [200, 100]] {
+            let got = rollout_ids_from_paths(root, pids.into_iter().map(|p| (p, path.clone())));
+            assert_eq!(got.ids, std::iter::once(UUID.to_string()).collect());
+            assert_eq!(
+                got.pid_of.get(UUID),
+                Some(&200),
+                "the larger pid must win in both enumeration orders"
+            );
+        }
     }
 
     #[test]

--- a/crates/pixtuoid-core/tests/reducer/liveness.rs
+++ b/crates/pixtuoid-core/tests/reducer/liveness.rs
@@ -681,7 +681,9 @@ fn unknown_cwd_agent_reaps_faster() {
         t0,
         Transport::Jsonl,
     );
-    let label = scene.agents.get(&id).unwrap().label.clone();
+    let slot = scene.agents.get(&id).unwrap();
+    assert!(slot.unknown_cwd, "empty cwd should set unknown_cwd");
+    let label = slot.label.clone();
     assert!(
         label.contains('#'),
         "empty cwd should produce source#N label, got {label}"
@@ -809,39 +811,6 @@ fn session_end_cascades_to_grandchildren() {
     assert!(
         scene.agents.get(&child).unwrap().exiting_at.is_some(),
         "grandchild should cascade to exiting via BFS"
-    );
-}
-
-#[test]
-fn unknown_cwd_agent_uses_faster_stale_timeout() {
-    use pixtuoid_core::state::reducer::STALE_UNKNOWN_CWD_TIMEOUT;
-    let mut scene = SceneState::uniform(4);
-    let mut r = Reducer::new();
-    let id = AgentId::from_transcript_path("/p/unknown.jsonl");
-    let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
-
-    r.apply(
-        &mut scene,
-        AgentEvent::SessionStart {
-            agent_id: id,
-            source: "claude-code".into(),
-            session_id: "u".into(),
-            cwd: PathBuf::new(),
-            parent_id: None,
-        },
-        t0,
-        Transport::Jsonl,
-    );
-    let slot = scene.agents.get(&id).unwrap();
-    assert!(slot.unknown_cwd, "empty cwd should set unknown_cwd");
-
-    r.tick(
-        &mut scene,
-        t0 + STALE_UNKNOWN_CWD_TIMEOUT + Duration::from_secs(1),
-    );
-    assert!(
-        scene.agents.get(&id).unwrap().exiting_at.is_some(),
-        "unknown_cwd agent should reap after STALE_UNKNOWN_CWD_TIMEOUT"
     );
 }
 


### PR DESCRIPTION
Drains the two follow-ups deferred from the module-geometry arc (the #240 precedent: residuals batched in one PR).

## #252 — cc_probe duplicate-sessionId pid flapping

`live_cc_session_ids` did last-writer-wins inserts while scanning `sessions/*.json`, so two live entries claiming one sessionId bound id→pid by unspecified `read_dir` order — flapping across refreshes, churning the exit-watch rebind, and letting the losing pid's death emit a spurious `SessionEnd` for a live session.

The scan now folds into a winners map with a deterministic rule: **newest `startedAt` > has-`startedAt` > larger pid**, plus a warn-once on the duplicate (`SHAPE_DRIFT_WARNED` pattern). The issue's "keep the first" sketch was itself scan-order-dependent, so the tiebreak refines it (documented in the code and the commit body). All pre-existing per-entry filtering (extension/file-type/bounded-read/parse/pid-alive/identity check) is unchanged and runs before the fold; the snapshot is byte-identical to before for unique ids.

Pinned by a symmetric winner-rule unit test (every arm, both presentation orders) and an e2e presenting the same two live pids under opposite file-name orders, asserting an identical binding (hermetic: children reaped before asserts).

**Sibling found in review** (reviewer 2): `codex.rs::rollout_ids_from_paths` had the same last-writer-wins shape for two live processes holding one rollout (resume overlap) — fixed with the same larger-pid rule, pinned in both enumeration orders.

## #254 — unknown_cwd twin tests

`unknown_cwd_agent_uses_faster_stale_timeout` was a ~90% duplicate of `unknown_cwd_agent_reaps_faster` (couldn't merge inside the move-only #255 without breaking its byte-identical verification property). Merged keeping BOTH distinguishing assertions (`unknown_cwd` flag + ghost-`#N` label fallback). Net −1 test, coverage preserved (reviewer 1 diffed both tests at base and confirmed only incidentals differed).

## Review

Two-agent review per house rule: correctness reviewer (winner rule proven a strict total order → scan-order independent for any number of duplicates; filtering semantics byte-identical on the unique-id path; consolidation loses zero coverage) — its one blocking finding (committed test code failed `fmt-check`) plus all nits are fixed in the review-round commit. Design reviewer **APPROVE-WITH-NITS** (traced exit-watch/rebind/negative-vouch interactions: the fix is strictly better-or-equal everywhere; the spurious-end residual stays the self-healing class with a smaller trigger surface) — its LOW (codex sibling) fixed in-PR, warn-wording nit applied.

Closes #252
Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)
