### PR TITLE
fix(scripts): strip control chars from disposition-harvester output (#339)

### DIFF
--- a/scripts/check_review_disposition.py
+++ b/scripts/check_review_disposition.py
@@ -52,6 +52,14 @@ class Finding:
     title: str
 
 
+def _strip_control(s: str) -> str:
+    """Drop C0/C1 control chars + DEL so untrusted bot-comment text / paths can't
+    emit a terminal escape (ANSI/OSC) when this report is printed — the Python
+    twin of the Rust side's `verify::display_safe` sanitize-at-the-boundary rule
+    (R0615-06). Applied where findings are constructed, not at each print site."""
+    return "".join(ch for ch in s if not (ord(ch) < 0x20 or 0x7F <= ord(ch) <= 0x9F))
+
+
 def severity_of(body: str) -> str | None:
     """The MEDIUM+/LOW severity a bot comment body leads with, or None."""
     m = _SEVERITY.search(body or "")
@@ -61,7 +69,7 @@ def severity_of(body: str) -> str | None:
 def title_of(body: str) -> str:
     """A one-line title for display: the bold heading, control chars stripped."""
     first = (body or "").strip().splitlines()[0] if (body or "").strip() else ""
-    return first.replace("*", "").strip()[:120]
+    return _strip_control(first.replace("*", "").strip())[:120]
 
 
 def extract_findings(comments: list[dict]) -> list[Finding]:
@@ -77,7 +85,7 @@ def extract_findings(comments: list[dict]) -> list[Finding]:
         out.append(
             Finding(
                 severity=sev,
-                path=c.get("path", "") or "",
+                path=_strip_control(c.get("path", "") or ""),
                 line=c.get("line"),
                 title=title_of(c.get("body", "")),
             )

--- a/scripts/check_review_disposition_selftest.py
+++ b/scripts/check_review_disposition_selftest.py
@@ -40,6 +40,17 @@ def run() -> int:
     check("extract paths", {f.path for f in findings} == {"a.rs", "b.rs"})
     check("extract keeps null line", any(f.line is None for f in findings))
 
+    # _strip_control (#339): control chars in the bot body/path are stripped at the
+    # construction boundary so the printed report can't emit a terminal escape.
+    check("strip_control removes ESC/OSC/DEL/C1",
+          m._strip_control("a\x1b[31mb\x07c\x7fd\x9ee") == "a[31mbcde")
+    check("strip_control keeps printable + unicode", m._strip_control("café ▪ ✓") == "café ▪ ✓")
+    hostile = [{"user": {"login": "claude[bot]"}, "path": "x\x1b[2J.rs", "line": 1,
+                "body": "**MEDIUM — \x1b]0;pwned\x07evil\x1b[0m title**"}]
+    hf = m.extract_findings(hostile)[0]
+    check("finding.title has no control chars", all(ord(ch) >= 0x20 and ord(ch) != 0x7f for ch in hf.title))
+    check("finding.path has no control chars", "\x1b" not in hf.path)
+
     # parse_marker_lines — the Bot-findings-adjudicated: block, ended by prose.
     body = (
         "fix(install): address #316 bot findings\n\n"


### PR DESCRIPTION
The carry-forward LOW from #337's review. `check_review_disposition.py` printed `f.path`/`f.title` (from claude[bot] comment bodies) to the terminal without stripping control chars — a theoretical ANSI/OSC-escape-into-terminal when a maintainer runs `just review-disposition <PR>`. `title_of`'s docstring claimed "control chars stripped" but the code didn't.

Adds `_strip_control` (C0/C1 + DEL) at the Finding-construction boundary — the Python twin of the Rust `verify::display_safe` discipline (R0615-06) — so every print site is safe. + selftest cases.

Trivial advisory-tool fix; `just review-disposition-selftest` passes locally and the path-filtered `review-disposition` CI gate (added in #337) self-validates this PR.

Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)