### PR TITLE
chore(raycast): store-readiness — required platforms field + reviewer-nit polish

### DIFF
--- a/integrations/raycast/package.json
+++ b/integrations/raycast/package.json
@@ -5,6 +5,7 @@
   "description": "Manage which AI coding-agent CLIs feed your Pixtuoid office, and launch the floating window — without leaving Raycast.",
   "icon": "pixtuoid.png",
   "author": "IvanWng97",
+  "platforms": ["macOS"],
   "categories": ["Developer Tools"],
   "license": "MIT",
   "commands": [

--- a/integrations/raycast/package.json
+++ b/integrations/raycast/package.json
@@ -12,7 +12,6 @@
     {
       "name": "manage-sources",
       "title": "Manage Sources",
-      "subtitle": "Pixtuoid",
       "description": "List every agent CLI Pixtuoid knows about and connect/disconnect each one.",
       "mode": "view",
       "keywords": ["agents", "ai", "claude", "codex", "cursor", "copilot", "office"]
@@ -20,7 +19,6 @@
     {
       "name": "start-floating",
       "title": "Start Floating Window",
-      "subtitle": "Pixtuoid",
       "description": "Open the Pixtuoid floating desktop window.",
       "mode": "no-view",
       "keywords": ["office", "desktop", "overlay", "pixel"]

--- a/integrations/raycast/src/manage-sources.tsx
+++ b/integrations/raycast/src/manage-sources.tsx
@@ -82,7 +82,7 @@ export default function ManageSources() {
                 shortcut={{ modifiers: ["cmd"], key: "r" }}
                 onAction={() => revalidate()}
               />
-              <Action.OpenInBrowser title="Open Pixtuoid on GitHub" url={REPO_URL} />
+              <Action.OpenInBrowser icon={Icon.Globe} title="Open Pixtuoid on GitHub" url={REPO_URL} />
               <Action
                 title="Open Extension Preferences"
                 icon={Icon.Gear}
@@ -116,7 +116,7 @@ function ErrorView({ error, onRetry }: { error: Error; onRetry: () => void }) {
             ) : (
               <Action title="Try Again" icon={Icon.ArrowClockwise} onAction={onRetry} />
             )}
-            <Action.OpenInBrowser title="Installation Docs" url={`${REPO_URL}#install`} />
+            <Action.OpenInBrowser icon={Icon.Globe} title="Installation Docs" url={`${REPO_URL}#install`} />
           </ActionPanel>
         }
       />


### PR DESCRIPTION
Makes the Raycast extension pass the store guidelines. Driven by actually
reading the official docs (prepare-an-extension-for-store + the manifest
reference) and a 4-agent audit over the live Raycast developer docs.

## The one real gap
- **`platforms` is a *required* manifest field** (red asterisk in the manifest
  reference) and we were missing it. Set `["macOS"]` — our binary resolver is
  macOS/Unix-centric (`/bin/zsh`, `command -v`, Homebrew/Cargo paths) and the
  floating window is the macOS-first surface, so scoping to macOS is the honest
  declaration for v1. `ray build` accepts it (rejects unknown keys).

## Reviewer-nit polish (the two near-certain change-requests)
- **Drop `subtitle: "Pixtuoid"` from both commands.** Guideline: a subtitle adds
  app/service context; one equal to the product name just repeats it in root
  search — the textbook "drop it" case.
- **Icon on every action.** Added `Icon.Globe` to both `Action.OpenInBrowser`
  (GitHub link, install docs); the docs say icons for all actions in a panel or
  none, and every sibling already had one.

## Audit verdict: store-ready, zero hard blockers
Every required field present + correctly shaped; custom 512×512 icon (not the
default — that's an auto-reject); CHANGELOG `## [..] - {PR_MERGE_DATE}` format;
graceful missing-binary UX; no Keychain / analytics / bundled binary (we call a
user-installed CLI from crates.io/npm/Homebrew — the safe side of the
no-opaque-binary rule). Deliberately left as-is (audit-verified fine): binaryPath
stays a `textfield` (a `file` picker can't restrict to executables, so the
`isExecutable` validation is load-bearing either way); the Refresh `cmd+R` is the
standard, non-reserved combo; "Disconnect" needs no ellipsis.

Verified `ray build` · `ray lint` · `tsc` · `eslint` all green.

**Still outstanding before `npm run publish`** (needs the Raycast app on the Mac):
3+ store screenshots in `integrations/raycast/metadata/` (2000×1250 PNG, 16:10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)