### PR TITLE
refactor(tui): hoist the drop-shadow cast offset to a named const

### DIFF
--- a/crates/pixtuoid/src/tui/widgets/mod.rs
+++ b/crates/pixtuoid/src/tui/widgets/mod.rs
@@ -56,6 +56,11 @@ fn to_color(c: Rgb) -> Color {
 const SHADOW_RIGHT_FALLOFF: [f32; 2] = [0.66, 0.85];
 const SHADOW_BOTTOM_FACTOR: f32 = 0.74;
 
+/// How far the shadow is cast down-and-right of the card, in cells. The whole
+/// L-band shifts by this, which is what makes it read as a cast shadow rather
+/// than a hard outline. Bumping it deepens the offset; the falloff stays as-is.
+const SHADOW_OFFSET: u16 = 1;
+
 /// Multiply an `Rgb` color toward black by `f`. Half-block office cells carry a
 /// real RGB on BOTH `fg` (top sub-pixel) and `bg` (bottom sub-pixel), so a clean
 /// shadow darkens both — ratatui's own `Block::shadow` tints bg-only / stamps a
@@ -95,16 +100,16 @@ fn cast_drop_shadow(f: &mut ratatui::Frame<'_>, area: Rect) {
     for (d, &factor) in SHADOW_RIGHT_FALLOFF.iter().enumerate() {
         let col = Rect {
             x: area.right().saturating_add(d as u16),
-            y: area.y.saturating_add(1),
+            y: area.y.saturating_add(SHADOW_OFFSET),
             width: 1,
             height: area.height,
         };
         dim_band(f, col, bounds, factor);
     }
     let bottom = Rect {
-        x: area.x.saturating_add(1),
+        x: area.x.saturating_add(SHADOW_OFFSET),
         y: area.bottom(),
-        width: area.width.saturating_sub(1),
+        width: area.width.saturating_sub(SHADOW_OFFSET),
         height: 1,
     };
     dim_band(f, bottom, bounds, SHADOW_BOTTOM_FACTOR);


### PR DESCRIPTION
## What

Names the drop-shadow's cast distance. The "1 cell down-and-right" offset lived as three bare literals in `cast_drop_shadow` — the right strip's down-shift (`area.y + 1`), the bottom strip's right-shift (`area.x + 1`), and its compensating width trim (`area.width - 1`). All three are now `SHADOW_OFFSET`, so the shadow's tunables — `SHADOW_RIGHT_FALLOFF` + `SHADOW_BOTTOM_FACTOR` + `SHADOW_OFFSET` — sit together.

The band *thicknesses* (`width: 1` per falloff column, `height: 1` for the bottom row) stay literal on purpose — those are the 1-cell strip widths, not the cast offset.

## Why

Pure readability follow-up to #411. A future tweak to "how deep does the shadow sit" is now a one-line change next to the falloff, instead of hunting three magic `1`s that happen to mean the same thing.

## Not a behavior change

`SHADOW_OFFSET = 1`, so the render is byte-identical:
- All three `*_casts_a_drop_shadow*` tests pass unchanged (`panel.rs`, `tooltip.rs` ×2).
- Snapshot baselines stay pixel-stable — no `just gen` needed.
- `just preflight` green (1926 tests); clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)