### PR TITLE
docs(claude-md): list the 3 governance scripts in the scripts/ map

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,18 @@ scripts/             gen-media.py + media.json (the ONE manifest-driven driver f
                      the lobster AND its backend `cc·<workspace>` coding sprite coexist live; real
                      account/gateway footprint, NOT a CI test),
                      check_upstream_drift.py (weekly wire-format watch),
-                     review-metrics.py (review-economics collector)
+                     review-metrics.py (review-economics collector),
+                     census_reminder.py (weekly `census-reminder` Action: is a
+                     review-history census due vs the ~50-PR window? → auto-files a
+                     deduped `census` issue; `just census-reminder` local),
+                     check_review_disposition.py (merge-time `review-disposition`
+                     gate: harvests a PR's claude[bot] MEDIUM+ findings → asserts each
+                     carries a disposition marker — the #283 silent-drop class),
+                     sharp_edge_inventory.py (CI-hygiene drift gate: keeps
+                     docs/review-metrics/sharp-edge-inventory.md in lockstep with the
+                     CLAUDE.md sharp-edge bullets + resolves ledger `[edge:<slug>]`
+                     citations → `just sharp-edge-inventory`; each governance script
+                     above has a `*_selftest.py` pinning its parsers, also CI-gated)
 site/                Astro landing page → GitHub Pages; self-contained Node project,
                      own CI; `just site-{setup,dev,check,fmt}` → see site/README.md
 integrations/raycast/  Raycast extension (TypeScript, self-contained Node project; NOT Rust):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,9 +67,10 @@ scripts/             gen-media.py + media.json (the ONE manifest-driven driver f
                      census_reminder.py (weekly `census-reminder` Action: is a
                      review-history census due vs the ~50-PR window? → auto-files a
                      deduped `census` issue; `just census-reminder` local),
-                     check_review_disposition.py (merge-time `review-disposition`
-                     gate: harvests a PR's claude[bot] MEDIUM+ findings → asserts each
-                     carries a disposition marker — the #283 silent-drop class),
+                     check_review_disposition.py (per-PR `review-disposition` Action,
+                     ADVISORY — never fails a PR: surfaces any claude[bot] MEDIUM+
+                     finding missing a `Bot-findings-adjudicated:` disposition marker so
+                     it can't be silently dropped — the #335/#384 silent-drop class),
                      sharp_edge_inventory.py (CI-hygiene drift gate: keeps
                      docs/review-metrics/sharp-edge-inventory.md in lockstep with the
                      CLAUDE.md sharp-edge bullets + resolves ledger `[edge:<slug>]`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,8 +69,8 @@ scripts/             gen-media.py + media.json (the ONE manifest-driven driver f
                      deduped `census` issue; `just census-reminder` local),
                      check_review_disposition.py (per-PR `review-disposition` Action,
                      ADVISORY — never fails a PR: surfaces any claude[bot] MEDIUM+
-                     finding missing a `Bot-findings-adjudicated:` disposition marker so
-                     it can't be silently dropped — the #335/#384 silent-drop class),
+                     finding lacking a `Bot-findings-adjudicated:` disposition marker —
+                     the #283 silent-drop class (channel built #335, adopted #384)),
                      sharp_edge_inventory.py (CI-hygiene drift gate: keeps
                      docs/review-metrics/sharp-edge-inventory.md in lockstep with the
                      CLAUDE.md sharp-edge bullets + resolves ledger `[edge:<slug>]`


### PR DESCRIPTION
## What

Adds three missing entries to the workspace `CLAUDE.md` `scripts/` map:

- `census_reminder.py` — weekly `census-reminder` Action (Mondays 09:00 UTC); flags a due review-history census vs the ~50-PR window → auto-files a deduped `census` issue (`just census-reminder` local).
- `check_review_disposition.py` — per-PR `review-disposition` Action, **advisory (never fails a PR)**; surfaces any `claude[bot]` MEDIUM+ finding missing a `Bot-findings-adjudicated:` disposition marker so it can't be silently dropped (the #335/#384 class).
- `sharp_edge_inventory.py` — CI-hygiene **drift gate**; keeps `docs/review-metrics/sharp-edge-inventory.md` in lockstep with the CLAUDE.md sharp-edge bullets + resolves ledger `[edge:<slug>]` citations (`just sharp-edge-inventory`).

## Why

All three were added across #390/#393/#395 **without** a line in the `scripts/` map — the first artifact a session reads. Each new line records *what the script does* **and** *when it runs* (its cron/CI gate, and whether it's advisory vs blocking), so that knowledge is discoverable from the map instead of by grep. Closes the exact docs-currency gap those governance gates are themselves built to prevent.

Prose-only change to `CLAUDE.md`; `just links` green. Descriptions verified against the actual workflow triggers — a second commit corrects the first draft, which mislabeled `review-disposition` as a "merge-time gate" (it's a per-PR advisory check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PucHLSPY32y1SRsXemYBGK