### PR TITLE
Impl-plan brief: the review's failure classes, shifted left

### DIFF
--- a/.github/prompts/impl-plan.prompt.md
+++ b/.github/prompts/impl-plan.prompt.md
@@ -1,0 +1,62 @@
+# Implementation-plan brief — the review, shifted left
+
+The upstream twin of [`pr-review.prompt.md`](pr-review.prompt.md): the review
+protocol catches the repo's known failure classes after the code exists; this
+brief front-loads the same classes while each costs one plan line instead of
+a finding plus a fix round. Evidence from the review-history census
+(`docs/review-metrics/mining-2026-06.md`): at least 4 of the 7 post-merge
+escapes were plan-preventable (the unwired field, the denylist gap, the
+sibling path, the half-pinned window), and the one design-class miss — PR
+#86's parallel config structure — was caught by a design-stage architect
+pass, not by review.
+
+**When to use:** new feature, new config key / CLI flag, new seam or module,
+or any change touching a documented sharp edge or ≥3 source files.
+**Skip for:** typo/docs fixes, mechanical renames, single-file bugfixes with
+an obvious pinning test — right-size the process; don't 700-line-plan a
+300-line change.
+
+## The plan must answer (the mined failure classes, moved left)
+
+Every section gets an answer; "n/a" counts only with a reason.
+
+1. **Data shapes** — for every NEW field, config key, map, or collection:
+   name its identity/key-space. If it overlaps an existing structure's
+   identity (two collections keyed by the same id; an attribute map
+   shadowing an entity list), the plan consolidates into one entity type or
+   justifies why not. Shared IDENTITY consolidates; shared TOPIC stays
+   separate (the `[pet-names]` lesson).
+2. **Consumers** — every new field, parameter, or asset names the consumer
+   this same change wires up. A plan line "add X" without "Y reads X at Z"
+   is the unwired-addition smell (CONTRIBUTING pitfall 5) at its cheapest
+   fix point — `_snap_prev` shipped unconsumed and defeated its own PR.
+3. **Siblings** — every guard or fix enumerates its sibling paths up front
+   (Unix/Windows arms, twin call sites, parallel manifests) and says which
+   get the same treatment in this change (pitfall 2's in-diff form).
+4. **Untrusted input** — if the change touches transcript/hook/file/config
+   input, name the decode boundary where it is sanitized (pitfall 3), and
+   whether any user-visible truncation is char-safe (pitfall 1). A
+   denylist's enumeration cites the platform's DOCUMENTED set, never memory
+   (pitfall 6).
+5. **Negative branches** — list the refusal paths the tests will pin, BOTH
+   sides of every window/threshold, with offsets derived from the constant
+   under test (pitfall 4).
+6. **Sharp edges + ledger** — read the nested `CLAUDE.md` for every crate
+   touched and list the sharp edges that constrain this design. Check
+   `docs/REVIEW-LEDGER.md` for CONFIRMED rows on the touched seams — those
+   are known hazards exactly where you are about to work. (Plan time is the
+   ledger's second consumption path; verification routing is its first.)
+7. **Verification plan** — the gates to run, and any watch-it requirement:
+   motion/pose changes render an animation and WATCH it; sprite changes run
+   the `beautify-decoration` loop. Verification steps are blocking plan
+   items, not checkboxes — PR #61 shipped five walk regressions behind an
+   unchecked "live run" checkbox.
+
+## The contract with review
+
+The plan's answers BECOME the review's change-specific checklist: lens 1's
+slot ("the change-specific claims to check") is filled from the plan's
+claims. A review finding the plan never named is a measured failure of the
+plan stage, not just a bug in the code — record it when it happens (the
+knowledge-base pilot's Phase-3 experiment measures exactly this rate; see
+`docs/KNOWLEDGE-BASE.md` "Measuring it").

--- a/.github/prompts/impl-plan.prompt.md
+++ b/.github/prompts/impl-plan.prompt.md
@@ -3,18 +3,16 @@
 The upstream twin of [`pr-review.prompt.md`](pr-review.prompt.md): the review
 protocol catches the repo's known failure classes after the code exists; this
 brief front-loads the same classes while each costs one plan line instead of
-a finding plus a fix round. Evidence from the review-history census
-(`docs/review-metrics/mining-2026-06.md`): at least 4 of the 7 post-merge
-escapes were plan-preventable (the unwired field, the denylist gap, the
-sibling path, the half-pinned window), and the one design-class miss — PR
-#86's parallel config structure — was caught by a design-stage architect
-pass, not by review.
+a finding plus a fix round. Census grounding: at least 4 of the 7 post-merge
+escapes and the one design-class miss (PR #86's parallel config structure)
+were plan-preventable — `docs/review-metrics/mining-2026-06.md`.
 
 **When to use:** new feature, new config key / CLI flag, new seam or module,
-or any change touching a documented sharp edge or ≥3 source files.
-**Skip for:** typo/docs fixes, mechanical renames, single-file bugfixes with
-an obvious pinning test — right-size the process; don't 700-line-plan a
-300-line change.
+any change touching a documented sharp edge, or any change you expect to
+span ≥3 source files.
+**Skip for (overrides the file count):** typo/docs fixes, mechanical
+renames/moves, single-file bugfixes with an obvious pinning test —
+right-size the process; don't 700-line-plan a 300-line change.
 
 ## The plan must answer (the mined failure classes, moved left)
 
@@ -30,17 +28,19 @@ Every section gets an answer; "n/a" counts only with a reason.
    this same change wires up. A plan line "add X" without "Y reads X at Z"
    is the unwired-addition smell (CONTRIBUTING pitfall 5) at its cheapest
    fix point — `_snap_prev` shipped unconsumed and defeated its own PR.
-3. **Siblings** — every guard or fix enumerates its sibling paths up front
-   (Unix/Windows arms, twin call sites, parallel manifests) and says which
-   get the same treatment in this change (pitfall 2's in-diff form).
+3. **Siblings** — every guard, fix, or NEW SURFACE enumerates its sibling
+   paths up front (Unix/Windows arms, twin call sites, parallel manifests —
+   for a config key: the docs and manifest twins) and says which get the
+   same treatment in this change (pitfall 2's in-diff form).
 4. **Untrusted input** — if the change touches transcript/hook/file/config
    input, name the decode boundary where it is sanitized (pitfall 3), and
    whether any user-visible truncation is char-safe (pitfall 1). A
    denylist's enumeration cites the platform's DOCUMENTED set, never memory
    (pitfall 6).
-5. **Negative branches** — list the refusal paths the tests will pin, BOTH
-   sides of every window/threshold, with offsets derived from the constant
-   under test (pitfall 4).
+5. **Tests** — name the failing test each implementation step starts with
+   (the repo is TDD-first), then the refusal paths those tests will pin —
+   BOTH sides of every window/threshold, with offsets derived from the
+   constant under test (pitfall 4).
 6. **Sharp edges + ledger** — read the nested `CLAUDE.md` for every crate
    touched and list the sharp edges that constrain this design. Check
    `docs/REVIEW-LEDGER.md` for CONFIRMED rows on the touched seams — those
@@ -54,9 +54,12 @@ Every section gets an answer; "n/a" counts only with a reason.
 
 ## The contract with review
 
-The plan's answers BECOME the review's change-specific checklist: lens 1's
-slot ("the change-specific claims to check") is filled from the plan's
-claims. A review finding the plan never named is a measured failure of the
-plan stage, not just a bug in the code — record it when it happens (the
-knowledge-base pilot's Phase-3 experiment measures exactly this rate; see
-`docs/KNOWLEDGE-BASE.md` "Measuring it").
+The plan's answers BECOME the review's change-specific checklist: put the
+section answers (or the claim list) in the PR body — that is where lens 1's
+slot is filled from; a plan that exists only in the planning session closes
+no loop. A review finding the plan never named is a measured failure of the
+plan stage, not just a bug in the code: the orchestrator records it as a
+`plan-miss:` line in the review-round commit message and carries it into
+the squash body — the channel the review-history census already harvests —
+so each census can compute the rate (metric row in `docs/KNOWLEDGE-BASE.md`
+"Measuring it"; the onboarding experiment, issue #264, measures it first).

--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -37,7 +37,9 @@ Worktree: <path> (branch <name>, base <sha>). Diff: git -C <path> diff <base>..H
 Verify rigorously (read the actual code, not just the diff):
 1. <the change-specific claims to check, one per line — e.g. "the staging math
    vs motion's bootstrap", "byte-identity of the refactor", "every cited
-   PR/sharp-edge exists">
+   PR/sharp-edge exists". When the change shipped with an impl-plan brief
+   (impl-plan.prompt.md), fill these slots from the plan's claims — a
+   finding the plan never named is a plan-stage miss; say so in the report>
 2. House rules on touched code: no unwrap() outside tests, tracing not
    println, comments WHY-only, docs-currency (CLAUDE.md/README updated when
    public surface moved).

--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -35,11 +35,12 @@ You are reviewer 1/2 (correctness lens) for <PR/branch> on pixtuoid.
 Worktree: <path> (branch <name>, base <sha>). Diff: git -C <path> diff <base>..HEAD.
 
 Verify rigorously (read the actual code, not just the diff):
-1. <the change-specific claims to check, one per line — e.g. "the staging math
-   vs motion's bootstrap", "byte-identity of the refactor", "every cited
-   PR/sharp-edge exists". When the change shipped with an impl-plan brief
-   (impl-plan.prompt.md), fill these slots from the plan's claims — a
-   finding the plan never named is a plan-stage miss; say so in the report>
+1. <the change-specific claims to check, one per line — filled from the
+   impl-plan brief's claims in the PR body when the change shipped with one
+   (impl-plan.prompt.md) — e.g. "the staging math vs motion's bootstrap",
+   "byte-identity of the refactor", "every cited PR/sharp-edge exists">
+   For planned changes: a finding the plan never named is a plan-stage
+   miss — flag it in your report.
 2. House rules on touched code: no unwrap() outside tests, tracing not
    println, comments WHY-only, docs-currency (CLAUDE.md/README updated when
    public surface moved).
@@ -124,7 +125,10 @@ history:
 Process notes for the orchestrator: dispatch both in parallel, in the
 worktree, background; verify every MEDIUM+ finding's premise yourself before
 coding a fix (reviewers have incomplete design context — check sharp edges
-first); fold accepted findings into ONE review-round commit. Before merging, sweep
+first); fold accepted findings into ONE review-round commit, recording any
+reviewer-flagged plan-misses as `plan-miss:` lines in that commit's message
+and carrying them into the squash body (the census harvests that channel).
+Before merging, sweep
 every reviewer/bot finding to exactly one terminal state — FIXED,
 REFUTED-with-trace (ledger row if it will recur), ISSUE FILED (no-deferral
 rule applies: only big/refactor work defers), or ACCEPTED-residual with its

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,7 @@ Needs cargo-edit (`just setup-tools`). See [`CONTRIBUTING.md`](docs/CONTRIBUTING
 
 ## Conventions
 
-- **TDD first.** Plan and existing tests are TDD-shaped — failing test → minimal impl → commit. Don't add code without a test that exercises it.
+- **TDD first.** Plan and existing tests are TDD-shaped — failing test → minimal impl → commit. Don't add code without a test that exercises it. Non-trivial changes (new feature/config key/seam, or touching a sharp edge) plan against [`.github/prompts/impl-plan.prompt.md`](.github/prompts/impl-plan.prompt.md) first — it front-loads the review's failure classes, and its answers fill the review's change-specific slots.
 - **DRY, YAGNI.** No features beyond what v1 specifies. v2 items are deferred — adding them in v1 code is a regression.
 - **No comments unless WHY.** Don't write comments that restate what the code does. Comment only when a future reader can't tell from the code why something is the way it is (a workaround, a non-obvious constraint, a surprising invariant).
 - **Errors propagate via `anyhow::Result` in app code, `thiserror` in core if a typed error becomes load-bearing.** The hook listener and JSONL watcher log + continue on malformed input — they never panic.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,7 @@ Needs cargo-edit (`just setup-tools`). See [`CONTRIBUTING.md`](docs/CONTRIBUTING
 
 ## Conventions
 
-- **TDD first.** Plan and existing tests are TDD-shaped — failing test → minimal impl → commit. Don't add code without a test that exercises it. Non-trivial changes (new feature/config key/seam, or touching a sharp edge) plan against [`.github/prompts/impl-plan.prompt.md`](.github/prompts/impl-plan.prompt.md) first — it front-loads the review's failure classes, and its answers fill the review's change-specific slots.
+- **TDD first.** Plan and existing tests are TDD-shaped — failing test → minimal impl → commit. Don't add code without a test that exercises it. Non-trivial changes (new feature/config key/seam, sharp edge, or spanning ≥3 files) plan against [`.github/prompts/impl-plan.prompt.md`](.github/prompts/impl-plan.prompt.md) first — it front-loads the review's failure classes, and its answers fill the review's change-specific slots.
 - **DRY, YAGNI.** No features beyond what v1 specifies. v2 items are deferred — adding them in v1 code is a regression.
 - **No comments unless WHY.** Don't write comments that restate what the code does. Comment only when a future reader can't tell from the code why something is the way it is (a workaround, a non-obvious constraint, a surprising invariant).
 - **Errors propagate via `anyhow::Result` in app code, `thiserror` in core if a typed error becomes load-bearing.** The hook listener and JSONL watcher log + continue on malformed input — they never panic.

--- a/docs/KNOWLEDGE-BASE.md
+++ b/docs/KNOWLEDGE-BASE.md
@@ -160,6 +160,7 @@ replicating this on their own repo:
 | onboarding proxy: standard tasks with / without KB | first-pass gate rate, review nits | task completion |
 | ledger calibration (every Nth review, ledger-blind) | false-suppression rate | — |
 | context health (quarterly) | auto-loaded tokens vs. sharp-edge citation rate | — |
+| plan-stage miss rate (planned changes) | review findings the plan never named, from `plan-miss:` commit lines | trigger compliance held constant |
 
 Efficiency metrics are only reported **paired with their quality guard** —
 a review that got cheaper by finding less is not a saving.


### PR DESCRIPTION
## Summary

The upstream twin of the review protocol (Part of the KB pilot; extends #264 — does not close anything): a plan-stage template (`.github/prompts/impl-plan.prompt.md`) that front-loads the mined failure classes while each costs a plan line instead of a review finding + fix round. Census grounding: at least 4 of the 7 post-merge escapes and the PR #86 design miss were plan-preventable (`docs/review-metrics/mining-2026-06.md`).

The seven sections a non-trivial change's plan must answer: data-shape identity (consolidate or justify), named consumers wired in the same change, sibling paths (incl. new-surface manifest/docs twins), untrusted-input boundaries, TDD failing-test-first + both-sides-of-window pins, sharp-edge + CONFIRMED-ledger-row sweep (the ledger's second consumption path), and blocking verification steps.

**The closed loop**: plans land in the PR body → lens 1's change-specific slot fills from the plan's claims → a finding the plan never named is flagged as a plan-stage miss → the orchestrator records it as a `plan-miss:` line in the review-round commit, carried into the squash body — the channel the review-history census already harvests, so the miss rate computes at each census. New row in the KNOWLEDGE-BASE "Measuring it" table; #264's Phase-3 experiment measures it first (KB arm plans against the brief, bare arm freestyle).

Load paths: CLAUDE.md TDD-first bullet → the brief; review template → the slot-fill contract.

## Review

Two-lens round, both folded in the review-round commit: lens 1 (grounding) APPROVE-WITH-NITS — citations six-for-six, caught the plan-miss duty sitting INSIDE the fillable slot where it would vanish on fill; lens 2 (design) REQUEST-CHANGES — caught the return path declared-not-wired (no recording destination, pointer at a non-existent metric row) and supplied the `plan-miss:` commit-line channel, plus the trigger self-contradiction and the §3 under-scoping. Disposition: 9 fixed, 0 refuted, 0 deferred.

## How I tested it

`just fmt-check` EXIT=0; diff is 4 markdown files, no code. Lens 2 executed a concrete walkthrough ("add a per-pet `mood` config attribute") through all 7 sections — 6 of 7 produced conforming answers pre-fold; the gaps it found are the ones fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)