### PR TITLE
docs: fix stale content across site, README, and distributed READMEs for v0.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Press `s` to open the **Sources** panel and connect your agent CLI (Claude Code,
 |---|---|---|
 | 🏢 | **Multi-agent office** | Each agent session gets a desk; overflow agents auto-fill new floors |
 | 🛗 | **Multi-floor office** | PageUp/PageDown/↑↓/jk to navigate floors with slide transition |
+| 🪟 | **Floating desktop window** | `pixtuoid floating` opens a frameless, always-on-top desktop window of the office — not just a terminal TUI |
 | 🎭 | **Animated characters** | Typing, waiting (`?`), sleeping (z's), walking with A\*-routed pathfinding |
 | 💡 | **Per-tool monitor glow** | Edit = blue, Bash = orange, Read = cyan — scannable at a glance |
 | 🎨 | **Per-agent identity** | Deterministic shirt/hair/skin palette from session hash, 16 curated outfits |
@@ -132,7 +133,7 @@ Agent CLIs emit events two ways — a hook shim (a 200ms fire-and-forget write t
 
 ## Contributing
 
-PRs welcome — especially new themes and `Source` adapters for other agent CLIs (Cursor, and more). See **[CONTRIBUTING.md](docs/CONTRIBUTING.md)** for the build/test workflow, conventions, the review process, and how to add a new agent CLI. Architecture and the load-bearing invariants live in [`CLAUDE.md`](CLAUDE.md).
+PRs welcome — especially new themes, sprite/decoration polish, and `Source` adapters for agent CLIs we don't support yet (the nine already wired up are in [Supported Tools](#supported-tools)). See **[CONTRIBUTING.md](docs/CONTRIBUTING.md)** for the build/test workflow, conventions, the review process, and how to add a new agent CLI. Architecture and the load-bearing invariants live in [`CLAUDE.md`](CLAUDE.md).
 
 ## Acknowledgments
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -37,7 +37,7 @@ kind = "dog"        # name omitted → "Office Dog"
 | Key | Purpose |
 |-----|---------|
 | `last-seen-version` | Tracks the highest version you've launched, so the "what's new" popup only fires once per upgrade. Pixtuoid overwrites this on every launch. |
-| `[sources]` | Per-agent-CLI connection state (`source-id = true/false`), written when you connect/disconnect a source in the in-TUI **Sources panel** (`c`). When a source has no entry, pixtuoid migrates a default on launch: connected if its hooks are already installed (or it has no hooks to install, like Antigravity), else disconnected. A disconnected source's characters are hidden even if its hooks/transcripts are still present. |
+| `[sources]` | Per-agent-CLI connection state (`source-id = true/false`), written when you connect/disconnect a source in the in-TUI **Sources panel** (`s`). When a source has no entry, pixtuoid migrates a default on launch: connected if its hooks are already installed (or it has no hooks to install, like Antigravity), else disconnected. A disconnected source's characters are hidden even if its hooks/transcripts are still present. |
 
 ## Themes
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,7 +1,8 @@
 # Contributing to pixtuoid
 
-Thanks for your interest! PRs are welcome — especially **new themes** and
-**`Source` adapters** for other agent CLIs (Copilot, Cursor, OpenCode).
+Thanks for your interest! PRs are welcome — especially **new themes**, sprite and
+decoration polish, and **`Source` adapters** for agent CLIs we don't support yet
+(the nine already wired up are listed in the README).
 
 Before you start, read [`CLAUDE.md`](../CLAUDE.md) at the repo root (and the nested
 `crates/*/CLAUDE.md` for the crate you touch). It holds the architecture

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -9,10 +9,10 @@ the two that changed something user-visible.
 Binding a CLI is now done live in the in-TUI **Sources panel**: launch
 `pixtuoid`, press `s`, and connect (or disconnect) each agent CLI — its
 characters appear when you connect and walk out when you disconnect, no restart.
-`pixtuoid run` is the only subcommand left (plus `validate-pack` / `init-pack`).
 
-If you scripted `pixtuoid install-hooks`, replace it with the panel — there is no
-non-interactive equivalent (hooks are installed/removed through the panel toggle).
+If you scripted `pixtuoid install-hooks`, replace it with the panel — or, for
+automation, the scriptable `pixtuoid connect` / `disconnect` / `sources`
+subcommands added later (the same surface the Raycast extension drives).
 This release also adds two new sources you can connect there: **CodeWhale**
 (`cw·`) and **opencode** (`oc·`).
 
@@ -40,7 +40,7 @@ This release also adds two new sources you can connect there: **CodeWhale**
    # or: cargo install pixtuoid pixtuoid-hook
    ```
 
-2. **Re-register hooks**: launch `pixtuoid`, press `s` to open the Connection
+2. **Re-register hooks**: launch `pixtuoid`, press `s` to open the Sources
    panel, and connect your agent CLI (this replaces any old `ascii-agents-hook`
    entries automatically). The old `pixtuoid install-hooks` subcommand is gone —
    binding a source is now done live inside the TUI.

--- a/integrations/raycast/README.md
+++ b/integrations/raycast/README.md
@@ -23,7 +23,7 @@ Install the `pixtuoid` binary with any of:
 ```sh
 cargo install pixtuoid pixtuoid-hook
 npm i -g pixtuoid
-brew install ivanwng97/pixtuoid/pixtuoid
+brew install IvanWng97/pixtuoid/pixtuoid
 ```
 
 The extension auto-detects it via your login shell's `PATH`, then the common

--- a/integrations/raycast/README.md
+++ b/integrations/raycast/README.md
@@ -21,7 +21,7 @@ does **not** bundle the binary.
 Install the `pixtuoid` binary with any of:
 
 ```sh
-cargo install pixtuoid
+cargo install pixtuoid pixtuoid-hook
 npm i -g pixtuoid
 brew install ivanwng97/pixtuoid/pixtuoid
 ```

--- a/npm/pixtuoid/package.json
+++ b/npm/pixtuoid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pixtuoid",
   "version": "0.0.0",
-  "description": "Terminal-native pixel-art visualizer for AI coding agents — watch Claude Code, Codex, Antigravity & Reasonix sessions as coworkers in an ASCII office.",
+  "description": "Terminal-native pixel-art visualizer for AI coding agents — watch Claude Code, Codex, Cursor, Copilot, and more sessions as coworkers in an ASCII office.",
   "keywords": [
     "cli",
     "tui",

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -23,7 +23,7 @@ import { REPO, asset } from '../consts';
         >
         <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer">★ Star on GitHub</a>
       </div>
-      <p class="hero__avail">macOS · Linux · crates.io · MIT licensed</p>
+      <p class="hero__avail">macOS · Linux · Windows · crates.io · MIT licensed</p>
     </div>
 
     <div class="hero__demo">

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -15,7 +15,7 @@ import tabs from '../install.json';
       <h2>Install pixtuoid.</h2>
       <p class="lead">
         macOS, Linux &amp; Windows. Then run <code>pixtuoid</code> and press
-        <code>c</code> to connect your CLI.
+        <code>s</code> to connect your CLI.
       </p>
     </div>
 

--- a/site/src/features.json
+++ b/site/src/features.json
@@ -18,6 +18,14 @@
     }
   },
   {
+    "icon": "🪟",
+    "name": "Floating desktop window",
+    "desc": "`pixtuoid floating` opens a frameless, always-on-top desktop window of the office — not just a terminal TUI",
+    "card": {
+      "blurb": "Pop the office out of the terminal into a frameless, always-on-top desktop window — the same living office, hovering over your other windows."
+    }
+  },
+  {
     "icon": "🎭",
     "name": "Animated characters",
     "desc": "Typing, waiting (`?`), sleeping (z's), walking with A\\*-routed pathfinding"


### PR DESCRIPTION
## Why

A read-only audit of **all** project docs against the shipped **v0.11.0** reality. The site renders `docs/*.md` verbatim at `/migration`, `/config`, `/contributing`, and the npm/Raycast READMEs are distributed user-facing docs. Several carried stale claims.

## Fixes

**Site-rendered docs + README** (commit 1):
| Sev | File (renders at) | Was → Now |
|-----|------|-----|
| HIGH | `docs/MIGRATION.md` (/migration) | "`run` is the only subcommand left" + "no non-interactive equivalent" → removed (the scriptable `connect`/`disconnect`/`sources` exist) |
| MED | `docs/MIGRATION.md` | "Connection panel" → "Sources panel" |
| MED | `docs/CONFIGURATION.md` (/config) | Sources panel `(c)` → `(s)` |
| MED | `docs/CONTRIBUTING.md` + `README.md` | stopped soliciting Copilot/Cursor/opencode adapters (all shipped) |
| MED | `site/.../Install.astro` | "press `c`" → `s` |
| — | `site/.../Hero.astro` | tagline now lists **Windows** |
| MED | `site/src/features.json` | added the **Floating desktop window** feature; README table regenerated |

**Distributed READMEs** (commit 2):
| Sev | File | Was → Now |
|-----|------|-----|
| MED | `npm/pixtuoid/package.json` | `description` (renders on npmjs.com) named only 4 sources → genericized to "…Cursor, Copilot, and more…" |
| MED | `integrations/raycast/README.md` | `cargo install pixtuoid` → `cargo install pixtuoid pixtuoid-hook` (hook shim was missing) |

Audited clean (no change): `docs/ARCHITECTURE.md`, `KNOWLEDGE-ENGINEERING.md`, `PARALLEL-DELIVERY.md`, `site/README.md`, `SECURITY.md`, all `CLAUDE.md`/`AGENTS.md` (kept current during 0.11.0 work). Confirmed `cargo install pixtuoid pixtuoid-hook` is complete — `pixtuoid-core`/`pixtuoid-scene` are libraries, not installable binaries.

## Verification
- `just gen-readme-check` ✓ · `just site-check` ✓ (8 pages built) · npm launcher JSON re-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)