### PR TITLE
Mechanize invariant #1 + the system lens (gap-closure audit)

### DIFF
--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -152,4 +152,5 @@ A/B clause: routing alone is the steady state. Whole-codebase reviews also
 carry a SYSTEM lens — module decomposition still right, dependency
 directions clean, cross-PR composition seams — because architecture erodes
 BETWEEN PRs, not within them (no per-PR lens can see it; the census's
-"emergent cross-PR composition" escape class is its bug-shaped form).
+"emergent cross-PR composition" bucket — a NON-escape class precisely
+because no per-PR review could have caught it — is its bug-shaped form).

--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -148,4 +148,8 @@ phase 2 never fired a demotion), verify A/B per that design: a control arm
 of full pairs on ALL candidates — which doubles the run's verification
 spend and doubles as protocol step 8's ledger-blind calibration — alongside
 the ledger-routed treatment arm. Once the rate is recorded, delete this
-A/B clause: routing alone is the steady state.
+A/B clause: routing alone is the steady state. Whole-codebase reviews also
+carry a SYSTEM lens — module decomposition still right, dependency
+directions clean, cross-PR composition seams — because architecture erodes
+BETWEEN PRs, not within them (no per-PR lens can see it; the census's
+"emergent cross-PR composition" escape class is its bug-shaped form).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           components: rustfmt
       - uses: extractions/setup-just@v4
       - run: just fmt-check
+      - run: just arch
 
   clippy:
     name: clippy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ git hooks call the same recipes (no local-vs-CI drift). `just setup-tools`
 installs the needed cargo tools once per clone.
 
 ```
-just preflight    # full pre-push gate: lint (fmt+machete+deny) → clippy → hack → test
+just preflight    # full pre-push gate: lint (fmt+machete+deny+arch) → clippy → hack → test
 just fmt          # auto-format
 git config core.hooksPath .githooks   # activate hooks once per clone
 ```

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -18,7 +18,7 @@ git hooks call the same recipes.
 
 ```bash
 just              # list recipes
-just preflight    # full pre-push gate: lint (fmt + machete + deny) → clippy → hack → test
+just preflight    # full pre-push gate: lint (fmt + machete + deny + arch) → clippy → hack → test
 just fmt          # auto-format
 just test         # the whole suite (cargo-nextest if installed, else cargo test)
 ```

--- a/justfile
+++ b/justfile
@@ -51,7 +51,19 @@ machete:
 deny:
     cargo deny check bans licenses sources
 
-# Fast, independent lint checks in parallel (fmt + machete + deny).
+# Architecture invariant #1, mechanized: pixtuoid-core must stay terminal-free.
+# The other five invariants have test/bridge backstops; this one was
+# review-enforced only until the 2026-06 KB pilot's gap audit (issue #265 arc).
+[group('rust')]
+arch:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if cargo tree -p pixtuoid-core --edges normal | grep -qE '(ratatui|crossterm)'; then
+        echo "ARCH VIOLATION: pixtuoid-core depends on a terminal crate (CLAUDE.md invariant #1)"; exit 1
+    fi
+    echo "arch: pixtuoid-core is terminal-free"
+
+# Fast, independent lint checks in parallel (fmt + machete + deny + arch).
 [group('rust')]
 lint:
     #!/usr/bin/env bash
@@ -63,6 +75,7 @@ lint:
     run fmt     cargo fmt --all --check & pids+=($!)
     run machete cargo machete           & pids+=($!)
     run deny    just deny                & pids+=($!)
+    run arch    just arch                & pids+=($!)
     for p in "${pids[@]}"; do wait "$p" || fail=1; done
     [[ $fail -eq 0 ]]
 

--- a/justfile
+++ b/justfile
@@ -53,12 +53,13 @@ deny:
 
 # Architecture invariant #1, mechanized: pixtuoid-core must stay terminal-free.
 # The other five invariants have test/bridge backstops; this one was
-# review-enforced only until the 2026-06 KB pilot's gap audit (issue #265 arc).
+# review-enforced only until the KB pilot's gap-closure audit (2026-06-12,
+# follow-on to the #261-#271 arc).
 [group('rust')]
 arch:
     #!/usr/bin/env bash
     set -euo pipefail
-    if cargo tree -p pixtuoid-core --edges normal | grep -qE '(ratatui|crossterm)'; then
+    if cargo tree -p pixtuoid-core --edges normal --prefix none | grep -qE '^(ratatui|crossterm)'; then
         echo "ARCH VIOLATION: pixtuoid-core depends on a terminal crate (CLAUDE.md invariant #1)"; exit 1
     fi
     echo "arch: pixtuoid-core is terminal-free"


### PR DESCRIPTION
## Summary

Closes the one unowned weakness from the 2026-06-12 gap audit: cross-PR architectural erosion had no structural watcher, and invariant #1 (pixtuoid-core stays terminal-free) was the only one of the six with no mechanical backstop. Three pieces:

- **`just arch`** — cargo tree over core's normal edges must contain no ratatui/crossterm (name-anchored, `--prefix none`, catches the 0.30 split crates). Wired into `lint` (preflight) AND as a CI step in the fmt job. Verified BOTH directions twice (pre- and post-fold): green on HEAD, exit 1 with a planted ratatui dep. Executability ladder: prose invariant → build gate.
- **System lens** in the whole-codebase review brief: module decomposition, dependency directions, cross-PR composition seams — architecture erodes between PRs, not within them.
- Census #266 gains the architecture-drift + sharp-edge-citation legs (issue comment).

## Review

Two-lens round, REQUEST-CHANGES → all five findings folded in `ae6c231`. The headline catch: ci.yml never calls `just lint` (sub-checks are individual jobs), so the gate originally had **zero CI reach** while claiming "mechanized" — the reviewer caught the gate-maker in the declared-not-wired pattern and the fix adds the explicit CI step. Also folded: grep anchoring, CONTRIBUTING enumeration, truthful WHY citation, the census-taxonomy label.

Note: this PR touches `.github/workflows/` — the security-review action's 401 red is the known org-spend artifact, advisory and self-healing.

## How I tested it

`just arch` EXIT=0 on HEAD; EXIT=1 with planted dep; restored clean; `just lint` 4/4; `just fmt-check` EXIT=0. All exit codes observed via file-redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)