### PR TITLE
fix(drift): repoint opencode + copilot watcher URLs after upstream restructures (#406)

### DIFF
--- a/scripts/check_upstream_drift.py
+++ b/scripts/check_upstream_drift.py
@@ -200,9 +200,15 @@ CODEWHALE_KNOWN_OMITTED = {
 # NB: the repo's default branch is `dev` (not `main`) — the `main` branch was
 # retired, which 404'd these URLs and (pre-`try_fetch`) was silently bucketed as
 # transient, blinding the opencode watch. Track `dev` (the active default).
+# NB2: opencode moved the schema definitions out of `packages/core/` into a
+# dedicated `packages/schema/` package (the old `core/src/v1/session.ts` is now a
+# re-export shim with no `type:` literals — it 200s but greps empty, which read as
+# a false "every event GONE" until these paths were repointed, #406). The session
+# lifecycle + `message.part.updated` live in `schema/src/v1/session.ts`; the v2
+# `permission.v2.asked` lives in the top-level `schema/src/permission.ts`.
 OPENCODE_EVENT_URLS = (
-    "https://raw.githubusercontent.com/anomalyco/opencode/dev/packages/core/src/v1/session.ts",
-    "https://raw.githubusercontent.com/anomalyco/opencode/dev/packages/core/src/permission.ts",
+    "https://raw.githubusercontent.com/anomalyco/opencode/dev/packages/schema/src/v1/session.ts",
+    "https://raw.githubusercontent.com/anomalyco/opencode/dev/packages/schema/src/permission.ts",
 )
 
 # `permission.asked` is forwarded/decoded DEFENSIVELY (a V1/alias spelling); only
@@ -210,16 +216,21 @@ OPENCODE_EVENT_URLS = (
 # don't alarm if the bare form isn't found as a `type:` literal.
 OPENCODE_TOLERATED = {"permission.asked"}
 
-# Copilot CLI publishes a session-events JSON schema in its npm package; unpkg
-# serves the file directly (the bare path 302-redirects to the latest pinned
-# version, which urllib follows — intentionally UNPINNED: a drift watch wants to
-# track the latest published shape, not freeze a tested one). Each event is a
-# `definitions.<Name>` object whose
+# Copilot CLI publishes a session-events JSON schema; unpkg serves the file
+# directly (the bare path 302-redirects to the latest published version, which
+# urllib follows — intentionally UNPINNED: a drift watch wants the latest shape,
+# not a frozen one). Each event is a `definitions.<Name>` object whose
 # `properties.type.const` is the wire `type` string. The check is ONE-DIRECTIONAL
 # (like opencode): Copilot emits ~100 event types and copilot.rs intentionally maps
 # only ~10, so "new upstream event" is noise — we alarm only when a type WE DEPEND
 # ON vanishes (a rename the transcript still carries but the decoder maps to nothing).
-COPILOT_SCHEMA_URL = "https://unpkg.com/@github/copilot/schemas/session-events.schema.json"
+# NB: `@github/copilot` is now a thin loader stub (its tarball is just package.json
+# + npm-loader.js that pulls a `@github/copilot-<os>-<arch>` binary package at
+# runtime), so the schema 404'd at the old root path (#406). The schema ships
+# inside the platform packages at `schemas/session-events.schema.json`; we fetch
+# the linux-x64 one (matches the CI host — every platform package carries the
+# identical schema, and unpkg serves the single file without the 100MB tarball).
+COPILOT_SCHEMA_URL = "https://unpkg.com/@github/copilot-linux-x64/schemas/session-events.schema.json"
 
 # Cursor CLI (`cursor-agent`) is HOOK-ONLY; the events we register/decode are
 # camelCase `hook_event_name`s (`source/cursor.rs`). Cursor is a closed binary,

--- a/scripts/check_upstream_drift.py
+++ b/scripts/check_upstream_drift.py
@@ -28,12 +28,13 @@ and compares against the live upstream:
   * opencode events    -> the EventV2 `type`s the decoder maps (the `match event`
                           block in crates/pixtuoid-core/src/source/opencode.rs)
                           vs the `EventV2.define` type literals in
-                          anomalyco/opencode core/src/v1/session.ts + permission.ts
+                          anomalyco/opencode packages/schema/src/v1/session.ts +
+                          packages/schema/src/permission.ts
                           (one-directional: only a VANISHED depended type alarms)
   * Copilot events     -> the event `type`s the decoder maps (the `match kind`
                           block in crates/pixtuoid-core/src/source/copilot.rs)
                           vs the per-event `type` consts in the published
-                          @github/copilot session-events JSON schema (unpkg)
+                          @github/copilot-<os>-<arch> session-events JSON schema (unpkg)
                           (one-directional: Copilot emits ~100 event types and we
                           map ~10 by design, so only a VANISHED depended type alarms)
   * Cursor hooks       -> the camelCase `hook_event_name`s we register


### PR DESCRIPTION
Fixes #406.

## What #406 actually was

The weekly upstream-drift watch auto-filed a report claiming four opencode events were "GONE from upstream" (decoder silently dropping events) plus a copilot schema 404. **Neither is real decoder drift** — both upstreams moved the files the watcher greps, and the watcher's URL constants went stale. Verified live against the real upstreams before touching anything.

## opencode — false positive

opencode hoisted its schema definitions out of `packages/core/` into a new `packages/schema/` package. The old `core/src/v1/session.ts` is now a re-export shim (`export * as SessionV1 from "./session"`) — it returns HTTP 200 but contains **zero** `type:` literals, so the grep matched nothing and flagged *every* depended event as gone (the tell: four lifecycle events don't get renamed in one release). All four still exist and our decoder matches them:

| event | now lives in |
|---|---|
| `session.created`, `session.deleted`, `message.part.updated` | `packages/schema/src/v1/session.ts` |
| `permission.v2.asked` | `packages/schema/src/permission.ts` |

## copilot — accurate report, fixed

`@github/copilot` is now a thin **loader stub** — its npm tarball is just `package.json` + an `npm-loader.js` that pulls a `@github/copilot-<os>-<arch>` binary package at runtime. So the schema genuinely 404'd at the old root path (the watch was correctly reporting itself blind). The schema now ships **inside** the platform packages at `schemas/session-events.schema.json`. Repointed to the linux-x64 package (matches the CI host; every platform package carries the identical schema, and unpkg serves the single file without the ~100 MB tarball).

## The fix

One file, `scripts/check_upstream_drift.py` (+19/−8): repoint `OPENCODE_EVENT_URLS` and `COPILOT_SCHEMA_URL`, with comments recording *why* each path looks unusual (the `core`→`schema` move; the loader-stub indirection) so the next person doesn't re-chase it. **No decoder change** — `opencode.rs` / `copilot.rs` were correct throughout.

## Verification

- Full watcher run → `✅ No drift. Every name we depend on is present upstream.` (exit 0)
- `check_upstream_drift_selftest.py` → `all checks passed`
- All 4 opencode events present at the new paths; all 10 copilot events present in the relocated schema (117 upstream consts, 0 missing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121vF6GrV7TEXC3H8eR5wBw
