### PR TITLE
ci: gate snapshot hygiene with cargo-insta (pending + orphan .snap)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,6 +267,25 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  snapshots:
+    name: snapshot hygiene
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v1-rust # see the clippy job's note
+      - uses: taiki-e/install-action@cargo-nextest
+      - uses: taiki-e/install-action@cargo-insta
+      - uses: extractions/setup-just@v4
+      # Runs the suite under nextest and fails on a pending OR unreferenced
+      # (orphan) snapshot — the rot plain `cargo test` can't see. Separate from
+      # the coverage job because cargo-insta needs an UNinstrumented run to track
+      # which snapshots were referenced.
+      - run: just snapshots
+
   smoke:
     name: smoke
     # No `needs:` — smoke builds the release binary + renders + pixel-diffs; it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,8 @@ Never pipe `preflight` through `tail`/`head` — the exit code becomes the
 pipe's and a real failure reads as green; redirect to a file and `echo $?`.
 CI-only gates: semver (pixtuoid-core only — the binary's lib target is not a
 semver surface), coverage/smoke, gen-check, gen-readme-check, npm-check,
-check-windows (cross-lint for msvc on every PR).
+check-windows (cross-lint for msvc on every PR), snapshots (`cargo insta` —
+fails on a pending OR orphan `.snap`, the rot plain `cargo test` can't see).
 
 **Release:** `just bump X.Y.Z` rewrites every version number, drafts
 `release_notes()`, runs preflight, and commits on a release branch — it

--- a/justfile
+++ b/justfile
@@ -188,6 +188,18 @@ semver:
 coverage:
     cargo llvm-cov nextest --workspace --features {{ features }} --lcov --output-path lcov.info --profile ci
 
+# Snapshot hygiene (cargo-insta): runs the suite under nextest and FAILS on a
+# pending (un-accepted `.snap.new`) OR unreferenced (orphan `.snap` — e.g. a
+# deleted test's leftover) snapshot. This is the gap plain `cargo test` misses:
+# a CHANGED snapshot already fails its own assertion, but an ORPHAN one rots
+# silently. CI-only in practice (a second full test run, like coverage/semver) —
+# NOT in preflight; run it after adding/removing an insta-snapshot test. Needs
+# cargo-insta + cargo-nextest.
+[group('rust')]
+[doc('Snapshot hygiene (cargo-insta): fail on pending OR orphan snapshots — CI-only')]
+snapshots:
+    cargo insta test --check --unreferenced=reject --test-runner nextest --workspace --features {{ features }}
+
 # Never-panic fuzz the per-source decoders over a JSONL corpus DIR (on-demand;
 # not in preflight/CI — points at local or public real sessions, not committed
 # data). Auto-routes each line to the CC / Codex / hook decoder by its shape;
@@ -472,7 +484,7 @@ verify: preflight site-check gen-check
 setup-tools:
     #!/usr/bin/env bash
     set -euo pipefail
-    tools=(cargo-nextest cargo-machete cargo-deny cargo-hack cargo-semver-checks cargo-edit lychee)
+    tools=(cargo-nextest cargo-machete cargo-deny cargo-hack cargo-semver-checks cargo-edit cargo-insta lychee)
     if command -v cargo-binstall &>/dev/null; then
         cargo binstall -y "${tools[@]}"
     else


### PR DESCRIPTION
## What

Adds a **snapshot-hygiene** CI gate via **cargo-insta**, catching the one snapshot rot plain `cargo test` can't see.

## The gap

insta already fails a **changed** snapshot (its assertion mismatches). But:
- an **orphan `.snap`** — left when a test is deleted or a snapshot renamed — lingers **silently** (nothing references it, nothing fails), and
- a pending **`.snap.new`** can slip past review.

`cargo insta test --check --unreferenced=reject` fails on **both**.

## Design

- **`just snapshots`** recipe = `cargo insta test --check --unreferenced=reject --test-runner nextest --workspace --features …`. **CI-only**, like `coverage`/`semver` (it's a second full test run) — **not** in `preflight` (keeps the local gate lean); run it after adding/removing an insta-snapshot test.
- A **dedicated `snapshots` CI job**: cargo-insta needs an *uninstrumented* run to track which snapshots were referenced, so it can't piggyback on the llvm-cov coverage job. cargo-insta installed via `taiki-e/install-action@cargo-insta` (the repo's cargo-tool convention) + added to `setup-tools`.
- **Zero new dependency** — `insta` + `cargo-insta` are companions, and `insta` is already used (15×).
- `CLAUDE.md` CI-only-gates note updated.

## Verification

- `just snapshots` ✓ "no unreferenced snapshots found, no snapshots to review" (repo clean today → pure guardrail) · `just --list` ✓ parses · `just actionlint` ✓ (new job) · `just lint` ✓ 7/7.

PR-7 of the lint/test tooling wave. Remaining tail: Codecov Components → cargo-mutants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)