### PR TITLE
docs(release): expand the in-app 0.11.0 release-notes popup

### DIFF
--- a/crates/pixtuoid/src/version.rs
+++ b/crates/pixtuoid/src/version.rs
@@ -59,6 +59,9 @@ pub fn release_notes(version: &str) -> Option<&'static [&'static str]> {
         // brace would silently break if the indentation ever shifted.
         // [bump-inject-here]
         "0.11.0" => Some(&[
+            "Pop the office out of the terminal — new `pixtuoid floating` opens a frameless, always-on-top desktop window of the same animated office",
+            "First launch greets you with a cinematic move-in and helps you connect your installed agent CLIs; `pixtuoid setup` is the headless twin for scripting and CI",
+            "Drive pixtuoid from Raycast — a new extension manages your sources, backed by scriptable `sources` / `connect` / `disconnect --json` commands",
             "Windows: a `~`-prefixed `--pack-dir` / `pack-dir` now expands to your home directory (no more literal `~` in the path)",
             "Internals tidied — a large code-quality pass (deduplication and a unified pixel-buffer type); the office renders identically, just leaner under the hood",
         ]),


### PR DESCRIPTION
## Why

Pre-tag release-readiness audit of `v0.11.0` found everything green **except** the in-app `release_notes("0.11.0")` popup, which undersold the release. The arm listed only the Windows pack-dir fix + the internals dedup, but `v0.10.0..HEAD` (30 commits) ships three headline user-facing features merged after the v0.10.0 tag:

- **`pixtuoid floating`** (#346) — a frameless, always-on-top desktop window of the office
- **First-run onboarding + `pixtuoid setup`** (#359) — cinematic move-in + the headless detect/connect twin
- **Raycast extension + scriptable `--json` CLI** (#355/#362/#367) — `sources`/`connect`/`disconnect`

The GitHub Release changelog (git-cliff `--latest`) was already complete from commit messages; this only fixes the hand-curated in-app "What's new" popup.

## What

Expanded the `0.11.0` arm in `crates/pixtuoid/src/version.rs` from 2 → 5 bullets. Wording verified against the real CLI surface (`cli.rs`: `Floating` = "frameless, always-on-top desktop window"; `Setup` = "the headless twin of the in-TUI onboarding").

## Verification

- `cargo test -p pixtuoid --lib version` → 41 passed (incl. `current_version_has_release_notes`)
- `just notes-curated` → ✓ (no leftover TODO marker)
- `cargo fmt -p pixtuoid -- --check` → clean

No version-number change, so no gen-check still drift (the popup text isn't baked into any committed still).

🤖 Generated with [Claude Code](https://claude.com/claude-code)