### PR TITLE
chore(lint): enforce pub(crate) for layer-internal items workspace-wide

### DIFF
--- a/.github/prompts/impl-plan.prompt.md
+++ b/.github/prompts/impl-plan.prompt.md
@@ -51,6 +51,18 @@ Every section gets an answer; "n/a" counts only with a reason.
    the `beautify-decoration` loop. Verification steps are blocking plan
    items, not checkboxes — PR #61 shipped five walk regressions behind an
    unchecked "live run" checkbox.
+8. **Layering / orchestration boundary** — if the change adds or crosses a
+   layer seam (a mechanism/foundation layer with an orchestrator over it,
+   like `install` ← `sources`), name the ONE orchestration entry point and
+   design the lower layer's mechanism API as `pub(crate)`, never `pub`:
+   callers reach it ONLY through the orchestrator, never directly. Do NOT
+   expose an underlayer/foundation API as crate-public so something can call
+   it around the facade — that is a design leak `unreachable_pub` can't catch
+   once the module itself is reachable, so the plan is where the
+   single-gateway shape is decided (install/uninstall route SOLELY through
+   `crate::sources`; the plan states "no second caller" and which existing
+   direct calls collapse into the orchestrator). A new public seam on a lower
+   layer needs a one-line justification of why the orchestrator can't own it.
 
 ## The contract with review
 

--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -94,6 +94,19 @@ Judge as a demanding critic:
    no-op wrapper renaming `mix_lab` (a cheap-sounding name fronting an expensive
    call — a LYING wrapper is the same finding); `Frame`/`RgbBuffer` each
    re-hand-rolled `Grid<T>`'s row-major buffer.
+7. Layering / orchestration boundary: when the diff adds a call into a
+   lower/mechanism layer (config-write, install, FS, a foundation helper) or
+   newly exposes one, check it routes THROUGH the layer's designated
+   orchestrator, not around it. Flag (a) a NEW `pub` item that exposes a
+   foundation/underlayer seam the orchestrator should own, and (b) a NEW call
+   site that reaches the mechanism directly instead of the facade. The
+   single-gateway rule: install/uninstall are `pub(crate)`, `crate::sources`
+   is the SOLE caller — a second direct caller (or a `pub` that invites one)
+   is the finding, even when it compiles cleanly. `unreachable_pub` (CI
+   `-D warnings`) is the mechanical half — a `pub` in a PRIVATE module tree;
+   this lens owns the half the lint can't see: a reachable-but-should-be-
+   funnelled API, where the right fix is "demote to `pub(crate)` and call the
+   orchestrator," not "leave it public."
 
 [the five hard requirements]
 Your final message is the report.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,7 @@ and stays a human step. See
 - **No comments unless WHY.** Comment only what a future reader can't tell from the code (a workaround, a non-obvious constraint, a surprising invariant).
 - **Errors propagate via `anyhow::Result` in app code, `thiserror` in core** if a typed error becomes load-bearing. The hook listener and JSONL watcher log + continue on malformed input — they never panic.
 - **No `unwrap()` in non-test code.** Tests can unwrap freely.
+- **Layer-internal items stay `pub(crate)`, not `pub`.** `unreachable_pub` is `warn` in `[workspace.lints.rust]` and CI's `just clippy` (`-D warnings`) makes it a hard gate — a `pub` item in a private module tree fails the build. Reserve bare `pub` for genuinely cross-crate API (and in `pixtuoid-core`, only those reach the semver surface). The lint is the mechanical enforcement of "the install/uninstall entry points are `pub(crate)`, `crate::sources` is the only caller" and every other inter-layer seam.
 - **No scan-the-history logic.** Keep persistent state (a set, a map, a bool) updated as events arrive; never derive state by scanning backward through time.
 - **Match the surrounding shell** (zsh interactive / POSIX sh); `shellcheck` any `.sh` you touch. **macOS first**: BSD CLI, brew, launchd.
 - **Keep docs current.** A change that alters module structure, architecture, workflow, or public API updates the relevant `CLAUDE.md` + `README.md` in the same commit.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,14 @@ homepage     = "https://github.com/IvanWng97/pixtuoid"
 keywords     = ["terminal", "tui", "pixel-art", "ai-agents", "claude"]
 categories   = ["command-line-utilities", "visualization"]
 
