### PR TITLE
Phase-3 onboarding-proxy report: a null result, honestly stated

### DIFF
--- a/docs/KNOWLEDGE-BASE.md
+++ b/docs/KNOWLEDGE-BASE.md
@@ -153,10 +153,13 @@ of which named a concrete guideline change — plus one bot-missed design
 lesson, caught pre-merge by a self-dispatched architect pass and validated
 by a controlled backtest on the original diff. The onboarding experiment
 ([`phase3-onboarding-2026-06.md`](review-metrics/phase3-onboarding-2026-06.md))
-ran the with/without-KB A/B: arms indistinguishable on first-pass quality —
-because the load-bearing lessons were already IN the code at the hazard
-seams (the executability ladder working); the KB differentiated on process
-(docs currency, ledger discipline, plan auditability). The experiment design, for anyone
+ran the with/without-KB A/B: arms indistinguishable on first-pass quality
+(n=2, directional; contamination caveats in the report) — consistent with
+the load-bearing lessons already being IN the code at the hazard seams (the
+executability ladder working). The KB's value showed up in process, not
+code: its prescribed duties (docs currency, ledger routing, plan
+auditability) executed correctly at +19% token overhead — duties a bare
+repo cannot perform at all. The experiment design, for anyone
 replicating this on their own repo:
 
 | experiment | metric | quality guard |

--- a/docs/KNOWLEDGE-BASE.md
+++ b/docs/KNOWLEDGE-BASE.md
@@ -151,7 +151,12 @@ into per-stage token/agent metrics, and the review history itself gets mined:
 merged PRs' reviews plus 50 post-merge fixes — 7 adjudicated escapes, each
 of which named a concrete guideline change — plus one bot-missed design
 lesson, caught pre-merge by a self-dispatched architect pass and validated
-by a controlled backtest on the original diff. The experiment design, for anyone
+by a controlled backtest on the original diff. The onboarding experiment
+([`phase3-onboarding-2026-06.md`](review-metrics/phase3-onboarding-2026-06.md))
+ran the with/without-KB A/B: arms indistinguishable on first-pass quality —
+because the load-bearing lessons were already IN the code at the hazard
+seams (the executability ladder working); the KB differentiated on process
+(docs currency, ledger discipline, plan auditability). The experiment design, for anyone
 replicating this on their own repo:
 
 | experiment | metric | quality guard |

