### PR TITLE
feat(review): canonical slug-anchored sharp-edge inventory + drift gate (#386)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,10 @@ jobs:
       - run: just shfmt-check
       - run: just actionlint
       - run: just links
+      # The sharp-edge inventory must stay in lockstep with the CLAUDE.md sharp
+      # edges (the census's citation leg counts against it) — #386.
+      - run: just sharp-edge-inventory-selftest
+      - run: just sharp-edge-inventory
 
   msrv:
     name: msrv

--- a/docs/KNOWLEDGE-ENGINEERING.md
+++ b/docs/KNOWLEDGE-ENGINEERING.md
@@ -63,10 +63,14 @@ found LLM-generated context files *reduced* agent success in 5 of 8 settings
 while raising cost ~20%; the converged practice is a ~100–300 line **map,
 not a manual**. **Counter:** size budgets, citation tracking (a sharp edge
 no review has cited across **two consecutive censuses** is a demotion
-candidate — counted against the **full** `CLAUDE.md` sharp-edge set, not a
-sampled subset, or a topic-concentrated review window manufactures false
-staleness; census #3 widened the inventory and re-anchored the clock rather
-than demote on the skew, #386), periodic audits.
+candidate — counted against the **full** `CLAUDE.md` sharp-edge set so a
+topic-concentrated review window can't manufacture false staleness; the canonical
+set is the committed
+[`sharp-edge-inventory.md`](review-metrics/sharp-edge-inventory.md) — each edge
+has a stable slug the ledger cites as `[edge:<slug>]`, and `just
+sharp-edge-inventory` keeps it in lockstep with the guides + harvests citations
+mechanically, so the census leg is a script run, not a hand-count, #386), periodic
+audits.
 
 ### Retrieval (knowledge computed on demand, never stored)
 

--- a/docs/REVIEW-LEDGER.md
+++ b/docs/REVIEW-LEDGER.md
@@ -30,9 +30,12 @@ and the HEAD it was rendered at.
 5. **Every NEW design-intent refutation MUST cite an existing sharp edge**
    (workspace or nested `CLAUDE.md`, or an in-code WHY doc) **or add one in
    the same PR**. No undocumented refutations enter this ledger. **Tag a cited
-   sharp edge `[edge:<slug>]`** (its kebab-name from the owning `CLAUDE.md`) in
-   the mechanism column, so the census's sharp-edge-citation leg harvests
-   citations mechanically instead of by hand-reading every anchor (#386).
+   sharp edge `[edge:<slug>]`** in the mechanism column — the slug is the
+   canonical one in
+   [`review-metrics/sharp-edge-inventory.md`](review-metrics/sharp-edge-inventory.md)
+   (CI's `just sharp-edge-inventory` rejects a tag that doesn't resolve there), so
+   the census's sharp-edge-citation leg harvests citations mechanically instead of
+   by hand-reading every anchor (#386).
 6. **Append-only.** A flipped verdict appends a superseding row that links the
    old one; the old row is never edited or deleted.
 7. **After adjudication, append**: a new dated `##` section, one row per

--- a/docs/review-metrics/sharp-edge-inventory.md
+++ b/docs/review-metrics/sharp-edge-inventory.md
@@ -1,0 +1,68 @@
+# Sharp-edge inventory — the canonical, slug-anchored set
+
+The full set of formal **"Known sharp edges"** bullets across the nested
+`crates/*/CLAUDE.md` guides, each with a STABLE kebab-slug. This is the canonical
+universe the review-history census's sharp-edge-citation leg counts against — so
+the leg is a script run (`scripts/sharp_edge_inventory.py`), not a hand-count, and
+the demotion clock is anchored to a committed artifact instead of being
+re-derived ad hoc each census (the #386 follow-through).
+
+**How it's used.** A REVIEW-LEDGER row that cites a documented sharp edge tags it
+`[edge:<slug>]` in the mechanism column (per the ledger protocol step 5). The
+census harvests those tags, counts citations per slug, and reports the uncited
+ones. **Demotion rule:** a slug uncited across **two consecutive censuses**
+(counting from census #4 — the first to use this committed inventory) is a
+demotion candidate (demote, never kill). The `last cited` column seeds the clock:
+`#2`/`#3` = the census that last cited it; `—` = not yet cited under the tracked
+window.
+
+**Drift guard.** `just sharp-edge-inventory` (and the CI hygiene job) asserts this
+inventory stays in lockstep with the CLAUDE.md sharp-edge bullets — a per-file
+count parity, so a sharp edge cannot be added or removed from a `CLAUDE.md`
+without updating this file (the `supported_sources_manifest` bridge-test pattern).
+It also flags any `[edge:<slug>]` in the ledger that doesn't resolve here (a typo
+or an orphaned citation).
+
+**`file` key → guide:** `core` = `crates/pixtuoid-core/CLAUDE.md` ·
+`tests` = `crates/pixtuoid-core/tests/CLAUDE.md` ·
+`scene` = `crates/pixtuoid-scene/CLAUDE.md` ·
+`bin` = `crates/pixtuoid/CLAUDE.md` ·
+`tui` = `crates/pixtuoid/src/tui/CLAUDE.md`.
+
+A `(←old-slug)` note records a slug whose prefix moved when its edge changed
+crates — the recolor / exit-compression / walk-leg edges moved `tui → scene` with
+the engine extraction (#346/#349), so the census's old `tui-*` names are re-anchored
+to `scene-*` here (the topic part is preserved so citation history stays traceable).
+
+| slug | file | last cited | headline |
+|---|---|---|---|
+| `core-cc-tool-use-id-dedup` | core | — | CC hook payloads DO include `tool_use_id` |
+| `core-cc-keys-on-session-uuid` | core | — | CC now keys on the session UUID, not the transcript path. |
+| `core-transcript-path-points-at-parent` | core | — | CC hook `transcript_path` always points to the PARENT'S transcript |
+| `core-jsonl-skips-historical-first-sight` | core | — | JSONL watcher skips historical transcripts — on EVERY first-sight path, not just startup. |
+| `core-watch-backend-native-vs-poll` | core | — | Watch backend: native in prod, polling in tests. |
+| `core-hook-from-unknown-id-registers` | core | — | A hook event from an UNKNOWN session id REGISTERS it — hooks are proof of life. |
+| `core-abrupt-exit-stale-sweep` | core | — | Agent removal needs a `SessionEnd`; abrupt exits have none and fall back to the slow stale-sweep. |
+| `core-resurrect-clean-correlation` | core | — | Resurrect-in-place starts from clean correlation state. |
+| `core-codex-subagents-via-hooks` | core | — | Codex subagents (`spawn_agent`) are wired via the `SubagentStart`/`SubagentStop` HOOKS, not JSONL paths. |
+| `core-subagent-name-from-attribution-agent` | core | — | Subagent display names come from `attributionAgent` in JSONL. |
+| `core-state-started-at-systemtime-serialize` | core | #2 | `AgentSlot.state_started_at` is `std::time::SystemTime` |
+| `core-active-not-tool-executing` | core | — | `ActivityState::Active` ≠ "tool is currently executing". |
+| `core-waiting-resolves-on-posttooluse` | core | — | The reducer's permission `Waiting` resolves on the gated tool's PostToolUse. |
+| `core-narrow-meeting-room-no-furniture` | core | — | A meeting room narrower than `MEETING_FURNITURE_MIN_W` (compute.rs) has NO sofa/table/seats — bare floor, BY DESIGN. |
+| `core-occlusion-is-emergent` | core | — | Occlusion is EMERGENT — there is no `occludes_behind` field / synthetic cap any more (deleted). |
+| `core-pantry-counter-shallow-strip` | core | #2 | Pantry counter blocks only a shallow `PANTRY_FOOTPRINT_DEPTH` south strip, not its full sprite height. |
+| `tests-two-tests-stay-flat` | tests | — | Two tests stay FLAT and MUST NOT be moved into a grouped binary |
+| `tests-multifile-binary-is-main-rs` | tests | — | A multi-file binary is `tests/<area>/main.rs`, NOT `tests/<area>.rs`. |
+| `tests-conformance-dir-must-be-registered-source` | tests | — | `conformance.rs` (the harness) asserts every dir under `sources/fixtures/` is a registered source |
+| `tests-insta-name-from-path` | tests | — | insta snapshot names = `<binary>__<module>__<explicit-name>` |
+| `scene-recolor-by-rgb-equality` | scene | #2 | `recolor_frame` substitutes by RGB equality. (←tui-recolor-by-rgb-equality) |
+| `scene-exit-compression-not-snapback` | scene | — | EXIT walks are time-compressed to fit the GC window; entry/wander/snap-back are not. (←tui-exit-compression-not-snapback) |
+| `scene-walk-leg-frozen-polyline` | scene | — | A walk leg's A\* polyline shape is frozen once per leg, not re-routed per frame. (←tui-walk-leg-frozen-polyline) |
+| `bin-terminal-cell-aspect` | bin | — | Terminal cell aspect drives sprite design. |
+| `bin-max-desks-no-default` | bin | #3 | `--max-desks` has no hard default. |
+| `bin-reinstall-noop-backup-append` | bin | — | Re-install is a SEMANTIC no-op, and backups APPEND their suffix. |
+| `bin-two-presenters-one-source-core` | bin | — | Two surfaces bind a source, ONE core. |
+| `bin-code-artifact-install-verify-coverage` | bin | — | Code-artifact targets: install writes ⊆ verify checks (#387). |
+| `tui-draw-scene-via-tuirenderer` | tui | — | `draw_scene` is called through `TuiRenderer` |
+| `tui-version-popup-url-rect-lockstep` | tui | — | The version popup's URL click-rect (`version_popup_url_rect`) derives its offsets from the SAME `PANEL_PAD_*` consts the painter insets by |

--- a/docs/review-metrics/sharp-edge-inventory.md
+++ b/docs/review-metrics/sharp-edge-inventory.md
@@ -1,68 +1,83 @@
 # Sharp-edge inventory — the canonical, slug-anchored set
 
-The full set of formal **"Known sharp edges"** bullets across the nested
-`crates/*/CLAUDE.md` guides, each with a STABLE kebab-slug. This is the canonical
-universe the review-history census's sharp-edge-citation leg counts against — so
-the leg is a script run (`scripts/sharp_edge_inventory.py`), not a hand-count, and
-the demotion clock is anchored to a committed artifact instead of being
-re-derived ad hoc each census (the #386 follow-through).
+The full set of sharp edges the review-history census's sharp-edge-citation leg
+counts against — a COMMITTED artifact with stable kebab-slugs, so the leg is a
+script run (`scripts/sharp_edge_inventory.py`), not a hand-count, and the demotion
+clock anchors here instead of being re-derived each census (the #386
+follow-through).
 
 **How it's used.** A REVIEW-LEDGER row that cites a documented sharp edge tags it
-`[edge:<slug>]` in the mechanism column (per the ledger protocol step 5). The
-census harvests those tags, counts citations per slug, and reports the uncited
-ones. **Demotion rule:** a slug uncited across **two consecutive censuses**
-(counting from census #4 — the first to use this committed inventory) is a
-demotion candidate (demote, never kill). The `last cited` column seeds the clock:
-`#2`/`#3` = the census that last cited it; `—` = not yet cited under the tracked
-window.
+`[edge:<slug>]` in the mechanism column (ledger protocol step 5). The census
+harvests those tags, counts citations per slug, reports the uncited.
 
-**Drift guard.** `just sharp-edge-inventory` (and the CI hygiene job) asserts this
-inventory stays in lockstep with the CLAUDE.md sharp-edge bullets — a per-file
-count parity, so a sharp edge cannot be added or removed from a `CLAUDE.md`
-without updating this file (the `supported_sources_manifest` bridge-test pattern).
-It also flags any `[edge:<slug>]` in the ledger that doesn't resolve here (a typo
-or an orphaned citation).
+**Three `kind`s of row:**
+- **`edge`** — a formal `- **…**` bullet in a guide's "Known sharp edges" section.
+  These are the count-parity'd set (see Drift guard).
+- **`qa`** — a load-bearing invariant documented in a guide's "Where to look" /
+  "Things NOT to do" prose rather than a bullet, but which the review corpus
+  demonstrably cites (e.g. `floor_idx`-immutable, the per-CLI path-resolution
+  rule — census #3 cited both). They are citeable + orphan-resolved but NOT
+  count-parity'd (they have no bullet to count).
+- **`alias`** — a retired slug kept so an OLD citation still resolves. The
+  recolor / exit-compression / walk-leg edges moved `tui → scene` with the engine
+  crate extraction (#346/#349), so the census's `tui-*` names alias the `scene-*`
+  ones.
+
+**Demotion clock.** The `last cited` value is a real clock position (the census
+that last cited the slug), not mere provenance: a slug uncited from its seed
+through two further consecutive censuses is a demotion candidate (demote, never
+kill). `—` = not yet cited under the tracked window.
+
+**Drift guard.** `just sharp-edge-inventory` (gated in CI hygiene) asserts the
+`edge` rows stay in **per-file count parity** with the CLAUDE.md sharp-edge bullets
+— a sharp edge can't be added/removed from a guide without updating this file (the
+`supported_sources_manifest` bridge-test pattern). It also rejects any ledger
+`[edge:<slug>]` that doesn't resolve to a row here. **Parity is by COUNT, not
+content**: an in-place edit that repurposes a bullet without changing the count is
+NOT caught here — the slug↔edge correspondence is by convention, re-verified when
+the census re-reads each edge. So a bullet rewrite should still update this file.
 
 **`file` key → guide:** `core` = `crates/pixtuoid-core/CLAUDE.md` ·
 `tests` = `crates/pixtuoid-core/tests/CLAUDE.md` ·
 `scene` = `crates/pixtuoid-scene/CLAUDE.md` ·
 `bin` = `crates/pixtuoid/CLAUDE.md` ·
-`tui` = `crates/pixtuoid/src/tui/CLAUDE.md`.
+`tui` = `crates/pixtuoid/src/tui/CLAUDE.md` ·
+`root` = `CLAUDE.md` (workspace; `qa` rows only).
 
-A `(←old-slug)` note records a slug whose prefix moved when its edge changed
-crates — the recolor / exit-compression / walk-leg edges moved `tui → scene` with
-the engine extraction (#346/#349), so the census's old `tui-*` names are re-anchored
-to `scene-*` here (the topic part is preserved so citation history stays traceable).
-
-| slug | file | last cited | headline |
-|---|---|---|---|
-| `core-cc-tool-use-id-dedup` | core | — | CC hook payloads DO include `tool_use_id` |
-| `core-cc-keys-on-session-uuid` | core | — | CC now keys on the session UUID, not the transcript path. |
-| `core-transcript-path-points-at-parent` | core | — | CC hook `transcript_path` always points to the PARENT'S transcript |
-| `core-jsonl-skips-historical-first-sight` | core | — | JSONL watcher skips historical transcripts — on EVERY first-sight path, not just startup. |
-| `core-watch-backend-native-vs-poll` | core | — | Watch backend: native in prod, polling in tests. |
-| `core-hook-from-unknown-id-registers` | core | — | A hook event from an UNKNOWN session id REGISTERS it — hooks are proof of life. |
-| `core-abrupt-exit-stale-sweep` | core | — | Agent removal needs a `SessionEnd`; abrupt exits have none and fall back to the slow stale-sweep. |
-| `core-resurrect-clean-correlation` | core | — | Resurrect-in-place starts from clean correlation state. |
-| `core-codex-subagents-via-hooks` | core | — | Codex subagents (`spawn_agent`) are wired via the `SubagentStart`/`SubagentStop` HOOKS, not JSONL paths. |
-| `core-subagent-name-from-attribution-agent` | core | — | Subagent display names come from `attributionAgent` in JSONL. |
-| `core-state-started-at-systemtime-serialize` | core | #2 | `AgentSlot.state_started_at` is `std::time::SystemTime` |
-| `core-active-not-tool-executing` | core | — | `ActivityState::Active` ≠ "tool is currently executing". |
-| `core-waiting-resolves-on-posttooluse` | core | — | The reducer's permission `Waiting` resolves on the gated tool's PostToolUse. |
-| `core-narrow-meeting-room-no-furniture` | core | — | A meeting room narrower than `MEETING_FURNITURE_MIN_W` (compute.rs) has NO sofa/table/seats — bare floor, BY DESIGN. |
-| `core-occlusion-is-emergent` | core | — | Occlusion is EMERGENT — there is no `occludes_behind` field / synthetic cap any more (deleted). |
-| `core-pantry-counter-shallow-strip` | core | #2 | Pantry counter blocks only a shallow `PANTRY_FOOTPRINT_DEPTH` south strip, not its full sprite height. |
-| `tests-two-tests-stay-flat` | tests | — | Two tests stay FLAT and MUST NOT be moved into a grouped binary |
-| `tests-multifile-binary-is-main-rs` | tests | — | A multi-file binary is `tests/<area>/main.rs`, NOT `tests/<area>.rs`. |
-| `tests-conformance-dir-must-be-registered-source` | tests | — | `conformance.rs` (the harness) asserts every dir under `sources/fixtures/` is a registered source |
-| `tests-insta-name-from-path` | tests | — | insta snapshot names = `<binary>__<module>__<explicit-name>` |
-| `scene-recolor-by-rgb-equality` | scene | #2 | `recolor_frame` substitutes by RGB equality. (←tui-recolor-by-rgb-equality) |
-| `scene-exit-compression-not-snapback` | scene | — | EXIT walks are time-compressed to fit the GC window; entry/wander/snap-back are not. (←tui-exit-compression-not-snapback) |
-| `scene-walk-leg-frozen-polyline` | scene | — | A walk leg's A\* polyline shape is frozen once per leg, not re-routed per frame. (←tui-walk-leg-frozen-polyline) |
-| `bin-terminal-cell-aspect` | bin | — | Terminal cell aspect drives sprite design. |
-| `bin-max-desks-no-default` | bin | #3 | `--max-desks` has no hard default. |
-| `bin-reinstall-noop-backup-append` | bin | — | Re-install is a SEMANTIC no-op, and backups APPEND their suffix. |
-| `bin-two-presenters-one-source-core` | bin | — | Two surfaces bind a source, ONE core. |
-| `bin-code-artifact-install-verify-coverage` | bin | — | Code-artifact targets: install writes ⊆ verify checks (#387). |
-| `tui-draw-scene-via-tuirenderer` | tui | — | `draw_scene` is called through `TuiRenderer` |
-| `tui-version-popup-url-rect-lockstep` | tui | — | The version popup's URL click-rect (`version_popup_url_rect`) derives its offsets from the SAME `PANEL_PAD_*` consts the painter insets by |
+| slug | file | kind | last cited | headline |
+|---|---|---|---|---|
+| `core-cc-tool-use-id-dedup` | core | edge | — | CC hook payloads DO include `tool_use_id` |
+| `core-cc-keys-on-session-uuid` | core | edge | — | CC now keys on the session UUID, not the transcript path. |
+| `core-transcript-path-points-at-parent` | core | edge | — | CC hook `transcript_path` always points to the PARENT'S transcript |
+| `core-jsonl-skips-historical-first-sight` | core | edge | — | JSONL watcher skips historical transcripts — on EVERY first-sight path, not just startup. |
+| `core-watch-backend-native-vs-poll` | core | edge | — | Watch backend: native in prod, polling in tests. |
+| `core-hook-from-unknown-id-registers` | core | edge | — | A hook event from an UNKNOWN session id REGISTERS it — hooks are proof of life. |
+| `core-abrupt-exit-stale-sweep` | core | edge | — | Agent removal needs a `SessionEnd`; abrupt exits have none and fall back to the slow stale-sweep. |
+| `core-resurrect-clean-correlation` | core | edge | — | Resurrect-in-place starts from clean correlation state. |
+| `core-codex-subagents-via-hooks` | core | edge | — | Codex subagents (`spawn_agent`) are wired via the `SubagentStart`/`SubagentStop` HOOKS, not JSONL paths. |
+| `core-subagent-name-from-attribution-agent` | core | edge | — | Subagent display names come from `attributionAgent` in JSONL. |
+| `core-state-started-at-systemtime-serialize` | core | edge | #2 | `AgentSlot.state_started_at` is `std::time::SystemTime` |
+| `core-active-not-tool-executing` | core | edge | — | `ActivityState::Active` ≠ "tool is currently executing". |
+| `core-waiting-resolves-on-posttooluse` | core | edge | — | The reducer's permission `Waiting` resolves on the gated tool's PostToolUse. |
+| `core-narrow-meeting-room-no-furniture` | core | edge | — | A meeting room narrower than `MEETING_FURNITURE_MIN_W` (compute.rs) has NO sofa/table/seats — bare floor, BY DESIGN. |
+| `core-occlusion-is-emergent` | core | edge | — | Occlusion is EMERGENT — there is no `occludes_behind` field / synthetic cap any more (deleted). |
+| `core-pantry-counter-shallow-strip` | core | edge | #2 | Pantry counter blocks only a shallow `PANTRY_FOOTPRINT_DEPTH` south strip, not its full sprite height. |
+| `tests-two-tests-stay-flat` | tests | edge | — | Two tests stay FLAT and MUST NOT be moved into a grouped binary |
+| `tests-multifile-binary-is-main-rs` | tests | edge | — | A multi-file binary is `tests/<area>/main.rs`, NOT `tests/<area>.rs`. |
+| `tests-conformance-dir-must-be-registered-source` | tests | edge | — | `conformance.rs` (the harness) asserts every dir under `sources/fixtures/` is a registered source |
+| `tests-insta-name-from-path` | tests | edge | — | insta snapshot names = `<binary>__<module>__<explicit-name>` |
+| `scene-recolor-by-rgb-equality` | scene | edge | #2 | `recolor_frame` substitutes by RGB equality. (←tui-recolor-by-rgb-equality) |
+| `scene-exit-compression-not-snapback` | scene | edge | — | EXIT walks are time-compressed to fit the GC window; entry/wander/snap-back are not. (←tui-exit-compression-not-snapback) |
+| `scene-walk-leg-frozen-polyline` | scene | edge | — | A walk leg's A\* polyline shape is frozen once per leg, not re-routed per frame. (←tui-walk-leg-frozen-polyline) |
+| `bin-terminal-cell-aspect` | bin | edge | — | Terminal cell aspect drives sprite design. |
+| `bin-max-desks-no-default` | bin | edge | #3 | `--max-desks` has no hard default. |
+| `bin-reinstall-noop-backup-append` | bin | edge | — | Re-install is a SEMANTIC no-op, and backups APPEND their suffix. |
+| `bin-two-presenters-one-source-core` | bin | edge | — | Two surfaces bind a source, ONE core. |
+| `bin-code-artifact-install-verify-coverage` | bin | edge | — | Code-artifact targets: install writes ⊆ verify checks (#387). |
+| `tui-draw-scene-via-tuirenderer` | tui | edge | — | `draw_scene` is called through `TuiRenderer` |
+| `tui-version-popup-url-rect-lockstep` | tui | edge | — | The version popup's URL click-rect (`version_popup_url_rect`) derives its offsets from the SAME `PANEL_PAD_*` consts the painter insets by |
+| `scene-floor-idx-immutable-snapshot` | scene | qa | #3 | `floor_idx` is set once at desk assignment and immutable thereafter; re-deriving it migrates agents to wrong desks (Q&A invariant, not a bullet). |
+| `root-path-resolution-policy` | root | qa | #3 | Mirror each CLI's own authoritative config resolver — don't blanket-generalize (the "Things NOT to do" per-CLI mirroring rule). |
+| `tui-recolor-by-rgb-equality` | scene | alias | — | retired → `scene-recolor-by-rgb-equality` (moved tui→scene, #346/#349). |
+| `tui-exit-compression-not-snapback` | scene | alias | — | retired → `scene-exit-compression-not-snapback` (moved tui→scene, #346/#349). |
+| `tui-walk-leg-frozen-polyline` | scene | alias | — | retired → `scene-walk-leg-frozen-polyline` (moved tui→scene, #346/#349). |

--- a/justfile
+++ b/justfile
@@ -550,6 +550,21 @@ census-reminder:
 census-reminder-selftest:
     python3 scripts/census_reminder_selftest.py
 
+# Validate docs/review-metrics/sharp-edge-inventory.md against the CLAUDE.md sharp
+# edges (per-file count parity) + the ledger's [edge:<slug>] citations. A sharp
+# edge can't be added/removed from a CLAUDE.md without updating the inventory (the
+# census sharp-edge leg counts against it). Gated in the CI hygiene job. Pure, no network.
+[group('meta')]
+[doc('Validate the sharp-edge inventory vs CLAUDE.md + the ledger (#386)')]
+sharp-edge-inventory:
+    python3 scripts/sharp_edge_inventory.py
+
+# Self-test the sharp-edge-inventory parsers (count/rows/citation regexes).
+[group('meta')]
+[doc('Self-test the sharp-edge-inventory validator (parsers)')]
+sharp-edge-inventory-selftest:
+    python3 scripts/sharp_edge_inventory_selftest.py
+
 # Audit one or more PRs' claude[bot] MEDIUM+ inline findings for a disposition
 # trace (a `Bot-findings-adjudicated:` marker — see CONTRIBUTING.md). ADVISORY:
 # run during the merge disposition sweep to catch the #283 class (a MEDIUM+

--- a/scripts/sharp_edge_inventory.py
+++ b/scripts/sharp_edge_inventory.py
@@ -74,9 +74,25 @@ def ledger_citations(ledger_md: str) -> "list[str]":
     return _CITE.findall(ledger_md)
 
 
+def duplicate_slugs(rows: "list[tuple[str, str, str]]") -> "list[str]":
+    """Slugs that appear on more than one inventory row — the slug is the citation
+    key, so a duplicate is ambiguous (and would otherwise surface only as a
+    misleading count DRIFT)."""
+    counts = Counter(slug for slug, _, _ in rows)
+    return sorted(slug for slug, n in counts.items() if n > 1)
+
+
 def check() -> "list[str]":
     problems: list[str] = []
     rows = inventory_rows(INVENTORY.read_text())
+
+    # A duplicate slug is named explicitly (else it only shows as a confusing
+    # per-file count DRIFT) — the slug is the ledger's citation key, must be unique.
+    for slug in duplicate_slugs(rows):
+        problems.append(
+            f"DUPLICATE SLUG: `{slug}` appears on multiple inventory rows — "
+            "the slug is the citation key and must be unique"
+        )
 
     # Count parity applies ONLY to `edge` rows (qa/alias have no `- **` bullet).
     edge_per_file = Counter(fk for _, fk, kind in rows if kind == "edge")

--- a/scripts/sharp_edge_inventory.py
+++ b/scripts/sharp_edge_inventory.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Keep `docs/review-metrics/sharp-edge-inventory.md` in lockstep with the
+CLAUDE.md sharp edges, and validate the ledger's `[edge:<slug>]` citations.
+
+The review-history census's sharp-edge-citation leg counts ledger citations
+against a canonical slug set. This makes that set a COMMITTED artifact (the
+inventory) instead of an ad-hoc per-census harvest (#386), and guards it two ways
+— the `supported_sources_manifest` bridge-test pattern:
+
+  1. **Per-file count parity** — each nested CLAUDE.md's "Known sharp edges"
+     bullet count must equal the inventory rows for that guide, so a sharp edge
+     can't be added/removed from a CLAUDE.md without updating the inventory (the
+     silent-drift the leg would otherwise mis-measure).
+  2. **No orphan citations** — every `[edge:<slug>]` in REVIEW-LEDGER.md must
+     resolve to an inventory slug (a typo / a removed edge is a dangling cite).
+
+Pure parsers + a thin I/O `main`; offline. Run: `python3 scripts/sharp_edge_inventory.py`
+(exit 0 = in sync) or `--selftest`.
+"""
+
+import argparse
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+# inventory `file` key → the guide it indexes.
+FILE_MAP = {
+    "core": "crates/pixtuoid-core/CLAUDE.md",
+    "tests": "crates/pixtuoid-core/tests/CLAUDE.md",
+    "scene": "crates/pixtuoid-scene/CLAUDE.md",
+    "bin": "crates/pixtuoid/CLAUDE.md",
+    "tui": "crates/pixtuoid/src/tui/CLAUDE.md",
+}
+INVENTORY = Path("docs/review-metrics/sharp-edge-inventory.md")
+LEDGER = Path("docs/REVIEW-LEDGER.md")
+
+_SECTION_HDR = re.compile(r"^## (Known sharp edges|Sharp edges)\b")
+_ROW = re.compile(r"^\|\s*`([a-z0-9-]+)`\s*\|\s*(\w+)\s*\|")
+_CITE = re.compile(r"\[edge:([a-z0-9-]+)\]")
+
+
+def count_sharp_edges(claude_md: str) -> int:
+    """Formal sharp-edge bullets = the `- **…**` lines under the
+    "Known sharp edges"/"Sharp edges" `##` header, up to the next `##`."""
+    in_section = False
+    n = 0
+    for line in claude_md.splitlines():
+        if _SECTION_HDR.match(line):
+            in_section = True
+            continue
+        if in_section and line.startswith("## "):
+            break
+        if in_section and line.startswith("- **"):
+            n += 1
+    return n
+
+
+def inventory_rows(inventory_md: str) -> "list[tuple[str, str]]":
+    """The (slug, file-key) pairs from the inventory table's data rows."""
+    return [(m.group(1), m.group(2)) for line in inventory_md.splitlines() if (m := _ROW.match(line))]
+
+
+def ledger_citations(ledger_md: str) -> "list[str]":
+    """Every `[edge:<slug>]` tag in the ledger."""
+    return _CITE.findall(ledger_md)
+
+
+def check() -> "list[str]":
+    problems: list[str] = []
+    rows = inventory_rows(INVENTORY.read_text())
+    per_file = Counter(fk for _, fk in rows)
+
+    for fk, path in FILE_MAP.items():
+        actual = count_sharp_edges(Path(path).read_text())
+        listed = per_file.get(fk, 0)
+        if actual != listed:
+            problems.append(
+                f"DRIFT: {path} has {actual} sharp-edge bullet(s) but the inventory "
+                f"lists {listed} for `{fk}` — update {INVENTORY}"
+            )
+    for slug, fk in rows:
+        if fk not in FILE_MAP:
+            problems.append(f"BAD FILE KEY: inventory slug `{slug}` names unknown guide `{fk}`")
+
+    slugs = {s for s, _ in rows}
+    for cited in sorted(set(ledger_citations(LEDGER.read_text()))):
+        if cited not in slugs:
+            problems.append(
+                f"ORPHAN CITATION: {LEDGER} cites [edge:{cited}] but no such slug is in "
+                f"the inventory (typo, or a removed edge)"
+            )
+    return problems
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Validate the sharp-edge inventory vs CLAUDE.md + the ledger.")
+    ap.add_argument("--selftest", action="store_true", help="run pure-fn tests, no I/O")
+    if ap.parse_args().selftest:
+        import sharp_edge_inventory_selftest as st
+
+        return st.run()
+    problems = check()
+    if problems:
+        print("sharp-edge inventory: OUT OF SYNC")
+        for p in problems:
+            print(f"  ✗ {p}")
+        return 1
+    rows = inventory_rows(INVENTORY.read_text())
+    print(
+        f"sharp-edge inventory: in sync ({len(rows)} edges across {len(FILE_MAP)} guides; "
+        "ledger citations resolve)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sharp_edge_inventory.py
+++ b/scripts/sharp_edge_inventory.py
@@ -32,11 +32,15 @@ FILE_MAP = {
     "bin": "crates/pixtuoid/CLAUDE.md",
     "tui": "crates/pixtuoid/src/tui/CLAUDE.md",
 }
+# `qa`/`alias` rows may also point at the workspace root guide (no countable
+# bullets there); only `edge` rows are count-parity'd against FILE_MAP.
+QA_FILES = set(FILE_MAP) | {"root"}
 INVENTORY = Path("docs/review-metrics/sharp-edge-inventory.md")
 LEDGER = Path("docs/REVIEW-LEDGER.md")
 
 _SECTION_HDR = re.compile(r"^## (Known sharp edges|Sharp edges)\b")
-_ROW = re.compile(r"^\|\s*`([a-z0-9-]+)`\s*\|\s*(\w+)\s*\|")
+# | `<slug>` | <file> | <kind> | …
+_ROW = re.compile(r"^\|\s*`([a-z0-9-]+)`\s*\|\s*(\w+)\s*\|\s*(\w+)\s*\|")
 _CITE = re.compile(r"\[edge:([a-z0-9-]+)\]")
 
 
@@ -56,9 +60,13 @@ def count_sharp_edges(claude_md: str) -> int:
     return n
 
 
-def inventory_rows(inventory_md: str) -> "list[tuple[str, str]]":
-    """The (slug, file-key) pairs from the inventory table's data rows."""
-    return [(m.group(1), m.group(2)) for line in inventory_md.splitlines() if (m := _ROW.match(line))]
+def inventory_rows(inventory_md: str) -> "list[tuple[str, str, str]]":
+    """The (slug, file-key, kind) triples from the inventory table's data rows."""
+    return [
+        (m.group(1), m.group(2), m.group(3))
+        for line in inventory_md.splitlines()
+        if (m := _ROW.match(line))
+    ]
 
 
 def ledger_citations(ledger_md: str) -> "list[str]":
@@ -69,21 +77,27 @@ def ledger_citations(ledger_md: str) -> "list[str]":
 def check() -> "list[str]":
     problems: list[str] = []
     rows = inventory_rows(INVENTORY.read_text())
-    per_file = Counter(fk for _, fk in rows)
 
+    # Count parity applies ONLY to `edge` rows (qa/alias have no `- **` bullet).
+    edge_per_file = Counter(fk for _, fk, kind in rows if kind == "edge")
     for fk, path in FILE_MAP.items():
         actual = count_sharp_edges(Path(path).read_text())
-        listed = per_file.get(fk, 0)
+        listed = edge_per_file.get(fk, 0)
         if actual != listed:
             problems.append(
                 f"DRIFT: {path} has {actual} sharp-edge bullet(s) but the inventory "
-                f"lists {listed} for `{fk}` — update {INVENTORY}"
+                f"lists {listed} `edge` row(s) for `{fk}` — update {INVENTORY}"
             )
-    for slug, fk in rows:
-        if fk not in FILE_MAP:
-            problems.append(f"BAD FILE KEY: inventory slug `{slug}` names unknown guide `{fk}`")
 
-    slugs = {s for s, _ in rows}
+    for slug, fk, kind in rows:
+        allowed = FILE_MAP if kind == "edge" else QA_FILES
+        if fk not in allowed:
+            problems.append(
+                f"BAD FILE KEY: inventory `{kind}` slug `{slug}` names unknown guide `{fk}`"
+            )
+
+    # Orphan check resolves against EVERY slug (edge + qa + alias).
+    slugs = {s for s, _, _ in rows}
     for cited in sorted(set(ledger_citations(LEDGER.read_text()))):
         if cited not in slugs:
             problems.append(
@@ -106,10 +120,10 @@ def main() -> int:
         for p in problems:
             print(f"  ✗ {p}")
         return 1
-    rows = inventory_rows(INVENTORY.read_text())
+    kinds = Counter(kind for _, _, kind in inventory_rows(INVENTORY.read_text()))
     print(
-        f"sharp-edge inventory: in sync ({len(rows)} edges across {len(FILE_MAP)} guides; "
-        "ledger citations resolve)"
+        f"sharp-edge inventory: in sync ({kinds['edge']} edges / {kinds['qa']} qa / "
+        f"{kinds['alias']} alias across {len(FILE_MAP)} guides; ledger citations resolve)"
     )
     return 0
 

--- a/scripts/sharp_edge_inventory_selftest.py
+++ b/scripts/sharp_edge_inventory_selftest.py
@@ -54,6 +54,13 @@ def run() -> int:
     )
     check("skips header + separator", all(s not in ("slug", "---") for s, _, _ in rows))
 
+    # duplicate_slugs: names a slug repeated across rows (the citation-key clash).
+    check(
+        "duplicate_slugs finds the repeat",
+        m.duplicate_slugs([("a", "core", "edge"), ("a", "scene", "qa"), ("b", "bin", "edge")]) == ["a"],
+    )
+    check("duplicate_slugs clean -> []", m.duplicate_slugs([("a", "core", "edge"), ("b", "bin", "edge")]) == [])
+
     # ledger_citations: every [edge:<slug>] tag, nothing else.
     led = "row cites [edge:core-foo] and [edge:bin-max-desks-no-default]; not [issue:1] or `code`."
     cites = m.ledger_citations(led)

--- a/scripts/sharp_edge_inventory_selftest.py
+++ b/scripts/sharp_edge_inventory_selftest.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Self-test for sharp_edge_inventory.py — pins the three parsers so a regex
+regression can't silently let the inventory drift from the CLAUDE.md edges (the
+census would then mis-count citations). Pure, no I/O. Run:
+`python3 scripts/sharp_edge_inventory_selftest.py` (exit 0 = pass)."""
+
+import sys
+
+import sharp_edge_inventory as m
+
+
+def run() -> int:
+    fails: list[str] = []
+
+    def check(name: str, cond: bool) -> None:
+        if not cond:
+            fails.append(name)
+
+    # count_sharp_edges: counts `- **` bullets ONLY inside the sharp-edges section.
+    # A bold bullet before the section, a sub-bullet, a wrapped continuation line,
+    # and a bullet in the NEXT section must all be excluded.
+    md = (
+        "# Guide\n\n"
+        "- **not an edge** this bullet is above the section\n\n"
+        "## Known sharp edges (don't be surprised by these)\n\n"
+        "- **Edge one** the first edge\n"
+        "  continuation line, still edge one\n"
+        "  - **a sub-bullet** must not count\n"
+        "- **Edge two** the second edge\n"
+        "- **Edge three** the third\n\n"
+        "## Where to look\n\n"
+        "- **not an edge** this is in the next section\n"
+    )
+    check("counts exactly the 3 section bullets", m.count_sharp_edges(md) == 3)
+    check("empty doc -> 0", m.count_sharp_edges("# x\n") == 0)
+    # the alternate header spelling ("## Sharp edges") also matches.
+    check(
+        "alternate 'Sharp edges' header",
+        m.count_sharp_edges("## Sharp edges\n- **a** x\n- **b** y\n") == 2,
+    )
+
+    # inventory_rows: data rows only (backtick slug + file key); header/separator skipped.
+    inv = (
+        "| slug | file | last cited | headline |\n"
+        "|---|---|---|---|\n"
+        "| `core-foo` | core | — | Foo |\n"
+        "| `scene-bar` | scene | #2 | Bar |\n"
+    )
+    rows = m.inventory_rows(inv)
+    check("parses 2 data rows", rows == [("core-foo", "core"), ("scene-bar", "scene")])
+    check("skips header + separator", all(s not in ("slug", "---") for s, _ in rows))
+
+    # ledger_citations: every [edge:<slug>] tag, nothing else.
+    led = "row cites [edge:core-foo] and [edge:bin-max-desks-no-default]; not [issue:1] or `code`."
+    cites = m.ledger_citations(led)
+    check("finds both edge cites", cites == ["core-foo", "bin-max-desks-no-default"])
+    check("no false cite", "issue" not in "".join(cites))
+
+    if fails:
+        print("sharp_edge_inventory selftest FAILED:")
+        for f in fails:
+            print(f"  ✗ {f}")
+        return 1
+    print("sharp_edge_inventory selftest: all assertions passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/scripts/sharp_edge_inventory_selftest.py
+++ b/scripts/sharp_edge_inventory_selftest.py
@@ -39,16 +39,20 @@ def run() -> int:
         m.count_sharp_edges("## Sharp edges\n- **a** x\n- **b** y\n") == 2,
     )
 
-    # inventory_rows: data rows only (backtick slug + file key); header/separator skipped.
+    # inventory_rows: (slug, file, kind) from data rows only; header/separator skipped.
     inv = (
-        "| slug | file | last cited | headline |\n"
-        "|---|---|---|---|\n"
-        "| `core-foo` | core | — | Foo |\n"
-        "| `scene-bar` | scene | #2 | Bar |\n"
+        "| slug | file | kind | last cited | headline |\n"
+        "|---|---|---|---|---|\n"
+        "| `core-foo` | core | edge | — | Foo |\n"
+        "| `scene-bar` | scene | qa | #2 | Bar |\n"
+        "| `tui-old` | scene | alias | — | retired → scene-bar |\n"
     )
     rows = m.inventory_rows(inv)
-    check("parses 2 data rows", rows == [("core-foo", "core"), ("scene-bar", "scene")])
-    check("skips header + separator", all(s not in ("slug", "---") for s, _ in rows))
+    check(
+        "parses 3 rows with kind",
+        rows == [("core-foo", "core", "edge"), ("scene-bar", "scene", "qa"), ("tui-old", "scene", "alias")],
+    )
+    check("skips header + separator", all(s not in ("slug", "---") for s, _, _ in rows))
 
     # ledger_citations: every [edge:<slug>] tag, nothing else.
     led = "row cites [edge:core-foo] and [edge:bin-max-desks-no-default]; not [issue:1] or `code`."


### PR DESCRIPTION
Closes the **#386** follow-through: makes census #4's sharp-edge-citation leg a script run instead of a hand-count, and anchors the demotion clock to a committed artifact.

## What
- **`docs/review-metrics/sharp-edge-inventory.md`** — the canonical set: all **30** formal CLAUDE.md sharp edges, each with a stable kebab-slug the ledger cites as `[edge:<slug>]`. Built by 5 parallel per-file extractors. Re-anchors the 3 edges that moved `tui→scene` with the engine-crate extraction (#346/#349); adds the 3 genuinely new edges since the census's 27-edge subset (`bin-two-presenters-one-source-core`, `bin-code-artifact-install-verify-coverage` #387, `tui-version-popup-url-rect-lockstep`).
- **`scripts/sharp_edge_inventory.py`** (+ selftest) — the **drift gate**:
  - *per-file count parity* — a sharp edge can't be added/removed from a `CLAUDE.md` without updating the inventory (the `supported_sources_manifest` bridge-test pattern).
  - *orphan-citation check* — every `[edge:<slug>]` in `REVIEW-LEDGER.md` must resolve to an inventory slug (a typo/removed edge is a dangling cite).
  - Wired into the **CI hygiene job** + `just sharp-edge-inventory`.
- **Docs** — `KNOWLEDGE-ENGINEERING.md`'s demotion rule + the REVIEW-LEDGER protocol step 5 now point at the committed inventory as the canonical slug source.

## Why it was needed
Census #3 deferred all sharp-edge demotions because the 27-edge subset was skewed and the slugs were census-internal/ad-hoc (the WCR review flagged `[edge:<slug>]` couldn't be applied — edges had no slugs). This commits the slugs + a drift gate so the leg is mechanical going forward.

## Verification
- Drift gate **has teeth**: caught an injected fake edge bullet **and** a non-kebab slug (`attributionAgent` → normalized).
- `sharp_edge_inventory` selftest green · live check **in sync** (30 edges / 5 guides; citations resolve) · `actionlint` + `lychee --offline` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PucHLSPY32y1SRsXemYBGK