+# Workspace-wide lints, inherited by every crate via `[lints] workspace = true`.
+# `unreachable_pub` forces every `pub` in a private module tree down to
+# `pub(crate)` — so a layer-internal item can't silently leak as crate API. It's
+# warn here; CI's `cargo clippy -- -D warnings` (just clippy) makes it a hard
+# gate. Semver-neutral: cargo-semver-checks never sees an unreachable item.
+[workspace.lints.rust]
+unreachable_pub = "warn"
+
 [profile.release]
 lto           = true
 codegen-units = 1

--- a/crates/pixtuoid-core/Cargo.toml
+++ b/crates/pixtuoid-core/Cargo.toml
@@ -18,6 +18,9 @@ categories.workspace   = true
 # build-verify, NOT cargo test on an extracted crate — so it must be excluded too).
 exclude                = ["tests/socket_path_parity.rs", "tests/supported_sources_manifest.rs"]
 
+[lints]
+workspace = true
+
 [features]
 default       = []
 test-renderer = []

--- a/crates/pixtuoid-core/src/layout/decor.rs
+++ b/crates/pixtuoid-core/src/layout/decor.rs
@@ -596,8 +596,8 @@ pub const SEAT_RENDER_Y_OFF: u16 = 7;
 /// The `walking_anchor(desk_walk_anchor(d)) == seated_anchor(d)` identity is
 /// locked by a tui-side test; if `DESK_W` or those anchors change they move
 /// together (X tracks `DESK_W`; `8` is the character sprite width).
-pub const DESK_WALK_X_OFF: u16 = (DESK_W - 8) / 2 + 4;
-pub const DESK_WALK_Y_OFF: u16 = 4;
+pub(crate) const DESK_WALK_X_OFF: u16 = (DESK_W - 8) / 2 + 4;
+pub(crate) const DESK_WALK_Y_OFF: u16 = 4;
 
 /// The cell an agent walks to/from for its home `desk` (top-left Point). The
 /// single source for what were ~10 scattered `desk + (6, 4)` literals across the

--- a/crates/pixtuoid-core/src/source/hook/router.rs
+++ b/crates/pixtuoid-core/src/source/hook/router.rs
@@ -25,7 +25,7 @@ use super::{HookPidWatch, HookSocketListener, PresenceSender, SocketBusy};
 
 /// Infrastructure name — NOT a registered source (no descriptor/badge). Used by
 /// `spawn_with_health` to attribute a fatal bind error in the footer.
-pub const SOURCE_NAME: &str = "hook-router";
+pub(crate) const SOURCE_NAME: &str = "hook-router";
 
 /// Producer half of the #246 child-end un-claim side-channel (see
 /// `ChildEndUnclaims` for the WHY). Interposed between the hook listener and the