--- a/docs/review-metrics/phase3-onboarding-2026-06.md
+++ b/docs/review-metrics/phase3-onboarding-2026-06.md
@@ -1,0 +1,97 @@
+# Phase 3 — onboarding-proxy A/B (with/without KB, 2026-06-12)
+
+The pilot's onboarding question, measured: does the knowledge base improve a
+fresh agent's first-pass code quality? Two standardized tasks × two arms at
+`a40977c`, implementations in throwaway worktrees (workflow
+`wf_5509ed8a-913`; all code discarded, reference patch preserved on #262):
+
+- **KB arm**: full repo (CLAUDE.md tree, AGENTS.md, CONTRIBUTING pitfalls,
+  REVIEW-LEDGER, prompts) + plans against
+  [`impl-plan.prompt.md`](../../.github/prompts/impl-plan.prompt.md) first.
+- **bare arm**: KB files physically removed from the worktree, instructed to
+  derive conventions from code + README only, freestyle planning.
+
+Task A: per-pet `mood` config attribute end-to-end (designed trap: the
+`[pet-names]` parallel-map temptation). Task B: diagnostic breadcrumb for the
+CONN_TIMEOUT mid-payload event loss, #262 item 2 (designed trap: fixing one
+platform sibling). Per-implementation two-lens reviews, identical briefs
+across arms; a blind classifier counted findings, pitfall classes, and
+plan-misses.
+
+## Results
+
+| metric | A-kb | A-bare | B-kb | B-bare |
+|---|---|---|---|---|
+| first `just preflight` exit | **0** | **0** | 1 | 1 |
+| preflight attempts to green | 1 | 1 | 2 | 2 |
+| distinct review findings (deduped\*) | 1 | 1 (+1 artifact†) | 2 | 2 |
+| worst severity | nit | low | low | low |
+| designed trap | avoided | avoided | avoided | avoided |
+| implementation output tokens | 34,776 | 29,975 | 33,775 | 26,705 |
+
+\* dual-lens duplicates and "verified clean" record entries excluded.
+† "nested CLAUDE.md not updated" — the bare worktree had no CLAUDE.md files
+to update; experiment scaffolding, not an agent failure (though it is what a
+genuinely KB-less repo looks like to a reviewer: docs-currency violations by
+construction).
+
+**On every quality metric the arms are indistinguishable.** Both arms put
+`mood` ON the existing `PetEntry`/`Pet` entities with a raw-string-then-
+validate field (no parallel map, config-reset-safe); both arms independently
+invented the same task-B design — a Drop-guard in the SHARED `hook/mod.rs`
+(one seam covers both platform listeners, defused on shutdown) — defeating
+the sibling trap architecturally. Task B's symmetric first-pass failures were
+both fixed in one retry. KB-arm cost: **+19% output tokens** (135k vs 113k
+across impl+review), buying the plan, the ledger consult, and the docs
+updates only it could make.
+
+## The central finding: knowledge redundancy
+
+The bare arm reproduced KB-grade decisions because the load-bearing lessons
+were not only in the KB files — they are embedded **in the code at the
+hazard seams**: `config.rs`'s field docs carry the entire
+raw-string-vs-serde-enum footgun story (the `[pet-names]`/all-or-nothing
+lesson), and the hook module's structure makes the shared-seam fix the
+natural one. The executability ladder predicts exactly this: knowledge that
+reached the code (WHY comments, types, tests) survives context stripping;
+prose-only knowledge would have differentiated. Both tasks landed on seams
+that June's arcs had already pushed down the ladder — a selection effect
+that under-measures KB value on less-documented seams.
+
+What the KB measurably added was **process-level**: B-kb consulted the
+ledger unprompted, cited R0609-15 (bounded drop = documented design) and
+correctly scoped the change as trace-only; A-kb updated the nested CLAUDE.md
+files in the same commit (docs currency); and the plan made review cheaper —
+lens 1 verified claims instead of re-deriving them.
+
+## Plan-miss rate (first measurement)
+
+KB-arm plans named everything reviews later found except: A-kb 1 miss (warn
+message detail), B-kb 1 distinct miss (the breadcrumb hard-attributes a
+cause that a second drop path — runtime shutdown — shares). Both misses are
+the same species: **diagnostic-message precision**, a class the plan brief's
+sections don't currently probe. n=2; recorded per the `plan-miss:` protocol,
+not yet a rate.
+
+## Caveats
+
+1. **Contamination upper bound**: bare-arm agents may carry harness-injected
+   context from the main checkout; physical file removal + explicit
+   ignore-instruction bounds but cannot eliminate it. The plan-brief effect
+   is clean (strictly present/absent); the context-file effect is an upper
+   bound.
+2. **n=2 tasks**, both on well-self-documented seams; directional only.
+3. Implementer self-reported first-pass exits (spot-checked by lens 1
+   against committed state, journal-verifiable).
+
+## Implications
+
+- For #265's CLAUDE.md slim: this LOWERS the risk — code-embedded knowledge
+  carried both tasks, so a map-not-manual context file is safer than feared.
+- For the KB roadmap: the highest-leverage promotion target is always the
+  code itself; KB files earn their keep on seams the code doesn't yet
+  self-document, and on process duties (docs currency, ledger discipline,
+  plan auditability) — which is where the arms actually diverged.
+- Total experiment cost: 248k output tokens / 13 agents — cheap enough to
+  re-run with harder tasks on undocumented seams, which is the natural
+  follow-up if a sharper signal is wanted.

--- a/docs/review-metrics/phase3-onboarding-2026-06.md
+++ b/docs/review-metrics/phase3-onboarding-2026-06.md
@@ -11,11 +11,18 @@ fresh agent's first-pass code quality? Two standardized tasks × two arms at
 - **bare arm**: KB files physically removed from the worktree, instructed to
   derive conventions from code + README only, freestyle planning.
 
