### PR TITLE
docs: add nested AGENTS.md symlinks for the 5 crate guides

### DIFF
--- a/crates/pixtuoid-core/AGENTS.md
+++ b/crates/pixtuoid-core/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/crates/pixtuoid-core/tests/AGENTS.md
+++ b/crates/pixtuoid-core/tests/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/crates/pixtuoid-scene/AGENTS.md
+++ b/crates/pixtuoid-scene/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/crates/pixtuoid/AGENTS.md
+++ b/crates/pixtuoid/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/crates/pixtuoid/src/tui/AGENTS.md
+++ b/crates/pixtuoid/src/tui/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
## What

Symlink `AGENTS.md -> CLAUDE.md` in the five nested crate/module guide dirs that were missing it:

- `crates/pixtuoid-core/`
- `crates/pixtuoid-core/tests/`
- `crates/pixtuoid-scene/`
- `crates/pixtuoid/`
- `crates/pixtuoid/src/tui/`

## Why

The [agents.md](https://agents.md) cross-tool standard (Codex, and other AGENTS.md-aware agents) loads `AGENTS.md` per directory the same way Claude Code loads `CLAUDE.md`. The repo root + `integrations/raycast/` + `site/` already shipped the `AGENTS.md -> CLAUDE.md` symlink, but the five nested crate guides did not — so an agent (notably Codex) working inside e.g. `crates/pixtuoid-core/` would not auto-load that crate's "Known sharp edges" guide. This completes the per-area coverage so cross-tool context matches the existing pattern.

## Scope / risk

- **Pure symlinks** (mode `120000`, same blob as each `CLAUDE.md`). Zero code, zero behavior change.
- Verified `cargo package --list -p {pixtuoid-core,pixtuoid-scene,pixtuoid}` lists `AGENTS.md` + `CLAUDE.md` cleanly for all three published crates — no symlink error, **no publish/semver impact** (`CLAUDE.md` already ships in published releases).
- No test or CI step pins a fixed set of `AGENTS.md` files (grep-verified).
- Windows-without-`core.symlinks` materializes these as one-line pointer files, exactly as the root `AGENTS.md` already does (documented in the root `CLAUDE.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)