### PR TITLE
chore(hardening): close 5 AI-dev best-practice gaps (lint + deny + CI gates)

### DIFF
--- a/.github/prompts/pr_review_rules.md
+++ b/.github/prompts/pr_review_rules.md
@@ -42,6 +42,25 @@ by reading actual code — no guessing, no "this might be an issue."
    same finding); `Frame`/`RgbBuffer` each re-hand-rolled `Grid<T>`'s row-major buffer. This is
    the ONE check that requires searching the codebase, not just reading the diff.
 
+### Escalate by what the diff touches
+
+The checks above apply to every PR; these fire only when the diff touches a
+high-risk seam, and they require looking BEYOND the diff:
+
+- **`crates/pixtuoid-hook/**` (the shim)** → audit the WHOLE shim, not just the
+  diff. It must use `args_os()` not `args()` (a non-UTF-8 argv panics → non-zero
+  exit, visible to CC), do no slicing/indexing on untrusted bytes, bound every
+  read, and route every error path to a silent `exit(0)`. Invariant #5 is the
+  most-documented contract here, yet a prod `env::args()` once slipped both the
+  bot and local review (#198).
+- **`motion/` / `pose/` / walk-leg behavior** → not diff-readable. State in your
+  summary that a human must render and WATCH it (an animation via the snapshot
+  example, or `scripts/replay-fixture.sh` for resume/lifecycle motion) before
+  merge — five walk regressions once shipped behind an unchecked "live run" (#61).
+- **reducer / liveness ladder / sweeps** → trace the downstream interaction graph
+  (rebind, TTLs, cascade, dedup), not just the changed lines; the bug is usually
+  in an interaction the diff doesn't show.
+
 ### Do NOT flag
 
 - Formatting or style (rustfmt enforced in CI)

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -21,7 +21,7 @@ jobs:
   review:
     if: >
       (github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/claude-review'))
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/claude-review') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     concurrency:

--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -23,7 +23,7 @@ jobs:
   security-review:
     if: >
       (github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/security-review'))
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/security-review') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,11 +19,15 @@ permissions:
 
 jobs:
   claude:
+    # Gate to repo-write actors. claude-code-action enforces this internally, but
+    # this is the only contents:write job — fail CLOSED at the yaml layer too,
+    # independent of the floating action tag. Each of the four event shapes needs
+    # its OWN author_association field, or the owner's own trigger gets blocked.
     if: >
-      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude')) ||
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)) ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     concurrency:

--- a/crates/pixtuoid-core/src/lib.rs
+++ b/crates/pixtuoid-core/src/lib.rs
@@ -1,5 +1,12 @@
 //! pixtuoid-core: headless logic for the pixtuoid TUI.
 
+// Invariant #1: this crate is headless and must never write to a terminal.
+// `just arch` greps the dep tree (ratatui/crossterm), but a raw `println!`
+// pulls no dep and slips past it — this clippy restriction lint closes that
+// gap (a hard error under the workspace `-D warnings`). Non-test builds only,
+// so test diagnostics may print freely.
+#![cfg_attr(not(test), warn(clippy::print_stdout, clippy::print_stderr))]
+
 pub mod grid;
 pub mod id;
 pub mod layout;

--- a/crates/pixtuoid-hook/src/main.rs
+++ b/crates/pixtuoid-hook/src/main.rs
@@ -1,3 +1,13 @@
+// Invariant #5 (non-negotiable): the shim must never block CC — it always exits
+// 0 silently on any error. A prod `unwrap()`/`expect()`/`panic!` violates that
+// (non-zero exit + a backtrace CC may surface), so they are compiler-denied in
+// non-test builds for this safety-critical crate (tests unwrap freely). Scoped
+// to the shim ONLY — a workspace-wide ban would churn ~150 grandfathered unwraps.
+#![cfg_attr(
+    not(test),
+    deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)
+)]
+
 use std::io::Read;
 use std::time::{SystemTime, UNIX_EPOCH};
 

--- a/crates/pixtuoid-scene/src/lib.rs
+++ b/crates/pixtuoid-scene/src/lib.rs
@@ -6,6 +6,12 @@
 //! dependency — `tui` (ratatui half-block) and `floating` (winit/softbuffer)
 //! are thin painters layered on top, and neither depends on the other.
 
