### PR TITLE
test(ci): isolate exit_watch live tests to fix the coverage-job flake

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -25,3 +25,17 @@ path = "junit.xml"
 [[profile.default.overrides]]
 filter = 'test(_exits_zero_without_blocking) | test(_within_watchdog_bound)'
 threads-required = "num-cpus"
+
+# The `exit_watch::tests::live::*` tests spawn a real child, watch its pid via
+# kqueue/pidfd, and assert the watcher THREAD wakes within LIVE_PID_DEADLINE (10s).
+# That deadline is a liveness bound, not a latency one — but under the fully-
+# parallel suite the watcher thread can be SCHEDULER-STARVED past it, and the
+# `coverage` job's `cargo llvm-cov` instrumentation (~2-3× slower) makes the
+# starvation likely: `drop_stops_cleanly` flaked there on main even AFTER #325
+# widened the deadline 3s→10s (a deadline bump can't fix CPU contention). Same
+# fix + same rationale as the shim block above — give them the machine so the
+# watcher thread is never starved. NOT a retry (#161's no-retries stance holds);
+# inherited by `ci`. The macOS/Linux `mod live` gate means Windows matches none.
+[[profile.default.overrides]]
+filter = 'test(exit_watch::tests::live)'
+threads-required = "num-cpus"

--- a/crates/pixtuoid-core/src/source/exit_watch.rs
+++ b/crates/pixtuoid-core/src/source/exit_watch.rs
@@ -627,6 +627,10 @@ mod tests {
         /// kqueue/pidfd wake just hadn't been scheduled yet. It is a liveness
         /// bound, NOT a latency assertion: a true hang is still failed by
         /// nextest's 180s slow-timeout, so a wider deadline doesn't weaken it.
+        /// The deadline alone wasn't enough (it still flaked at 10s under
+        /// instrumentation), so these `live::*` tests ALSO run isolated via a
+        /// `threads-required = "num-cpus"` override in `.config/nextest.toml`,
+        /// keeping the watcher thread off a contended scheduler.
         const LIVE_PID_DEADLINE: Duration = Duration::from_secs(10);
 
         fn sleeper() -> Child {


### PR DESCRIPTION
## What

Fixes the flaky `coverage` job on `main`. After #352 merged, the post-merge coverage run failed when `exit_watch::tests::live::drop_stops_cleanly` timed out at **10.021s** (its `LIVE_PID_DEADLINE` is 10s). The same content had passed on the PR run — a textbook timing flake, not a regression.

## Root cause

The `exit_watch::tests::live::*` tests spawn a real child process, watch its pid via kqueue (macOS) / pidfd (Linux), and assert the watcher **thread** wakes within `LIVE_PID_DEADLINE`. That's a liveness bound — but under the fully-parallel suite the watcher thread can be **scheduler-starved** past it, and the `coverage` job's `cargo llvm-cov` instrumentation (~2-3× slower) makes the starvation likely. #325 already widened the deadline 3s→10s and it *still* flaked: a deadline bump can't fix CPU contention.

## Fix

Apply the repo's existing pattern for this exact failure class — the shim-latency `threads-required = "num-cpus"` override (#161) — to the `live::*` group, so they run **isolated** and the watcher thread is never starved:

```toml
[[profile.default.overrides]]
filter = 'test(exit_watch::tests::live)'
threads-required = "num-cpus"
```

- **NOT a retry** — #161's no-retries stance is preserved (`retries` stays 0).
- The `ci` profile inherits the default override.
- The macOS/Linux `mod live` cfg-gate means the Windows job matches none.
- A one-line cross-reference added at `LIVE_PID_DEADLINE` so both halves of the de-flake (wide deadline + isolation) are documented together.

## Verification

- `cargo nextest list -E 'test(exit_watch::tests::live)'` matches **exactly** the 5 `live::*` tests and nothing else (also proves the config parses).
- Isolated runs are stable (5/5 green; clean under an artificially CPU-loaded machine).
- Local flake-repro of the *rare* CI failure isn't reliably possible without the instrumented + slower CI environment — the fix rests on mechanism + the #161 precedent for the identical test class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
