### PR TITLE
test(cli): pin the sources --json contract end-to-end with snapbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1174,7 +1184,7 @@ dependencies = [
  "console",
  "once_cell",
  "serde",
- "similar",
+ "similar 2.7.0",
  "tempfile",
 ]
 
@@ -1589,6 +1599,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "notify"
@@ -2201,6 +2217,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "snapbox",
  "softbuffer",
  "tempfile",
  "tokio",
@@ -2819,6 +2836,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "similar"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6505efef05804732ed8a3f2d4f279429eb485bd69d5b0cc6b19cc02005cda16"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2868,6 +2894,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "snapbox"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de56eb4784a2c5c1efede55a0f06fbf481bc12b42b355b9525c15db1e3581a8"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "normalize-line-endings",
+ "serde",
+ "serde_json",
+ "similar 3.1.1",
+ "snapbox-macros",
+]
+
+[[package]]
+name = "snapbox-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed4a172e483585ebbc7c7f7d1705ca7e3f94f606ed78caa14805673189fd5455"
+dependencies = [
+ "anstream",
 ]
 
 [[package]]

--- a/crates/pixtuoid/Cargo.toml
+++ b/crates/pixtuoid/Cargo.toml
@@ -51,6 +51,10 @@ windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
 
 [dev-dependencies]
 tempfile = "3"
+# End-to-end CLI golden for `sources --json` (the Raycast contract): runs the real
+# binary in an isolated empty HOME and pins its stdout JSON order-insensitively.
+# Goldens update with SNAPSHOTS=overwrite. See tests/cli_json.rs.
+snapbox  = { version = "1", features = ["json"] }
 # Emits the SourceStatus JSON Schema (the Raycast --json contract) — test/gen
 # only, so the `JsonSchema` derive is `cfg_attr(test)` and this stays a dev-dep
 # (no production-binary impact). See sources.rs + `just gen-contract`.

--- a/crates/pixtuoid/tests/cli_json.rs
+++ b/crates/pixtuoid/tests/cli_json.rs
@@ -1,0 +1,41 @@
+//! End-to-end golden for the `sources --json` CLI contract (the shape the Raycast
+//! extension parses). Runs the REAL `pixtuoid` binary — exercising clap parse →
+//! `sources::status` → the JSON presenter → stdout — which the in-process
+//! `source_status_*` unit tests (struct shape + committed schema) never cover.
+//!
+//! Determinism: each source's `connected`/`cli_present` is a function of whether
+//! it is target-bearing (probed absent in an empty HOME → disconnected) or
+//! no-target (always present + migrate-default connected), NOT of what's installed
+//! on the test machine — SO LONG AS the environment is fully isolated. We clear the
+//! env and point HOME at an empty tempdir so every presence/hook probe sees nothing
+//! (see the e2e-isolate-home lesson). Unix-only: the Windows home-var isolation
+//! differs and can't be verified from here; the wire SHAPE is pinned cross-platform
+//! by `source_status_json_shape_is_the_raycast_contract` + the schema golden.
+#![cfg(unix)]
+
+#[test]
+fn sources_json_lists_every_source_in_an_isolated_home() {
+    let home = tempfile::tempdir().expect("tempdir");
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pixtuoid"))
+        .args(["sources", "--json"])
+        // Full isolation: an empty env + empty HOME means every CLI's presence /
+        // hook probe resolves absent, so the output depends only on the registry —
+        // deterministic across machines. A minimal PATH is kept for the spawn.
+        .env_clear()
+        .env("HOME", home.path())
+        .env("PATH", "/usr/bin:/bin")
+        .output()
+        .expect("run pixtuoid sources --json");
+
+    assert!(
+        output.status.success(),
+        "sources --json exited non-zero: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
+    // `.json` golden → snapbox compares structurally (key-order-insensitive), so a
+    // serde field reorder doesn't churn it; update with `SNAPSHOTS=overwrite`.
+    snapbox::assert_data_eq!(stdout, snapbox::file!["snapshots/cli/sources.json"]);
+}

--- a/crates/pixtuoid/tests/snapshots/cli/sources.json
+++ b/crates/pixtuoid/tests/snapshots/cli/sources.json
@@ -1,0 +1,65 @@
+[
+  {
+    "cli_present": false,
+    "connected": false,
+    "display_name": "Claude Code",
+    "health": null,
+    "id": "claude-code"
+  },
+  {
+    "cli_present": false,
+    "connected": false,
+    "display_name": "Codex",
+    "health": null,
+    "id": "codex"
+  },
+  {
+    "cli_present": true,
+    "connected": true,
+    "display_name": "Antigravity",
+    "health": null,
+    "id": "antigravity"
+  },
+  {
+    "cli_present": false,
+    "connected": false,
+    "display_name": "Reasonix",
+    "health": null,
+    "id": "reasonix"
+  },
+  {
+    "cli_present": false,
+    "connected": false,
+    "display_name": "CodeWhale",
+    "health": null,
+    "id": "codewhale"
+  },
+  {
+    "cli_present": false,
+    "connected": false,
+    "display_name": "opencode",
+    "health": null,
+    "id": "opencode"
+  },
+  {
+    "cli_present": true,
+    "connected": true,
+    "display_name": "Copilot CLI",
+    "health": null,
+    "id": "copilot"
+  },
+  {
+    "cli_present": false,
+    "connected": false,
+    "display_name": "Cursor CLI",
+    "health": null,
+    "id": "cursor"
+  },
+  {
+    "cli_present": false,
+    "connected": false,
+    "display_name": "OpenClaw",
+    "health": null,
+    "id": "openclaw"
+  }
+]


### PR DESCRIPTION
## What

Adds an **end-to-end golden** for the `pixtuoid sources --json` contract (the shape the Raycast extension parses), via **snapbox**.

## The gap it closes

The `--json` contract was only covered **in-process**: the `SourceStatus` struct shape (`source_status_json_shape_is_the_raycast_contract`) + the committed JSON Schema. **Nothing exercised the real binary** — clap parse → `sources::status` → the JSON presenter → stdout — nor the multi-source **array** it actually emits. A regression in the CLI wiring (bad arg parse, presenter bug, a source dropped from the array) would ship silently.

## Determinism (the hard part — verified, not assumed)

`sources --json` probes each source's presence/hooks under `$HOME`. So the test **clears the env and points HOME at an empty tempdir** → every target-bearing source resolves absent (disconnected), every no-target source (antigravity/copilot) is its migrate-default (connected). The output is then a pure function of the **registry**, not of what's installed on the machine — **verified byte-identical across isolated runs** before committing the golden. (See the `e2e-isolate-home` lesson — this is why it isolates `HOME`, not just `XDG_CONFIG_HOME`.)

## Decisions

- **`#[cfg(unix)]`**: the Windows home-var isolation differs and can't be verified from here; the cross-platform wire **shape** stays pinned by the existing `source_status_*` tests.
- **snapbox `.json` golden** → key-order-insensitive (a serde field reorder won't churn it); update with `SNAPSHOTS=overwrite`.
- Runs under **`just test`** (nextest) automatically — **no new entry point**.

## Verification

- `cargo nextest run -p pixtuoid --test cli_json` ✓ 1 passed · full suite ✓ **1902 passed** · `cargo machete` ✓ (snapbox detected used) · clippy ✓ · fmt ✓.

PR-5 of the lint/test tooling wave — first of the **test-coverage** layer (proptest, cargo-insta --check, Codecov Components, cargo-mutants to follow). The 3-layer mantra: **proptest generates inputs · mutants checks assertions · snapbox pins the contract.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)