### PR TITLE
ci: mutation-test the diff with cargo-mutants (advisory)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,21 @@
+# cargo-mutants config (see `just mutants`). Mutation testing injects bugs and
+# checks the tests catch them — the "do your assertions have teeth?" dimension
+# that line/region coverage can't see. Use the project's runner (nextest) and
+# exclude paths where a surviving mutant is NOISE, not a real gap, so the
+# advisory signal stays high.
+test_tool = "nextest"
+
+exclude_globs = [
+    # Untestable painter / async + winit glue — the SAME set codecov.yml ignores.
+    # No headless test can kill a mutant here, so every mutant "survives" = noise.
+    "crates/pixtuoid/src/main.rs",
+    "crates/pixtuoid/src/tui/mod.rs",
+    "crates/pixtuoid/src/runtime/driver.rs",
+    "crates/pixtuoid/src/floating/mod.rs",
+    "crates/pixtuoid/src/floating/window.rs",
+    # Timing / FFI liveness probes: their tests assert wall-clock + OS behavior and
+    # flake under mutation load — a "survivor" here is a flaked test, not a missing
+    # assertion (this repo is flake-averse; #352-#354).
+    "crates/pixtuoid-core/src/source/exit_watch.rs",
+    "crates/pixtuoid-core/src/source/fd_probe.rs",
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,6 +286,41 @@ jobs:
       # which snapshots were referenced.
       - run: just snapshots
 
+  mutants:
+    name: mutation testing (advisory)
+    # PR-only (mutating a merge-to-main has no meaningful diff base) and
+    # diff-scoped, so cost scales with the change. ADVISORY: `continue-on-error`
+    # keeps a surviving mutant OFF the required-checks path — it's a hint to
+    # strengthen a test, never a merge gate (flake-averse repo). The survivor
+    # list rides out as the `mutants-report` artifact.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # `--in-diff` needs the merge base in history
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v1-rust # see the clippy job's note
+      - uses: taiki-e/install-action@cargo-mutants
+      - uses: taiki-e/install-action@cargo-nextest
+      - uses: extractions/setup-just@v4
+      - name: Mutation-test the PR diff (advisory, non-blocking)
+        env:
+          MUTANTS_BASE: ${{ github.event.pull_request.base.sha }}
+        run: just mutants
+      - name: Upload surviving-mutants report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mutants-report
+          path: mutants.out/
+          retention-days: 7
+          if-no-files-found: ignore
+
   smoke:
     name: smoke
     # No `needs:` — smoke builds the release binary + renders + pixel-diffs; it

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ docs/superpowers/
 drift-report.md
 __pycache__/
 lcov.info
+mutants.out/
+mutants.out.old/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,11 @@ deliberately flat publish-excluded) with `#[cfg(windows)]` parity twins, all map
 the headless render harness (`tui_renderer/harness.rs`) drives the real
 `TuiRenderer` through ratatui `TestBackend` — see the tui guide. Coverage:
 `just coverage`. Decoder never-panic fuzz vs a real session corpus:
-`just fuzz <jsonl-dir>` (on-demand, not in CI).
+`just fuzz <jsonl-dir>` (on-demand, not in CI). Mutation testing (do the
+assertions have teeth?): `just mutants` — diff-scoped (`cargo-mutants
+--in-diff` vs origin/main), config in `.cargo/mutants.toml`; CI runs it
+**advisory / non-blocking** on every PR (a surviving mutant is a hint, not a
+gate). Property-based invariants use `proptest` (e.g. `walkable.rs`).
 
 ### Visual verification
 

--- a/justfile
+++ b/justfile
@@ -200,6 +200,25 @@ coverage:
 snapshots:
     cargo insta test --check --unreferenced=reject --test-runner nextest --workspace --features {{ features }}
 
+# Mutation testing (cargo-mutants): inject bugs into the CHANGED lines and check
+# the tests catch them — the "do your assertions have TEETH?" dimension that
+# line/region coverage can't see (a covered-but-toothless assertion). DIFF-scoped
+# (`--in-diff` vs `$MUTANTS_BASE`, default origin/main) so cost scales with the
+# change, not the ~6,900-mutant tree; reads `.cargo/mutants.toml` (nextest + the
+# untestable/timing exclusions). ADVISORY — CI runs it NON-blocking; a surviving
+# mutant is a hint to strengthen a test, not a merge gate. Run on a
+# reducer/decoder/layout PR; forwards args (e.g. `just mutants --list`). Needs
+# cargo-mutants + nextest.
+[group('rust')]
+[doc('Mutation-test the diff vs origin/main (cargo-mutants --in-diff) — advisory')]
+mutants *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    base="${MUTANTS_BASE:-origin/main}"
+    mkdir -p target
+    git diff "$base...HEAD" > target/mutants.diff
+    cargo mutants --in-diff target/mutants.diff --features {{ features }} {{ args }}
+
 # Never-panic fuzz the per-source decoders over a JSONL corpus DIR (on-demand;
 # not in preflight/CI — points at local or public real sessions, not committed
 # data). Auto-routes each line to the CC / Codex / hook decoder by its shape;


### PR DESCRIPTION
## What

The **finale** of the test-tooling wave: **cargo-mutants** mutation testing, completing the trio — **proptest generates inputs · mutants checks assertions · snapbox pins the contract**.

## The gap it closes

Mutation testing injects bugs into the code and checks the tests catch them — the **"covered-but-toothless assertion"** dimension that line/region coverage is *blind* to (a line can be 100% covered while its assertions pin nothing). It's the systematized form of the repo's existing ad-hoc "mutation teeth" practice.

## Design — diff-scoped + advisory (the two things that make it viable here)

- **`just mutants`** = `cargo mutants --in-diff` vs `$MUTANTS_BASE` (default `origin/main`). **Diff-scoped**, so cost scales with the *change*, not the ~6,900-mutant tree — a docs PR = 0 mutants, a 5-line core change = a handful. This sidesteps the "a full workspace run is minutes-to-tens-of-minutes" problem.
- **`.cargo/mutants.toml`**: `test_tool = "nextest"` + `exclude_globs` for (a) the untestable painter/async/winit glue — the *same* set `codecov.yml` ignores (no headless test can kill a mutant there → pure noise), and (b) the timing/FFI liveness probes (`exit_watch`/`fd_probe` — their wall-clock tests flake under mutation load, so a "survivor" there is a flaked test, not a real gap; this repo is flake-averse).
- **PR-only, `continue-on-error` CI job** — **advisory, never a merge gate**. A surviving mutant is a hint to strengthen a test; the survivor list rides out as the **`mutants-report`** artifact.
- cargo-mutants via `taiki-e/install-action`; `mutants.out/` gitignored.

## Verification

- Config: `cargo mutants --list` reads it — excludes applied (the binary `main.rs` / `tui` / `driver` / `floating` / `exit_watch` / `fd_probe` all drop to 0), high-value files covered (reducer 119, layout 748, physics 137, walkable 28).
- **End-to-end**: a bounded run confirmed the **baseline builds + passes** under nextest + `test-renderer` (14s build + 5s test) and a walkable.rs mutant is **caught** — i.e. the new proptest properties have teeth.
- `just --list` ✓ · `just actionlint` ✓ (new job) · `just lint` ✓ 7/7.

PR-9 — the last of the 9-PR lint/test tooling wave (shfmt → actionlint → lychee → knip → snapbox → proptest → cargo-insta → Codecov components → **mutants**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)