### PR TITLE
feat(cli): truecolor preflight, completions/man, macOS CI, trust docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,38 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  macos-test:
+    name: macos-test
+    # macOS is the primary dev/user platform (BSD CLI / launchd / ~/.config /
+    # ~/.claude path behavior diverges from Linux) yet was previously untested in
+    # CI — the homebrew-core submission was the first macOS build. macos-14 = Apple
+    # Silicon (the modern default); the winit/softbuffer `floating` deps build
+    # against the bundled SDK.
+    runs-on: macos-14
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v1-rust # see the clippy job's note
+      - uses: extractions/setup-just@v4
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@cargo-nextest
+      - run: just test
+        env:
+          NEXTEST_PROFILE: ci
+      - name: Upload test results to Codecov
+        if: always()
+        uses: codecov/codecov-action@v7
+        with:
+          files: target/nextest/ci/junit.xml
+          report-type: test_results
+          flags: macos
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
   semver:
     name: semver-checks
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,6 +403,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,6 +428,16 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clap_mangen"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82842b45bf9f6a3be090dd860095ac30728042c08e0d6261ca7259b5d850f07"
+dependencies = [
+ "clap",
+ "roff",
+]
 
 [[package]]
 name = "color_quant"
@@ -2222,6 +2241,8 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "clap_complete",
+ "clap_mangen",
  "crossterm",
  "image",
  "insta",
@@ -2662,6 +2683,12 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "roff"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
 
 [[package]]
 name = "rustc_version"