--- a/crates/pixtuoid-core/src/state/mod.rs
+++ b/crates/pixtuoid-core/src/state/mod.rs
@@ -27,11 +27,11 @@ mod arc_str_serde {
 
     use serde::{Deserialize, Deserializer, Serializer};
 
-    pub fn serialize<S: Serializer>(v: &Arc<str>, s: S) -> Result<S::Ok, S::Error> {
+    pub(crate) fn serialize<S: Serializer>(v: &Arc<str>, s: S) -> Result<S::Ok, S::Error> {
         s.serialize_str(v)
     }
 
-    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Arc<str>, D::Error> {
+    pub(crate) fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Arc<str>, D::Error> {
         Ok(Arc::from(String::deserialize(d)?.as_str()))
     }
 }
@@ -41,11 +41,13 @@ mod opt_arc_str_serde {
 
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-    pub fn serialize<S: Serializer>(v: &Option<Arc<str>>, s: S) -> Result<S::Ok, S::Error> {
+    pub(crate) fn serialize<S: Serializer>(v: &Option<Arc<str>>, s: S) -> Result<S::Ok, S::Error> {
         v.as_deref().serialize(s)
     }
 
-    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Option<Arc<str>>, D::Error> {
+    pub(crate) fn deserialize<'de, D: Deserializer<'de>>(
+        d: D,
+    ) -> Result<Option<Arc<str>>, D::Error> {
         Ok(Option::<String>::deserialize(d)?.map(|s| Arc::from(s.as_str())))
     }
 }
@@ -56,12 +58,12 @@ mod arc_path_serde {
 
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-    pub fn serialize<S: Serializer>(v: &Arc<Path>, s: S) -> Result<S::Ok, S::Error> {
+    pub(crate) fn serialize<S: Serializer>(v: &Arc<Path>, s: S) -> Result<S::Ok, S::Error> {
         let p: &Path = v;
         p.serialize(s)
     }
 
-    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Arc<Path>, D::Error> {
+    pub(crate) fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Arc<Path>, D::Error> {
         Ok(Arc::from(PathBuf::deserialize(d)?.as_path()))
     }
 }

--- a/crates/pixtuoid-hook/Cargo.toml
+++ b/crates/pixtuoid-hook/Cargo.toml
@@ -11,6 +11,9 @@ homepage.workspace     = true
 keywords.workspace     = true
 categories.workspace   = true
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "pixtuoid-hook"
 path = "src/main.rs"

--- a/crates/pixtuoid-hook/src/paths.rs
+++ b/crates/pixtuoid-hook/src/paths.rs
@@ -7,7 +7,7 @@
 //! arrive. If you move or rename this file, that test breaks loudly — fix the
 //! `#[path]` there, don't drop the parity pin.
 
-pub fn default_socket_path() -> String {
+pub(crate) fn default_socket_path() -> String {
     if let Ok(p) = std::env::var("PIXTUOID_SOCKET") {
         // Set-but-empty/whitespace = unset (the #172 RUST_LOG policy):
         // honored verbatim, "" would make the daemon's bind fail fatally and

--- a/crates/pixtuoid-hook/src/transport.rs
+++ b/crates/pixtuoid-hook/src/transport.rs
@@ -5,7 +5,7 @@
 
 use std::time::Duration;
 
-pub const WRITE_TIMEOUT: Duration = Duration::from_millis(200);
+pub(crate) const WRITE_TIMEOUT: Duration = Duration::from_millis(200);
 
 /// Arm the send-timeout watchdog: a thread that hard-exits the process after
 /// `WRITE_TIMEOUT`, bounding the whole connect+write phase on BOTH platforms
@@ -23,7 +23,7 @@ fn spawn_timeout_watchdog() -> bool {
 }
 
 #[cfg(unix)]
-pub fn send_line(endpoint: &str, line: &[u8]) {
+pub(crate) fn send_line(endpoint: &str, line: &[u8]) {
     use std::io::Write;
     // `UnixStream::connect` has no timeout knob — a missing daemon fails
     // fast (NotFound/ConnectionRefused), but a backlog-saturated listener
@@ -45,7 +45,7 @@ pub fn send_line(endpoint: &str, line: &[u8]) {
 }
 
 #[cfg(windows)]
-pub fn send_line(endpoint: &str, line: &[u8]) {
+pub(crate) fn send_line(endpoint: &str, line: &[u8]) {
     use std::io::Write;
     // Named pipes have no SO_SNDTIMEO equivalent for sync writes, so the
     // 200ms invariant is enforced by a watchdog thread that hard-exits the

--- a/crates/pixtuoid-scene/Cargo.toml
+++ b/crates/pixtuoid-scene/Cargo.toml
@@ -11,6 +11,9 @@ homepage.workspace     = true
 keywords.workspace     = true
 categories.workspace   = true
 
+[lints]
+workspace = true
+
 [dependencies]
 pixtuoid-core = { path = "../pixtuoid-core", version = "0.11.0" }
 anyhow        = { workspace = true }

--- a/crates/pixtuoid/Cargo.toml
+++ b/crates/pixtuoid/Cargo.toml
@@ -11,6 +11,9 @@ homepage.workspace     = true
 keywords.workspace     = true
 categories.workspace   = true
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "pixtuoid"
 path = "src/main.rs"

--- a/crates/pixtuoid/src/floating/window.rs
+++ b/crates/pixtuoid/src/floating/window.rs
@@ -36,7 +36,7 @@ use pixtuoid_scene::theme::Theme;
 
 /// Wake reasons delivered to the winit loop from the background tokio pipeline.
 #[derive(Debug, Clone, Copy)]
-pub enum FloatingEvent {
+pub(crate) enum FloatingEvent {
     /// The reducer published a new scene — repaint.
     SceneChanged,
 }
@@ -44,7 +44,7 @@ pub enum FloatingEvent {
 /// The floating window app: window + surface (created lazily on `Resumed`), the office
 /// renderer (owns cross-frame caches), the live scene receiver, and the per-floor desk
 /// capacity atomics it keeps in sync with the rendered office.
-pub struct FloatingApp {
+pub(crate) struct FloatingApp {
     cfg: FloatingConfig,
     theme: &'static Theme,
     pack: Pack,
@@ -77,7 +77,7 @@ const IDLE_AMBIENT_FPS: u64 = 1;
 
 impl FloatingApp {
     #[allow(clippy::too_many_arguments)] // flat construction inputs; bundling adds no clarity
-    pub fn new(
+    pub(crate) fn new(
         cfg: FloatingConfig,
         theme: &'static Theme,
         pack: Pack,

--- a/crates/pixtuoid/src/tui/widgets/tooltip.rs
+++ b/crates/pixtuoid/src/tui/widgets/tooltip.rs
@@ -309,7 +309,7 @@ pub(crate) fn paint_pet_tooltip(
 /// (the multi-tenant power-user case). Plain text (no emoji) to keep
 /// `paint_simple_tooltip`'s width math exact.
 #[allow(clippy::too_many_arguments)]
-pub fn paint_mascot_tooltip(
+pub(crate) fn paint_mascot_tooltip(
     f: &mut ratatui::Frame<'_>,
     name: &str,
     busy: bool,


### PR DESCRIPTION
## What

Mechanically enforce the encapsulation rule "inter-layer items don't leak as public API" workspace-wide.

- Add `unreachable_pub = "warn"` to `[workspace.lints.rust]` (root `Cargo.toml`) and opt every crate in via `[lints] workspace = true`.
- CI's `just clippy` (`cargo clippy --workspace --all-targets -- -D warnings`) turns the warn into a **hard gate** — a `pub` item in a private module tree (one unreachable as crate API) now fails the build and must be `pub(crate)`.
- Fix the 16 pre-existing offenders the lint surfaces.

## Why

This is the backstop for the encapsulation work: `install_target`/`uninstall_target` are already `pub(crate)` (`crate::sources` is the sole caller), but nothing *stopped* a future inter-layer seam from silently shipping as `pub`. `unreachable_pub` is that stop.

## The 16 fixes (all crate-internal → semver-neutral)

`cargo-semver-checks` never sees an unreachable item, so none of these touch the public API / semver surface:

| crate | items |
|---|---|
| `pixtuoid-core` | `decor::DESK_WALK_{X,Y}_OFF`, `hook::router::SOURCE_NAME`, the 6 `state/*_serde` adapter fns |
| `pixtuoid-hook` | `paths::default_socket_path`, `transport::WRITE_TIMEOUT` + both `send_line` arms |
| `pixtuoid` | `floating::window::{FloatingEvent, FloatingApp, FloatingApp::new}`, `tui::widgets::tooltip::paint_mascot_tooltip` |

## Verification

- `RUSTFLAGS="-W unreachable_pub" cargo build` → exactly these 16 before, **0 after**.
- Confirmed the gate fires *via the workspace config* (no RUSTFLAGS): reverting one item to `pub` reproduces the warning, restoring clears it.
- `just preflight` green (lint → clippy → hack → **1865 tests pass**).

## Scope

`unreachable_pub` only catches `pub`-in-private-module leaks. A deeper `cargo-public-api` audit (items that are reachable-`pub` but used by no other crate) is a separate, optional follow-up — not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)