### PR TITLE
feat(site): SEO pass — sitemap, JSON-LD, self-hosted fonts (tighter CSP)

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -3,6 +3,7 @@ import { defineConfig } from 'astro/config';
 import { readFileSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { posix } from 'node:path';
+import sitemap from '@astrojs/sitemap';
 import rehypeMermaid from 'rehype-mermaid';
 
 // Single-source the displayed version from the workspace Cargo.toml so the boot
@@ -176,5 +177,10 @@ export default defineConfig({
       rehypeRepoLinks, // after mermaid so it walks the final tree
     ],
   },
+  // Sitemap respects `site` + `base`, so emitted URLs carry the /pixtuoid
+  // prefix → submit /pixtuoid/sitemap-index.xml to Search Console (this is a
+  // project page, so a repo-local robots.txt would serve under /pixtuoid/ and
+  // crawlers only read robots.txt from the origin root — see the PR notes).
+  integrations: [sitemap()],
   vite: { define: { __PIXTUOID_VERSION__: JSON.stringify(version) } },
 });

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -8,6 +8,10 @@
       "name": "pixtuoid-site",
       "version": "0.0.0",
       "dependencies": {
+        "@astrojs/sitemap": "^3.7.3",
+        "@fontsource/jersey-10": "^5.2.8",
+        "@fontsource/jetbrains-mono": "^5.2.8",
+        "@fontsource/lora": "^5.2.8",
         "astro": "^6.1.10"
       },
       "devDependencies": {
@@ -201,6 +205,17 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.3.tgz",
+      "integrity": "sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA==",
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^9.0.0",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -973,6 +988,33 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fontsource/jersey-10": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/jersey-10/-/jersey-10-5.2.8.tgz",
+      "integrity": "sha512-5kjCLWNO/3n4zQ6fFvYratSSe61rgY/KRpQIayrblv6dW9jvOxAQXa8MJmWCJUHQlFK9GHH5bj/GSE7C6vgZHQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/lora": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/lora/-/lora-5.2.8.tgz",
+      "integrity": "sha512-AQlfsHw4TP1x/eb2IZ6VjQ70ctKa39m9JN9A4zlvDOeKYLrCs+GaYIEQ86Y6YfSPGHn01bErXkRcyktOW0LOPQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@fortawesome/fontawesome-free": {
@@ -2412,10 +2454,18 @@
       "version": "22.19.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
       "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/trusted-types": {
@@ -2893,6 +2943,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -9092,6 +9148,40 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/sitemap": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
+      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^24.9.2",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/esm/cli.js"
+      },
+      "engines": {
+        "node": ">=20.19.5",
+        "npm": ">=10.8.2"
+      }
+    },
+    "node_modules/sitemap/node_modules/@types/node": {
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/sitemap/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
+    },
     "node_modules/smol-toml": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
@@ -9136,6 +9226,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
+      "license": "MIT"
     },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
@@ -9619,7 +9715,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/site/package.json
+++ b/site/package.json
@@ -18,6 +18,10 @@
     "verify": "npm run format:check && npm run lint && npm run check && npm run build"
   },
   "dependencies": {
+    "@astrojs/sitemap": "^3.7.3",
+    "@fontsource/jersey-10": "^5.2.8",
+    "@fontsource/jetbrains-mono": "^5.2.8",
+    "@fontsource/lora": "^5.2.8",
     "astro": "^6.1.10"
   },
   "devDependencies": {

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -35,6 +35,11 @@ const ogImage = new URL(asset('demos/hero-poster.png'), SITE).href;
 // the static build, so /config no longer self-declares the homepage as canonical.
 const canonical = new URL(Astro.url.pathname, SITE).href;
 const version = __PIXTUOID_VERSION__; // from the workspace Cargo.toml at build
+
+// Escape `<` so no string value can break out of the <script> block (a `</script`
+// or `<!--` in serialized JSON would otherwise close it). Defense-in-depth: every
+// value is a build-time constant today, but the jsonLd prop is typed open.
+const jsonLdSafe = jsonLd ? JSON.stringify(jsonLd).replace(/</g, '\\u003c') : null;
 ---
 
 <!doctype html>
@@ -80,7 +85,7 @@ const version = __PIXTUOID_VERSION__; // from the workspace Cargo.toml at build
       /* schema.org structured data — the homepage passes a SoftwareApplication
         so search engines can render a rich result for the tool. */
     }
