### PR TITLE
feat(ci): auto-file the review-history census reminder (no hand-filed placeholder)

### DIFF
--- a/.github/workflows/census-reminder.yml
+++ b/.github/workflows/census-reminder.yml
@@ -67,7 +67,6 @@ jobs:
             gh issue create \
               --title "Re-run the review-history census" \
               --label census \
-              --label "priority: low" \
               --body-file census-body.md
           fi
 

--- a/.github/workflows/census-reminder.yml
+++ b/.github/workflows/census-reminder.yml
@@ -12,6 +12,11 @@ on:
   schedule:
     - cron: "0 9 * * 1" # Mondays 09:00 UTC
   workflow_dispatch:
+    inputs:
+      interval:
+        description: "PRs-past-the-last-window threshold (lower it — e.g. 0 — to force a due check for a manual end-to-end test)"
+        required: false
+        default: "50"
   # On PRs touching the script/workflow, run ONLY the selftest — the live `gh`
   # check + issue-filing stay schedule/dispatch-only (they need network + must
   # never gate a PR). A parser/threshold regression IS caught here.
@@ -40,15 +45,18 @@ jobs:
       - name: Check whether a census is due
         id: check
         if: github.event_name != 'pull_request'
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-        shell: bash
+          # workflow_dispatch can lower the threshold for a manual end-to-end test;
+          # scheduled runs get the empty default → the script's own 50.
+          INTERVAL: ${{ github.event.inputs.interval }}
         run: |
           set +e
           # max-by-number, NOT `--limit 1`: `gh pr list`'s sort order isn't a
           # guaranteed max-by-PR-number, so take the explicit max over a recent window.
           latest=$(gh pr list --state merged --limit 100 --json number --jq 'max_by(.number).number')
-          python3 scripts/census_reminder.py --latest-pr "$latest" > census-body.md
+          python3 scripts/census_reminder.py --latest-pr "$latest" --interval "${INTERVAL:-50}" > census-body.md
           echo "exit=$?" >> "$GITHUB_OUTPUT"
 
       - name: Open the census tracking issue (deduped on the `census` label)

--- a/.github/workflows/census-reminder.yml
+++ b/.github/workflows/census-reminder.yml
@@ -1,0 +1,74 @@
+name: census-reminder
+
+# The review-history census cadence, automated. When the merged-PR backlog crosses
+# ~50 PRs past the last census's window (parsed from the newest
+# docs/review-metrics/mining-*.md filename), auto-open a deduped `census` issue so
+# the NEXT census is tracked WITHOUT a hand-filed placeholder ("the cadence rides
+# the issue backlog, not memory" — now it rides this scheduled check). Mirrors the
+# upstream-drift watcher's scheduled-deduped-issue pattern. See
+# docs/KNOWLEDGE-ENGINEERING.md + scripts/census_reminder.py.
+
+on:
+  schedule:
+    - cron: "0 9 * * 1" # Mondays 09:00 UTC
+  workflow_dispatch:
+  # On PRs touching the script/workflow, run ONLY the selftest — the live `gh`
+  # check + issue-filing stay schedule/dispatch-only (they need network + must
+  # never gate a PR). A parser/threshold regression IS caught here.
+  pull_request:
+    paths:
+      - "scripts/census_reminder*.py"
+      - ".github/workflows/census-reminder.yml"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  reminder:
+    name: census cadence reminder
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      # Always runs (incl. PRs): a parser/threshold regression = a silent monitor
+      # death (never files, or files the wrong window), so guard it first.
+      - name: Self-test the reminder parser
+        run: python3 scripts/census_reminder_selftest.py
+
+      - name: Check whether a census is due
+        id: check
+        if: github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set +e
+          latest=$(gh pr list --state merged --limit 1 --json number --jq '.[0].number')
+          python3 scripts/census_reminder.py --latest-pr "$latest" > census-body.md
+          echo "exit=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Open the census tracking issue (deduped on the `census` label)
+        if: steps.check.outputs.exit == '1'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh label create census --color 0E8A16 \
+            --description "Recurring review-history census cadence" 2>/dev/null || true
+          num=$(gh issue list --label census --state open \
+            --json number --jq '.[0].number // empty')
+          if [ -n "$num" ]; then
+            echo "census issue #$num is already open — nothing to file."
+          else
+            gh issue create \
+              --title "Re-run the review-history census" \
+              --label census \
+              --label "priority: low" \
+              --body-file census-body.md
+          fi
+
+      - name: Note check error
+        if: steps.check.outputs.exit == '2'
+        run: echo "::warning::census-reminder could not determine the last census window (no ranged report?)."

