### PR TITLE
test(core): property-test the walkable-mask invariants with proptest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,7 +202,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -210,6 +219,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -821,7 +836,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
 dependencies = [
- "bit-set",
+ "bit-set 0.5.3",
  "regex",
 ]
 
@@ -2149,7 +2164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2239,6 +2254,7 @@ dependencies = [
  "insta",
  "libc",
  "notify",
+ "proptest",
  "serde",
  "serde_json",
  "tempfile",
@@ -2325,6 +2341,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2353,10 +2378,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
+ "bitflags 2.13.0",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
@@ -2394,7 +2444,27 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2402,6 +2472,24 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "ratatui"
@@ -2615,6 +2703,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -3366,6 +3466,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3437,6 +3543,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/crates/pixtuoid-core/Cargo.toml
+++ b/crates/pixtuoid-core/Cargo.toml
@@ -44,6 +44,11 @@ windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Securit
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["sync", "rt", "macros", "fs", "net", "time", "io-util", "rt-multi-thread"] }
+# Property-based testing of the pure-core algebraic invariants (the walkable-mask
+# geometry today): generate thousands of inputs to falsify a property, shrinking
+# any failure to a minimal counterexample. Found failures persist under
+# `proptest-regressions/` so they re-run forever.
+proptest = "1"
 tempfile = "3"
 filetime = "0.2"
 insta = { version = "1", features = ["yaml"] }

--- a/crates/pixtuoid-core/src/walkable.rs
+++ b/crates/pixtuoid-core/src/walkable.rs
@@ -210,3 +210,69 @@ mod tests {
         assert_eq!(a.signature(), b.signature());
     }
 }
+
+// Property-based generalizations of the `WalkableMask` example tests above: the
+// hand-picked cases pin a few points; these falsify the same invariants across
+// thousands of generated dims/rects/pads — exercising the saturating-arithmetic
+// clip path (overflowing + out-of-bounds rects, zero-size rects, edge queries)
+// the example cases can't reach. All three are provably true from the impl, so a
+// failure means a real regression, not flake.
+#[cfg(test)]
+mod prop {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        // An OPEN mask is walkable at EXACTLY the in-bounds cells, and `is_walkable`
+        // never panics for any query — routers probe near/over the edges unchecked.
+        // (Generalizes `out_of_bounds_query_is_not_walkable` + `new_open_is_all_walkable`.)
+        #[test]
+        fn open_mask_is_walkable_iff_in_bounds(
+            w in 1u16..=256, h in 1u16..=256, x in 0u16..512, y in 0u16..512,
+        ) {
+            let m = WalkableMask::new_open(w, h);
+            prop_assert_eq!(m.is_walkable(x, y), x < w && y < h);
+        }
+
+        // `mark_blocked` clips, so it NEVER panics for any rect/pad — including
+        // out-of-bounds and arithmetic-overflowing ones (the documented "caller
+        // needn't bounds-check" contract). The result blocks EXACTLY its clipped,
+        // padded rect: nothing outside is touched, nothing inside is missed.
+        // (Generalizes `mark_blocked_pads_and_clips`.)
+        #[test]
+        fn mark_blocked_blocks_exactly_its_clipped_padded_rect(
+            w in 1u16..=48, h in 1u16..=48,
+            x in 0u16..160, y in 0u16..160, rw in 0u16..160, rh in 0u16..160, pad in 0u16..24,
+        ) {
+            let mut m = WalkableMask::new_open(w, h);
+            m.mark_blocked(x, y, rw, rh, pad); // must not panic for any input
+            let min_x = x.saturating_sub(pad);
+            let max_x = x.saturating_add(rw).saturating_add(pad).min(w);
+            let min_y = y.saturating_sub(pad);
+            let max_y = y.saturating_add(rh).saturating_add(pad).min(h);
+            for yy in 0..h {
+                for xx in 0..w {
+                    let blocked = (min_x..max_x).contains(&xx) && (min_y..max_y).contains(&yy);
+                    prop_assert_eq!(m.is_walkable(xx, yy), !blocked, "cell ({}, {})", xx, yy);
+                }
+            }
+        }
+
+        // Carving the whole mask walkable after any block fully restores it — a door
+        // cutout can always re-open ground. (Generalizes `mark_walkable_carves_a_cutout`.)
+        #[test]
+        fn mark_walkable_over_the_whole_mask_restores_walkability(
+            w in 1u16..=48, h in 1u16..=48,
+            x in 0u16..96, y in 0u16..96, rw in 0u16..96, rh in 0u16..96, pad in 0u16..16,
+        ) {
+            let mut m = WalkableMask::new_open(w, h);
+            m.mark_blocked(x, y, rw, rh, pad);
+            m.mark_walkable(0, 0, w, h);
+            for yy in 0..h {
+                for xx in 0..w {
+                    prop_assert!(m.is_walkable(xx, yy));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

Introduces **proptest** to the repo and uses it to property-test the **WalkableMask** geometry (the foundation of invariant #6 — "walkable mask = ground footprint only").

## The gap it closes

WalkableMask had only **example-based** unit tests pinning a handful of hand-picked points. Those answer "is the formula right for *these* cases"; they never exercise the **saturating-arithmetic clip path** — overflowing/out-of-bounds rects, zero-size rects, edge queries — which is exactly where a geometry bug (an off-by-one stamp, a panic on overflow, a missed clamp) hides.

## The 3 properties (provably true from the impl → a failure is a real regression, not flake)

- **`open_mask_is_walkable_iff_in_bounds`** — an open mask is walkable at *exactly* the in-bounds cells, and `is_walkable` never panics for any query (the "routers probe over the edges unchecked" contract).
- **`mark_blocked_blocks_exactly_its_clipped_padded_rect`** — `mark_blocked` never panics for *any* rect/pad (the documented clip-so-the-caller-needn't-bounds-check contract) and blocks exactly its clipped padded rect — nothing outside touched, nothing inside missed.
- **`mark_walkable_over_the_whole_mask_restores_walkability`** — a door cutout always re-opens ground.

proptest generates thousands of inputs per property, shrinks any failure to a minimal counterexample, and persists found failures under `proptest-regressions/`.

## Scope / blast radius

- **dev-dependency only** → no `hack` / `msrv` / `semver` surface (those don't build dev-deps; verified `just lint` incl. `deny` is green with proptest's new transitive deps).
- Runs under **`just test`** (nextest) automatically — no new entry point.
- First property test in the repo; the **reducer** (event-ordering invariants) and **physics** (monotone/bounded `walk_progress`) invariants are the natural follow-ups.

## Verification

- `cargo nextest run -p pixtuoid-core --lib` ✓ **551 passed** (incl. the 3 new) · `just lint` ✓ 7/7 · clippy ✓ · fmt ✓.

PR-6 of the lint/test tooling wave. The 3-layer test mantra: **proptest generates inputs · mutants checks assertions · snapbox pins the contract** — this is the first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)