-    {jsonLd && <script type="application/ld+json" is:inline set:html={JSON.stringify(jsonLd)} />}
+    {jsonLdSafe && <script type="application/ld+json" is:inline set:html={jsonLdSafe} />}
 
     {
       /* Fonts are self-hosted via @fontsource (imported in the frontmatter), so

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -1,4 +1,14 @@
 ---
+// Self-hosted fonts (@fontsource): bundled into the build + served same-origin,
+// so no Google Fonts round-trip on load — faster LCP, a CSP with no external
+// font origins, no third-party tracking, and they actually load behind the GFW.
+// Family names ('Jersey 10' / 'JetBrains Mono' / 'Lora') match global.css as-is.
+import '@fontsource/jersey-10/400.css';
+import '@fontsource/jetbrains-mono/400.css';
+import '@fontsource/jetbrains-mono/500.css';
+import '@fontsource/jetbrains-mono/700.css';
+import '@fontsource/lora/400.css';
+import '@fontsource/lora/500.css';
 import '../styles/global.css';
 import { asset, THEMES } from '../consts';
 
@@ -6,12 +16,16 @@ interface Props {
   title?: string;
   description?: string;
   preloadImage?: string;
+  // schema.org JSON-LD for this page (e.g. the homepage's SoftwareApplication).
+  // Rendered verbatim as an `application/ld+json` block when present.
+  jsonLd?: Record<string, unknown>;
 }
 
 const {
   title = 'pixtuoid — your coding agents, alive in a pixel office',
   description = 'A terminal-native pixel-art office that visualizes your AI coding agents (Claude Code, Codex, and more) as little animated coworkers — day/night lighting, weather, themes, and pets included.',
   preloadImage,
+  jsonLd,
 } = Astro.props;
 
 // Absolute URLs for crawlers (Astro.site is the deploy origin).
@@ -38,7 +52,7 @@ const version = __PIXTUOID_VERSION__; // from the workspace Cargo.toml at build
     }
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; base-uri 'self'; object-src 'none'; img-src 'self' data:; media-src 'self'; font-src 'self' https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self' 'unsafe-inline'; connect-src 'self'; form-action 'self'"
+      content="default-src 'self'; base-uri 'self'; object-src 'none'; img-src 'self' data:; media-src 'self'; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; connect-src 'self'; form-action 'self'"
     />
     <title>{title}</title>
     <meta name="description" content={description} />
@@ -62,13 +76,16 @@ const version = __PIXTUOID_VERSION__; // from the workspace Cargo.toml at build
     <meta property="og:image" content={ogImage} />
     <meta name="twitter:card" content="summary_large_image" />
 
-    <!-- Fonts: Jersey 10 (pixel display, single weight) + JetBrains Mono (UI/code) + Lora (warm body) -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Jersey+10&family=JetBrains+Mono:wght@400;500;700&family=Lora:wght@400;500&display=swap"
-      rel="stylesheet"
-    />
+    {
+      /* schema.org structured data — the homepage passes a SoftwareApplication
+        so search engines can render a rich result for the tool. */
+    }
+    {jsonLd && <script type="application/ld+json" is:inline set:html={JSON.stringify(jsonLd)} />}
+
+    {
+      /* Fonts are self-hosted via @fontsource (imported in the frontmatter), so
+        there is no Google Fonts <link> to preconnect to or render-block on. */
+    }
 
     <!-- No-FOUC theme init: ?theme= override → saved choice → system → day -->
     <script is:inline>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -10,10 +10,31 @@ import SupportedTools from '../components/SupportedTools.astro';
 import Install from '../components/Install.astro';
 import Elevator from '../components/Elevator.astro';
 import Footer from '../components/Footer.astro';
