### PR TITLE
KB cadence hooks: convert the three written-down cadences into habit-riding triggers

### DIFF
--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -131,3 +131,10 @@ governs). "Acknowledged, no action" is not a state: #40's ignored migration
 finding became a 0.4.1 release-blocker (#46); two more drop cases:
 docs/review-metrics/mining-2026-06.md. After a fix
 round, re-run the gates and watch the NEW head's CI.
+
+Whole-codebase reviews additionally: finder briefs do NOT carry the ledger —
+unbiased candidate recall is what keeps the ledger's calibration measurable;
+the ledger enters at routing/verification only. Until the demote path's
+false-suppression rate has a measurement, run the A/B harness alongside
+(control arm = the ledger-blind pass; see
+docs/review-metrics/phase2-ab-2026-06.md).

--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -132,9 +132,14 @@ finding became a 0.4.1 release-blocker (#46); two more drop cases:
 docs/review-metrics/mining-2026-06.md. After a fix
 round, re-run the gates and watch the NEW head's CI.
 
-Whole-codebase reviews additionally: finder briefs do NOT carry the ledger —
-unbiased candidate recall is what keeps the ledger's calibration measurable;
-the ledger enters at routing/verification only. Until the demote path's
-false-suppression rate has a measurement, run the A/B harness alongside
-(control arm = the ledger-blind pass; see
-docs/review-metrics/phase2-ab-2026-06.md).
+Whole-codebase reviews (the finder → dedup → ledger-routing → verification
+pipeline; worked design: docs/review-metrics/phase2-ab-2026-06.md)
+additionally: finder briefs do NOT carry the ledger — unbiased candidate
+recall is what keeps the ledger's calibration measurable; the ledger enters
+at routing/verification only. Until a run records the demote path's
+false-suppression rate (status lives in that report or its successor —
+phase 2 never fired a demotion), verify A/B per that design: a control arm
+of full pairs on ALL candidates — which doubles the run's verification
+spend and doubles as protocol step 8's ledger-blind calibration — alongside
+the ledger-routed treatment arm. Once the rate is recorded, delete this
+A/B clause: routing alone is the steady state.

--- a/docs/KNOWLEDGE-BASE.md
+++ b/docs/KNOWLEDGE-BASE.md
@@ -85,9 +85,11 @@ repo's maintainer agent repeated a known `preflight | tail` exit-code mistake
 
 **Counter:** friction goes on the distiller, never the capturer; recurrence is
 the promotion trigger (twice = it leaves prose and becomes a rule); and the
-ladder has a top rung — see Layer 4. The distillation pass itself rides the
-existing periodic context-file audit rather than its own calendar (the
-graveyard rule below: maintenance must ride an existing habit). Git-native, review-gated promotion is
+ladder has a top rung — see Layer 4. The distillation pass has no calendar
+of its own — it rides Layer 1's periodic context-file audit
+(`/revise-claude-md`): every audit also sweeps recent session memories for
+promote-to-repo candidates (the graveyard rule below: maintenance must ride
+an existing habit). Git-native, review-gated promotion is
 the only team-memory pattern we've found without a public postmortem as of
 mid-2026.
 

--- a/docs/KNOWLEDGE-BASE.md
+++ b/docs/KNOWLEDGE-BASE.md
@@ -85,7 +85,9 @@ repo's maintainer agent repeated a known `preflight | tail` exit-code mistake
 
 **Counter:** friction goes on the distiller, never the capturer; recurrence is
 the promotion trigger (twice = it leaves prose and becomes a rule); and the
-ladder has a top rung — see Layer 4. Git-native, review-gated promotion is
+ladder has a top rung — see Layer 4. The distillation pass itself rides the
+existing periodic context-file audit rather than its own calendar (the
+graveyard rule below: maintenance must ride an existing habit). Git-native, review-gated promotion is
 the only team-memory pattern we've found without a public postmortem as of
 mid-2026.
 

--- a/docs/review-metrics/mining-2026-06.md
+++ b/docs/review-metrics/mining-2026-06.md
@@ -90,3 +90,7 @@ Re-run this census after the next ~50 PRs. Success criteria: the 7 named
 escape classes at zero recurrences; stale-external-fact rounds at zero;
 disposition sweep verified by harvesting `bot-finding-ignored` records
 (currently the drop channel is invisible until something breaks).
+
+Each census files the next one as a tracked issue at +~50 PRs, so the cadence
+rides the issue backlog rather than anyone's memory (next: #266, due ~PR
+#310).

--- a/docs/review-metrics/mining-2026-06.md
+++ b/docs/review-metrics/mining-2026-06.md
@@ -92,5 +92,5 @@ disposition sweep verified by harvesting `bot-finding-ignored` records
 (currently the drop channel is invisible until something breaks).
 
 Each census files the next one as a tracked issue at +~50 PRs, so the cadence
-rides the issue backlog rather than anyone's memory (next: #266, due ~PR
-#310).
+rides the issue backlog rather than anyone's memory (next: #266, pinned, due
+~PR #310).


### PR DESCRIPTION
## Summary

Gap 2 of #265 (Part of #265 — does NOT close it; gap 1 and the user-side skill wiring remain open). Three maintenance cadences from the KB pilot currently live as prose with no trigger; this converts each to ride an existing habit, per the graveyard rule:

- **Ledger-blind calibration** (`pr-review.prompt.md`): whole-codebase reviews keep finder briefs ledger-blind (unbiased recall is what keeps protocol step 8 measurable; the ledger enters at routing/verification only), and run control + treatment arms per the Phase-2 design until the demote path's false-suppression rate has a measurement — the clause names its doubled cost and instructs its own deletion once the rate is recorded.
- **Census recurrence** (`mining-2026-06.md`): each census files the next as a pinned issue at +~50 PRs (#266, pinned, due ~PR #310) — the cadence rides the issue backlog.
- **Memory distillation** (`KNOWLEDGE-BASE.md` Layer 3): now a directive — every `/revise-claude-md` audit also sweeps recent session memories for promote-to-repo candidates. (The checklist line inside the user-side plugin skill itself can't ship from this repo — tracked as the open remainder on #265.)

## Review

Two-lens round per the canonical briefs, both folded in `3d1d00a`: lens 1 (grounding) APPROVE-WITH-NITS — all cross-references verified in-session, fmt EXIT=0; lens 2 (design) REQUEST-CHANGES — caught the hook naming a non-existent in-tree "harness" artifact, the missing exit mechanism, and the declared-not-wired distillation hook. Disposition: 6 fixed, 0 refuted, 1 tracked open on #265.

## How I tested it

`just fmt-check` EXIT=0; diff is 3 markdown files, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)