### PR TITLE
docs(lint): gate internal links with lychee --offline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,20 +82,25 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      # shfmt + actionlint are Go binaries (not crates) — install via the runner's
-      # preinstalled Go, pinned to match `just setup-tools`. This ONE lightweight
-      # job is the home for the non-Rust hygiene linters (link checkers join it as
-      # they land): single Go/Rust binaries that need no Rust toolchain, so they
-      # share a job instead of one boilerplate job each. actionlint shells out to
-      # shellcheck (preinstalled on the runner) for its `run:`-block checks.
+      # The ONE lightweight home for the non-Rust hygiene linters — single Go/Rust
+      # binaries that need no Rust toolchain, so they share a job instead of one
+      # boilerplate job each. shfmt + actionlint via the runner's preinstalled Go
+      # (pinned to `just setup-tools`); lychee via taiki-e/install-action (the
+      # repo's prebuilt-tool installer). actionlint shells out to shellcheck
+      # (preinstalled on the runner) for its `run:`-block checks; lychee runs
+      # `--offline` so the link check needs no network.
       - name: Install shfmt + actionlint
         run: |
           go install mvdan.cc/sh/v3/cmd/shfmt@v3.13.1
           go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: lychee
       - uses: extractions/setup-just@v4
       - run: just shfmt-check
       - run: just actionlint
+      - run: just links
 
   msrv:
     name: msrv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
       - uses: taiki-e/install-action@v2
         with:
-          tool: lychee
+          tool: lychee@0.24.2
       - uses: extractions/setup-just@v4
       - run: just shfmt-check
       - run: just actionlint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ git hooks call the same recipes (no local-vs-CI drift). `just setup-tools`
 installs the needed cargo tools once per clone.
 
 ```
-just preflight    # full pre-push gate: lint (fmt+machete+deny+arch+shfmt+actionlint) → clippy → hack → test
+just preflight    # full pre-push gate: lint (fmt+machete+deny+arch+shfmt+actionlint+links) → clippy → hack → test
 just fmt          # auto-format
 git config core.hooksPath .githooks   # activate hooks once per clone
 ```

--- a/justfile
+++ b/justfile
@@ -58,6 +58,17 @@ shfmt-fix:
 actionlint:
     actionlint
 
+# Offline link + anchor check (lychee) over the repo's OWN markdown: every
+# relative cross-link between the nested CLAUDE.md/AGENTS.md guides + docs/ must
+# resolve, and `#anchor` fragments must exist. Directory-walk mode respects
+# .gitignore (vendored node_modules etc. auto-skipped); `--offline` = no network,
+# so it's deterministic + flake-free. External-URL decay is deliberately NOT
+# gated here (it's flaky on the PR path). Gated via `lint`; CI `hygiene` runs it.
+[group('rust')]
+[doc('Offline link + anchor check (lychee) over the repo markdown — no network, .gitignore-aware')]
+links:
+    lychee --offline --include-fragments .
+
 # Clippy across the workspace, warnings denied.
 [group('rust')]
 clippy:
@@ -95,7 +106,7 @@ arch:
     done
     echo "arch: pixtuoid-core + pixtuoid-scene are terminal/window-free"
 
-# Fast, independent lint checks in parallel (fmt + machete + deny + arch + shfmt + actionlint).
+# Fast, independent lint checks in parallel (fmt + machete + deny + arch + shfmt + actionlint + links).
 [group('rust')]
 lint:
     #!/usr/bin/env bash
@@ -110,6 +121,7 @@ lint:
     run arch    just arch                & pids+=($!)
     run shfmt   just shfmt-check         & pids+=($!)
     run actions just actionlint          & pids+=($!)
+    run links   just links               & pids+=($!)
     for p in "${pids[@]}"; do wait "$p" || fail=1; done
     [[ $fail -eq 0 ]]
 
@@ -460,7 +472,7 @@ verify: preflight site-check gen-check
 setup-tools:
     #!/usr/bin/env bash
     set -euo pipefail
-    tools=(cargo-nextest cargo-machete cargo-deny cargo-hack cargo-semver-checks cargo-edit)
+    tools=(cargo-nextest cargo-machete cargo-deny cargo-hack cargo-semver-checks cargo-edit lychee)
     if command -v cargo-binstall &>/dev/null; then
         cargo binstall -y "${tools[@]}"
     else


### PR DESCRIPTION
## What

Adds **lychee** `--offline` as a gated internal-link + anchor checker over the repo's own markdown — the doc-heavy repo's one real link-rot gap (nothing verified the dense relative cross-links between the nested `CLAUDE.md`/`AGENTS.md` guides + `docs/` resolve; a dead link in a "sharp edges" guide is active misinformation).

## Design — fold in, zero new entry/job

- `just links` joins the **parallel `just lint` block** → covered by `just preflight`. No new command.
- Joins the **shared CI `hygiene` job** (alongside shfmt + actionlint) → **CI grows by 0 jobs**.

## Key decisions

- `lychee --offline --include-fragments .` — **directory-walk mode respects `.gitignore`**, so vendored `site/node_modules` etc. are skipped. (An explicit `**/*.md` glob drags them in → 859 false errors from deps' READMEs.) No `lychee.toml` needed.
- **`--offline`** = relative links + `#anchor` fragments only, **no network** → deterministic, ~8ms, zero flake. External-URL decay is deliberately **not** gated here (flaky on the PR path).
- `setup-tools` installs lychee via cargo-binstall; CI via `taiki-e/install-action`.

## Verification

- `just links` ✓ **166 links, 0 errors** (repo links already clean — pure guardrail) · `just lint` ✓ (7 checks now) · `just --list` ✓ parses.

PR-3 of the lint/test tooling wave (after #369 shfmt, #370 actionlint). Next: knip → snapbox → proptest → …

🤖 Generated with [Claude Code](https://claude.com/claude-code)