--- a/.github/workflows/census-reminder.yml
+++ b/.github/workflows/census-reminder.yml
@@ -45,7 +45,9 @@ jobs:
         shell: bash
         run: |
           set +e
-          latest=$(gh pr list --state merged --limit 1 --json number --jq '.[0].number')
+          # max-by-number, NOT `--limit 1`: `gh pr list`'s sort order isn't a
+          # guaranteed max-by-PR-number, so take the explicit max over a recent window.
+          latest=$(gh pr list --state merged --limit 100 --json number --jq 'max_by(.number).number')
           python3 scripts/census_reminder.py --latest-pr "$latest" > census-body.md
           echo "exit=$?" >> "$GITHUB_OUTPUT"
 
@@ -55,7 +57,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          gh label create census --color 0E8A16 \
+          gh label create census --color 006B75 \
             --description "Recurring review-history census cadence" 2>/dev/null || true
           num=$(gh issue list --label census --state open \
             --json number --jq '.[0].number // empty')

--- a/docs/KNOWLEDGE-ENGINEERING.md
+++ b/docs/KNOWLEDGE-ENGINEERING.md
@@ -123,7 +123,7 @@ each gate a versioned file with an automatic reader:
 | implement | the 6 recurring pitfalls + the PR template checkbox pointing at them | the template is forced on every author |
 | review | [`pr-review.prompt.md`](../.github/prompts/pr-review.prompt.md) — two differentiated lenses, five hard requirements, escalation triggers, ledger routing | copied verbatim into reviewer prompts; the bot loads its own rules file |
 | merge | the disposition sweep — every finding ends FIXED / REFUTED-with-trace / ISSUE-FILED / ACCEPTED-residual; plan-misses become `plan-miss:` commit lines | the orchestrator's process notes; commit messages become the data channel |
-| periodic | the history census (each run files its successor as a pinned issue), ledger-blind calibration, `scripts/review-metrics.py` + the reports below | the issue backlog and the harvest scripts |
+| periodic | the history census (the weekly `census-reminder` workflow auto-files its successor as a `census` issue once the merged-PR backlog crosses ~50 past the last window — `scripts/census_reminder.py`, no hand-filed placeholder), ledger-blind calibration, `scripts/review-metrics.py` + the reports below | the issue backlog and the harvest scripts |
 
 Three properties make this a system rather than a document set:
 

--- a/justfile
+++ b/justfile
@@ -540,7 +540,7 @@ drift-selftest:
 [group('meta')]
 [doc('Check whether a review-history census is due (merged-PR backlog)')]
 census-reminder:
-    python3 scripts/census_reminder.py --latest-pr "$(gh pr list --state merged --limit 1 --json number --jq '.[0].number')"
+    python3 scripts/census_reminder.py --latest-pr "$(gh pr list --state merged --limit 100 --json number --jq 'max_by(.number).number')"
 
 # Self-test the census-reminder parser — a regex/off-by-one regression silently
 # mis-files (or never files) a census, the upstream-drift silent-death class.

--- a/justfile
+++ b/justfile
@@ -534,6 +534,22 @@ setup-tools:
 drift-selftest:
     python3 scripts/check_upstream_drift_selftest.py
 
+# Whether a review-history census is due (the merged-PR backlog vs ~50 PRs past the
+# last census window). The weekly `census-reminder` workflow runs this + auto-files
+# a deduped `census` issue when due — this recipe is the local/manual check. Needs `gh`.
+[group('meta')]
+[doc('Check whether a review-history census is due (merged-PR backlog)')]
+census-reminder:
+    python3 scripts/census_reminder.py --latest-pr "$(gh pr list --state merged --limit 1 --json number --jq '.[0].number')"
+
+# Self-test the census-reminder parser — a regex/off-by-one regression silently
+# mis-files (or never files) a census, the upstream-drift silent-death class.
+# Pure Python, no network.
+[group('meta')]
+[doc('Self-test the census-reminder (filename parser + due threshold)')]
+census-reminder-selftest:
+    python3 scripts/census_reminder_selftest.py
+
 # Audit one or more PRs' claude[bot] MEDIUM+ inline findings for a disposition
 # trace (a `Bot-findings-adjudicated:` marker — see CONTRIBUTING.md). ADVISORY:
 # run during the merge disposition sweep to catch the #283 class (a MEDIUM+