--- a/README.md
+++ b/README.md
@@ -131,6 +131,15 @@ Agent CLIs emit events two ways — a hook shim (a 200ms fire-and-forget write t
 
 **[Full architecture with diagrams →](https://ivanwng97.github.io/pixtuoid/architecture)** · single source: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
 
+## Privacy & Security
+
+pixtuoid is **local-only and telemetry-free** — it makes no network connections,
+ships no analytics or "phone home", and reads your agent transcripts read-only to
+animate the office. Your session data never leaves your machine. The dependency
+set is audited for advisories daily (`cargo-deny`). For the trust boundaries (the
+hook shim, the owner-only socket, and how hook installation edits another tool's
+config), see **[SECURITY.md](SECURITY.md)**.
+
 ## Contributing
 
 PRs welcome — especially new themes, sprite/decoration polish, and `Source` adapters for agent CLIs we don't support yet (the nine already wired up are in [Supported Tools](#supported-tools)). See **[CONTRIBUTING.md](docs/CONTRIBUTING.md)** for the build/test workflow, conventions, the review process, and how to add a new agent CLI. Architecture and the load-bearing invariants live in [`CLAUDE.md`](CLAUDE.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,14 +2,68 @@
 
 ## Supported Versions
 
-| Version | Supported |
-|---------|-----------|
-| latest  | Yes       |
+Fixes land on the latest released version; there are no maintained back-branches.
+Upgrade to the newest release (`cargo install pixtuoid`, `brew upgrade`, or
+`npm i -g pixtuoid`) to receive security fixes.
+
+| Version        | Supported |
+|----------------|-----------|
+| latest         | ✅        |
+| older releases | ❌        |
+
+## Privacy posture
+
+pixtuoid is **local-only and telemetry-free by design**:
+
+- **No network egress.** The binary makes no outbound network connections — no
+  analytics, crash-reporting upload, update check, or "phone home". (The crash
+  hook writes a backtrace to a *local* file and only ever offers a pre-filled
+  GitHub URL for you to open manually.) The dependency set is audited daily for
+  advisories via `cargo-deny` (see `.github/workflows/audit.yml`).
+- **Your session data stays on your machine.** pixtuoid reads your agent CLIs'
+  transcripts (e.g. `~/.claude/projects`, `~/.codex/sessions`) **read-only**, to
+  derive what each sprite is doing; nothing is transmitted anywhere.
+
+## Trust boundaries / attack surface
+
+The components that handle untrusted or privileged input, and how they're bounded:
+
+1. **The hook shim (`pixtuoid-hook`)** is invoked by your agent CLI and forwards a
+   single JSON line from stdin to the office over a **Unix domain socket** (a
+   per-user runtime path — `$XDG_RUNTIME_DIR/pixtuoid.sock`, else
+   `/tmp/pixtuoid-<uid>.sock`; `PIXTUOID_SOCKET` overrides — created `0600`,
+   owner-only) or a Windows named pipe. It is a *local IPC* — there is no network
+   listener. The shim is hardened to **never block the agent**: it always exits
+   `0`, within a hard ~200 ms watchdog bound, on any error. It does not execute or
+   shell out to anything in the payload.
+
+2. **The office's socket listener** binds that owner-only socket with a flock'd,
+   `O_NOFOLLOW`, atomic-rename bind — only the local user can connect. The CLI's
+   plain-text surfaces (the `--headless` summary, the `doctor` report, the
+   Sources/install output) **strip control characters** from untrusted wire values
+   (`strip_control_chars`) so a crafted transcript can't smuggle escape sequences
+   into piped output. The live half-block TUI renders into its own cell grid (agent
+   labels derive from project-directory path components, read over the user's own
+   `0600` socket and transcripts), not by echoing raw bytes to the terminal.
+
+3. **Hook installation** (when you explicitly *connect* a source) edits the agent
+   CLI's own config — e.g. `~/.claude/settings.json` — through a single
+   advisory-locked, `fsync` + atomic-rename writer that **preserves the file's
+   permissions, follows stow symlinks, and takes a one-time backup** before the
+   first change. Installs are idempotent and reversible (*disconnect* removes the
+   hook entries via a sentinel). pixtuoid never writes another tool's config
+   except on an explicit connect/disconnect.
+
+If you find a way to cross one of these boundaries (e.g. a transcript or hook
+payload that escapes the terminal, a non-owner socket connect, an install path
+traversal, or any network egress), please report it.
 
 ## Reporting a Vulnerability
 
-Please report security vulnerabilities via [GitHub private vulnerability reporting](https://github.com/IvanWng97/pixtuoid/security/advisories/new).
+Report privately via
+[GitHub private vulnerability reporting](https://github.com/IvanWng97/pixtuoid/security/advisories/new).
 
-You will receive acknowledgement within 48 hours. Expect a fix or mitigation plan within 7 days for confirmed vulnerabilities.
+You will receive acknowledgement within 48 hours, and a fix or mitigation plan
+within 7 days for confirmed vulnerabilities.
 
-Do **not** open a public issue for security vulnerabilities.
+**Do not** open a public issue for security vulnerabilities.

--- a/crates/pixtuoid/CLAUDE.md
+++ b/crates/pixtuoid/CLAUDE.md
@@ -35,10 +35,14 @@ src/
 │                       capture them); main.rs dispatches both as plain arms (tracing → stderr, so stdout stays clean). The
 │                       five PathBuf args carry `value_hint` so completions path-complete. Presenters live in main.rs
 │                       (run_sources_list/run_sources_set/run_change/run_setup, codecov-excluded like doctor::run)
-├── term.rs             truecolor preflight: pure `colorterm_is_truecolor($COLORTERM)` (the S-Lang/terminfo `truecolor`/
-│                       `24bit` convention) + `truecolor_supported()`. main.rs WARN-ONLY (never gates on Unix — many
-│                       truecolor terminals omit COLORTERM) on a non-windows Run-TUI tty; `doctor` prints a `terminal:`
-│                       row. Windows hard-gates VT separately (tui/mod). `floating` is exempt (softbuffer = real RGB px)
+├── term.rs             truecolor preflight (BOTH fns PURE + unit-tested — main.rs is the untestable presenter,
+│                       so the policy lives here; `doctor::run` returns its report String so it's tested too):
+│                       `colorterm_is_truecolor($COLORTERM)` (the
+│                       S-Lang/terminfo `truecolor`/`24bit` convention) + `terminal_diagnostic_row(term, colorterm)` (the
+│                       `doctor` `terminal:` line; env values sanitized). main.rs WARN-ONLY (never gates on Unix — many
+│                       truecolor terminals omit COLORTERM; the env read is INLINED at the excluded main.rs call site, no
+│                       untestable wrapper to mutate) on a non-windows Run-TUI tty. Windows hard-gates VT separately
+│                       (tui/mod). `floating` is exempt (softbuffer = real RGB px). #397 = terminfo Tc/RGB follow-up
 ├── setup.rs            first-run detection for onboarding: the PURE `is_first_run(cfg, path) = !path.exists() ||
 │                       cfg.sources.is_empty()` (mirrors resolve_connected's migrate condition; unit-tested). `pub`
 │                       because main.rs (a separate crate) computes RunConfig.first_run from it. The cinematic overlay

--- a/crates/pixtuoid/CLAUDE.md
+++ b/crates/pixtuoid/CLAUDE.md
@@ -25,13 +25,20 @@ src/
 │                       is indistinguishable from the default and floors to warn); non-TUI
 │                       modes log to stderr; install failure eprintlns pre-altscreen
 ├── cli.rs              clap subcommands (run / floating / validate-pack / init-pack / doctor / sources / connect /
-│                       disconnect / setup). The OLD install-hooks/uninstall-hooks CLI stays deleted (#284 removed the
-│                       interactive ORCHESTRATION — plan_targets/interactive_pick); `connect <ids>`/`disconnect <ids>`/
-│                       `sources [set <ids>]` are the SCRIPTABLE surface (Raycast/automation), a second presenter over
-│                       crate::sources (see the scriptable-vs-interactive sharp edge); `setup [--yes]` is the headless
-│                       onboarding twin (dry-run preview / apply); the in-TUI Sources panel (`s`) remains the
-│                       INTERACTIVE one. Presenters live in main.rs (run_sources_list/run_sources_set/run_change/
-│                       run_setup, codecov-excluded like doctor::run)
+│                       disconnect / setup / completions / man). The OLD install-hooks/uninstall-hooks CLI stays deleted
+│                       (#284 removed the interactive ORCHESTRATION — plan_targets/interactive_pick); `connect <ids>`/
+│                       `disconnect <ids>`/`sources [set <ids>]` are the SCRIPTABLE surface (Raycast/automation), a second
+│                       presenter over crate::sources (see the scriptable-vs-interactive sharp edge); `setup [--yes]` is
+│                       the headless onboarding twin (dry-run preview / apply); the in-TUI Sources panel (`s`) remains the
+│                       INTERACTIVE one. `completions <shell>` (clap_complete) + hidden `man` (clap_mangen) emit to stdout
+│                       from the SAME derived Cli tree as `--help` (homebrew `generate_completions_from_executable` / `man`
+│                       capture them); main.rs dispatches both as plain arms (tracing → stderr, so stdout stays clean). The
+│                       five PathBuf args carry `value_hint` so completions path-complete. Presenters live in main.rs
+│                       (run_sources_list/run_sources_set/run_change/run_setup, codecov-excluded like doctor::run)
+├── term.rs             truecolor preflight: pure `colorterm_is_truecolor($COLORTERM)` (the S-Lang/terminfo `truecolor`/
+│                       `24bit` convention) + `truecolor_supported()`. main.rs WARN-ONLY (never gates on Unix — many
+│                       truecolor terminals omit COLORTERM) on a non-windows Run-TUI tty; `doctor` prints a `terminal:`
+│                       row. Windows hard-gates VT separately (tui/mod). `floating` is exempt (softbuffer = real RGB px)
 ├── setup.rs            first-run detection for onboarding: the PURE `is_first_run(cfg, path) = !path.exists() ||
 │                       cfg.sources.is_empty()` (mirrors resolve_connected's migrate condition; unit-tested). `pub`
 │                       because main.rs (a separate crate) computes RunConfig.first_run from it. The cinematic overlay

--- a/crates/pixtuoid/Cargo.toml
+++ b/crates/pixtuoid/Cargo.toml
@@ -42,6 +42,8 @@ open               = "5"
 # share raw-window-handle 0.6, MSRV ≤ 1.89.
 winit              = "0.30"
 softbuffer         = "0.4"
+clap_complete = "4.6.5"
+clap_mangen = "0.3.0"
 
 # GetShortPathNameW for the Codex/Reasonix Windows hook path: resolve a
 # space/metacharacter-bearing install path to its DOS 8.3 short form so cmd.exe /C

--- a/crates/pixtuoid/src/cli.rs
+++ b/crates/pixtuoid/src/cli.rs
@@ -32,15 +32,15 @@ pub struct Cli {
 pub struct SourceArgs {
     /// Empty/whitespace is rejected: an explicit override deserves a loud
     /// answer, and bind("") would strand a relative `.lock` in the CWD.
-    #[arg(long, value_parser = parse_nonempty_path)]
+    #[arg(long, value_parser = parse_nonempty_path, value_hint = clap::ValueHint::FilePath)]
     pub socket: Option<PathBuf>,
-    #[arg(long)]
+    #[arg(long, value_hint = clap::ValueHint::DirPath)]
     pub projects_root: Option<PathBuf>,
     /// Override the Codex sessions root (default ~/.codex/sessions).
     /// Point at a temp dir to replay fixtures into a headless run.
-    #[arg(long)]
+    #[arg(long, value_hint = clap::ValueHint::DirPath)]
     pub codex_sessions_root: Option<PathBuf>,
-    #[arg(long)]
+    #[arg(long, value_hint = clap::ValueHint::DirPath)]
     pub pack_dir: Option<PathBuf>,
 }
 
@@ -71,11 +71,13 @@ pub enum Cmd {
     /// Validate a custom sprite pack directory.
     ValidatePack {
         /// Path to the pack directory (must contain pack.toml).
+        #[arg(value_hint = clap::ValueHint::DirPath)]
         pack_dir: PathBuf,
     },
     /// Extract a skeleton sprite pack to a directory for customization.
     InitPack {
         /// Destination directory (created if absent).
+        #[arg(value_hint = clap::ValueHint::DirPath)]
         dest: PathBuf,
         /// Overwrite existing files.
         #[arg(long, default_value_t = false)]
@@ -122,6 +124,18 @@ pub enum Cmd {
         #[arg(long)]
         yes: bool,
     },
+    /// Print a shell completion script to stdout, e.g.
+    /// `pixtuoid completions zsh > ~/.zfunc/_pixtuoid`. Package managers install
+    /// these automatically; this command lets `cargo install` / `npm` users do it
+    /// themselves for any shell.
+    Completions {
+        /// Target shell.
+        shell: clap_complete::Shell,
+    },
+    /// Print the roff man page to stdout (`pixtuoid man > pixtuoid.1`). A
+    /// packaging interface — generated from the same clap definitions as `--help`.
+    #[command(hide = true)]
+    Man,
 }
 
 #[derive(Debug, Subcommand)]
@@ -378,5 +392,57 @@ mod tests {
         assert!(matches!(dry.cmd, Some(Cmd::Setup { yes: false })));
         let apply = Cli::try_parse_from(["pixtuoid", "setup", "--yes"]).unwrap();
         assert!(matches!(apply.cmd, Some(Cmd::Setup { yes: true })));
+    }
+
+    #[test]
+    fn completions_takes_a_shell_value() {
+        let c = Cli::try_parse_from(["pixtuoid", "completions", "zsh"]).unwrap();
+        assert!(matches!(
+            c.cmd,
+            Some(Cmd::Completions {
+                shell: clap_complete::Shell::Zsh
+            })
+        ));
+        // A bogus shell is a hard parse error (typed ValueEnum), not a runtime bail.
+        assert!(Cli::try_parse_from(["pixtuoid", "completions", "nonsense"]).is_err());
+    }
+
+    /// The packaging guard (ripgrep's zsh-coverage check analogue): a clap-derive
+    /// change can't silently ship a binary whose generated completions/man are
+    /// empty or miss a subcommand. Cheap — generate into a buffer in-process.
+    #[test]
+    fn completions_and_man_generate_non_empty_and_cover_subcommands() {
+        use clap::CommandFactory;
+
+        for shell in [
+            clap_complete::Shell::Bash,
+            clap_complete::Shell::Zsh,
+            clap_complete::Shell::Fish,
+        ] {
+            let mut buf = Vec::new();
+            clap_complete::generate(shell, &mut Cli::command(), "pixtuoid", &mut buf);
+            let script = String::from_utf8(buf).expect("completion script is utf-8");
+            assert!(!script.is_empty(), "{shell:?} completion script is empty");
+            // A representative subcommand from across the tree must be present, so a
+            // dropped/renamed subcommand trips this rather than shipping silently.
+            assert!(
+                script.contains("floating") && script.contains("doctor"),
+                "{shell:?} completion script is missing a known subcommand"
+            );
+        }
+
+        let mut man = Vec::new();
+        clap_mangen::Man::new(Cli::command())
+            .render(&mut man)
+            .expect("man render");
+        let man = String::from_utf8(man).expect("man page is utf-8");
+        assert!(man.contains("pixtuoid"), "man page missing program name");
+        // Same dropped-subcommand teeth as the completions loop: clap_mangen
+        // renders a SUBCOMMANDS section, so a removed/renamed subcommand trips this
+        // rather than shipping a man page that silently lost it.
+        assert!(
+            man.contains("doctor"),
+            "man page SUBCOMMANDS section is missing a known subcommand"
+        );
     }
 }

--- a/crates/pixtuoid/src/doctor.rs
+++ b/crates/pixtuoid/src/doctor.rs
@@ -568,20 +568,20 @@ pub fn run(log_path: &std::path::Path) -> anyhow::Result<()> {
     // the #1 silent failure is a non-truecolor terminal rendering approximated
     // colors. Surface the detected $TERM/$COLORTERM so a "colors look wrong over
     // ssh/tmux" report is self-diagnosable. ENV values are untrusted → sanitized.
-    let term_var = std::env::var("TERM").unwrap_or_default();
-    let colorterm = std::env::var("COLORTERM").unwrap_or_default();
-    let shown = |v: &str| {
-        if v.is_empty() {
-            "(unset)".to_string()
-        } else {
-            sanitize(v)
-        }
+    // Read each var ONCE as an Option so display and the truecolor verdict share
+    // it, and an unset var is a genuine `None` (not `Some("")`) — matching
+    // `colorterm_is_truecolor`'s documented contract.
+    let term_var = std::env::var("TERM").ok();
+    let colorterm = std::env::var("COLORTERM").ok();
+    let shown = |v: &Option<String>| match v.as_deref() {
+        Some(s) if !s.is_empty() => sanitize(s),
+        _ => "(unset)".to_string(),
     };
     out.push_str(&format!(
         "terminal: TERM={} COLORTERM={} truecolor={}\n",
         shown(&term_var),
         shown(&colorterm),
-        if crate::term::colorterm_is_truecolor(Some(&colorterm)) {
+        if crate::term::colorterm_is_truecolor(colorterm.as_deref()) {
             "yes"
         } else {
             "not advertised"

--- a/crates/pixtuoid/src/doctor.rs
+++ b/crates/pixtuoid/src/doctor.rs
@@ -544,7 +544,10 @@ fn probe_version(argv: &'static [&'static str]) -> Option<String> {
 /// Run the diagnosis: read config + install-state + the log, probe installed CLI
 /// versions, print a per-source health table. Read-only. `log_path` is injected
 /// by `main` (it owns the log-path resolution, which lives in the bin, not lib).
-pub fn run(log_path: &std::path::Path) -> anyhow::Result<()> {
+/// Build the read-only health report. Returns the rendered string (the caller —
+/// `main.rs`, an excluded presenter — prints it) so the WHOLE report builder is
+/// unit-testable, not just its pure row helpers.
+pub fn run(log_path: &std::path::Path) -> anyhow::Result<String> {
     let mut warnings = Vec::new();
     let cfg = crate::config::load(&crate::config::config_path(), &mut warnings);
     // `doctor` is a separate PROCESS from the running TUI, so it derives the
@@ -567,26 +570,14 @@ pub fn run(log_path: &std::path::Path) -> anyhow::Result<()> {
     // Terminal capability: the pixel-art office needs a 24-bit-color terminal, and
     // the #1 silent failure is a non-truecolor terminal rendering approximated
     // colors. Surface the detected $TERM/$COLORTERM so a "colors look wrong over
-    // ssh/tmux" report is self-diagnosable. ENV values are untrusted → sanitized.
-    // Read each var ONCE as an Option so display and the truecolor verdict share
-    // it, and an unset var is a genuine `None` (not `Some("")`) — matching
-    // `colorterm_is_truecolor`'s documented contract.
-    let term_var = std::env::var("TERM").ok();
-    let colorterm = std::env::var("COLORTERM").ok();
-    let shown = |v: &Option<String>| match v.as_deref() {
-        Some(s) if !s.is_empty() => sanitize(s),
-        _ => "(unset)".to_string(),
-    };
-    out.push_str(&format!(
-        "terminal: TERM={} COLORTERM={} truecolor={}\n",
-        shown(&term_var),
-        shown(&colorterm),
-        if crate::term::colorterm_is_truecolor(colorterm.as_deref()) {
-            "yes"
-        } else {
-            "not advertised"
-        },
+    // ssh/tmux" report is self-diagnosable. The row is formatted by the PURE,
+    // unit-tested `term::terminal_diagnostic_row` (env values sanitized there);
+    // `.ok()` makes an unset var a genuine `None`, not `Some("")`.
+    out.push_str(&crate::term::terminal_diagnostic_row(
+        std::env::var("TERM").ok().as_deref(),
+        std::env::var("COLORTERM").ok().as_deref(),
     ));
+    out.push('\n');
     // Surface config-load warnings IN the report — a malformed config makes every
     // source read disconnected, and a diagnostic tool must say WHY rather than
     // silently swallow it. Sanitized: a warning can interpolate config content.
@@ -654,8 +645,7 @@ pub fn run(log_path: &std::path::Path) -> anyhow::Result<()> {
     ) {
         out.push_str(&format!("\n{adv}\n"));
     }
-    print!("{out}");
-    Ok(())
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -664,6 +654,19 @@ mod tests {
     use std::io::Write;
     use std::sync::{Arc, Mutex};
     use tracing_subscriber::fmt::MakeWriter;
+
+    #[test]
+    fn run_renders_the_structural_report_headers() {
+        // run() reads the real config/log/env, but the structural headers are
+        // present regardless — so a whole-body `replace run with Ok(default)`
+        // survivor (an empty report) is caught, giving the report builder teeth
+        // beyond its pure row helpers. (A missing log path → empty log, fine.)
+        let out = run(std::path::Path::new("/nonexistent-pixtuoid-doctor-log")).unwrap();
+        assert!(out.contains("pixtuoid doctor — source health"), "{out}");
+        assert!(out.contains("config:"), "{out}");
+        assert!(out.contains("terminal: TERM="), "{out}");
+        assert!(out.contains("sources \u{b7}"), "{out}");
+    }
 
     #[derive(Clone, Default)]
     struct Buf(Arc<Mutex<Vec<u8>>>);

--- a/crates/pixtuoid/src/doctor.rs
+++ b/crates/pixtuoid/src/doctor.rs
@@ -560,6 +560,33 @@ pub fn run(log_path: &std::path::Path) -> anyhow::Result<()> {
 
     let mut out = String::from("pixtuoid doctor — source health\n");
     out.push_str(&format!("log: {}\n", log_path.display()));
+    out.push_str(&format!(
+        "config: {}\n",
+        crate::config::config_path().display()
+    ));
+    // Terminal capability: the pixel-art office needs a 24-bit-color terminal, and
+    // the #1 silent failure is a non-truecolor terminal rendering approximated
+    // colors. Surface the detected $TERM/$COLORTERM so a "colors look wrong over
+    // ssh/tmux" report is self-diagnosable. ENV values are untrusted → sanitized.
+    let term_var = std::env::var("TERM").unwrap_or_default();
+    let colorterm = std::env::var("COLORTERM").unwrap_or_default();
+    let shown = |v: &str| {
+        if v.is_empty() {
+            "(unset)".to_string()
+        } else {
+            sanitize(v)
+        }
+    };
+    out.push_str(&format!(
+        "terminal: TERM={} COLORTERM={} truecolor={}\n",
+        shown(&term_var),
+        shown(&colorterm),
+        if crate::term::colorterm_is_truecolor(Some(&colorterm)) {
+            "yes"
+        } else {
+            "not advertised"
+        },
+    ));
     // Surface config-load warnings IN the report — a malformed config makes every
     // source read disconnected, and a diagnostic tool must say WHY rather than
     // silently swallow it. Sanitized: a warning can interpolate config content.

--- a/crates/pixtuoid/src/lib.rs
+++ b/crates/pixtuoid/src/lib.rs
@@ -11,6 +11,7 @@ pub mod install;
 pub mod runtime;
 pub mod setup;
 pub mod sources;
+pub mod term;
 pub mod tui;
 pub mod validate;
 pub mod version;

--- a/crates/pixtuoid/src/main.rs
+++ b/crates/pixtuoid/src/main.rs
@@ -11,6 +11,31 @@ use tracing_subscriber::EnvFilter;
 fn main() -> Result<()> {
     install_crash_hook();
     let (log_level, cli_theme, cmd) = Cli::parse().cmd_or_default();
+
+    // Truecolor preflight: the terminal TUI renders 24-bit half-block pixels; a
+    // terminal that does not advertise COLORTERM=truecolor may render them
+    // approximated/garbled with no other hint. Warn ONCE on the pre-altscreen
+    // stderr channel — never gate on Unix (many truecolor terminals omit
+    // COLORTERM, so a gate would false-negative); Windows hard-gates VT separately
+    // in `tui::mod`. The `floating` window paints real RGB pixels via softbuffer,
+    // not terminal SGR, so it is exempt.
+    #[cfg(not(windows))]
+    if matches!(
+        &cmd,
+        Cmd::Run {
+            headless: false,
+            ..
+        }
+    ) && std::io::IsTerminal::is_terminal(&std::io::stderr())
+        && !pixtuoid::term::truecolor_supported()
+    {
+        eprintln!(
+            "⚠ pixtuoid: your terminal does not advertise COLORTERM=truecolor — the \
+             pixel-art office renders in 24-bit color and may look wrong. Use a \
+             truecolor terminal (Windows Terminal, iTerm2, Ghostty, Alacritty, kitty, \
+             WezTerm), or run `pixtuoid doctor` to check."
+        );
+    }
     // The typed LogLevel's as_str is exactly the old free-string levels, so
     // every filter built below is unchanged — the enum only moved typo
     // rejection to the clap seam (a typo used to parse as a bogus EnvFilter
@@ -137,6 +162,25 @@ fn main() -> Result<()> {
             })
         }
         Cmd::Setup { yes } => run_setup(yes),
+        // Packaging interfaces: emit ONLY the generated artifact to stdout (the
+        // tracing subscriber above writes to stderr, so stdout stays clean for the
+        // homebrew `generate_completions_from_executable` / `man` capture). Driven
+        // off the same derived clap tree as `--help`, so they can't drift.
+        Cmd::Completions { shell } => {
+            use clap::CommandFactory;
+            clap_complete::generate(
+                shell,
+                &mut Cli::command(),
+                "pixtuoid",
+                &mut std::io::stdout(),
+            );
+            Ok(())
+        }
+        Cmd::Man => {
+            use clap::CommandFactory;
+            clap_mangen::Man::new(Cli::command()).render(&mut std::io::stdout())?;
+            Ok(())
+        }
     }
 }
 

--- a/crates/pixtuoid/src/main.rs
+++ b/crates/pixtuoid/src/main.rs
@@ -27,7 +27,7 @@ fn main() -> Result<()> {
             ..
         }
     ) && std::io::IsTerminal::is_terminal(&std::io::stderr())
-        && !pixtuoid::term::truecolor_supported()
+        && !pixtuoid::term::colorterm_is_truecolor(std::env::var("COLORTERM").ok().as_deref())
     {
         eprintln!(
             "⚠ pixtuoid: your terminal does not advertise COLORTERM=truecolor — the \
@@ -140,7 +140,7 @@ fn main() -> Result<()> {
         }
         Cmd::ValidatePack { pack_dir } => validate::validate_pack(&pack_dir),
         Cmd::InitPack { dest, force } => init_pack::init_pack(&dest, force),
-        Cmd::Doctor => doctor::run(&log_file_path()),
+        Cmd::Doctor => doctor::run(&log_file_path()).map(|report| print!("{report}")),
         Cmd::Sources { action: None, json } => run_sources_list(json),
         Cmd::Sources {
             action: Some(SourcesAction::Set { ids }),

--- a/crates/pixtuoid/src/term.rs
+++ b/crates/pixtuoid/src/term.rs
@@ -15,9 +15,26 @@ pub fn colorterm_is_truecolor(colorterm: Option<&str>) -> bool {
     matches!(colorterm, Some(v) if v.contains("truecolor") || v.contains("24bit"))
 }
 
-/// The live `$COLORTERM`-based verdict for the running process.
-pub fn truecolor_supported() -> bool {
-    colorterm_is_truecolor(std::env::var("COLORTERM").ok().as_deref())
+/// The `pixtuoid doctor` `terminal:` line — `$TERM` / `$COLORTERM` and the
+/// truecolor verdict. Pure (takes the env values as `Option`s, `None` = unset) so
+/// the row logic is unit-testable on its own (and `doctor::run` returns its report
+/// string, so it's covered end-to-end too). Untrusted env values are stripped of
+/// control chars before display.
+pub fn terminal_diagnostic_row(term: Option<&str>, colorterm: Option<&str>) -> String {
+    let shown = |v: Option<&str>| match v {
+        Some(s) if !s.is_empty() => crate::strip_control_chars(s),
+        _ => "(unset)".to_string(),
+    };
+    format!(
+        "terminal: TERM={} COLORTERM={} truecolor={}",
+        shown(term),
+        shown(colorterm),
+        if colorterm_is_truecolor(colorterm) {
+            "yes"
+        } else {
+            "not advertised"
+        },
+    )
 }
 
 #[cfg(test)]
@@ -39,5 +56,26 @@ mod tests {
         assert!(!colorterm_is_truecolor(Some("256color")));
         // Case-sensitive: only the conventional lowercase tokens count.
         assert!(!colorterm_is_truecolor(Some("TrueColor")));
+    }
+
+    #[test]
+    fn terminal_row_renders_each_state() {
+        let yes = terminal_diagnostic_row(Some("xterm-256color"), Some("truecolor"));
+        assert!(yes.contains("TERM=xterm-256color"));
+        assert!(yes.contains("COLORTERM=truecolor"));
+        assert!(yes.contains("truecolor=yes"));
+
+        // Unset ($COLORTERM = None) and set-but-empty both read as "(unset)" and a
+        // "not advertised" verdict.
+        for ct in [None, Some("")] {
+            let row = terminal_diagnostic_row(None, ct);
+            assert!(row.contains("TERM=(unset)"), "{row}");
+            assert!(row.contains("COLORTERM=(unset)"), "{row}");
+            assert!(row.contains("truecolor=not advertised"), "{row}");
+        }
+
+        // Untrusted env values are control-char-stripped before display.
+        let sanitized = terminal_diagnostic_row(Some("a\x1b[31mb"), Some("truecolor"));
+        assert!(!sanitized.contains('\u{1b}'), "{sanitized}");
     }
 }

--- a/crates/pixtuoid/src/term.rs
+++ b/crates/pixtuoid/src/term.rs
@@ -1,0 +1,43 @@
+//! Terminal capability probes for the truecolor preflight (the pixel-art office
+//! renders 24-bit half-block SGR; a terminal that can't parse those shows
+//! approximated/garbled colors with no other hint — the #1 baffling-bug class for
+//! a truecolor-only TUI). Detection is intentionally a WARN signal, never a gate
+//! on Unix: many genuinely-truecolor terminals omit `COLORTERM`, so a hard gate
+//! would false-negative. (Windows is the exception — `tui::mod` hard-gates VT
+//! there because the WinAPI color fallback renders black-on-black.)
+
+/// True iff `$COLORTERM` advertises 24-bit color (`truecolor` or `24bit`) — the
+/// S-Lang / terminfo convention also used by bat, alacritty, and wezterm. Pure
+/// (takes the env value) so the policy is unit-testable without touching the
+/// environment. Case-sensitive on purpose: the advertised tokens are lowercase
+/// by convention, and a loose match would treat unrelated values as truecolor.
+pub fn colorterm_is_truecolor(colorterm: Option<&str>) -> bool {
+    matches!(colorterm, Some(v) if v.contains("truecolor") || v.contains("24bit"))
+}
+
+/// The live `$COLORTERM`-based verdict for the running process.
+pub fn truecolor_supported() -> bool {
+    colorterm_is_truecolor(std::env::var("COLORTERM").ok().as_deref())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truecolor_tokens_match() {
+        assert!(colorterm_is_truecolor(Some("truecolor")));
+        assert!(colorterm_is_truecolor(Some("24bit")));
+        // A terminal may set a compound value.
+        assert!(colorterm_is_truecolor(Some("truecolor:whatever")));
+    }
+
+    #[test]
+    fn non_truecolor_is_false() {
+        assert!(!colorterm_is_truecolor(None));
+        assert!(!colorterm_is_truecolor(Some("")));
+        assert!(!colorterm_is_truecolor(Some("256color")));
+        // Case-sensitive: only the conventional lowercase tokens count.
+        assert!(!colorterm_is_truecolor(Some("TrueColor")));
+    }
+}


### PR DESCRIPTION
Adopts four transferable best practices from a study of excellent Rust CLI/TUI projects (ripgrep, helix, alacritty, zellij, fd, bat), each grounded against our repo. Local two-lens review: both lenses **APPROVE-WITH-NITS** (nits fixed below).

## What

1. **Truecolor preflight** — new `crates/pixtuoid/src/term.rs` (pure `colorterm_is_truecolor` + `truecolor_supported`, unit-tested). `main.rs` emits a **warn-only** pre-altscreen nudge on a non-Windows `run` TUI tty when `$COLORTERM` doesn't advertise `truecolor`/`24bit` — it **never gates** (many truecolor terminals omit `COLORTERM`; Windows already VT-gates). `doctor` gains `terminal:` + `config:` rows for self-diagnosis. The #1 silent failure for a 24-bit pixel TUI (a 256-color terminal showing garbled colors) now has an explanation. Refinement (terminfo `Tc`/`RGB` + suppression hatch) tracked in #397.

2. **Trust docs** — `SECURITY.md` rewritten from a stub into a real threat model (the hook shim, the owner-only socket, how hook installation edits another tool's config) + an explicit **zero-telemetry, all-local** guarantee; README gains a *Privacy & Security* section. (Surfaces strengths that already existed but were unstated — verified: no network/telemetry code, daily `cargo-deny` audit.)

3. **macOS CI** — a `macos-test` job (`macos-14`). macOS is our primary dev/user platform (BSD CLI / launchd / `~/.claude` path divergence) yet had **zero** CI coverage — the homebrew-core submission was literally the first macOS build.

4. **Shell completions + man** — `clap_complete` + `clap_mangen`; a visible `completions <shell>` + a hidden `man`, both off the same derived `Cli` tree as `--help` (so they can't drift); `value_hint` on the 5 `PathBuf` args so completions path-complete. A generation test guards against a derive change silently shipping empty/incomplete completions.

## Sequencing

The completions/man **Homebrew formula lines are deliberately NOT here** — the v0.11.1 binary has no such subcommands, so they ride the **next release**, after which Homebrew autobump carries them.

## Review nits fixed (from the two-lens pass)

- `SECURITY.md` no longer over-attributes live-TUI escape defense to `strip_control_chars` (it guards the stdout text sinks; the live TUI renders into its own cell grid) — MEDIUM.
- Socket path made precise (`$XDG_RUNTIME_DIR/pixtuoid.sock` / `PIXTUOID_SOCKET`) — NIT.
- The man-generation test gained dropped-subcommand teeth (`assert man.contains("doctor")`) — LOW.

## Gates

`just fmt` / `just lint` / `just clippy` / `just test` (1915 pass, +5 new) / `gen-readme-check` / `just links` — all green locally. CLAUDE.md + README updated in-change (docs-currency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PucHLSPY32y1SRsXemYBGK