-Task A: per-pet `mood` config attribute end-to-end (designed trap: the
-`[pet-names]` parallel-map temptation). Task B: diagnostic breadcrumb for the
-CONN_TIMEOUT mid-payload event loss, #262 item 2 (designed trap: fixing one
-platform sibling). Per-implementation two-lens reviews, identical briefs
-across arms; a blind classifier counted findings, pitfall classes, and
+Design: issue #264, which registered THREE tasks — the third (a
+negative-branch test probing the derived-offset pitfall) was cut for budget
+under a reduced-scope authorization, so this is n=2 of 3. Task completion,
+the design's quality guard, was full in all four runs: both arms shipped a
+working implementation of each task. Task A: per-pet `mood` config attribute
+end-to-end (designed trap: the `[pet-names]` parallel-map temptation). Task
+B: diagnostic breadcrumb for the CONN_TIMEOUT mid-payload event loss, #262
+item 2 (designed trap: fixing one platform sibling). Per-implementation two-lens reviews, identical briefs
+across arms (reviewers of bare-arm code read the bare worktree, but were not
+themselves stripped of ambient context — the instrument is constant in
+brief, not in ambience); a hypothesis-blind (not arm-blind — the run ids
+leak arm identity) classifier counted findings, pitfall classes, and
 plan-misses.
 
 ## Results
@@ -25,7 +32,7 @@ plan-misses.
 | first `just preflight` exit | **0** | **0** | 1 | 1 |
 | preflight attempts to green | 1 | 1 | 2 | 2 |
 | distinct review findings (deduped\*) | 1 | 1 (+1 artifact†) | 2 | 2 |
-| worst severity | nit | low | low | low |
+| worst severity (deduped; artifact excluded) | nit | nit | low | low |
 | designed trap | avoided | avoided | avoided | avoided |
 | implementation output tokens | 34,776 | 29,975 | 33,775 | 26,705 |
 
@@ -35,7 +42,11 @@ to update; experiment scaffolding, not an agent failure (though it is what a
 genuinely KB-less repo looks like to a reviewer: docs-currency violations by
 construction).
 
-**On every quality metric the arms are indistinguishable.** Both arms put
+The opening question, answered on this evidence: **no — the KB did not
+improve first-pass code quality on these two tasks.** The rest of this
+report is why, and what the KB bought instead. No quality row separates the
+arms by more than one severity step, and none in the KB arm's favor. Both
+arms put
 `mood` ON the existing `PetEntry`/`Pet` entities with a raw-string-then-
 validate field (no parallel map, config-reset-safe); both arms independently
 invented the same task-B design — a Drop-guard in the SHARED `hook/mod.rs`
@@ -47,22 +58,30 @@ updates only it could make.
 
 ## The central finding: knowledge redundancy
 
-The bare arm reproduced KB-grade decisions because the load-bearing lessons
-were not only in the KB files — they are embedded **in the code at the
-hazard seams**: `config.rs`'s field docs carry the entire
+The bare arm reproduced KB-grade decisions, and the explanation with
+in-repo evidence is that the load-bearing lessons were never only in the KB
+files — they are embedded **in the code at the hazard seams** (A-bare's own
+summary credits "mirroring the existing `kind` pattern", read from the
+field docs): `config.rs`'s field docs carry the entire
 raw-string-vs-serde-enum footgun story (the `[pet-names]`/all-or-nothing
 lesson), and the hook module's structure makes the shared-seam fix the
 natural one. The executability ladder predicts exactly this: knowledge that
 reached the code (WHY comments, types, tests) survives context stripping;
-prose-only knowledge would have differentiated. Both tasks landed on seams
+prose-only knowledge is where the ladder predicts the arms would diverge —
+untested here. Both tasks landed on seams
 that June's arcs had already pushed down the ladder — a selection effect
 that under-measures KB value on less-documented seams.
 