--- a/scripts/census_reminder.py
+++ b/scripts/census_reminder.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Auto-file the next review-history census reminder when the merged-PR backlog
+crosses the cadence threshold (~50 PRs past the last census's window).
+
+The census cadence used to ride a HAND-FILED placeholder issue ("the cadence rides
+the issue backlog, not memory"). This replaces the placeholder with a scheduled
+check: parse the last census window-END from the newest
+`docs/review-metrics/mining-*.md` filename, compare it to the highest merged PR,
+and (when due) emit an issue body for the weekly workflow to open — deduped on the
+`census` label, exactly like the upstream-drift watcher.
+
+Pure + offline: the highest merged PR is passed in (`--latest-pr`), so the logic
+is fully unit-testable; the workflow does the one `gh` call.
+
+    census_reminder.py --latest-pr <N> [--reports-dir docs/review-metrics] [--interval 50]
+    census_reminder.py --selftest
+
+Exit: 1 = census DUE (issue body on stdout), 0 = not due, 2 = error.
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+CENSUS_INTERVAL = 50
+
+# A census report filename carries the window as `mining-<YYYY>-<MM>-<start>-<end>.md`.
+# Anchor on the YYYY-MM date so the date digits can't be mistaken for the PR range,
+# and so the first census (`mining-2026-06.md`, no range) is correctly ignored.
+_RANGE = re.compile(r"mining-\d{4}-\d{2}-(\d+)-(\d+)\.md$")
+
+
+def last_window_end(filenames) -> "int | None":
+    """The highest PR-range END across the census report filenames, or None when
+    no ranged report exists (only the first, un-ranged census)."""
+    ends = [int(m.group(2)) for f in filenames if (m := _RANGE.search(str(f)))]
+    return max(ends) if ends else None
+
+
+def census_due(last_end, latest_pr: int, interval: int = CENSUS_INTERVAL) -> bool:
+    """A census is due once the highest merged PR reaches `last_end + interval`."""
+    return last_end is not None and latest_pr >= last_end + interval
+
+
+def issue_body(last_end: int, latest_pr: int, interval: int = CENSUS_INTERVAL) -> str:
+    window_start = last_end + 1
+    return (
+        f"The merged-PR backlog crossed the census cadence threshold: the last census "
+        f"window ended at **#{last_end}** and **{latest_pr - last_end}** PRs have merged "
+        f"since (≥ the ~{interval}-PR interval).\n\n"
+        f"**Run the next review-history census** — window ≈ **#{window_start}–#{latest_pr}**. "
+        f"Same harvest → escapes → synthesis → adversarial-verify pipeline; carry forward "
+        f"the items from the last report's *Re-measuring* section "
+        f"(`docs/review-metrics/mining-*-{last_end}.md`). Methodology + the standing legs: "
+        f"`docs/KNOWLEDGE-ENGINEERING.md`.\n\n"
+        f"Auto-filed by `.github/workflows/census-reminder.yml` — the cadence rides this "
+        f"scheduled check, not a hand-filed placeholder. Close this when the census runs.\n\n"
+        f"\U0001f916 Generated with [Claude Code](https://claude.com/claude-code)\n"
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Review-history census cadence reminder.")
+    ap.add_argument("--latest-pr", type=int, help="the highest merged PR number")
+    ap.add_argument("--reports-dir", default="docs/review-metrics")
+    ap.add_argument("--interval", type=int, default=CENSUS_INTERVAL)
+    ap.add_argument("--selftest", action="store_true", help="run pure-fn tests, no network")
+    a = ap.parse_args()
+    if a.selftest:
+        import census_reminder_selftest as st
+
+        return st.run()
+    if a.latest_pr is None:
+        ap.error("pass --latest-pr <N> (or --selftest)")
+    files = list(Path(a.reports_dir).glob("mining-*.md"))
+    last_end = last_window_end(files)
+    if last_end is None:
+        print(
+            "no census report with a PR range found in "
+            f"{a.reports_dir} — nothing to compare",
+            file=sys.stderr,
+        )
+        return 2
+    threshold = last_end + a.interval
+    if census_due(last_end, a.latest_pr, a.interval):
+        print(issue_body(last_end, a.latest_pr, a.interval))
+        print(
+            f"census DUE: last_end={last_end} latest={a.latest_pr} threshold={threshold}",
+            file=sys.stderr,
+        )
+        return 1
+    print(
+        f"not due: last_end={last_end} latest={a.latest_pr} threshold={threshold}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/census_reminder_selftest.py
+++ b/scripts/census_reminder_selftest.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Self-test for census_reminder.py — pins the filename parser + the due-threshold
+so a regex / off-by-one regression can't silently mis-file (or never file) a census
+reminder, the exact silent-monitor-death class the upstream-drift selftest guards.
+Pure, no network. Run: `python3 scripts/census_reminder_selftest.py` (exit 0 = pass)."""
+
+import sys
+
+import census_reminder as m
+
+
+def run() -> int:
+    fails: list[str] = []
+
+    def check(name: str, cond: bool) -> None:
+        if not cond:
+            fails.append(name)
+
+    # last_window_end: the MAX range END across ranged reports; the un-ranged first
+    # census (`mining-2026-06.md`) and the YYYY-MM date digits must NOT be mistaken
+    # for a PR range (the off-by-a-date-segment trap).
+    files = [
+        "mining-2026-06.md",
+        "mining-2026-06-262-328.md",
+        "mining-2026-06-329-383.md",
+    ]
+    check("max range end across reports", m.last_window_end(files) == 383)
+    check("un-ranged file alone -> None", m.last_window_end(["mining-2026-06.md"]) is None)
+    check("date digits are not a range", m.last_window_end(["mining-2026-12.md"]) is None)
+    check("empty list -> None", m.last_window_end([]) is None)
+    check(
+        "full paths parse",
+        m.last_window_end(["docs/review-metrics/mining-2026-06-329-383.md"]) == 383,
+    )
+    check(
+        "picks the newer of two ranges regardless of order",
+        m.last_window_end(["mining-2026-07-384-433.md", "mining-2026-06-329-383.md"]) == 433,
+    )
+
+    # census_due: latest >= last_end + interval (inclusive at exactly the threshold).
+    check("due at exactly the threshold", m.census_due(383, 433, 50) is True)
+    check("due past the threshold", m.census_due(383, 500, 50) is True)
+    check("not due one below the threshold", m.census_due(383, 432, 50) is False)
+    check("None last_end is never due", m.census_due(None, 999, 50) is False)
+
+    # issue_body: names the window + the no-placeholder note (so a human/agent knows
+    # exactly what to run, and that the Action — not a placeholder — files it).
+    body = m.issue_body(383, 440, 50)
+    check("body states the window", "#384" in body and "#440" in body)
+    check("body cites the workflow", "census-reminder.yml" in body)
+    check("body points at the methodology doc", "KNOWLEDGE-ENGINEERING.md" in body)
+
+    if fails:
+        print("census_reminder selftest FAILED:")
+        for f in fails:
+            print(f"  ✗ {f}")
+        return 1
+    print("census_reminder selftest: all assertions passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())


### PR DESCRIPTION
Automates the review-history census cadence so it no longer rides a hand-filed placeholder issue.

## What
- **`scripts/census_reminder.py`** — pure logic: parse the last census window-END from the newest `docs/review-metrics/mining-*.md` filename, compare to the highest merged PR, emit an issue body when due. `--latest-pr` is injected so it's offline-unit-testable; `--selftest` runs the pins.
- **`scripts/census_reminder_selftest.py`** — pins the filename parser (the date-segment-vs-PR-range trap, e.g. `mining-2026-06.md` must NOT parse `06` as a window) + the `last_end + ~50` threshold.
- **`.github/workflows/census-reminder.yml`** — weekly cron + `workflow_dispatch` get the highest merged PR via `gh` and, when due, open a **deduped `census` issue** (skips if one is already open). PRs touching the script/workflow run **only the selftest** — the live `gh` check + issue-filing are schedule/dispatch-only and never gate a PR. Mirrors `upstream-drift.yml`.
- **`justfile`**: `census-reminder` (manual check) + `census-reminder-selftest`.
- **`KNOWLEDGE-ENGINEERING.md`**: the conveyor's *periodic* row now rides the Action.
- **`census` label** added to **#388** so the dedup recognizes the open tracker.

## Issue Types note
You wanted #388 typed as **Task**. GitHub issue Types require a **GitHub org**; `IvanWng97/pixtuoid` is user-owned (`/orgs/IvanWng97/issue-types` → 404), so Types aren't available without transferring the repo into an org (heavyweight). The `census` label is the practical substitute (same filter/visual benefit, zero migration).

## Verification
- Dry-run: **not due** now (#392 < threshold #433); **fires** at #433 (simulated #440 → exit 1 + body).
- `census_reminder` selftest green · `actionlint` OK · `lychee --offline` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PucHLSPY32y1SRsXemYBGK