### PR TITLE
fix: truecolor preflight false positives (terminfo Tc/RGB + PIXTUOID_NO_TRUECOLOR_WARN)

### DIFF
--- a/crates/pixtuoid/CLAUDE.md
+++ b/crates/pixtuoid/CLAUDE.md
@@ -38,11 +38,16 @@ src/
 ├── term.rs             truecolor preflight (BOTH fns PURE + unit-tested — main.rs is the untestable presenter,
 │                       so the policy lives here; `doctor::run` returns its report String so it's tested too):
 │                       `colorterm_is_truecolor($COLORTERM)` (the
-│                       S-Lang/terminfo `truecolor`/`24bit` convention) + `terminal_diagnostic_row(term, colorterm)` (the
-│                       `doctor` `terminal:` line; env values sanitized). main.rs WARN-ONLY (never gates on Unix — many
-│                       truecolor terminals omit COLORTERM; the env read is INLINED at the excluded main.rs call site, no
+│                       S-Lang/terminfo `truecolor`/`24bit` convention) + `terminal_diagnostic_row(term, colorterm, terminfo_caps)` (the
+│                       `doctor` `terminal:` line; env values sanitized; verdict shares the COLORTERM-OR-terminfo signals with
+│                       the warn policy so doctor + the startup warning agree on a TERM-only-truecolor terminal) + the WARN POLICY `should_warn_no_truecolor(colorterm,
+│                       term, suppress_env, terminfo_caps)` (#397: suppresses on $COLORTERM truecolor OR terminfo Tc/RGB for
+│                       $TERM OR a truthy $PIXTUOID_NO_TRUECOLOR_WARN — every input passed in / terminfo lookup INJECTED as a
+│                       closure, so the policy is pure + unit-tested; `terminfo_boolean_caps` is the real `infocmp` seam,
+│                       None on any failure = graceful degrade). main.rs WARN-ONLY (never gates on Unix — many
+│                       truecolor terminals omit COLORTERM; the env reads are INLINED at the excluded main.rs call site, no
 │                       untestable wrapper to mutate) on a non-windows Run-TUI tty. Windows hard-gates VT separately
-│                       (tui/mod). `floating` is exempt (softbuffer = real RGB px). #397 = terminfo Tc/RGB follow-up
+│                       (tui/mod). `floating` is exempt (softbuffer = real RGB px).
 ├── setup.rs            first-run detection for onboarding: the PURE `is_first_run(cfg, path) = !path.exists() ||
 │                       cfg.sources.is_empty()` (mirrors resolve_connected's migrate condition; unit-tested). `pub`
 │                       because main.rs (a separate crate) computes RunConfig.first_run from it. The cinematic overlay

--- a/crates/pixtuoid/src/doctor.rs
+++ b/crates/pixtuoid/src/doctor.rs
@@ -572,10 +572,13 @@ pub fn run(log_path: &std::path::Path) -> anyhow::Result<String> {
     // colors. Surface the detected $TERM/$COLORTERM so a "colors look wrong over
     // ssh/tmux" report is self-diagnosable. The row is formatted by the PURE,
     // unit-tested `term::terminal_diagnostic_row` (env values sanitized there);
-    // `.ok()` makes an unset var a genuine `None`, not `Some("")`.
+    // `.ok()` makes an unset var a genuine `None`, not `Some("")`. The terminfo
+    // probe (`terminfo_boolean_caps`) is threaded in so the verdict matches the
+    // startup warning policy for a TERM-only-truecolor terminal (#397).
     out.push_str(&crate::term::terminal_diagnostic_row(
         std::env::var("TERM").ok().as_deref(),
         std::env::var("COLORTERM").ok().as_deref(),
+        crate::term::terminfo_boolean_caps,
     ));
     out.push('\n');
     // Surface config-load warnings IN the report — a malformed config makes every

--- a/crates/pixtuoid/src/main.rs
+++ b/crates/pixtuoid/src/main.rs
@@ -27,13 +27,19 @@ fn main() -> Result<()> {
             ..
         }
     ) && std::io::IsTerminal::is_terminal(&std::io::stderr())
-        && !pixtuoid::term::colorterm_is_truecolor(std::env::var("COLORTERM").ok().as_deref())
+        && pixtuoid::term::should_warn_no_truecolor(
+            std::env::var("COLORTERM").ok().as_deref(),
+            std::env::var("TERM").ok().as_deref(),
+            std::env::var("PIXTUOID_NO_TRUECOLOR_WARN").ok().as_deref(),
+            pixtuoid::term::terminfo_boolean_caps,
+        )
     {
         eprintln!(
-            "⚠ pixtuoid: your terminal does not advertise COLORTERM=truecolor — the \
-             pixel-art office renders in 24-bit color and may look wrong. Use a \
-             truecolor terminal (Windows Terminal, iTerm2, Ghostty, Alacritty, kitty, \
-             WezTerm), or run `pixtuoid doctor` to check."
+            "⚠ pixtuoid: your terminal does not advertise truecolor (COLORTERM or a \
+             terminfo Tc/RGB capability) — the pixel-art office renders in 24-bit color \
+             and may look wrong. Use a truecolor terminal (Windows Terminal, iTerm2, \
+             Ghostty, Alacritty, kitty, WezTerm), or run `pixtuoid doctor` to check. \
+             To silence this warning, set PIXTUOID_NO_TRUECOLOR_WARN=1."
         );
     }
     // The typed LogLevel's as_str is exactly the old free-string levels, so

--- a/crates/pixtuoid/src/term.rs
+++ b/crates/pixtuoid/src/term.rs
@@ -15,25 +15,148 @@ pub fn colorterm_is_truecolor(colorterm: Option<&str>) -> bool {
     matches!(colorterm, Some(v) if v.contains("truecolor") || v.contains("24bit"))
 }
 
+/// True iff the value of the suppression env var (`$PIXTUOID_NO_TRUECOLOR_WARN`)
+/// is set to a truthy token (`1`, `true`, `yes`, `on`, case-insensitive). Pure
+/// (takes the env value, `None` = unset) so the policy stays unit-testable
+/// without touching the environment. Empty / `0` / `false` / anything else =
+/// not suppressed, so a leftover `PIXTUOID_NO_TRUECOLOR_WARN=` doesn't silently
+/// kill the warning.
+fn truecolor_warn_suppressed(suppress_env: Option<&str>) -> bool {
+    matches!(
+        suppress_env.map(str::trim),
+        Some(v) if v.eq_ignore_ascii_case("1")
+            || v.eq_ignore_ascii_case("true")
+            || v.eq_ignore_ascii_case("yes")
+            || v.eq_ignore_ascii_case("on")
+    )
+}
+
+/// True iff terminfo advertises 24-bit color for `$TERM` — i.e. the entry
+/// carries the `Tc` (S-Lang / tmux) or `RGB` (ncurses 6.0+) capability. Many
+/// genuinely-truecolor terminals (tmux that strips `$COLORTERM`, some SSH
+/// sessions) signal truecolor THIS way rather than via `$COLORTERM`, so this is
+/// the real fix for the false-positive nag (#397). Pure over an INJECTED
+/// capability lookup (`caps`: given a `$TERM` entry name, return its terminfo
+/// boolean-cap names) so the policy is unit-testable without touching the
+/// terminfo database. Lookup failure degrades gracefully: a `caps` that returns
+/// `None` (no entry / db unreadable) is treated as "not advertised", leaving
+/// behavior unchanged from today.
+fn terminfo_advertises_truecolor<F>(term: Option<&str>, caps: F) -> bool
+where
+    F: FnOnce(&str) -> Option<Vec<String>>,
+{
+    let Some(term) = term.filter(|t| !t.is_empty()) else {
+        return false;
+    };
+    caps(term).is_some_and(|names| {
+        names
+            .iter()
+            .any(|n| n.eq_ignore_ascii_case("Tc") || n.eq_ignore_ascii_case("RGB"))
+    })
+}
+
+/// The single truecolor-warning POLICY: return `true` iff the pre-altscreen
+/// "your terminal does not advertise truecolor" warning should fire. It does
+/// NOT fire when `$COLORTERM` already advertises truecolor, when terminfo
+/// exposes `Tc`/`RGB` for `$TERM` (#397's real fix), or when the suppression
+/// env var is truthy (the documented escape hatch). Every input is passed in
+/// as a value / `Option` (and the terminfo lookup is an injected closure), so
+/// the policy is unit-testable without touching the process environment — the
+/// same pure-and-injected style as `colorterm_is_truecolor`. main.rs reads
+/// `$COLORTERM` / `$TERM` / `$PIXTUOID_NO_TRUECOLOR_WARN` at the call site and
+/// passes them in.
+pub fn should_warn_no_truecolor<F>(
+    colorterm: Option<&str>,
+    term: Option<&str>,
+    suppress_env: Option<&str>,
+    terminfo_caps: F,
+) -> bool
+where
+    F: FnOnce(&str) -> Option<Vec<String>>,
+{
+    !colorterm_is_truecolor(colorterm)
+        && !truecolor_warn_suppressed(suppress_env)
+        && !terminfo_advertises_truecolor(term, terminfo_caps)
+}
+
+/// Probe the system terminfo database for the boolean capability names of a
+/// `$TERM` entry, via `infocmp` (ships with ncurses on macOS + Linux). Returns
+/// `None` on ANY failure (binary missing, no entry, non-UTF-8, non-zero exit)
+/// so the policy degrades to the `$COLORTERM` + suppression-env checks — the
+/// graceful-degradation contract `should_warn_no_truecolor`'s `terminfo_caps`
+/// closure expects. This is the real-environment seam (`should_warn_no_truecolor`
+/// stays pure); main.rs passes it in. The returned names are the entry's
+/// boolean caps as `infocmp -1x` prints them (one per line, comma-stripped), so
+/// `Tc` / `RGB` are matched verbatim by `terminfo_advertises_truecolor`.
+///
+/// `-x` is load-bearing: ncurses classifies `Tc` (tmux/S-Lang) and `RGB`
+/// (ncurses 6.0+) as USER-DEFINED / extended capabilities, which `infocmp`
+/// omits UNLESS `-x` is passed — without it the probe drops the very caps it
+/// exists to detect, leaving the false-positive warning intact in exactly the
+/// tmux/SSH targets this fixes (#397).
+pub fn terminfo_boolean_caps(term: &str) -> Option<Vec<String>> {
+    let out = std::process::Command::new("infocmp")
+        .arg("-1x")
+        .arg(term)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8(out.stdout).ok()?;
+    Some(
+        text.lines()
+            .map(str::trim)
+            .map(|l| l.trim_end_matches(','))
+            // A boolean cap is a bare name (no `=`/`#` value assignment); the
+            // header comment line starts with `#`.
+            .filter(|l| {
+                !l.is_empty() && !l.starts_with('#') && !l.contains('=') && !l.contains('#')
+            })
+            .map(str::to_string)
+            .collect(),
+    )
+}
+
 /// The `pixtuoid doctor` `terminal:` line — `$TERM` / `$COLORTERM` and the
-/// truecolor verdict. Pure (takes the env values as `Option`s, `None` = unset) so
-/// the row logic is unit-testable on its own (and `doctor::run` returns its report
-/// string, so it's covered end-to-end too). Untrusted env values are stripped of
-/// control chars before display.
-pub fn terminal_diagnostic_row(term: Option<&str>, colorterm: Option<&str>) -> String {
+/// truecolor verdict. Pure (takes the env values as `Option`s, `None` = unset,
+/// plus an INJECTED terminfo lookup) so the row logic is unit-testable on its
+/// own (and `doctor::run` returns its report string, so it's covered end-to-end
+/// too). Untrusted env values are stripped of control chars before display.
+///
+/// The verdict shares the SAME signals as the startup-warning policy
+/// (`should_warn_no_truecolor`): truecolor is advertised when `$COLORTERM` says
+/// so OR when terminfo exposes `Tc`/`RGB` for `$TERM` — so `doctor` no longer
+/// reports `not advertised` for a TERM-only-truecolor terminal (ghostty,
+/// `tmux-direct`) that the startup warning correctly stays silent on (#397).
+/// The verdict names which signal matched so a "colors look wrong" report is
+/// self-diagnosable. The suppression env var is deliberately NOT consulted here:
+/// silencing the nag must not flip the diagnostic to claim a capability the
+/// terminal may not have.
+pub fn terminal_diagnostic_row<F>(
+    term: Option<&str>,
+    colorterm: Option<&str>,
+    terminfo_caps: F,
+) -> String
+where
+    F: FnOnce(&str) -> Option<Vec<String>>,
+{
     let shown = |v: Option<&str>| match v {
         Some(s) if !s.is_empty() => crate::strip_control_chars(s),
         _ => "(unset)".to_string(),
+    };
+    let verdict = if colorterm_is_truecolor(colorterm) {
+        "yes (COLORTERM)"
+    } else if terminfo_advertises_truecolor(term, terminfo_caps) {
+        "yes (terminfo Tc/RGB)"
+    } else {
+        "not advertised"
     };
     format!(
         "terminal: TERM={} COLORTERM={} truecolor={}",
         shown(term),
         shown(colorterm),
-        if colorterm_is_truecolor(colorterm) {
-            "yes"
-        } else {
-            "not advertised"
-        },
+        verdict,
     )
 }
 
@@ -60,22 +183,176 @@ mod tests {
 
     #[test]
     fn terminal_row_renders_each_state() {
-        let yes = terminal_diagnostic_row(Some("xterm-256color"), Some("truecolor"));
+        let yes = terminal_diagnostic_row(Some("xterm-256color"), Some("truecolor"), no_caps);
         assert!(yes.contains("TERM=xterm-256color"));
         assert!(yes.contains("COLORTERM=truecolor"));
-        assert!(yes.contains("truecolor=yes"));
+        assert!(yes.contains("truecolor=yes (COLORTERM)"));
 
         // Unset ($COLORTERM = None) and set-but-empty both read as "(unset)" and a
-        // "not advertised" verdict.
+        // "not advertised" verdict (terminfo also not advertising).
         for ct in [None, Some("")] {
-            let row = terminal_diagnostic_row(None, ct);
+            let row = terminal_diagnostic_row(None, ct, no_caps);
             assert!(row.contains("TERM=(unset)"), "{row}");
             assert!(row.contains("COLORTERM=(unset)"), "{row}");
             assert!(row.contains("truecolor=not advertised"), "{row}");
         }
 
+        // $COLORTERM unset but terminfo advertises Tc/RGB -> the verdict names
+        // the terminfo signal (the #397 doctor/warning coherence case).
+        let tc = |_t: &str| Some(vec!["Tc".to_string()]);
+        let terminfo_row = terminal_diagnostic_row(Some("ghostty"), None, tc);
+        assert!(
+            terminfo_row.contains("truecolor=yes (terminfo Tc/RGB)"),
+            "{terminfo_row}"
+        );
+
         // Untrusted env values are control-char-stripped before display.
-        let sanitized = terminal_diagnostic_row(Some("a\x1b[31mb"), Some("truecolor"));
+        let sanitized = terminal_diagnostic_row(Some("a\x1b[31mb"), Some("truecolor"), no_caps);
         assert!(!sanitized.contains('\u{1b}'), "{sanitized}");
+    }
+
+    // A `terminfo_caps` lookup that never advertises truecolor — the "real db
+    // has no Tc/RGB" / graceful-degradation (None) cases use this.
+    fn no_caps(_term: &str) -> Option<Vec<String>> {
+        Some(vec!["am".to_string(), "bce".to_string(), "ccc".to_string()])
+    }
+    // The terminfo db is unavailable (binary missing / no entry / unreadable).
+    fn caps_unavailable(_term: &str) -> Option<Vec<String>> {
+        None
+    }
+
+    #[test]
+    fn happy_path_colorterm_truecolor_no_warning() {
+        // $COLORTERM advertises truecolor -> no warning, unchanged from today,
+        // regardless of terminfo / suppression.
+        for ct in [Some("truecolor"), Some("24bit"), Some("truecolor:foo")] {
+            assert!(!should_warn_no_truecolor(
+                ct,
+                Some("xterm-256color"),
+                None,
+                no_caps
+            ));
+        }
+    }
+
+    #[test]
+    fn terminfo_tc_or_rgb_suppresses_warning() {
+        // $COLORTERM unset but $TERM exposes Tc / RGB -> no warning (#397 fix).
+        let tc = |_t: &str| Some(vec!["am".to_string(), "Tc".to_string()]);
+        let rgb = |_t: &str| Some(vec!["RGB".to_string()]);
+        assert!(!should_warn_no_truecolor(
+            None,
+            Some("tmux-256color"),
+            None,
+            tc
+        ));
+        assert!(!should_warn_no_truecolor(
+            None,
+            Some("xterm-direct"),
+            None,
+            rgb
+        ));
+        // Case-insensitive on the cap name.
+        let lc = |_t: &str| Some(vec!["rgb".to_string()]);
+        assert!(!should_warn_no_truecolor(None, Some("foo"), None, lc));
+    }
+
+    #[test]
+    fn suppression_env_var_silences_warning() {
+        // Truthy suppression var with no other signal -> no warning.
+        for v in ["1", "true", "TRUE", "yes", "on", " on "] {
+            assert!(
+                !should_warn_no_truecolor(None, Some("xterm-256color"), Some(v), no_caps),
+                "{v:?} should suppress"
+            );
+        }
+        // Falsy / empty suppression var -> warning still fires.
+        for v in [
+            None,
+            Some(""),
+            Some("0"),
+            Some("false"),
+            Some("no"),
+            Some("x"),
+        ] {
+            assert!(
+                should_warn_no_truecolor(None, Some("xterm-256color"), v, no_caps),
+                "{v:?} should NOT suppress"
+            );
+        }
+    }
+
+    #[test]
+    fn negative_non_truecolor_term_still_warns() {
+        // $COLORTERM unset, $TERM a non-truecolor entry, suppression unset ->
+        // warning fires (current behavior preserved).
+        assert!(should_warn_no_truecolor(
+            None,
+            Some("xterm-256color"),
+            None,
+            no_caps
+        ));
+    }
+
+    #[test]
+    fn terminfo_unavailable_degrades_gracefully() {
+        // terminfo db missing/unreadable (caps -> None) falls back to the
+        // COLORTERM + suppression checks with no panic.
+        assert!(should_warn_no_truecolor(
+            None,
+            Some("xterm-256color"),
+            None,
+            caps_unavailable
+        ));
+        // ...and the COLORTERM / suppression escape hatches still win.
+        assert!(!should_warn_no_truecolor(
+            Some("truecolor"),
+            Some("xterm-256color"),
+            None,
+            caps_unavailable
+        ));
+        assert!(!should_warn_no_truecolor(
+            None,
+            Some("xterm-256color"),
+            Some("1"),
+            caps_unavailable
+        ));
+        // An empty/absent $TERM never advertises (and never calls into caps).
+        assert!(should_warn_no_truecolor(None, None, None, no_caps));
+        assert!(should_warn_no_truecolor(None, Some(""), None, no_caps));
+    }
+
+    // Exercises the REAL infocmp seam to pin the `-x` requirement: `Tc`/`RGB`
+    // are extended caps that `infocmp` omits without `-x`. Skips when the host
+    // has no `infocmp` or no entry carrying an extended truecolor cap (CI
+    // runners vary) — a pure presence assertion would be flaky, so we only
+    // assert the parse + policy WHEN we can confirm the entry actually
+    // advertises one.
+    #[test]
+    fn real_terminfo_probe_surfaces_extended_truecolor_caps() {
+        // ghostty is the most reliable bearer of a bare `Tc`; fall through
+        // others a truecolor host might have.
+        let advertised = ["ghostty", "xterm-direct", "tmux-direct", "alacritty"]
+            .into_iter()
+            .find_map(|t| {
+                terminfo_boolean_caps(t)
+                    .filter(|caps| {
+                        caps.iter()
+                            .any(|c| c.eq_ignore_ascii_case("Tc") || c.eq_ignore_ascii_case("RGB"))
+                    })
+                    .map(|_| t)
+            });
+
+        let Some(term) = advertised else {
+            eprintln!("skipping: no infocmp entry with an extended Tc/RGB cap on this host");
+            return;
+        };
+
+        // The real probe surfaced the extended cap (proving `-x` is wired), so
+        // the policy must NOT warn even with $COLORTERM unset + no suppression.
+        assert!(
+            !should_warn_no_truecolor(None, Some(term), None, terminfo_boolean_caps),
+            "{term} advertises truecolor via terminfo — policy must not warn"
+        );
     }
 }


### PR DESCRIPTION
## Summary

The truecolor preflight nags legitimate users. It warns on a non-headless `run` tty whenever `$COLORTERM` doesn't advertise `truecolor`/`24bit`, but that variable is widely unset on genuinely-truecolor setups: tmux strips it, some SSH sessions drop it, and a class of terminals signal 24-bit color through the terminfo `Tc`/`RGB` capability instead of `$COLORTERM` at all. Those users get a warning they can't act on and can't silence, which is the false-positive class this issue describes.

This teaches the warning to consult terminfo before firing, and adds a documented escape hatch. The check now stays silent when `$COLORTERM` advertises truecolor, when terminfo exposes `Tc`/`RGB` for the current `$TERM`, or when `PIXTUOID_NO_TRUECOLOR_WARN` is set to a truthy value, and the warning copy itself now names that env var so a nagged user has a way out. The behavior that matters is preserved: it stays warn-only and never gates on Unix, prints pre-altscreen, and Windows continues to hard-gate VT separately.

The policy lives in one pure function that takes its env values and an injected terminfo lookup, so every branch is unit-testable without touching the process environment, matching the existing style in this module. The real terminfo probe shells out to `infocmp` and degrades gracefully: any failure (no binary, no entry, unreadable database) is treated as not advertised, so a host without terminfo behaves exactly as it does today.

One subtlety worth calling out for review is that the probe must pass the extended-capabilities flag, because `Tc` and `RGB` are user-defined capabilities that the default output omits, which would otherwise drop the very signal this fix relies on. The `pixtuoid doctor` terminal verdict was also updated to read the same signals, so the diagnostic and the startup warning can no longer disagree about whether a terminal is truecolor.

## Related issue

Fixes #397

## Type of change

Bug fix.

## How I tested it

New unit tests cover every scenario the issue lists: the COLORTERM happy path, the terminfo fallback that is the real fix, the suppression hatch firing for truthy values but not for empty or falsy ones, the non-truecolor case where the warning is correctly preserved, and graceful degradation when terminfo is unavailable. One test drives the real `infocmp` seam to pin the extended-capabilities requirement, skipping when the host has no entry advertising it so it never goes flaky on CI. Locally I ran format, clippy, build, and the full library test suite for the crate, and all 650 tests pass.

## Visual verification (required for sprite / rendering changes)

Not a visual change. This touches terminal-capability detection and the `doctor` diagnostic only, with no sprite or pixel-painter edit.

## Checklist

I read the root and crate `CLAUDE.md`, added tests for the new behavior (TDD-first), kept non-test code free of `unwrap()` with errors propagating via `anyhow`, added no new production-path `println!`/`eprintln!` (the existing pre-altscreen warning is preserved, not added), and updated the crate guide's term entry in the same commit. I ran the per-step equivalent of `just preflight` (format, clippy, build, and the crate test suite); a pre-existing `collapsible_match` clippy warning elsewhere in `pixtuoid-core` is unrelated to this change.

## AI assistance

This PR was written with AI-agent assistance.