-What the KB measurably added was **process-level**: B-kb consulted the
-ledger unprompted, cited R0609-15 (bounded drop = documented design) and
-correctly scoped the change as trace-only; A-kb updated the nested CLAUDE.md
-files in the same commit (docs currency); and the plan made review cheaper —
-lens 1 verified claims instead of re-deriving them.
+What the KB added was **process-level — with the qualifier that all three
+duties were prescribed by the KB's own machinery, not emergent**: the plan
+brief's §6 routed B-kb to the ledger, where it went beyond the letter of
+the instruction (§6 asks for CONFIRMED rows; it also cited the
+REFUTED-design row R0609-15 governing the exact seam) and correctly scoped
+the change as trace-only; A-kb updated the nested CLAUDE.md files in the
+same commit — a duty the bare arm could not perform by construction; and
+the plan made review cheaper (lens 1 verified claims instead of re-deriving
+them). The measured result is that the prescribed machinery executes
+correctly at +19% overhead — not that agents adopt it spontaneously.
 
 ## Plan-miss rate (first measurement)
 
@@ -70,8 +89,9 @@ KB-arm plans named everything reviews later found except: A-kb 1 miss (warn
 message detail), B-kb 1 distinct miss (the breadcrumb hard-attributes a
 cause that a second drop path — runtime shutdown — shares). Both misses are
 the same species: **diagnostic-message precision**, a class the plan brief's
-sections don't currently probe. n=2; recorded per the `plan-miss:` protocol,
-not yet a rate.
+sections don't currently probe. n=2 — and the protocol's harvest channel
+(`plan-miss:` lines in review-round commits) died with the throwaway
+worktrees, so this report is the record for these two; not yet a rate.
 
 ## Caveats
 
@@ -86,8 +106,11 @@ not yet a rate.
 
 ## Implications
 
-- For #265's CLAUDE.md slim: this LOWERS the risk — code-embedded knowledge
-  carried both tasks, so a map-not-manual context file is safer than feared.
+- For #265's CLAUDE.md slim: supports it **for knowledge that has already
+  reached the code** — both tasks were carried by code-embedded lessons, so
+  thinning the prose map costs nothing on promoted seams. It says nothing
+  about prose-only sharp edges, the seams this experiment by selection never
+  touched — gate those cuts on Layer 1's citation tracking, not this result.
 - For the KB roadmap: the highest-leverage promotion target is always the
   code itself; KB files earn their keep on seams the code doesn't yet
   self-document, and on process duties (docs currency, ledger discipline,


### PR DESCRIPTION
## Summary

Closes #264. The pilot's onboarding experiment, run as the authorized reduced scope (2 of the 3 registered tasks; deviation + quality guard stated in the report): 2 tasks × KB/bare arms at `a40977c`, throwaway worktrees, per-implementation two-lens reviews, hypothesis-blind classification. Report: `docs/review-metrics/phase3-onboarding-2026-06.md` + a qualified pointer on the knowledge-base page.

**Headline, plainly**: the KB did not improve first-pass code quality on these two tasks — identical first-pass results, identical deduped finding counts, both designed traps (parallel-map, platform-sibling) avoided by BOTH arms, which independently converged on the same designs. The in-repo-evidenced explanation: the load-bearing lessons were already embedded in the code at the hazard seams (`config.rs` field docs carry the whole raw-string-vs-enum story), so context stripping didn't strip the knowledge — the executability ladder working. What the KB measurably bought, with its qualifier: its prescribed process duties executed correctly at +19% token overhead (ledger routing — B-kb cited the REFUTED-design row governing the exact seam and scoped trace-only; same-commit docs currency; plan auditability with the first 2 plan-miss data points).

Caveats stated in the report: contamination upper bound on the bare arm, n=2 on self-documented seams (selection effect), self-reported first-pass exits (spot-checked). Implication for #265 scoped accordingly: the slim is supported for already-promoted seams only; prose-only edges gate on citation tracking.

Task B's working fix (#262 item 2) is preserved as a reference patch on #262 with the review residuals to fold; experiment code discarded per protocol.

## Review

Two-lens round, both folded (`72f64eb`): lens 1 (grounding) APPROVE-WITH-NITS — all table numbers and token figures reproduced exactly from raw journals, dedup independently re-derived, "unprompted" corrected to prescribed-by-§6; lens 2 (editorial, explicitly briefed as the null-result honesty skeptic) REQUEST-CHANGES — the headline answer now stated plainly, consolation-prize framing qualified, #265 license narrowed, design deviation registered. Disposition: 11 fixed, 0 refuted, 0 deferred.

## How I tested it

`just fmt-check` EXIT=0; diff is 2 markdown files, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)