-import { asset } from '../consts';
+import { asset, REPO, CRATES } from '../consts';
+
+// Homepage structured data: a free cross-platform developer tool. Search
+// engines use this for a rich result; the version is single-sourced from the
+// workspace Cargo.toml at build (same define as everywhere else).
+const SITE = Astro.site ?? new URL('https://ivanwng97.github.io');
+const softwareJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareApplication',
+  name: 'pixtuoid',
+  description:
+    'A terminal-native pixel-art office that visualizes your AI coding agents (Claude Code, Codex, and more) as animated coworkers.',
+  applicationCategory: 'DeveloperApplication',
+  operatingSystem: 'macOS, Linux, Windows',
+  url: new URL(asset(''), SITE).href,
+  downloadUrl: CRATES,
+  softwareVersion: __PIXTUOID_VERSION__,
+  license: 'https://opensource.org/licenses/MIT',
+  codeRepository: REPO,
+  author: { '@type': 'Person', name: 'Ivan Wang', url: REPO },
+  offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+};
 ---
 
-<Base preloadImage={asset('demos/hero-poster.png')}>
+<Base preloadImage={asset('demos/hero-poster.png')} jsonLd={softwareJsonLd}>
   <span id="top"></span>
   <Nav />
   <Elevator />


### PR DESCRIPTION
Three SEO/perf improvements to the Astro landing site.

### 1. `@astrojs/sitemap`
Emits `sitemap-index.xml` + `sitemap-0.xml`, base-prefixed (`https://ivanwng97.github.io/pixtuoid/...`). Submit `/pixtuoid/sitemap-index.xml` to Google Search Console / Bing.

### 2. `SoftwareApplication` JSON-LD (homepage)
A `<script type="application/ld+json">` describing pixtuoid as a free, cross-platform `DeveloperApplication` (version single-sourced from the workspace `Cargo.toml`) so search engines can render a rich result. Passed via a new optional `Base` prop, so only the homepage emits it.

### 3. Self-hosted fonts via `@fontsource`
Jersey 10 / JetBrains Mono / Lora are now bundled into the build and served same-origin instead of fetched from Google Fonts at load:
- **Faster LCP** — no cross-origin preconnect + render-blocking stylesheet round-trip.
- **Tighter CSP** — `font-src` / `style-src` drop `fonts.gstatic.com` + `fonts.googleapis.com` back to `'self'`.
- **No third-party tracking**, and the fonts **actually load behind the GFW** (Google Fonts is often slow/blocked in CN).
- Family names (`'Jersey 10'` / `'JetBrains Mono'` / `'Lora'`) match `global.css` as-is → **no CSS change**. `unicode-range` gates non-latin subsets so English visitors fetch only latin.

### Deliberately NOT included: `robots.txt`
This is a GitHub Pages **project page** (`base: /pixtuoid`). Crawlers read `robots.txt` only from the **origin root** (`ivanwng97.github.io/robots.txt`, RFC 9309) — a repo-local one would serve under `/pixtuoid/` and be ignored. The real robots.txt + `Sitemap:` directive belongs in the `ivanwng97.github.io` **user-pages repo**, or just submit the sitemap to Search Console.

### Verification
- `just site-check` (format → lint → astro check → build) **green**.
- Built HTML: **zero** `fonts.googleapis`/`fonts.gstatic` refs; sitemap + JSON-LD present; CSP = `font-src 'self'; style-src 'self' 'unsafe-inline'`.
- 28 woff2 bundled (all subsets); only latin fetched at runtime via `unicode-range`.

Separate from #323 (dep bump) and the jsx-a11y/eslint-10 decision — touches neither eslint nor the bumped deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)