### PR TITLE
fix(scripts): drift-watch flags permanent HTTP as breaking (+ selftest, un-blind opencode)

### DIFF
--- a/.github/workflows/upstream-drift.yml
+++ b/.github/workflows/upstream-drift.yml
@@ -11,6 +11,13 @@ on:
   schedule:
     - cron: "0 9 * * 1" # Mondays 09:00 UTC
   workflow_dispatch:
+  # On PRs that touch the watcher itself, run ONLY the selftest (the live network
+  # check + issue-filing stay schedule/dispatch-only — a flaky upstream fetch must
+  # never gate a PR). A parser/classifier regression IS caught here.
+  pull_request:
+    paths:
+      - "scripts/check_upstream_drift*.py"
+      - ".github/workflows/upstream-drift.yml"
 
 permissions:
   contents: read
@@ -24,8 +31,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Always runs (incl. PRs): a parser/classifier regression = silent monitor
+      # death, so guard it before the live check trusts the parsers.
+      - name: Self-test the watcher
+        run: python3 scripts/check_upstream_drift_selftest.py
+
       - name: Check upstream drift
         id: check
+        if: github.event_name != 'pull_request'
         shell: bash
         run: |
           set +e

--- a/docs/review-metrics/drift-incidents.md
+++ b/docs/review-metrics/drift-incidents.md
@@ -1,0 +1,41 @@
+# Upstream wire-format drift — incident log
+
+The institutional record of every **actual** upstream drift that reached
+pixtuoid: what changed, **which defense layer caught it**, how late, and the fix.
+
+Why this exists: the drift defense is layered (semantic detection → in-code
+self-monitoring → internal consistency tests → weekly upstream watch), and we've
+*claimed* "layer 2 (real-stream self-monitoring) is the real backstop for
+closed-binary CLIs." This log turns that claim into **data** — the
+`#266` review-history census reads it to measure the defense's true-positive
+rate and catch-latency, and to retire layers that never fire.
+
+Layers (see `crates/pixtuoid-core/CLAUDE.md` "Keeping the decode mapping current"):
+- **L1 — semantic detection** (e.g. `subagent_type` over the tool name): survives a
+  rename by construction.
+- **L2 — in-code self-monitoring** from the real stream (`bail!`/`debug!`
+  breadcrumb / shape-drift warn): sees ground truth, no network. Catches
+  *undocumented* drift.
+- **L3 — internal consistency tests** (`every_registered_*_event_decodes`).
+- **L4 — weekly upstream watch** (`scripts/check_upstream_drift.py`): docs/schema
+  diff; weakest for closed binaries (docs lag/omit).
+
+## How to add a row
+
+When a real drift is found (a user report, a `pixtuoid doctor` finding, a weekly
+watch alarm, or a maintainer observation), add a row. `caught_by` is the layer
+that *first surfaced* it; `latency` is roughly how long it shipped before we
+noticed (or "unknown" for undocumented renames found by observation).
+
+| date | source | what drifted | caught_by | latency | fix |
+|---|---|---|---|---|---|
+| 2026-05 (approx) | claude-code | subagent-dispatch tool renamed `Task` → `Agent` (CC v2.1.63, **undocumented**, upstream #29677) — silently disabled subagent suppression + b1 completion (the parent showed the subagent's tools) | **L2** (observed live; L4 doc-scrape could NOT — the rename was undocumented) | unknown (undocumented) | L1 hardening: `make_tool_detail` keys on the stable `subagent_type` input field, not the tool name (survives the next rename by construction); the name set is now a fallback + a `debug!` drift breadcrumb. Wire-monitoring added (`#79/#80` era). |
+
+## Reading the log
+
+- Most rows in **L2** for closed binaries (CC/Cursor) ⇒ the doc-scrape (L4) is
+  structurally blind to undocumented change; that's the argument for surfacing
+  L2's breadcrumbs to users (the `doctor` / footer self-diagnosis work).
+- An L4 row ⇒ the weekly watch earned its keep on that source.
+- A long `latency` ⇒ the defense was slow there; consider a tighter cadence or a
+  real-capture canary for that CLI.

--- a/justfile
+++ b/justfile
@@ -423,3 +423,12 @@ setup-tools:
         echo "brew install cargo-binstall (or cargo install cargo-binstall) to grab prebuilt binaries instead." >&2
         cargo install "${tools[@]}"
     fi
+
+# Self-test the upstream-drift watcher — its ONLY test. A regex-parser regression
+# is a silent monitor death (the script returns empty / raises, the weekly job
+# alarms on junk or watches nothing); this pins the parsers + the fetch
+# classifier. Pure Python, no deps, no network.
+[group('meta')]
+[doc('Self-test the upstream-drift watcher (parsers + fetch classifier)')]
+drift-selftest:
+    python3 scripts/check_upstream_drift_selftest.py

--- a/scripts/check_upstream_drift.py
+++ b/scripts/check_upstream_drift.py
@@ -72,6 +72,15 @@ import urllib.request
 # URLError is itself an OSError subclass; kept explicit to document intent.
 FETCH_ERRORS = (urllib.error.URLError, OSError, http.client.HTTPException)
 
+# A permanent HTTP status means the URL itself is wrong/gone — our pinned
+# upstream path moved, so the watch is BLIND for that source until fixed. This is
+# BREAKING, never transient. Everything else (403/429 throttling behind a CDN,
+# 5xx server hiccups, connect/read timeouts) is genuinely retry-later. The trap
+# this guards: `HTTPError` subclasses `URLError` ⊂ FETCH_ERRORS, so a 404 used to
+# fall into the transient bucket and the weekly job stayed green while silently
+# watching nothing.
+PERMANENT_HTTP_STATUS = frozenset({404, 410, 451})
+
 REPO = pathlib.Path(__file__).resolve().parent.parent
 
 CODEX_PROTOCOL_URL = (
@@ -187,9 +196,12 @@ CODEWHALE_KNOWN_OMITTED = {
 # ~50 event types and we intentionally map only a handful, so "new upstream event"
 # is noise; we only alarm when a type WE DEPEND ON vanishes (a rename the plugin
 # would forward but the decoder would map to nothing).
+# NB: the repo's default branch is `dev` (not `main`) — the `main` branch was
+# retired, which 404'd these URLs and (pre-`try_fetch`) was silently bucketed as
+# transient, blinding the opencode watch. Track `dev` (the active default).
 OPENCODE_EVENT_URLS = (
-    "https://raw.githubusercontent.com/anomalyco/opencode/main/packages/core/src/v1/session.ts",
-    "https://raw.githubusercontent.com/anomalyco/opencode/main/packages/core/src/permission.ts",
+    "https://raw.githubusercontent.com/anomalyco/opencode/dev/packages/core/src/v1/session.ts",
+    "https://raw.githubusercontent.com/anomalyco/opencode/dev/packages/core/src/permission.ts",
 )
 
 # `permission.asked` is forwarded/decoded DEFENSIVELY (a V1/alias spelling); only
@@ -224,6 +236,35 @@ def fetch(url: str) -> str:
     req = urllib.request.Request(url, headers={"User-Agent": "pixtuoid-drift-watch"})
     with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310 (trusted hosts)
         return resp.read().decode("utf-8", "replace")
+
+
+def try_fetch(
+    url: str, label: str, breaking: list[str], errors: list[str]
+) -> str | None:
+    """Fetch `url`, classifying failures so a PERMANENT upstream move is loud.
+
+    A `PERMANENT_HTTP_STATUS` (404/410/451) means our pinned URL is wrong/gone →
+    `breaking` (the watch is blind for this source until the `*_URL` constant is
+    fixed). 403/429/5xx + connect/read timeouts → `errors` (transient). Returns
+    the body, or None on any failure (the caller skips that source's checks).
+    Centralizes the try/except every fetch site repeated, AND fixes the
+    `HTTPError ⊂ URLError ⊂ FETCH_ERRORS` swallow that bucketed 404 as transient.
+    """
+    try:
+        return fetch(url)
+    except urllib.error.HTTPError as e:
+        if e.code in PERMANENT_HTTP_STATUS:
+            breaking.append(
+                f"{label}: HTTP {e.code} at {url} — the upstream URL moved or was "
+                f"removed; drift-watch is BLIND for this source until the *_URL "
+                f"constant / parser is updated."
+            )
+        else:
+            errors.append(f"{label}: transient HTTP {e.code} at {url}: {e}")
+        return None
+    except FETCH_ERRORS as e:
+        errors.append(f"{label}: fetch failed (transient?): {e}")
+        return None
 
 
 def read_codex_events() -> set[str]:
@@ -387,11 +428,7 @@ def run_checks(
     stays inside main(), before this is called, and still exits 1."""
     # --- Codex hook events (only the FETCH is transient) -------------------
     if codex_ours is not None:
-        try:
-            text = fetch(CODEX_PROTOCOL_URL)
-        except FETCH_ERRORS as e:
-            errors.append(f"Codex source fetch failed (transient?): {e}")
-            text = None
+        text = try_fetch(CODEX_PROTOCOL_URL, "Codex source", breaking, errors)
         if text is not None:
             upstream = upstream_codex_hooks(text)
             if upstream is None:
@@ -417,11 +454,7 @@ def run_checks(
 
     # --- Reasonix hook events + payload fields (only the FETCH is transient)
     if reasonix_ours is not None:
-        try:
-            text = fetch(REASONIX_HOOK_URL)
-        except FETCH_ERRORS as e:
-            errors.append(f"Reasonix source fetch failed (transient?): {e}")
-            text = None
+        text = try_fetch(REASONIX_HOOK_URL, "Reasonix source", breaking, errors)
         if text is not None:
             upstream = upstream_reasonix_hooks(text)
             if upstream is None:
@@ -454,11 +487,7 @@ def run_checks(
 
     # --- CodeWhale hook events (only the FETCH is transient) ---------------
     if codewhale_ours is not None:
-        try:
-            text = fetch(CODEWHALE_HOOK_URL)
-        except FETCH_ERRORS as e:
-            errors.append(f"CodeWhale source fetch failed (transient?): {e}")
-            text = None
+        text = try_fetch(CODEWHALE_HOOK_URL, "CodeWhale source", breaking, errors)
         if text is not None:
             upstream = upstream_codewhale_hooks(text)
             if upstream is None:
@@ -484,11 +513,14 @@ def run_checks(
 
     # --- opencode EventV2 types (only the FETCH is transient) --------------
     if opencode_ours is not None:
-        try:
-            text = "\n".join(fetch(u) for u in OPENCODE_EVENT_URLS)
-        except FETCH_ERRORS as e:
-            errors.append(f"opencode source fetch failed (transient?): {e}")
-            text = None
+        parts = [
+            try_fetch(u, "opencode source", breaking, errors)
+            for u in OPENCODE_EVENT_URLS
+        ]
+        # If ANY url failed, skip the check — a partial concat would
+        # false-positive a depended type as "GONE" just because it lived in the
+        # half we couldn't fetch. (try_fetch already classified each failure.)
+        text = "\n".join(parts) if all(p is not None for p in parts) else None
         if text is not None:
             for ev in sorted(opencode_ours - OPENCODE_TOLERATED):
                 # The type strings appear as `type: "session.created"` etc. in
@@ -502,11 +534,7 @@ def run_checks(
 
     # --- Copilot event types (only the FETCH is transient) -----------------
     if copilot_ours is not None:
-        try:
-            text = fetch(COPILOT_SCHEMA_URL)
-        except FETCH_ERRORS as e:
-            errors.append(f"Copilot schema fetch failed (transient?): {e}")
-            text = None
+        text = try_fetch(COPILOT_SCHEMA_URL, "Copilot schema", breaking, errors)
         if text is not None:
             upstream = upstream_copilot_events(text)
             if upstream is None:
@@ -527,11 +555,7 @@ def run_checks(
 
     # --- Cursor hook events (only the FETCH is transient) ------------------
     if cursor_ours is not None:
-        try:
-            text = fetch(CURSOR_HOOKS_URL)
-        except FETCH_ERRORS as e:
-            errors.append(f"Cursor hooks doc fetch failed (transient?): {e}")
-            text = None
+        text = try_fetch(CURSOR_HOOKS_URL, "Cursor hooks doc", breaking, errors)
         if text is not None:
             for ev in sorted(cursor_ours):
                 # Word-boundary token match (the docs render the names inline /
@@ -547,11 +571,7 @@ def run_checks(
 
     # --- CC subagent-dispatch tool (only the FETCH is transient) -----------
     if dispatch_names is not None:
-        try:
-            tools = fetch(CC_TOOLS_URL)
-        except FETCH_ERRORS as e:
-            errors.append(f"CC tools-reference fetch failed (transient?): {e}")
-            tools = None
+        tools = try_fetch(CC_TOOLS_URL, "CC tools-reference", breaking, errors)
         if tools is not None:
             # At least one name we'd detect by-name must still be the documented
             # dispatch tool. (Losing a legacy name like `Task` is fine.)
@@ -571,11 +591,7 @@ def run_checks(
     # lifecycle-marker scan is unconditional (nothing to read from our source
     # first — we depend on those surfaces' ABSENCE; see
     # CC_LIFECYCLE_SURFACE_MARKERS).
-    try:
-        hooks_doc = fetch(CC_HOOKS_URL)
-    except FETCH_ERRORS as e:
-        errors.append(f"CC hooks doc fetch failed (transient?): {e}")
-        hooks_doc = None
+    hooks_doc = try_fetch(CC_HOOKS_URL, "CC hooks doc", breaking, errors)
     if hooks_doc is not None:
         if cc_ours is not None:
             upstream = upstream_cc_hook_events(hooks_doc)

--- a/scripts/check_upstream_drift_selftest.py
+++ b/scripts/check_upstream_drift_selftest.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Self-test for check_upstream_drift.py — the drift watcher had ZERO tests, yet
+a regex-parser regression = a SILENT monitor death (it returns empty / raises and
+the weekly job either alarms on junk or watches nothing). This pins:
+
+  1. `try_fetch` failure classification — the PR that added it fixed the
+     `HTTPError ⊂ URLError ⊂ FETCH_ERRORS` swallow that bucketed a permanent 404
+     as transient. A 404/410/451 MUST be breaking; 5xx/429/timeouts transient.
+  2. The `read_*_events` source parsers still find a non-empty, well-shaped set
+     (catches "the regex broke" / "it grabbed the wrong block").
+  3. The `upstream_*` parsers extract names from a representative snippet.
+
+Run: `python3 scripts/check_upstream_drift_selftest.py` (exit 0 = pass).
+No pytest dependency on purpose — the repo has no Python test harness.
+"""
+
+from __future__ import annotations
+
+import io
+import pathlib
+import re
+import sys
+import urllib.error
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import check_upstream_drift as d  # noqa: E402
+
+FAILS: list[str] = []
+
+
+def check(cond: bool, msg: str) -> None:
+    if not cond:
+        FAILS.append(msg)
+
+
+def _http_error(code: int) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError("https://x/y", code, "msg", {}, io.BytesIO(b""))
+
+
+def test_try_fetch_classifies_permanent_vs_transient() -> None:
+    real = d.fetch
+    try:
+        # Permanent HTTP → breaking (the URL moved; watch blind).
+        for code in (404, 410, 451):
+            d.fetch = lambda _u, c=code: (_ for _ in ()).throw(_http_error(c))
+            br: list[str] = []
+            er: list[str] = []
+            out = d.try_fetch("https://x/y", "T", br, er)
+            check(out is None, f"{code}: returns None")
+            check(len(br) == 1 and not er, f"{code}: -> breaking (got breaking={br} errors={er})")
+            check(str(code) in br[0], f"{code}: message names the status")
+
+        # Transient HTTP (server/throttle) → errors, NOT breaking.
+        for code in (500, 502, 503, 429, 403):
+            d.fetch = lambda _u, c=code: (_ for _ in ()).throw(_http_error(c))
+            br, er = [], []
+            d.try_fetch("https://x/y", "T", br, er)
+            check(not br and len(er) == 1, f"{code}: -> transient (got breaking={br} errors={er})")
+
+        # Network-layer failure → transient.
+        d.fetch = lambda _u: (_ for _ in ()).throw(urllib.error.URLError("conn refused"))
+        br, er = [], []
+        d.try_fetch("https://x/y", "T", br, er)
+        check(not br and len(er) == 1, f"URLError -> transient (got breaking={br} errors={er})")
+
+        # Success → returns the body, no buckets touched.
+        d.fetch = lambda _u: "BODY"
+        br, er = [], []
+        out = d.try_fetch("https://x/y", "T", br, er)
+        check(out == "BODY" and not br and not er, "success returns body, no buckets")
+    finally:
+        d.fetch = real
+
+
+def test_source_parsers_find_nonempty_well_shaped_sets() -> None:
+    # (reader, a shape regex every member must match) — non-empty + shape catches
+    # a broken regex / wrong-block grab WITHOUT coupling to the exact event set
+    # (which legitimately grows as sources are added).
+    cases = [
+        (d.read_codex_events, r"^[A-Za-z]\w+$"),
+        (d.read_cc_events, r"^[A-Za-z]\w+$"),
+        (d.read_dispatch_names, r"^[A-Za-z]\w+$"),
+        (d.read_reasonix_events, r"^[A-Za-z]\w+$"),
+        (d.read_codewhale_events, r"^[a-z][a-z_]*$"),
+        (d.read_opencode_events, r"^[a-z][a-z0-9._]*$"),
+        (d.read_copilot_events, r"^[a-z][a-z0-9._]*$"),
+        (d.read_cursor_events, r"^[a-zA-Z]\w+$"),
+    ]
+    for reader, shape in cases:
+        name = reader.__name__
+        got = reader()
+        check(isinstance(got, set) and len(got) >= 2, f"{name}: non-empty (>=2), got {got!r}")
+        bad = [m for m in got if not re.match(shape, m)]
+        check(not bad, f"{name}: members match {shape}; offenders={bad}")
+
+
+def test_upstream_parsers_extract_from_a_snippet() -> None:
+    # Codex HookEventName enum snippet.
+    codex = 'pub enum HookEventName {\n    SessionStart,\n    PreToolUse,\n    Stop,\n}'
+    up = d.upstream_codex_hooks(codex)
+    check(up is not None and {"SessionStart", "PreToolUse"} <= up, f"codex enum parse: {up}")
+
+    # Copilot schema: definitions[*].properties.type.const.
+    schema = (
+        '{"definitions":{"A":{"properties":{"type":{"const":"session.start"}}},'
+        '"B":{"properties":{"type":{"const":"tool.execution_start"}}}}}'
+    )
+    up = d.upstream_copilot_events(schema)
+    check(up is not None and {"session.start", "tool.execution_start"} <= up, f"copilot schema parse: {up}")
+
+    # A malformed schema → None (signals "restructured", handled as breaking upstream).
+    check(d.upstream_copilot_events("not json") is None, "copilot bad json -> None")
+
+
+def main() -> int:
+    for t in (
+        test_try_fetch_classifies_permanent_vs_transient,
+        test_source_parsers_find_nonempty_well_shaped_sets,
+        test_upstream_parsers_extract_from_a_snippet,
+    ):
+        t()
+    if FAILS:
+        print("DRIFT SELFTEST FAILED:")
+        for f in FAILS:
+            print(f"  - {f}")
+        return 1
+    print("drift selftest: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_upstream_drift_selftest.py
+++ b/scripts/check_upstream_drift_selftest.py
@@ -111,6 +111,32 @@ def test_upstream_parsers_extract_from_a_snippet() -> None:
     # A malformed schema → None (signals "restructured", handled as breaking upstream).
     check(d.upstream_copilot_events("not json") is None, "copilot bad json -> None")
 
+    # CC hook-event summary table — the MOST complex parser (anchors to the
+    # "| Event |" header + separator, extracts the backtick-quoted first cell).
+    # A wrong-but-non-None match here would silently miss a renamed event, so pin
+    # both a real table and the no-table -> None case.
+    cc_md = (
+        "| Event | When it fires |\n"
+        "|---|---|\n"
+        "| `PreToolUse` | before a tool call |\n"
+        "| `PostToolUse` | after a tool call |\n"
+    )
+    up = d.upstream_cc_hook_events(cc_md)
+    check(up is not None and {"PreToolUse", "PostToolUse"} <= up, f"cc table parse: {up}")
+    check(d.upstream_cc_hook_events("no table here") is None, "cc no table -> None")
+
+    # Reasonix Go consts: `Ident Event = "Wire"`.
+    reasonix_go = 'const (\n\tPreToolUse Event = "PreToolUse"\n\tStop Event = "Stop"\n)'
+    up = d.upstream_reasonix_hooks(reasonix_go)
+    check(up is not None and {"PreToolUse", "Stop"} <= up, f"reasonix consts parse: {up}")
+    check(d.upstream_reasonix_hooks("no consts here") is None, "reasonix none -> None")
+
+    # CodeWhale Rust enum → snake_case wire names (serde rename_all = snake_case).
+    codewhale_rs = "pub enum HookEvent {\n    SessionStart,\n    PreToolUse,\n}"
+    up = d.upstream_codewhale_hooks(codewhale_rs)
+    check(up is not None and {"session_start", "pre_tool_use"} <= up, f"codewhale enum parse: {up}")
+    check(d.upstream_codewhale_hooks("no enum here") is None, "codewhale none -> None")
+
 
 def main() -> int:
     for t in (


### PR DESCRIPTION
**PR 1 of the source-self-diagnosis arc** (spec: local `docs/superpowers/specs/2026-06-15-source-self-diagnosis-design.md`). The smallest, verified piece — and it caught a live bug on its first run.

## The bug (Gap 2)
The weekly `check_upstream_drift.py` swallowed *permanent* failures: `HTTPError ⊂ URLError ⊂ FETCH_ERRORS`, so a 404 (pinned URL moved) fell into the **transient** bucket → exit 2 → a `::warning::` nobody actions, while the job stayed green and **silently watched nothing** — the worst monitor failure (alive, watching nothing).

## Fix
- New **`try_fetch(url, label, breaking, errors)`** classifier that DRYs the 8 fetch sites and splits failures: **404/410/451 → breaking** ("URL moved; watch BLIND until fixed"); **403/429/5xx + connect/read timeouts → transient**.
- It **immediately caught a live instance**: opencode's `anomalyco/opencode` URLs 404'd because the repo's default branch moved `main`→`dev`. Updated to `dev` → **un-blinds the opencode watch** (silently dead until now). A live run confirms every opencode event type we depend on is present on `dev`.

## First tests for the watcher (it had zero)
`scripts/check_upstream_drift_selftest.py` (plain asserts — no pytest in the repo) pins:
- `try_fetch` classification (404/410/451→breaking; 5xx/429/403/URLError→transient; success→body),
- the `read_*_events` source parsers (non-empty + per-source shape — catches a broken regex / wrong-block grab without coupling to the exact event set),
- the `upstream_*` parsers against representative snippets.

`just drift-selftest` runs it; CI runs it on PRs touching the script (the live network check stays schedule/dispatch-only so a flaky upstream fetch can't gate a PR).

## Drift-incident ledger
`docs/review-metrics/drift-incidents.md` — turns "layer 2 (real-stream self-monitoring) is the real backstop" into measurable data (which layer caught each drift, how late). Seeded with the Task→Agent case.

## Surfaced for separate triage (not in this PR)
The live run flagged a genuine review-class item: **Reasonix now emits a `PermissionRequest` hook** we neither register nor omit. That's a real decode decision (map → Waiting, or add to `REASONIX_KNOWN_OMITTED`) — the watch doing its job. Filing separately.

## Verification
- `just drift-selftest` ✓ · `python3 -m py_compile` both ✓ · live run: opencode resolves clean, only the Reasonix review item remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)