### PR TITLE
test(core): de-flake exit_watch live tests (10s liveness bound + reap-before-assert)

### DIFF
--- a/crates/pixtuoid-core/src/source/exit_watch.rs
+++ b/crates/pixtuoid-core/src/source/exit_watch.rs
@@ -620,6 +620,15 @@ mod tests {
 
         use super::ExitWatch;
 
+        /// Liveness ceiling for the real-process `live::` tests. Generous
+        /// enough to absorb `cargo llvm-cov` instrumentation + full-parallel
+        /// scheduling jitter on CI — the coverage job intermittently flaked
+        /// `drop_stops_cleanly` at 3s, where the watcher thread's post-`Drop`
+        /// kqueue/pidfd wake just hadn't been scheduled yet. It is a liveness
+        /// bound, NOT a latency assertion: a true hang is still failed by
+        /// nextest's 180s slow-timeout, so a wider deadline doesn't weaken it.
+        const LIVE_PID_DEADLINE: Duration = Duration::from_secs(10);
+
         fn sleeper() -> Child {
             Command::new("sleep").arg("30").spawn().unwrap()
         }
@@ -674,7 +683,7 @@ mod tests {
             watch.watch(pid);
             kill_and_reap(&mut child);
             assert!(
-                wait_for_pid(&mut rx, pid, Duration::from_secs(3)).await,
+                wait_for_pid(&mut rx, pid, LIVE_PID_DEADLINE).await,
                 "a watched process dying must surface its pid on the exit channel"
             );
         }
@@ -694,7 +703,7 @@ mod tests {
             let watch = ExitWatch::spawn(tx).expect("backend must init on macOS/Linux");
             watch.watch(pid);
             assert!(
-                wait_for_pid(&mut rx, pid, Duration::from_secs(3)).await,
+                wait_for_pid(&mut rx, pid, LIVE_PID_DEADLINE).await,
                 "watching an already-dead pid must synthesize its exit (ESRCH path)"
             );
         }
@@ -709,7 +718,7 @@ mod tests {
             watch.watch(pid);
             kill_and_reap(&mut child);
             assert!(
-                wait_for_pid(&mut rx, pid, Duration::from_secs(3)).await,
+                wait_for_pid(&mut rx, pid, LIVE_PID_DEADLINE).await,
                 "the first exit must arrive"
             );
             assert_no_pid_within(
@@ -735,14 +744,14 @@ mod tests {
             watch.watch(pid);
             kill_and_reap(&mut child);
             assert!(
-                wait_for_pid(&mut rx, pid, Duration::from_secs(3)).await,
+                wait_for_pid(&mut rx, pid, LIVE_PID_DEADLINE).await,
                 "a bogus registration must not break later real watches"
             );
         }
 
         /// Drop sets `closed` + wakes: the thread must exit, observable as
-        /// the channel closing (the thread owns the only sender). The later
-        /// kill exercises the dead machinery for no-panic.
+        /// the channel closing (the thread owns the only sender). The kill
+        /// also exercises the post-Drop machinery for no-panic.
         #[tokio::test]
         async fn drop_stops_cleanly() {
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
@@ -750,15 +759,18 @@ mod tests {
             let mut child = sleeper();
             watch.watch(child.id() as i32);
             drop(watch);
-            let closed = tokio::time::timeout(Duration::from_secs(3), async {
+            let closed = tokio::time::timeout(LIVE_PID_DEADLINE, async {
                 while rx.recv().await.is_some() {}
             })
             .await;
+            // Reap BEFORE asserting: were the drop slow enough for the assert
+            // to fire, a trailing reap would be skipped and the sleeper would
+            // leak (the nextest LEAK that paired with this test's flake).
+            kill_and_reap(&mut child);
             assert!(
                 closed.is_ok(),
                 "dropping the ExitWatch must stop the thread (its sender must drop)"
             );
-            kill_and_reap(&mut child);
         }
     }
 }


### PR DESCRIPTION
## Symptom
`#322`'s coverage job intermittently failed `pixtuoid-core::source::exit_watch::tests::live::drop_stops_cleanly` with **`FAIL + LEAK`** — unrelated to that PR's lockfile bump (passed 1707/1707 locally and on re-run).

## Root cause
The `exit_watch::live` tests assert a **3s wall-clock deadline** on real-process / thread machinery. Under `cargo llvm-cov` instrumentation + full nextest parallelism on a loaded runner, the watcher thread's post-`Drop` kqueue/pidfd wake occasionally isn't scheduled within 3s → the assert fires (**FAIL**). The panic then skips `drop_stops_cleanly`'s trailing `kill_and_reap` → the `sleep 30` child is left running → nextest reports **LEAK** (a *secondary* effect of the FAIL, not an independent leak).

This is **not** a regression of the #161/#167 shim de-flake — that fixed the `pixtuoid-hook` latency tests (given `threads-required`). `exit_watch`'s `live::` tests arrived later (#228, kqueue/pidfd) and reused the "wall-clock bound on real-process machinery" pattern without inheriting the mitigation.

`Drop` itself is race-free (the module doc is explicit: kqueue retains the `EVFILT_USER` trigger — no lost wakeups; the thread re-checks `closed` after each wake), so this is scheduling-jitter headroom, **not** masking a real bug.

## Fix — test-only, no production change
- **`LIVE_PID_DEADLINE = 10s`** const replaces the five `Duration::from_secs(3)` deadlines. It's a *liveness ceiling*, not a latency assertion — a true hang is still failed by nextest's 180s `slow-timeout`, so the wider bound doesn't weaken what's tested.
- **`drop_stops_cleanly` reaps the child BEFORE the assert**, so a slow drop can never *also* leak the sleeper (kills the LEAK half unconditionally).

## Verification
- `exit_watch::live` tests **10/10** green locally.
- `just preflight` **1707** green.
- The coverage job here (instrumented) is the real-condition check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)