### PR TITLE
chore(raycast): publish prep — author casing + command keywords

### DIFF
--- a/integrations/raycast/package.json
+++ b/integrations/raycast/package.json
@@ -4,7 +4,7 @@
   "title": "Pixtuoid",
   "description": "Manage which AI coding-agent CLIs feed your Pixtuoid office, and launch the floating window — without leaving Raycast.",
   "icon": "pixtuoid.png",
-  "author": "ivanwng97",
+  "author": "IvanWng97",
   "categories": ["Developer Tools"],
   "license": "MIT",
   "commands": [
@@ -13,14 +13,16 @@
       "title": "Manage Sources",
       "subtitle": "Pixtuoid",
       "description": "List every agent CLI Pixtuoid knows about and connect/disconnect each one.",
-      "mode": "view"
+      "mode": "view",
+      "keywords": ["agents", "ai", "claude", "codex", "cursor", "copilot", "office"]
     },
     {
       "name": "start-floating",
       "title": "Start Floating Window",
       "subtitle": "Pixtuoid",
       "description": "Open the Pixtuoid floating desktop window.",
-      "mode": "no-view"
+      "mode": "no-view",
+      "keywords": ["office", "desktop", "overlay", "pixel"]
     }
   ],
   "preferences": [


### PR DESCRIPTION
Pre-publish polish for the Raycast extension (no behavior change).

- **`author`: `ivanwng97` → `IvanWng97`.** Verified against the Raycast users
  API: both casings resolve to the same account (id `bb73e724-…`), so the lookup
  is case-insensitive — that's why `ray lint` passed with the lowercase form in
  #362 — but the **canonical stored handle is `IvanWng97`**, so match it.
- **Command `keywords`** for store/launcher search (aliases the titles don't
  already carry): Manage Sources → `agents/ai/claude/codex/cursor/copilot/office`;
  Start Floating → `office/desktop/overlay/pixel`. Tasteful, no stuffing.

Verified `ray build` · `tsc` · `eslint` green; the API lookup above confirms the
handle is valid (the only check the sandbox can't run is `ray lint`'s *online*
author/schema validation — it runs on the maintainer's Mac pre-publish).

Still outstanding before `npm run publish` (needs the Raycast app on the Mac):
store screenshots in `integrations/raycast/metadata/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)