+// Terminal- and window-free (invariant #1, crate-boundary enforced). The dep
+// boundary can't see a raw `println!` (std, no dep); this restriction lint does
+// (a hard error under the workspace `-D warnings`). Non-test builds only, so
+// test diagnostics may print freely.
+#![cfg_attr(not(test), warn(clippy::print_stdout, clippy::print_stderr))]
+
 pub mod anim;
 pub mod chitchat;
 pub mod embedded_pack;

--- a/deny.toml
+++ b/deny.toml
@@ -19,7 +19,7 @@ multiple-versions = "warn"
 wildcards = "allow"
 
 [sources]
-unknown-registry = "warn"
-unknown-git = "warn"
+unknown-registry = "deny"
+unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = []


### PR DESCRIPTION
## Why

A web-grounded audit against **2026 AI-driven-development best practices** (Anthropic context-engineering, the lethal-trifecta / PromptPwnd security work, CSA slopsquatting, GitHub agent-PR-review guidance) — run as a multi-agent workflow and **adversarially verified** (5 of 13 candidate gaps refuted as already-covered) — surfaced five cheap, no-ceremony hardening wins. All live *inside gates already kept* (`clippy -D warnings`, `cargo-deny`, the review prompt) — no re-added scripts, ledgers, or attestations. Every surviving gap was rated LOW; this is hardening, not a hole.

## Changes

| Area | Change | Closes (2026 practice) |
|---|---|---|
| **deny.toml** | `unknown-registry` / `unknown-git` `warn` → `deny` | An out-of-registry / typosquatted dep an agent adds now **fails** the gate. No-op today (all 453 deps → crates.io). [slopsquatting] |
| **pixtuoid-core + pixtuoid-scene** | `clippy::print_stdout/print_stderr = warn` (non-test) | The one corner of invariant #1 `just arch` can't see — a raw `println!` pulls no terminal dep and slips the dep-grep. Replaces the prod-print grep deleted with `check_dod`. [executability ladder] |
| **pixtuoid-hook** | `deny clippy::unwrap_used/expect_used/panic` (non-test) | Pins invariant #5 (the shim never panics) at the compiler. Scoped to the shim only — workspace-wide would churn ~150 grandfathered unwraps. Zero churn today. [verification gates] |
| **claude.yml + comment triggers** | actor-gate to `OWNER/MEMBER/COLLABORATOR` | The `contents:write` `@claude` job + `/claude-review` `/security-review` now fail closed at the yaml layer (all four event shapes), independent of the action's internal actor check. [lethal trifecta] |
| **pr_review_rules.md** | add a "by touched path" escalation block | The auto bot now carries the #198 (whole-shim never-panic) / #61 (motion render+watch) escalations its manual sibling has. [agentic review] |

All non-test scoping uses `cfg_attr(not(test), ...)` so the lints fire on production code but test diagnostics print / unwrap freely.

## Deliberately NOT done

- **SHA-pinning the actions** (and the workflows that would carry the pins aren't touched here). The local two-lens review corrected an earlier draft's claim that the actions are "first-party only" — they are not. The honest split:
  - **Read-only CI actions** (`dtolnay/rust-toolchain`, `Swatinem/rust-cache`, `taiki-e/install-action`, `extractions/setup-just`, `EmbarkStudios/cargo-deny-action`, `withastro/action`): a moved tag could poison a CI run, but these jobs hold no publish secrets. Floating tags + Dependabot is an accepted posture — left as-is.
  - **Publish / credentialed path** (`softprops/action-gh-release`, `orhun/git-cliff-action`, `rust-lang/crates-io-auth-action` — mints the crates.io OIDC token — and `codecov/codecov-action`): a moved tag here could exfiltrate the release / crates.io / codecov token. SHA-pinning these is genuinely worth it. This PR doesn't touch the release workflow, so it's deferred to a tracked follow-up rather than smuggled in.

## Verification

`just preflight` green (1924/1924) · the print/unwrap lints found **zero existing violations** (the audit's zero-churn prediction held) · `cargo deny check sources` ok · `actionlint` green · all 30 CI checks green on this PR · **two-lens review run locally** (the auto bot self-skips a PR that edits the review workflows — by design) — both lenses SAFE TO MERGE; the one MEDIUM (the SHA-pin justification above) corrected and deferred to a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121vF6GrV7TEXC3H8eR5wBw
