### PR TITLE
ci(security): lint workflows with actionlint (+ fix 2 findings it caught)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,22 +77,25 @@ jobs:
       - run: just machete
 
   hygiene:
-    name: shell hygiene
+    name: hygiene
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      # shfmt is a Go binary (not a crate) — install via the runner's preinstalled
-      # Go, pinned to match `just setup-tools`. This ONE lightweight job is the
-      # home for the non-Rust hygiene linters (actionlint / workflow + link
-      # checkers join it as they land): they're single Go/Rust binaries that need
-      # no Rust toolchain, so they share a job instead of one boilerplate job each.
-      - name: Install shfmt
+      # shfmt + actionlint are Go binaries (not crates) — install via the runner's
+      # preinstalled Go, pinned to match `just setup-tools`. This ONE lightweight
+      # job is the home for the non-Rust hygiene linters (link checkers join it as
+      # they land): single Go/Rust binaries that need no Rust toolchain, so they
+      # share a job instead of one boilerplate job each. actionlint shells out to
+      # shellcheck (preinstalled on the runner) for its `run:`-block checks.
+      - name: Install shfmt + actionlint
         run: |
           go install mvdan.cc/sh/v3/cmd/shfmt@v3.13.1
+          go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
       - uses: extractions/setup-just@v4
       - run: just shfmt-check
+      - run: just actionlint
 
   msrv:
     name: msrv

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,7 +209,7 @@ jobs:
       - name: Generate checksums
         run: |
           cd artifacts
-          sha256sum *.tar.gz *.deb *.zip > sha256sums.txt
+          sha256sum -- *.tar.gz *.deb *.zip > sha256sums.txt
 
       - name: Generate changelog
         id: changelog
@@ -353,7 +353,7 @@ jobs:
                 To start visualizing your AI coding sessions:
                   pixtuoid
 
-                Then press `s` to open the Sources panel and connect your
+                Then press \`s\` to open the Sources panel and connect your
                 CLI (Claude Code, Codex, ...). Disconnect there before
                 uninstalling to remove its hooks.
               EOS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ git hooks call the same recipes (no local-vs-CI drift). `just setup-tools`
 installs the needed cargo tools once per clone.
 
 ```
-just preflight    # full pre-push gate: lint (fmt+machete+deny+arch+shfmt) → clippy → hack → test
+just preflight    # full pre-push gate: lint (fmt+machete+deny+arch+shfmt+actionlint) → clippy → hack → test
 just fmt          # auto-format
 git config core.hooksPath .githooks   # activate hooks once per clone
 ```

--- a/justfile
+++ b/justfile
@@ -48,6 +48,16 @@ shfmt-check:
 shfmt-fix:
     shfmt -i 4 -w scripts/*.sh .githooks/*
 
+# Lint the GitHub Actions workflows (actionlint): YAML schema, expression types,
+# action input/output names, runner labels, AND shellcheck over every `run:`
+# block (so a shell bug inside a workflow is caught at author time, not on a red
+# main). Gated via `lint`; the CI `hygiene` job runs it too. Needs shellcheck on
+# PATH for the run-block checks (the house-rule tool — already required).
+[group('rust')]
+[doc('Lint the GitHub Actions workflows (actionlint + shellcheck over run: blocks)')]
+actionlint:
+    actionlint
+
 # Clippy across the workspace, warnings denied.
 [group('rust')]
 clippy:
@@ -85,7 +95,7 @@ arch:
     done
     echo "arch: pixtuoid-core + pixtuoid-scene are terminal/window-free"
 
-# Fast, independent lint checks in parallel (fmt + machete + deny + arch + shfmt).
+# Fast, independent lint checks in parallel (fmt + machete + deny + arch + shfmt + actionlint).
 [group('rust')]
 lint:
     #!/usr/bin/env bash
@@ -99,6 +109,7 @@ lint:
     run deny    just deny                & pids+=($!)
     run arch    just arch                & pids+=($!)
     run shfmt   just shfmt-check         & pids+=($!)
+    run actions just actionlint          & pids+=($!)
     for p in "${pids[@]}"; do wait "$p" || fail=1; done
     [[ $fail -eq 0 ]]
 
@@ -457,16 +468,19 @@ setup-tools:
         echo "brew install cargo-binstall (or cargo install cargo-binstall) to grab prebuilt binaries instead." >&2
         cargo install "${tools[@]}"
     fi
-    # Non-cargo lint tools that `just lint` gates on (shfmt = a Go binary, not a
-    # crate). brew on macOS; elsewhere point at the install docs rather than
-    # silently leaving `just lint` unable to run.
-    if ! command -v shfmt &>/dev/null; then
+    # Non-cargo lint tools that `just lint` gates on (Go binaries, not crates:
+    # shfmt formats shell, actionlint lints the workflows). brew on macOS;
+    # elsewhere point at the install docs rather than silently leaving `just
+    # lint` unable to run. (actionlint also shells out to `shellcheck`, the
+    # house-rule tool, for its run-block checks.)
+    for t in shfmt actionlint; do
+        command -v "$t" &>/dev/null && continue
         if command -v brew &>/dev/null; then
-            brew install shfmt
+            brew install "$t"
         else
-            echo "shfmt not found — install it (https://github.com/mvdan/sh); \`just lint\` needs it." >&2
+            echo "$t not found — install it via your package manager; \`just lint\` needs it." >&2
         fi
-    fi
+    done
 
 # Self-test the upstream-drift watcher — its ONLY test. A regex-parser regression
 # is a silent monitor death (the script returns empty / raises, the weekly job


### PR DESCRIPTION
## What

Adds **actionlint** to the gated lint set — it type-checks GitHub Actions workflow expressions, action inputs/outputs, runner labels, and runs **shellcheck over every `run:` block**.

## Design — fold in, zero new entry/job

- `just actionlint` joins the **parallel `just lint` block** → covered by `just preflight` (no new command to remember).
- Joins the **existing shared CI `hygiene` job** (renamed from "shell hygiene") — **CI grows by zero jobs**; the non-Rust linters share one lightweight Go/Rust-binary job.

## It caught 2 real findings in `release.yml` — both fixed here

1. **SC2006 — a LATENT RELEASE BUG, not cosmetic.** The Homebrew-formula heredoc is **unquoted** (`<<RUBY`, required so `${VERSION}`/`${SHA_*}` expand). That means the caveats line `` press `s` `` was being evaluated as **command substitution** — the published formula's caveats text silently dropped the `s` (and emitted `s: command not found` to the release log). Fixed by escaping the backticks so they stay literal.
2. **SC2035.** `sha256sum *.tar.gz *.deb *.zip` → `sha256sum -- *.tar.gz *.deb *.zip` — shellcheck's recommended `--` form (guards against a future dash-named artifact) while **preserving the bare filenames** in `sha256sums.txt` that a `./*` rewrite would have prefixed.

## Also

- `just actionlint` recipe; `just setup-tools` brews actionlint alongside shfmt (fail-loud-if-missing, never silent-skip); `CLAUDE.md` preflight quick-ref synced.

## Verification

- `just actionlint` ✓ clean across all 11 workflows · `just lint` ✓ (6 checks now) · `just --list` ✓ parses.

PR-2 of the lint/test tooling wave (after #369 shfmt). Next: lychee, knip, snapbox, proptest, …

🤖 Generated with [Claude Code](https://claude.com/claude-code)