### PR TITLE
chore(coverage): per-crate Codecov components

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -15,8 +15,36 @@ coverage:
         threshold: 5%
         informational: true
 
+# Per-crate coverage VIEWS over the one workspace upload (a virtual split — no
+# extra CI jobs / flags / uploads). Turns the single blended % into the DAG's
+# topology (pixtuoid-core ← pixtuoid-scene ← pixtuoid + the standalone hook), so a
+# regression in one crate can't hide behind the binary's untestable TTY paths the
+# `ignore` list already drops. Non-blocking (`informational`) to match the
+# top-level statuses — these are a lens, not a gate. The global `ignore` above
+# still applies, so the `pixtuoid` view counts only its headless-testable files.
+component_management:
+  default_rules:
+    statuses:
+      - type: project
+        target: auto
+        threshold: 5%
+        informational: true
+  individual_components:
+    - component_id: core
+      name: pixtuoid-core
+      paths: ["crates/pixtuoid-core/**"]
+    - component_id: scene
+      name: pixtuoid-scene
+      paths: ["crates/pixtuoid-scene/**"]
+    - component_id: binary
+      name: pixtuoid
+      paths: ["crates/pixtuoid/**"]
+    - component_id: hook
+      name: pixtuoid-hook
+      paths: ["crates/pixtuoid-hook/**"]
+
 comment:
-  layout: "condensed_header, diff, files"
+  layout: "condensed_header, diff, components, files"
   behavior: default
   require_changes: true
   require_base: false


### PR DESCRIPTION
## What

Splits the single workspace coverage upload into **per-crate Codecov components** — operationalizing the repo's stated "coverage topology > %".

## Why

Today coverage is one blended number for a 4-crate DAG (`pixtuoid-core ← pixtuoid-scene ← pixtuoid` + the standalone `pixtuoid-hook`). A regression in the headless **core** can hide behind the binary's large untestable TTY surface. Components give a per-crate view so the topology is visible.

## Design — pure config, zero cost

- A **virtual split** over the *existing* single upload — **no extra CI jobs, flags, or uploads** (Codecov computes the views server-side).
- The global `ignore` list still applies, so the `pixtuoid` view counts only its **headless-testable** files (not main.rs / tui / driver / floating).
- **Non-blocking** (`informational: true`) to match the existing project/patch statuses — a lens, not a gate.
- Surfaced in the PR comment via the new `components` layout row.

## Verification

- `codecov.io/validate` → **"Valid!"**, all 4 components (`core`/`scene`/`binary`/`hook`) parsed in the normalized config.
- Config-only: no code, no CI-job, no test impact.

PR-8 of the lint/test tooling wave. **Last one:** cargo-mutants (diff-scoped mutation testing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)