### PR TITLE
fix(exit-watch): close the Linux self-pipe lost-wakeup (supersedes #353)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -25,17 +25,3 @@ path = "junit.xml"
 [[profile.default.overrides]]
 filter = 'test(_exits_zero_without_blocking) | test(_within_watchdog_bound)'
 threads-required = "num-cpus"
-
-# The `exit_watch::tests::live::*` tests spawn a real child, watch its pid via
-# kqueue/pidfd, and assert the watcher THREAD wakes within LIVE_PID_DEADLINE (10s).
-# That deadline is a liveness bound, not a latency one — but under the fully-
-# parallel suite the watcher thread can be SCHEDULER-STARVED past it, and the
-# `coverage` job's `cargo llvm-cov` instrumentation (~2-3× slower) makes the
-# starvation likely: `drop_stops_cleanly` flaked there on main even AFTER #325
-# widened the deadline 3s→10s (a deadline bump can't fix CPU contention). Same
-# fix + same rationale as the shim block above — give them the machine so the
-# watcher thread is never starved. NOT a retry (#161's no-retries stance holds);
-# inherited by `ci`. The macOS/Linux `mod live` gate means Windows matches none.
-[[profile.default.overrides]]
-filter = 'test(exit_watch::tests::live)'
-threads-required = "num-cpus"

--- a/crates/pixtuoid-core/src/source/exit_watch.rs
+++ b/crates/pixtuoid-core/src/source/exit_watch.rs
@@ -493,6 +493,21 @@ mod imp {
         // stays aligned with the fds snapshot taken before any mutation).
         let mut watched: Vec<(i32, OwnedFd)> = Vec::new();
         loop {
+            // Re-check `closed` BEFORE blocking in poll(). `Drop` sets `closed`
+            // then writes a wake byte, but `drain_pipe` below drains the pipe
+            // unconditionally — so a Drop landing after the post-poll `closed`
+            // check (further down) but before that drain has its wake byte
+            // EATEN, leaving `closed = true` with an empty pipe. Without this
+            // top check the thread would re-enter poll() and block on a still-
+            // live watched pid until it exits (or forever) — the self-pipe
+            // lost-wakeup that flaked `drop_stops_cleanly` on the Linux CI.
+            // SeqCst pairs with Drop's store-before-wake: if the drain consumed
+            // the byte, this load is guaranteed to observe `true`. (macOS is
+            // immune — its EVFILT_USER trigger is consumed by kevent() itself,
+            // no separate drain to eat it.)
+            if shared.closed.load(Ordering::SeqCst) {
+                return;
+            }
             let mut fds: Vec<libc::pollfd> = Vec::with_capacity(watched.len() + 1);
             fds.push(libc::pollfd {
                 fd: pipe_rd,
@@ -627,10 +642,6 @@ mod tests {
         /// kqueue/pidfd wake just hadn't been scheduled yet. It is a liveness
         /// bound, NOT a latency assertion: a true hang is still failed by
         /// nextest's 180s slow-timeout, so a wider deadline doesn't weaken it.
-        /// The deadline alone wasn't enough (it still flaked at 10s under
-        /// instrumentation), so these `live::*` tests ALSO run isolated via a
-        /// `threads-required = "num-cpus"` override in `.config/nextest.toml`,
-        /// keeping the watcher thread off a contended scheduler.
         const LIVE_PID_DEADLINE: Duration = Duration::from_secs(10);
 
         fn sleeper() -> Child {
@@ -756,25 +767,35 @@ mod tests {
         /// Drop sets `closed` + wakes: the thread must exit, observable as
         /// the channel closing (the thread owns the only sender). The kill
         /// also exercises the post-Drop machinery for no-panic.
+        ///
+        /// Looped to STRESS the `watch()`-then-`drop()` wake race: on Linux a
+        /// Drop landing between the watcher thread's post-poll `closed` check
+        /// and its unconditional `drain_pipe` could have its wake byte EATEN by
+        /// that drain, stranding the thread in `poll()` on the still-live child
+        /// until LIVE_PID_DEADLINE (the self-pipe lost-wakeup the top-of-loop
+        /// `closed` re-check fixes). One unfixed iteration hangs the whole test;
+        /// fixed, every iteration closes in ms.
         #[tokio::test]
         async fn drop_stops_cleanly() {
-            let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-            let watch = ExitWatch::spawn(tx).expect("backend must init on macOS/Linux");
-            let mut child = sleeper();
-            watch.watch(child.id() as i32);
-            drop(watch);
-            let closed = tokio::time::timeout(LIVE_PID_DEADLINE, async {
-                while rx.recv().await.is_some() {}
-            })
-            .await;
-            // Reap BEFORE asserting: were the drop slow enough for the assert
-            // to fire, a trailing reap would be skipped and the sleeper would
-            // leak (the nextest LEAK that paired with this test's flake).
-            kill_and_reap(&mut child);
-            assert!(
-                closed.is_ok(),
-                "dropping the ExitWatch must stop the thread (its sender must drop)"
-            );
+            for _ in 0..50 {
+                let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+                let watch = ExitWatch::spawn(tx).expect("backend must init on macOS/Linux");
+                let mut child = sleeper();
+                watch.watch(child.id() as i32);
+                drop(watch);
+                let closed = tokio::time::timeout(LIVE_PID_DEADLINE, async {
+                    while rx.recv().await.is_some() {}
+                })
+                .await;
+                // Reap BEFORE asserting: were the drop slow enough for the assert
+                // to fire, a trailing reap would be skipped and the sleeper would
+                // leak (the nextest LEAK that paired with this test's flake).
+                kill_and_reap(&mut child);
+                assert!(
+                    closed.is_ok(),
+                    "dropping the ExitWatch must stop the thread (its sender must drop)"
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
## What

Fixes the `coverage` job flake on `main` for real — `exit_watch::tests::live::drop_stops_cleanly` kept timing out at exactly **10.02s**, including after #353. **This supersedes #353**: that PR misdiagnosed the flake as CPU contention and added a `threads-required = "num-cpus"` nextest override, which didn't help because the bug is a **logic race**, not scheduling. This change reverts that override and fixes the actual cause.

## Root cause — a Linux self-pipe lost-wakeup

The `exit_watch` pidfd backend (Linux only) wakes its watcher thread via a self-pipe: `Drop` sets `closed` then writes a wake byte; the run loop's `poll()` includes the pipe read-end. But the loop drains the pipe **unconditionally** after its post-poll `closed` check. So this interleaving loses the wake:

1. Thread returns from `poll()` (woken by an earlier `watch()` byte), checks `closed` → **false**.
2. **`Drop` runs here**: `closed = true`, writes its wake byte.
3. `drain_pipe()` drains **both** bytes — eating the drop's wake.
4. Thread rebuilds the fd set and re-enters `poll(-1)`: `closed` is true but unchecked, pipe empty, the watched child (`sleep 30`) won't signal → **blocks until the 10s test timeout**.

The clean, repeatable 10.02s (not variable jitter) is the signature of a lost wakeup. It only reproduces on the ubuntu CI — macOS's `EVFILT_USER` trigger is consumed by `kevent()` itself, with no separate drain to eat it (so it was never reproducible locally, and isolation couldn't fix it).

## Fix

Re-check `closed` at the **top of the loop**, before blocking in `poll()`. `SeqCst` pairs with `Drop`'s store-before-wake, so even if the drain consumed the byte, the next load is guaranteed to observe `true` — the window is closed by construction. This is a genuine production bug too (the watcher thread could leak on shutdown), not only a test flake.

## Also

- **Reverts #353** — removes the now-pointless `threads-required` override + its (wrong-cause) doc comment.
- **Strengthens the regression test** — loops `drop_stops_cleanly` 50× to stress the `watch()`-then-`drop()` race, so CI reliably catches a regression. One unfixed iteration hangs the whole test; fixed, all 50 close in ms (0.53s locally).

## Verification

- macOS build / clippy / fmt clean; full `pixtuoid-core` lib suite green (546).
- The Linux block can't be built locally (Homebrew-vs-rustup toolchain), but the added line is **byte-identical** to the existing post-poll `closed` check in the same `cfg(target_os = "linux")` block, so it compiles by construction — **ubuntu CI is the authoritative check** (and the looped test is the teeth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
