### PR TITLE
chore(dev): install rust-analyzer in setup-tools (fix the agent/editor LSP)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,9 @@ baselines) plus `site/public/demos/` in the same change, or the smoke job's
 
 The `justfile` is the single source of truth for every check — CI and the
 git hooks call the same recipes (no local-vs-CI drift). `just setup-tools`
-installs the needed cargo tools once per clone.
+installs the needed cargo tools once per clone (including the `rust-analyzer`
+component — `rust-toolchain.toml` pins only `rustfmt`+`clippy`, so without it the
+editor / AI-agent LSP silently degrades to grep).
 
 ```
 just preflight    # full pre-push gate: lint (fmt+machete+deny+arch+shfmt+actionlint+links) → clippy → hack → test

--- a/justfile
+++ b/justfile
@@ -511,6 +511,16 @@ setup-tools:
         echo "brew install cargo-binstall (or cargo install cargo-binstall) to grab prebuilt binaries instead." >&2
         cargo install "${tools[@]}"
     fi
+    # The rust-analyzer component powers the editor / AI-agent LSP (go-to-def,
+    # find-references — the tool the "change all N keying sites in lockstep"
+    # invariants depend on). rust-toolchain.toml pins only rustfmt+clippy, so
+    # without this the `~/.cargo/bin/rust-analyzer` rustup shim errors with
+    # "Unknown binary" and the LSP silently degrades to grep. Idempotent; skipped
+    # cleanly when rustup is absent (e.g. a distro-packaged toolchain).
+    if command -v rustup &>/dev/null; then
+        rustup component add rust-analyzer >/dev/null 2>&1 ||
+            echo "could not add the rust-analyzer component — install it for LSP support" >&2
+    fi
     # Non-cargo lint tools that `just lint` gates on (Go binaries, not crates:
     # shfmt formats shell, actionlint lints the workflows). brew on macOS;
     # elsewhere point at the install docs rather than silently leaving `just


### PR DESCRIPTION
## Problem

The LSP (the agent's `find-references`/`go-to-def` tool, and any editor's) was **silently dead** on this repo. `~/.cargo/bin/rust-analyzer` is a rustup **proxy shim**, but `rust-toolchain.toml` pins only `rustfmt`+`clippy` — the `rust-analyzer` component was never installed, so the shim errors instantly (`Unknown binary 'rust-analyzer' in official toolchain`), the harness LSP plugin retries 3× and gives up, and symbol navigation falls back to grep. That's a real hazard on a codebase whose CLAUDE.md repeatedly says *"change all N keying sites in lockstep."*

## Fix

`just setup-tools` now runs `rustup component add rust-analyzer` (idempotent; cleanly skipped when rustup is absent). Verified: the component installs and RA loads the workspace **headlessly in ~6s** (`analysis-stats`: `Database loaded: 5.98s`) — healthy, not a cold-start crash.

Deliberately **not** added to `rust-toolchain.toml` (which CI reads) — RA is a dev-machine tool; adding it there would make every CI job download a component CI never uses.

## Scope

`justfile` setup recipe + a CLAUDE.md note. No runtime/code change. `just lint` green. Right-sized review: dev-infra only, so the online bot rather than a full multi-agent two-lens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PucHLSPY32y1SRsXemYBGK