### PR TITLE
docs(release): add Windows install-path fix highlight to 0.10.0 notes

### DIFF
--- a/crates/pixtuoid/src/version.rs
+++ b/crates/pixtuoid/src/version.rs
@@ -61,6 +61,7 @@ pub fn release_notes(version: &str) -> Option<&'static [&'static str]> {
         "0.10.0" => Some(&[
             "`pixtuoid doctor` now flags an OpenClaw plugin whose files went missing — a source that would silently never load is reported broken instead of healthy",
             "Smoother Sources panel — connecting or disconnecting a CLI no longer hitches the office while it writes hook config",
+            "Windows: agent hooks now install to the exact path each CLI reads — CodeWhale, OpenClaw, Reasonix and Cursor sessions show up reliably (no more installed-but-invisible)",
         ]),
         "0.9.0" => Some(&[
             "OpenClaw gateway visualized as a presence-gated wandering lobster mascot whose motion tracks the daemon (idle ambles, busy shuttles, down walks out); connect it in the Sources panel (press s)",


### PR DESCRIPTION
The 0.10.0 changeset's most user-facing change — #343/#344 correcting the Windows hook-install paths so CodeWhale/OpenClaw/Reasonix/Cursor sessions stop installing-but-never-showing — was missing from the in-app release-notes popup (`release_notes("0.10.0")`). This adds it as a third highlight ahead of tagging `v0.10.0`.

The other two 0.10.0 bullets (doctor OpenClaw plugin-missing flag #332, off-executor Sources-panel I/O #330) are unchanged. `cargo fmt` clean; `current_version_has_release_notes` + 19 other `version::` unit tests green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)