### PR TITLE
fix(cli): truecolor by terminal query (DECRQSS) + refuse the canvas under $NO_COLOR/$TERM=dumb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2246,6 +2246,7 @@ dependencies = [
  "crossterm",
  "image",
  "insta",
+ "libc",
  "open",
  "pixtuoid-core",
  "pixtuoid-scene",

--- a/crates/pixtuoid/CLAUDE.md
+++ b/crates/pixtuoid/CLAUDE.md
@@ -37,9 +37,11 @@ src/
 │                       (run_sources_list/run_sources_set/run_change/run_setup, codecov-excluded like doctor::run)
 ├── term.rs             truecolor preflight — does NOT guess from a $TERM name allowlist; ASKS the terminal (#397).
 │                       `query_truecolor(timeout)` (the IO seam, cfg(unix), codecov-excluded): opens `/dev/tty`,
-│                       raw-modes it (RAII `TermiosRestore`), writes the DECRQSS probe (`ESC[48:2:1:2:3m ESC P$qm ESC\\
-│                       ESC[0m` — set unlikely 24-bit bg, query SGR back, reset), reads the reply via `libc::poll` until
-│                       the `ESC\\`/BEL terminator or the budget, then `parse_decrqss_truecolor` (PURE, unit-tested):
+│                       raw-modes it (RAII `TermiosRestore`), writes the DECRQSS probe (`ESC[48;2;1;2;3m ESC P$qm ESC\\
+│                       ESC[0m` — set unlikely 24-bit bg in the SEMICOLON form crossterm emits, query SGR back, reset),
+│                       reads the reply via `libc::select` (NOT poll — macOS `poll()` returns POLLNVAL on tty/pty fds,
+│                       found by PTY dogfood) until the `ESC\\`/BEL terminator or the budget, then `parse_decrqss_truecolor`
+│                       (PURE, unit-tested):
 │                       Some(true)=our RGB triple echoed back, Some(false)=valid-but-downsampled, None=`0$r`/empty/timeout.
 │                       The pure policy pieces: `warn_zone(cmd_is_run_tui, is_tty, colorterm, suppress_env)` (the cheap
 │                       pre-gate — only QUERY when this holds; truth-table tested) + `colorterm_is_truecolor` (an explicit

--- a/crates/pixtuoid/CLAUDE.md
+++ b/crates/pixtuoid/CLAUDE.md
@@ -56,7 +56,21 @@ src/
 │                       (softbuffer = real RGB px). **Sharp edges:** a truecolor terminal that doesn't answer DECRQSS (rare)
 │                       false-positives → the escape hatch covers it; a very-laggy reply past the 100ms budget could leak a
 │                       few bytes to the TUI's stdin (accepted, rare). The query is the authority — there is NO $TERM/
-│                       $TERM_PROGRAM allowlist to keep current (deleted on purpose; that was the "magic variable" smell)
+│                       $TERM_PROGRAM allowlist to keep current (deleted on purpose; that was the "magic variable" smell).
+│                       SEPARATE axis (color ON/OFF, not depth): `color_preflight(no_color, clicolor_force, term)` →
+│                       `ColorPreflight` {Proceed / ForceColor / RefuseNoColor / RefuseDumbTerm}. The office is 24-bit with
+│                       NO legible monochrome fallback, so when color is disabled we REFUSE the canvas + explain (mirrors the
+│                       Windows VT hard-gate) instead of rendering block-soup. Precedence: `$TERM=dumb` first (can't render
+│                       escapes at all — a force can't fix it), then NON-EMPTY `$NO_COLOR` (crossterm strips our SGR to a bare
+│                       reset — VERIFIED empirically) UNLESS NON-EMPTY `$CLICOLOR_FORCE` overrides it (BSD precedence →
+│                       `ForceColor`; main.rs MUST call `crossterm::style::force_color_output(true)` itself — crossterm
+│                       honors `$NO_COLOR` but NOT `$CLICOLOR_FORCE`, also verified). Empty `$NO_COLOR` is ignored (matches
+│                       crossterm — the thing that strips). Gated to the `run` TUI only (--headless/doctor/sources are plain
+│                       text; floating = softbuffer). `color_status_row(pf)` is the `doctor` color line (reuses the SAME
+│                       policy so the diagnostic matches `run`; doctor also SKIPS the DECRQSS probe under `$TERM=dumb`).
+│                       **Sharp edge:** tmux (#4034) doesn't implement DECRQSS, so a truecolor tmux can false-positive the
+│                       depth warn — `$PIXTUOID_NO_TRUECOLOR_WARN=1` covers it (tmux usually sets `$COLORTERM`, skipping the
+│                       query entirely anyway).
 ├── setup.rs            first-run detection for onboarding: the PURE `is_first_run(cfg, path) = !path.exists() ||
 │                       cfg.sources.is_empty()` (mirrors resolve_connected's migrate condition; unit-tested). `pub`
 │                       because main.rs (a separate crate) computes RunConfig.first_run from it. The cinematic overlay

--- a/crates/pixtuoid/CLAUDE.md
+++ b/crates/pixtuoid/CLAUDE.md
@@ -38,13 +38,24 @@ src/
 ├── term.rs             truecolor preflight (ALL fns PURE + unit-tested — main.rs is the untestable presenter,
 │                       so the policy lives here; `doctor::run` returns its report String so it's tested too):
 │                       `colorterm_is_truecolor($COLORTERM)` (the
-│                       S-Lang/terminfo `truecolor`/`24bit` convention) + `should_warn_truecolor(cmd_is_run_tui, is_tty,
-│                       colorterm)` (the warn-gate PREDICATE — its truth table is unit-tested) + `terminal_diagnostic_row(
-│                       term, colorterm)` (the `doctor` `terminal:` line; env values sanitized). main.rs WARN-ONLY (never
-│                       gates on Unix — many truecolor terminals omit COLORTERM; the `#[cfg(not(windows))]`, `IsTerminal`
-│                       probe, and the env read stay INLINED at the excluded main.rs call site — which just calls
-│                       `should_warn_truecolor`, no untestable policy wrapper to mutate) on a non-windows Run-TUI tty. Windows hard-gates VT separately
-│                       (tui/mod). `floating` is exempt (softbuffer = real RGB px). #397 = terminfo Tc/RGB follow-up
+│                       S-Lang/terminfo `truecolor`/`24bit` convention) + `term_is_truecolor($TERM,$TERM_PROGRAM)` (the
+│                       static allowlist — `*-direct`/`*-truecolor`, kitty/ghostty/alacritty/wezterm/foot/contour/rio,
+│                       TERM_PROGRAM ∈ {iTerm.app,WezTerm,ghostty,vscode,Hyper,rio,Tabby}; mirrors what supports-color/
+│                       anstyle-query do — neither reads terminfo) + `should_warn_truecolor(cmd_is_run_tui, is_tty,
+│                       colorterm, term, term_program, suppress_env)` (the warn-gate PREDICATE — truth table unit-tested) +
+│                       `terminal_diagnostic_row(term, colorterm, term_program)` (the `doctor` `terminal:` line; shares the
+│                       same advertise signals so doctor + the warning can't disagree; names WHICH signal fired; env values
+│                       sanitized). main.rs WARN-ONLY (never gates on Unix — many truecolor terminals omit COLORTERM; the
+│                       `#[cfg(not(windows))]`, `IsTerminal` probe, and the env reads stay INLINED at the excluded main.rs
+│                       call site — no untestable policy wrapper to mutate) on a non-windows Run-TUI tty. Windows hard-gates
+│                       VT separately (tui/mod). `floating` is exempt (softbuffer = real RGB px). **Known sharp edge (#397):**
+│                       the deep tmux/SSH case whose ONLY truecolor signal is a terminfo `Tc`/`RGB` override is intentionally
+│                       NOT auto-detected — that needs an `infocmp` subprocess (absent on musl/alpine/Nix, and stale on stock
+│                       macOS where `tmux-256color` carries no `Tc`) or a terminfo dep, far too much for a warn-only nag; it's
+│                       covered by the `$PIXTUOID_NO_TRUECOLOR_WARN` escape hatch (truthy `1`/`true`/`yes`/`on`) instead.
+│                       Apple `Terminal.app` (`xterm-256color`, 256-color until macOS 26/Tahoe) is deliberately EXCLUDED from
+│                       the allowlist so it still warns. Upgrade path IF false-positive reports arrive: the pure-Rust `termini`
+│                       crate reads the extended `Tc`/`RGB` boolean cap with no subprocess — NOT an `infocmp` shell-out
 ├── setup.rs            first-run detection for onboarding: the PURE `is_first_run(cfg, path) = !path.exists() ||
 │                       cfg.sources.is_empty()` (mirrors resolve_connected's migrate condition; unit-tested). `pub`
 │                       because main.rs (a separate crate) computes RunConfig.first_run from it. The cinematic overlay

--- a/crates/pixtuoid/CLAUDE.md
+++ b/crates/pixtuoid/CLAUDE.md
@@ -35,27 +35,26 @@ src/
 │                       capture them); main.rs dispatches both as plain arms (tracing → stderr, so stdout stays clean). The
 │                       five PathBuf args carry `value_hint` so completions path-complete. Presenters live in main.rs
 │                       (run_sources_list/run_sources_set/run_change/run_setup, codecov-excluded like doctor::run)
-├── term.rs             truecolor preflight (ALL fns PURE + unit-tested — main.rs is the untestable presenter,
-│                       so the policy lives here; `doctor::run` returns its report String so it's tested too):
-│                       `colorterm_is_truecolor($COLORTERM)` (the
-│                       S-Lang/terminfo `truecolor`/`24bit` convention) + `term_is_truecolor($TERM,$TERM_PROGRAM)` (the
-│                       static allowlist — `*-direct`/`*-truecolor`, kitty/ghostty/alacritty/wezterm/foot/contour/rio,
-│                       TERM_PROGRAM ∈ {iTerm.app,WezTerm,ghostty,vscode,Hyper,rio,Tabby}; mirrors what supports-color/
-│                       anstyle-query do — neither reads terminfo) + `should_warn_truecolor(cmd_is_run_tui, is_tty,
-│                       colorterm, term, term_program, suppress_env)` (the warn-gate PREDICATE — truth table unit-tested) +
-│                       `terminal_diagnostic_row(term, colorterm, term_program)` (the `doctor` `terminal:` line; shares the
-│                       same advertise signals so doctor + the warning can't disagree; names WHICH signal fired; env values
-│                       sanitized). main.rs WARN-ONLY (never gates on Unix — many truecolor terminals omit COLORTERM; the
-│                       `#[cfg(not(windows))]`, `IsTerminal` probe, and the env reads stay INLINED at the excluded main.rs
-│                       call site — no untestable policy wrapper to mutate) on a non-windows Run-TUI tty. Windows hard-gates
-│                       VT separately (tui/mod). `floating` is exempt (softbuffer = real RGB px). **Known sharp edge (#397):**
-│                       the deep tmux/SSH case whose ONLY truecolor signal is a terminfo `Tc`/`RGB` override is intentionally
-│                       NOT auto-detected — that needs an `infocmp` subprocess (absent on musl/alpine/Nix, and stale on stock
-│                       macOS where `tmux-256color` carries no `Tc`) or a terminfo dep, far too much for a warn-only nag; it's
-│                       covered by the `$PIXTUOID_NO_TRUECOLOR_WARN` escape hatch (truthy `1`/`true`/`yes`/`on`) instead.
-│                       Apple `Terminal.app` (`xterm-256color`, 256-color until macOS 26/Tahoe) is deliberately EXCLUDED from
-│                       the allowlist so it still warns. Upgrade path IF false-positive reports arrive: the pure-Rust `termini`
-│                       crate reads the extended `Tc`/`RGB` boolean cap with no subprocess — NOT an `infocmp` shell-out
+├── term.rs             truecolor preflight — does NOT guess from a $TERM name allowlist; ASKS the terminal (#397).
+│                       `query_truecolor(timeout)` (the IO seam, cfg(unix), codecov-excluded): opens `/dev/tty`,
+│                       raw-modes it (RAII `TermiosRestore`), writes the DECRQSS probe (`ESC[48:2:1:2:3m ESC P$qm ESC\\
+│                       ESC[0m` — set unlikely 24-bit bg, query SGR back, reset), reads the reply via `libc::poll` until
+│                       the `ESC\\`/BEL terminator or the budget, then `parse_decrqss_truecolor` (PURE, unit-tested):
+│                       Some(true)=our RGB triple echoed back, Some(false)=valid-but-downsampled, None=`0$r`/empty/timeout.
+│                       The pure policy pieces: `warn_zone(cmd_is_run_tui, is_tty, colorterm, suppress_env)` (the cheap
+│                       pre-gate — only QUERY when this holds; truth-table tested) + `colorterm_is_truecolor` (an explicit
+│                       positive that SKIPS the round-trip — the terminal declaring itself, not a guess) +
+│                       `truecolor_warn_suppressed($PIXTUOID_NO_TRUECOLOR_WARN`, truthy `1`/`true`/`yes`/`on`) +
+│                       `terminal_diagnostic_row(term, colorterm, probe)` (the `doctor` `terminal:` line; names HOW it was
+│                       determined — COLORTERM / terminal query / downsamples / unknown). main.rs WARN-ONLY (never gates on
+│                       Unix): `warn_zone(..) && query_truecolor(..) != Some(true)`, env/tty reads INLINED at the excluded
+│                       call site. `doctor` runs the query ONLY when stdout is a tty (piped `doctor > file` neither emits
+│                       escape codes nor probes — also why the test harness, output captured, never probes). Windows
+│                       hard-gates VT separately (tui/mod); `query_truecolor` is a `None` stub there. `floating` is exempt
+│                       (softbuffer = real RGB px). **Sharp edges:** a truecolor terminal that doesn't answer DECRQSS (rare)
+│                       false-positives → the escape hatch covers it; a very-laggy reply past the 100ms budget could leak a
+│                       few bytes to the TUI's stdin (accepted, rare). The query is the authority — there is NO $TERM/
+│                       $TERM_PROGRAM allowlist to keep current (deleted on purpose; that was the "magic variable" smell)
 ├── setup.rs            first-run detection for onboarding: the PURE `is_first_run(cfg, path) = !path.exists() ||
 │                       cfg.sources.is_empty()` (mirrors resolve_connected's migrate condition; unit-tested). `pub`
 │                       because main.rs (a separate crate) computes RunConfig.first_run from it. The cinematic overlay

--- a/crates/pixtuoid/CLAUDE.md
+++ b/crates/pixtuoid/CLAUDE.md
@@ -62,10 +62,11 @@ src/
 │                       NO legible monochrome fallback, so when color is disabled we REFUSE the canvas + explain (mirrors the
 │                       Windows VT hard-gate) instead of rendering block-soup. Precedence: `$TERM=dumb` first (can't render
 │                       escapes at all — a force can't fix it), then NON-EMPTY `$NO_COLOR` (crossterm strips our SGR to a bare
-│                       reset — VERIFIED empirically) UNLESS NON-EMPTY `$CLICOLOR_FORCE` overrides it (BSD precedence →
+│                       reset — VERIFIED empirically) UNLESS `$CLICOLOR_FORCE` (bixense `!= 0`) overrides it (precedence →
 │                       `ForceColor`; main.rs MUST call `crossterm::style::force_color_output(true)` itself — crossterm
 │                       honors `$NO_COLOR` but NOT `$CLICOLOR_FORCE`, also verified). Empty `$NO_COLOR` is ignored (matches
-│                       crossterm — the thing that strips). Gated to the `run` TUI only (--headless/doctor/sources are plain
+│                       crossterm — the thing that strips); `$FORCE_COLOR`/`$CLICOLOR` are deliberately NOT read (crossterm
+│                       keys only on `$NO_COLOR`, so they'd no-op the render). Gated to the `run` TUI only (--headless/doctor/sources are plain
 │                       text; floating = softbuffer). `color_status_row(pf)` is the `doctor` color line (reuses the SAME
 │                       policy so the diagnostic matches `run`; doctor also SKIPS the DECRQSS probe under `$TERM=dumb`).
 │                       **Sharp edge:** tmux (#4034) doesn't implement DECRQSS, so a truecolor tmux can false-positive the

--- a/crates/pixtuoid/Cargo.toml
+++ b/crates/pixtuoid/Cargo.toml
@@ -45,6 +45,12 @@ softbuffer         = "0.4"
 clap_complete = "4.6.5"
 clap_mangen = "0.3.0"
 
+# termios/poll for the truecolor preflight's DECRQSS terminal query (term.rs):
+# raw-mode the controlling tty + timed read of the reply. Unix-only — Windows
+# hard-gates VT separately. Same 0.2 as pixtuoid-core/hook — no second build.
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 # GetShortPathNameW for the Codex/Reasonix Windows hook path: resolve a
 # space/metacharacter-bearing install path to its DOS 8.3 short form so cmd.exe /C
 # can invoke it (#195). Same 0.61 major as pixtuoid-core — no second build.

--- a/crates/pixtuoid/src/doctor.rs
+++ b/crates/pixtuoid/src/doctor.rs
@@ -569,14 +569,21 @@ pub fn run(log_path: &std::path::Path) -> anyhow::Result<String> {
     ));
     // Terminal capability: the pixel-art office needs a 24-bit-color terminal, and
     // the #1 silent failure is a non-truecolor terminal rendering approximated
-    // colors. Surface the detected $TERM/$COLORTERM so a "colors look wrong over
-    // ssh/tmux" report is self-diagnosable. The row is formatted by the PURE,
-    // unit-tested `term::terminal_diagnostic_row` (env values sanitized there);
-    // `.ok()` makes an unset var a genuine `None`, not `Some("")`.
+    // colors. When $COLORTERM hasn't already declared truecolor, ASK the terminal
+    // directly (DECRQSS) — but ONLY when stdout is a real tty, so a piped
+    // `pixtuoid doctor > file` neither emits escape codes nor blocks (and the
+    // test harness, whose output is captured, never probes). The row is formatted
+    // by the PURE, unit-tested `term::terminal_diagnostic_row`; `.ok()` makes an
+    // unset var a genuine `None`, not `Some("")`.
+    let truecolor_probe = if std::io::IsTerminal::is_terminal(&std::io::stdout()) {
+        crate::term::query_truecolor(crate::term::TRUECOLOR_PROBE_TIMEOUT)
+    } else {
+        None
+    };
     out.push_str(&crate::term::terminal_diagnostic_row(
         std::env::var("TERM").ok().as_deref(),
         std::env::var("COLORTERM").ok().as_deref(),
-        std::env::var("TERM_PROGRAM").ok().as_deref(),
+        truecolor_probe,
     ));
     out.push('\n');
     // Surface config-load warnings IN the report — a malformed config makes every

--- a/crates/pixtuoid/src/doctor.rs
+++ b/crates/pixtuoid/src/doctor.rs
@@ -576,6 +576,7 @@ pub fn run(log_path: &std::path::Path) -> anyhow::Result<String> {
     out.push_str(&crate::term::terminal_diagnostic_row(
         std::env::var("TERM").ok().as_deref(),
         std::env::var("COLORTERM").ok().as_deref(),
+        std::env::var("TERM_PROGRAM").ok().as_deref(),
     ));
     out.push('\n');
     // Surface config-load warnings IN the report — a malformed config makes every

--- a/crates/pixtuoid/src/doctor.rs
+++ b/crates/pixtuoid/src/doctor.rs
@@ -570,12 +570,22 @@ pub fn run(log_path: &std::path::Path) -> anyhow::Result<String> {
     // Terminal capability: the pixel-art office needs a 24-bit-color terminal, and
     // the #1 silent failure is a non-truecolor terminal rendering approximated
     // colors. When $COLORTERM hasn't already declared truecolor, ASK the terminal
-    // directly (DECRQSS) — but ONLY when stdout is a real tty, so a piped
-    // `pixtuoid doctor > file` neither emits escape codes nor blocks (and the
-    // test harness, whose output is captured, never probes). The row is formatted
-    // by the PURE, unit-tested `term::terminal_diagnostic_row`; `.ok()` makes an
-    // unset var a genuine `None`, not `Some("")`.
-    let truecolor_probe = if std::io::IsTerminal::is_terminal(&std::io::stdout()) {
+    // directly (DECRQSS) — but ONLY when stdout is a real tty (so a piped
+    // `pixtuoid doctor > file` neither emits escape codes nor blocks, and the test
+    // harness, whose output is captured, never probes) AND the terminal isn't
+    // $TERM=dumb (which can't answer DECRQSS — don't emit escapes at it). The same
+    // `color_preflight` the launcher acts on drives both the probe skip and the
+    // color-status line, so the diagnostic matches what `run` would do. The row is
+    // formatted by the PURE, unit-tested `term::terminal_diagnostic_row`; `.ok()`
+    // makes an unset var a genuine `None`, not `Some("")`.
+    let color_pf = crate::term::color_preflight(
+        std::env::var("NO_COLOR").ok().as_deref(),
+        std::env::var("CLICOLOR_FORCE").ok().as_deref(),
+        std::env::var("TERM").ok().as_deref(),
+    );
+    let probe_ok = std::io::IsTerminal::is_terminal(&std::io::stdout())
+        && color_pf != crate::term::ColorPreflight::RefuseDumbTerm;
+    let truecolor_probe = if probe_ok {
         crate::term::query_truecolor(crate::term::TRUECOLOR_PROBE_TIMEOUT)
     } else {
         None
@@ -586,6 +596,10 @@ pub fn run(log_path: &std::path::Path) -> anyhow::Result<String> {
         truecolor_probe,
     ));
     out.push('\n');
+    if let Some(line) = crate::term::color_status_row(color_pf) {
+        out.push_str(line);
+        out.push('\n');
+    }
     // Surface config-load warnings IN the report — a malformed config makes every
     // source read disconnected, and a diagnostic tool must say WHY rather than
     // silently swallow it. Sanitized: a warning can interpolate config content.

--- a/crates/pixtuoid/src/main.rs
+++ b/crates/pixtuoid/src/main.rs
@@ -13,16 +13,17 @@ fn main() -> Result<()> {
     let (log_level, cli_theme, cmd) = Cli::parse().cmd_or_default();
 
     // Truecolor preflight: the terminal TUI renders 24-bit half-block pixels; a
-    // terminal that advertises neither COLORTERM=truecolor nor a known-truecolor
-    // TERM/TERM_PROGRAM may render them approximated/garbled with no other hint.
-    // Warn ONCE on the pre-altscreen stderr channel — never gate on Unix (many
-    // truecolor terminals omit COLORTERM, so a gate would false-negative); Windows
-    // hard-gates VT separately in `tui::mod`. The deep tmux/SSH terminfo-Tc case
-    // isn't auto-detected (no startup infocmp subprocess) — $PIXTUOID_NO_TRUECOLOR_WARN
-    // is the escape hatch (#397). The `floating` window paints real RGB pixels via
-    // softbuffer, not terminal SGR, so it is exempt.
+    // non-truecolor terminal renders them approximated/garbled with no other hint.
+    // Rather than guess from a $TERM allowlist, ASK the terminal (DECRQSS) when
+    // $COLORTERM hasn't already declared truecolor — warn ONCE on the pre-altscreen
+    // stderr channel only if the terminal doesn't confirm. Never gate on Unix;
+    // Windows hard-gates VT separately in `tui::mod`. $PIXTUOID_NO_TRUECOLOR_WARN
+    // is an explicit escape hatch for a terminal we can't auto-detect (#397). The
+    // `floating` window paints real RGB pixels via softbuffer, not terminal SGR,
+    // so it is exempt. The query only runs when warn_zone holds, so a healthy
+    // truecolor session (COLORTERM set) pays nothing.
     #[cfg(not(windows))]
-    if pixtuoid::term::should_warn_truecolor(
+    if pixtuoid::term::warn_zone(
         matches!(
             &cmd,
             Cmd::Run {
@@ -32,16 +33,15 @@ fn main() -> Result<()> {
         ),
         std::io::IsTerminal::is_terminal(&std::io::stderr()),
         std::env::var("COLORTERM").ok().as_deref(),
-        std::env::var("TERM").ok().as_deref(),
-        std::env::var("TERM_PROGRAM").ok().as_deref(),
         std::env::var("PIXTUOID_NO_TRUECOLOR_WARN").ok().as_deref(),
-    ) {
+    ) && pixtuoid::term::query_truecolor(pixtuoid::term::TRUECOLOR_PROBE_TIMEOUT) != Some(true)
+    {
         eprintln!(
-            "⚠ pixtuoid: your terminal does not advertise truecolor (COLORTERM or a \
-             known truecolor TERM) — the pixel-art office renders in 24-bit color and \
-             may look wrong. Use a truecolor terminal (Windows Terminal, iTerm2, \
-             Ghostty, Alacritty, kitty, WezTerm), run `pixtuoid doctor` to check, or \
-             set PIXTUOID_NO_TRUECOLOR_WARN=1 to silence."
+            "⚠ pixtuoid: your terminal didn't confirm truecolor support — the \
+             pixel-art office renders in 24-bit color and may look wrong. Use a \
+             truecolor terminal (Windows Terminal, iTerm2, Ghostty, Alacritty, kitty, \
+             WezTerm), run `pixtuoid doctor` to check, or set \
+             PIXTUOID_NO_TRUECOLOR_WARN=1 to silence."
         );
     }
     // The typed LogLevel's as_str is exactly the old free-string levels, so

--- a/crates/pixtuoid/src/main.rs
+++ b/crates/pixtuoid/src/main.rs
@@ -13,12 +13,14 @@ fn main() -> Result<()> {
     let (log_level, cli_theme, cmd) = Cli::parse().cmd_or_default();
 
     // Truecolor preflight: the terminal TUI renders 24-bit half-block pixels; a
-    // terminal that does not advertise COLORTERM=truecolor may render them
-    // approximated/garbled with no other hint. Warn ONCE on the pre-altscreen
-    // stderr channel — never gate on Unix (many truecolor terminals omit
-    // COLORTERM, so a gate would false-negative); Windows hard-gates VT separately
-    // in `tui::mod`. The `floating` window paints real RGB pixels via softbuffer,
-    // not terminal SGR, so it is exempt.
+    // terminal that advertises neither COLORTERM=truecolor nor a known-truecolor
+    // TERM/TERM_PROGRAM may render them approximated/garbled with no other hint.
+    // Warn ONCE on the pre-altscreen stderr channel — never gate on Unix (many
+    // truecolor terminals omit COLORTERM, so a gate would false-negative); Windows
+    // hard-gates VT separately in `tui::mod`. The deep tmux/SSH terminfo-Tc case
+    // isn't auto-detected (no startup infocmp subprocess) — $PIXTUOID_NO_TRUECOLOR_WARN
+    // is the escape hatch (#397). The `floating` window paints real RGB pixels via
+    // softbuffer, not terminal SGR, so it is exempt.
     #[cfg(not(windows))]
     if pixtuoid::term::should_warn_truecolor(
         matches!(
@@ -30,12 +32,16 @@ fn main() -> Result<()> {
         ),
         std::io::IsTerminal::is_terminal(&std::io::stderr()),
         std::env::var("COLORTERM").ok().as_deref(),
+        std::env::var("TERM").ok().as_deref(),
+        std::env::var("TERM_PROGRAM").ok().as_deref(),
+        std::env::var("PIXTUOID_NO_TRUECOLOR_WARN").ok().as_deref(),
     ) {
         eprintln!(
-            "⚠ pixtuoid: your terminal does not advertise COLORTERM=truecolor — the \
-             pixel-art office renders in 24-bit color and may look wrong. Use a \
-             truecolor terminal (Windows Terminal, iTerm2, Ghostty, Alacritty, kitty, \
-             WezTerm), or run `pixtuoid doctor` to check."
+            "⚠ pixtuoid: your terminal does not advertise truecolor (COLORTERM or a \
+             known truecolor TERM) — the pixel-art office renders in 24-bit color and \
+             may look wrong. Use a truecolor terminal (Windows Terminal, iTerm2, \
+             Ghostty, Alacritty, kitty, WezTerm), run `pixtuoid doctor` to check, or \
+             set PIXTUOID_NO_TRUECOLOR_WARN=1 to silence."
         );
     }
     // The typed LogLevel's as_str is exactly the old free-string levels, so

--- a/crates/pixtuoid/src/main.rs
+++ b/crates/pixtuoid/src/main.rs
@@ -12,6 +12,56 @@ fn main() -> Result<()> {
     install_crash_hook();
     let (log_level, cli_theme, cmd) = Cli::parse().cmd_or_default();
 
+    // The terminal `run` TUI is the only command that paints the pixel-art canvas:
+    // --headless is a text summary, `doctor`/`sources` are plain output, and
+    // `floating` paints real RGB via softbuffer — none need the terminal's color.
+    let is_run_tui = matches!(
+        &cmd,
+        Cmd::Run {
+            headless: false,
+            ..
+        }
+    );
+
+    // Color preflight (cross-platform — crossterm strips our 24-bit SGR to a bare
+    // reset under $NO_COLOR, and a $TERM=dumb terminal can't render escapes at all;
+    // either way the office, which has no legible monochrome fallback, would be
+    // unreadable). Refuse the canvas with a one-line explanation instead of
+    // rendering block-soup, honoring the BSD $CLICOLOR_FORCE > $NO_COLOR override
+    // (crossterm needs the force call applied explicitly — it ignores
+    // $CLICOLOR_FORCE on its own). This runs before the truecolor probe, so a dumb
+    // terminal never gets DECRQSS escapes.
+    if is_run_tui {
+        use pixtuoid::term::ColorPreflight;
+        match pixtuoid::term::color_preflight(
+            std::env::var("NO_COLOR").ok().as_deref(),
+            std::env::var("CLICOLOR_FORCE").ok().as_deref(),
+            std::env::var("TERM").ok().as_deref(),
+        ) {
+            ColorPreflight::Proceed => {}
+            ColorPreflight::ForceColor => crossterm::style::force_color_output(true),
+            ColorPreflight::RefuseNoColor => {
+                eprintln!(
+                    "pixtuoid: $NO_COLOR is set, so your terminal strips color — the \
+                     pixel-art office is 24-bit color with no legible monochrome mode \
+                     and would render as unreadable blocks. Unset NO_COLOR (or set \
+                     CLICOLOR_FORCE=1 to override) to run it, or use \
+                     `pixtuoid run --headless` for a text summary."
+                );
+                return Ok(());
+            }
+            ColorPreflight::RefuseDumbTerm => {
+                eprintln!(
+                    "pixtuoid: $TERM=dumb — this terminal can't render the pixel-art \
+                     office (no cursor addressing or color). Use a graphical terminal \
+                     (Windows Terminal, iTerm2, Ghostty, Alacritty, kitty, WezTerm), \
+                     or `pixtuoid run --headless` for a text summary."
+                );
+                return Ok(());
+            }
+        }
+    }
+
     // Truecolor preflight: the terminal TUI renders 24-bit half-block pixels; a
     // non-truecolor terminal renders them approximated/garbled with no other hint.
     // Rather than guess from a $TERM allowlist, ASK the terminal (DECRQSS) when
@@ -24,13 +74,7 @@ fn main() -> Result<()> {
     // truecolor session (COLORTERM set) pays nothing.
     #[cfg(not(windows))]
     if pixtuoid::term::warn_zone(
-        matches!(
-            &cmd,
-            Cmd::Run {
-                headless: false,
-                ..
-            }
-        ),
+        is_run_tui,
         std::io::IsTerminal::is_terminal(&std::io::stderr()),
         std::env::var("COLORTERM").ok().as_deref(),
         std::env::var("PIXTUOID_NO_TRUECOLOR_WARN").ok().as_deref(),

--- a/crates/pixtuoid/src/main.rs
+++ b/crates/pixtuoid/src/main.rs
@@ -42,7 +42,7 @@ fn main() -> Result<()> {
             ColorPreflight::ForceColor => crossterm::style::force_color_output(true),
             ColorPreflight::RefuseNoColor => {
                 eprintln!(
-                    "pixtuoid: $NO_COLOR is set, so your terminal strips color — the \
+                    "pixtuoid: $NO_COLOR is set, so color output is disabled — the \
                      pixel-art office is 24-bit color with no legible monochrome mode \
                      and would render as unreadable blocks. Unset NO_COLOR (or set \
                      CLICOLOR_FORCE=1 to override) to run it, or use \

--- a/crates/pixtuoid/src/term.rs
+++ b/crates/pixtuoid/src/term.rs
@@ -92,14 +92,21 @@ pub enum ColorPreflight {
 ///   1. `$TERM=dumb` — a terminal that can't interpret escape sequences at all;
 ///      nothing we emit renders, and forcing color can't fix it, so refuse first.
 ///   2. `$NO_COLOR` non-empty — crossterm strips our 24-bit SGR to a bare reset,
-///      so the office would be unreadable blocks. Honor the BSD `$CLICOLOR_FORCE`
-///      \> `$NO_COLOR` precedence: a non-empty `$CLICOLOR_FORCE` is the user
+///      so the office would be unreadable blocks. Honor the `$CLICOLOR_FORCE`
+///      \> `$NO_COLOR` precedence: a non-zero `$CLICOLOR_FORCE` is the user
 ///      explicitly wanting color, so force it on rather than refuse.
 ///   3. otherwise proceed.
 ///
 /// `$NO_COLOR` counts as active only when NON-EMPTY — matching crossterm, the
 /// thing that actually strips the color (it ignores an empty `$NO_COLOR`). An
 /// empty value therefore doesn't break the render and must not block launch.
+/// `$CLICOLOR_FORCE` follows the bixense convention (active when set and `!= 0`),
+/// the Rust CLI-ecosystem norm — so `$CLICOLOR_FORCE=0` does NOT override.
+///
+/// `$FORCE_COLOR` (npm) and `$CLICOLOR` are intentionally NOT read: crossterm —
+/// the thing that actually strips our color — keys only on `$NO_COLOR`, so they
+/// would have no effect on the render. `$CLICOLOR_FORCE` is the lone override
+/// because we enact it ourselves (`force_color_output` at the call site).
 pub fn color_preflight(
     no_color: Option<&str>,
     clicolor_force: Option<&str>,
@@ -110,7 +117,9 @@ pub fn color_preflight(
     }
     let no_color_set = matches!(no_color, Some(v) if !v.is_empty());
     if no_color_set {
-        let forced = matches!(clicolor_force, Some(v) if !v.is_empty());
+        // bixense `!= 0` semantics (not mere presence): `CLICOLOR_FORCE=0` means
+        // "do NOT force", so it must not override $NO_COLOR.
+        let forced = matches!(clicolor_force.map(str::trim), Some(v) if !v.is_empty() && v != "0");
         return if forced {
             ColorPreflight::ForceColor
         } else {
@@ -408,8 +417,13 @@ mod tests {
         assert_eq!(color_preflight(Some("anything"), None, None), RefuseNoColor);
         // CLICOLOR_FORCE overrides NO_COLOR (BSD precedence) → force, don't refuse.
         assert_eq!(color_preflight(Some("1"), Some("1"), None), ForceColor);
+        // A non-zero value other than "1" still forces (active when set && != 0).
+        assert_eq!(color_preflight(Some("1"), Some("yes"), None), ForceColor);
         // ...but an EMPTY CLICOLOR_FORCE is not a force → still refuse.
         assert_eq!(color_preflight(Some("1"), Some(""), None), RefuseNoColor);
+        // ...and CLICOLOR_FORCE=0 means "do not force" (bixense != 0) → still refuse.
+        assert_eq!(color_preflight(Some("1"), Some("0"), None), RefuseNoColor);
+        assert_eq!(color_preflight(Some("1"), Some(" 0 "), None), RefuseNoColor);
         // CLICOLOR_FORCE with no NO_COLOR is a no-op here (nothing to override).
         assert_eq!(color_preflight(None, Some("1"), None), Proceed);
         // TERM=dumb outranks everything — even a force can't make dumb render.

--- a/crates/pixtuoid/src/term.rs
+++ b/crates/pixtuoid/src/term.rs
@@ -5,6 +5,15 @@
 //! on Unix: many genuinely-truecolor terminals omit `COLORTERM`, so a hard gate
 //! would false-negative. (Windows is the exception — `tui::mod` hard-gates VT
 //! there because the WinAPI color fallback renders black-on-black.)
+//!
+//! Truecolor is detected from env only — `$COLORTERM` OR a static
+//! `$TERM`/`$TERM_PROGRAM` allowlist, the same signals `supports-color` /
+//! `anstyle-query` use (neither reads terminfo). The deep case whose ONLY
+//! truecolor signal is a terminfo `Tc`/`RGB` override (some tmux/SSH setups) is
+//! deliberately NOT auto-detected: that needs an `infocmp` subprocess or a
+//! terminfo dependency that is absent on musl/alpine/Nix and stale on stock
+//! macOS, far too much for a warn-only nag. It's covered by the
+//! `$PIXTUOID_NO_TRUECOLOR_WARN` escape hatch instead (#397).
 
 /// True iff `$COLORTERM` advertises 24-bit color (`truecolor` or `24bit`) — the
 /// S-Lang / terminfo convention also used by bat, alacritty, and wezterm. Pure
@@ -15,35 +24,127 @@ pub fn colorterm_is_truecolor(colorterm: Option<&str>) -> bool {
     matches!(colorterm, Some(v) if v.contains("truecolor") || v.contains("24bit"))
 }
 
-/// Whether to emit the truecolor preflight warning: a TUI `run` (not headless),
-/// attached to a tty, whose `$COLORTERM` doesn't advertise 24-bit. Pure so the
-/// gate LOGIC is unit-tested over its truth table; `main.rs` keeps the
-/// `#[cfg(not(windows))]`, the `IsTerminal` probe, and the `$COLORTERM` read
-/// inline at its (codecov-excluded) call site — the policy lives here, the
-/// untestable env/tty/cfg reads stay there (the "policy in term.rs" pattern).
-pub fn should_warn_truecolor(cmd_is_run_tui: bool, is_tty: bool, colorterm: Option<&str>) -> bool {
-    cmd_is_run_tui && is_tty && !colorterm_is_truecolor(colorterm)
+/// Terminals that are genuinely truecolor but don't reliably set `$COLORTERM`
+/// (notably over SSH, which forwards `$TERM` via the pty-req but not
+/// `$COLORTERM`), identified by `$TERM` / `$TERM_PROGRAM`. This mirrors the
+/// static allowlist `supports-color` / `anstyle-query` use — neither reads
+/// terminfo. Deliberately does NOT match `*-256color`: that's Apple Terminal.app
+/// (256-color until macOS 26 / Tahoe), a genuinely-non-truecolor terminal that
+/// MUST still get the warning. Pure (takes the env values) for unit-testing.
+fn term_is_truecolor(term: Option<&str>, term_program: Option<&str>) -> bool {
+    // `$TERM` names are lowercase by convention → case-sensitive substring match.
+    let term_advertises = term.is_some_and(|t| {
+        t.ends_with("-direct")
+            || t.ends_with("-truecolor")
+            || [
+                "kitty",
+                "ghostty",
+                "alacritty",
+                "wezterm",
+                "foot",
+                "contour",
+                "rio",
+            ]
+            .iter()
+            .any(|name| t.contains(name))
+    });
+    // `$TERM_PROGRAM` is a proper name (mixed case: `iTerm.app`, `WezTerm`) →
+    // exact, case-insensitive. `Apple_Terminal` is intentionally absent.
+    let program_advertises = term_program.is_some_and(|p| {
+        [
+            "iTerm.app",
+            "WezTerm",
+            "ghostty",
+            "vscode",
+            "Hyper",
+            "rio",
+            "Tabby",
+        ]
+        .iter()
+        .any(|name| p.eq_ignore_ascii_case(name))
+    });
+    term_advertises || program_advertises
 }
 
-/// The `pixtuoid doctor` `terminal:` line — `$TERM` / `$COLORTERM` and the
-/// truecolor verdict. Pure (takes the env values as `Option`s, `None` = unset) so
-/// the row logic is unit-testable on its own (and `doctor::run` returns its report
-/// string, so it's covered end-to-end too). Untrusted env values are stripped of
-/// control chars before display.
-pub fn terminal_diagnostic_row(term: Option<&str>, colorterm: Option<&str>) -> String {
+/// The single "is this terminal advertising truecolor?" signal, shared by the
+/// warn policy and the `doctor` verdict so the two can NEVER disagree: `true`
+/// when `$COLORTERM` advertises it OR a known-truecolor `$TERM`/`$TERM_PROGRAM`.
+fn truecolor_advertised(
+    colorterm: Option<&str>,
+    term: Option<&str>,
+    term_program: Option<&str>,
+) -> bool {
+    colorterm_is_truecolor(colorterm) || term_is_truecolor(term, term_program)
+}
+
+/// True iff `$PIXTUOID_NO_TRUECOLOR_WARN` is set to a truthy token (`1` / `true`
+/// / `yes` / `on`, case-insensitive, trimmed) — the documented escape hatch for
+/// a user whose terminal is fine but isn't auto-detected (e.g. a tmux/SSH setup
+/// whose only truecolor signal is a terminfo override). Empty / `0` / `false` /
+/// anything else = not suppressed, so a leftover `PIXTUOID_NO_TRUECOLOR_WARN=`
+/// doesn't silently kill the warning. Pure (takes the env value) for testing.
+fn truecolor_warn_suppressed(suppress_env: Option<&str>) -> bool {
+    matches!(
+        suppress_env.map(str::trim),
+        Some(v) if v.eq_ignore_ascii_case("1")
+            || v.eq_ignore_ascii_case("true")
+            || v.eq_ignore_ascii_case("yes")
+            || v.eq_ignore_ascii_case("on")
+    )
+}
+
+/// Whether to emit the truecolor preflight warning: a TUI `run` (not headless),
+/// attached to a tty, whose terminal does NOT advertise truecolor (`$COLORTERM`
+/// or the `$TERM`/`$TERM_PROGRAM` allowlist) and hasn't set the
+/// `$PIXTUOID_NO_TRUECOLOR_WARN` escape hatch. Pure so the gate LOGIC is
+/// unit-tested over its truth table; `main.rs` keeps the `#[cfg(not(windows))]`,
+/// the `IsTerminal` probe, and the env reads inline at its (codecov-excluded)
+/// call site — the policy lives here, the untestable env/tty/cfg reads stay there
+/// (the "policy in term.rs" pattern).
+pub fn should_warn_truecolor(
+    cmd_is_run_tui: bool,
+    is_tty: bool,
+    colorterm: Option<&str>,
+    term: Option<&str>,
+    term_program: Option<&str>,
+    suppress_env: Option<&str>,
+) -> bool {
+    cmd_is_run_tui
+        && is_tty
+        && !truecolor_advertised(colorterm, term, term_program)
+        && !truecolor_warn_suppressed(suppress_env)
+}
+
+/// The `pixtuoid doctor` `terminal:` line — `$TERM` / `$COLORTERM` /
+/// `$TERM_PROGRAM` and the truecolor verdict, naming WHICH signal advertised it
+/// so a "colors look wrong" report is self-diagnosable. Pure (takes the env
+/// values as `Option`s, `None` = unset) so the row logic is unit-testable on its
+/// own (and `doctor::run` returns its report string, so it's covered end-to-end
+/// too). Shares `truecolor_advertised`'s inputs with the warn policy, so the
+/// diagnostic and the startup warning can never disagree. Untrusted env values
+/// are stripped of control chars before display.
+pub fn terminal_diagnostic_row(
+    term: Option<&str>,
+    colorterm: Option<&str>,
+    term_program: Option<&str>,
+) -> String {
     let shown = |v: Option<&str>| match v {
         Some(s) if !s.is_empty() => crate::strip_control_chars(s),
         _ => "(unset)".to_string(),
     };
+    let verdict = if colorterm_is_truecolor(colorterm) {
+        "yes (COLORTERM)"
+    } else if term_is_truecolor(term, term_program) {
+        "yes (TERM/TERM_PROGRAM)"
+    } else {
+        "not advertised"
+    };
     format!(
-        "terminal: TERM={} COLORTERM={} truecolor={}",
+        "terminal: TERM={} COLORTERM={} TERM_PROGRAM={} truecolor={}",
         shown(term),
         shown(colorterm),
-        if colorterm_is_truecolor(colorterm) {
-            "yes"
-        } else {
-            "not advertised"
-        },
+        shown(term_program),
+        verdict,
     )
 }
 
@@ -60,14 +161,124 @@ mod tests {
     }
 
     #[test]
+    fn term_allowlist_matches_modern_terminals_but_not_256color() {
+        // Direct-color entries + the modern-terminal $TERM family advertise.
+        for t in [
+            "xterm-direct",
+            "tmux-truecolor",
+            "xterm-kitty",
+            "xterm-ghostty",
+            "alacritty",
+            "wezterm",
+            "foot-extra",
+            "contour",
+            "rio",
+        ] {
+            assert!(term_is_truecolor(Some(t), None), "{t} should advertise");
+        }
+        // $TERM_PROGRAM (proper-name, case-insensitive); Apple_Terminal must NOT.
+        for p in [
+            "iTerm.app",
+            "WezTerm",
+            "ghostty",
+            "vscode",
+            "Hyper",
+            "tabby",
+        ] {
+            assert!(
+                term_is_truecolor(None, Some(p)),
+                "{p} program should advertise"
+            );
+        }
+        // The load-bearing exclusion: Apple Terminal.app is genuinely 256-color
+        // (until macOS 26) and MUST still warn — neither its $TERM nor its
+        // $TERM_PROGRAM may match the allowlist.
+        assert!(!term_is_truecolor(
+            Some("xterm-256color"),
+            Some("Apple_Terminal")
+        ));
+        // tmux/screen default $TERM carries no truecolor signal by name (the deep
+        // terminfo-Tc case is the documented residual, covered by the hatch).
+        assert!(!term_is_truecolor(Some("tmux-256color"), None));
+        assert!(!term_is_truecolor(Some("screen-256color"), None));
+        assert!(!term_is_truecolor(None, None));
+    }
+
+    #[test]
+    fn suppress_env_truthy_tokens_only() {
+        for v in ["1", "true", "TRUE", "yes", "on", " on "] {
+            assert!(truecolor_warn_suppressed(Some(v)), "{v:?} should suppress");
+        }
+        for v in [
+            None,
+            Some(""),
+            Some(" "),
+            Some("0"),
+            Some("false"),
+            Some("no"),
+        ] {
+            assert!(!truecolor_warn_suppressed(v), "{v:?} must NOT suppress");
+        }
+    }
+
+    #[test]
     fn should_warn_truecolor_truth_table() {
-        // Warn ONLY for a TUI run, on a tty, without an advertised truecolor.
-        assert!(should_warn_truecolor(true, true, None));
-        assert!(should_warn_truecolor(true, true, Some("256color")));
-        // Suppressed by ANY of: not a TUI run, not a tty, or truecolor advertised.
-        assert!(!should_warn_truecolor(false, true, None));
-        assert!(!should_warn_truecolor(true, false, None));
-        assert!(!should_warn_truecolor(true, true, Some("truecolor")));
+        // Warn ONLY for a TUI run, on a tty, with no truecolor signal + no hatch.
+        assert!(should_warn_truecolor(true, true, None, None, None, None));
+        assert!(should_warn_truecolor(
+            true,
+            true,
+            Some("256color"),
+            Some("xterm-256color"),
+            Some("Apple_Terminal"),
+            None
+        ));
+        // Suppressed by ANY of: not a TUI run, not a tty, $COLORTERM truecolor, a
+        // known-truecolor $TERM / $TERM_PROGRAM, or the escape hatch.
+        assert!(!should_warn_truecolor(false, true, None, None, None, None));
+        assert!(!should_warn_truecolor(true, false, None, None, None, None));
+        assert!(!should_warn_truecolor(
+            true,
+            true,
+            Some("truecolor"),
+            None,
+            None,
+            None
+        ));
+        assert!(!should_warn_truecolor(
+            true,
+            true,
+            None,
+            Some("xterm-kitty"),
+            None,
+            None
+        ));
+        assert!(!should_warn_truecolor(
+            true,
+            true,
+            None,
+            None,
+            Some("iTerm.app"),
+            None
+        ));
+        assert!(!should_warn_truecolor(
+            true,
+            true,
+            None,
+            None,
+            None,
+            Some("1")
+        ));
+        // The SSH false-positive #397 targets: $COLORTERM stripped but $TERM
+        // survives the pty-req → no warning.
+        assert!(!should_warn_truecolor(
+            true,
+            true,
+            None,
+            Some("xterm-ghostty"),
+            None,
+            None
+        ));
     }
 
     #[test]
@@ -81,22 +292,33 @@ mod tests {
 
     #[test]
     fn terminal_row_renders_each_state() {
-        let yes = terminal_diagnostic_row(Some("xterm-256color"), Some("truecolor"));
+        let yes = terminal_diagnostic_row(Some("xterm-256color"), Some("truecolor"), None);
         assert!(yes.contains("TERM=xterm-256color"));
         assert!(yes.contains("COLORTERM=truecolor"));
-        assert!(yes.contains("truecolor=yes"));
+        assert!(yes.contains("truecolor=yes (COLORTERM)"));
+
+        // $COLORTERM unset but a known-truecolor $TERM → the verdict names the
+        // TERM signal (the doctor/warning coherence case).
+        let by_term = terminal_diagnostic_row(Some("xterm-kitty"), None, None);
+        assert!(by_term.contains("TERM=xterm-kitty"), "{by_term}");
+        assert!(
+            by_term.contains("truecolor=yes (TERM/TERM_PROGRAM)"),
+            "{by_term}"
+        );
 
         // Unset ($COLORTERM = None) and set-but-empty both read as "(unset)" and a
-        // "not advertised" verdict.
+        // "not advertised" verdict (no $TERM signal either).
         for ct in [None, Some("")] {
-            let row = terminal_diagnostic_row(None, ct);
+            let row = terminal_diagnostic_row(None, ct, None);
             assert!(row.contains("TERM=(unset)"), "{row}");
             assert!(row.contains("COLORTERM=(unset)"), "{row}");
+            assert!(row.contains("TERM_PROGRAM=(unset)"), "{row}");
             assert!(row.contains("truecolor=not advertised"), "{row}");
         }
 
         // Untrusted env values are control-char-stripped before display.
-        let sanitized = terminal_diagnostic_row(Some("a\x1b[31mb"), Some("truecolor"));
+        let sanitized =
+            terminal_diagnostic_row(Some("a\x1b[31mb"), Some("truecolor"), Some("x\x1by"));
         assert!(!sanitized.contains('\u{1b}'), "{sanitized}");
     }
 }

--- a/crates/pixtuoid/src/term.rs
+++ b/crates/pixtuoid/src/term.rs
@@ -17,7 +17,7 @@
 
 /// Default round-trip budget for the `DECRQSS` probe: long enough for a laggy SSH
 /// link to answer, short enough that a terminal which never answers (no DECRQSS
-/// support → genuinely suspect) only costs this once at startup. `poll` returns
+/// support → genuinely suspect) only costs this once at startup. `select` returns
 /// the instant a reply arrives, so a responsive terminal never waits the full
 /// budget — only non-responders pay it.
 pub const TRUECOLOR_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(100);
@@ -130,7 +130,7 @@ const DECRQSS_TRUECOLOR_PROBE: &[u8] = b"\x1b[48;2;1;2;3m\x1bP$qm\x1b\\\x1b[0m";
 /// allowlist). Opens the controlling terminal (`/dev/tty`, so a piped
 /// `pixtuoid doctor > file` never receives escape codes), switches it to raw so
 /// the reply isn't echoed and arrives un-buffered, writes the probe, reads the
-/// reply with a `poll` timeout, restores the terminal, and parses. Returns `None`
+/// reply with a `select` timeout, restores the terminal, and parses. Returns `None`
 /// on any I/O failure or no answer — degrading to "warn", unchanged from a
 /// terminal we can't confirm. The IO seam (codecov-excluded); the parser and the
 /// policy around it are the unit-tested pure pieces.
@@ -205,14 +205,29 @@ fn read_until_terminator(
         if elapsed >= timeout {
             break;
         }
-        let remaining_ms = (timeout - elapsed).as_millis().min(i32::MAX as u128) as i32;
-        let mut pfd = libc::pollfd {
-            fd,
-            events: libc::POLLIN,
-            revents: 0,
+        let remaining = timeout - elapsed;
+        let mut tv = libc::timeval {
+            tv_sec: remaining.as_secs() as libc::time_t,
+            tv_usec: remaining.subsec_micros() as libc::suseconds_t,
         };
-        // SAFETY: `pfd` is a single valid pollfd; `poll` only reads/writes it.
-        let ready = unsafe { libc::poll(&mut pfd, 1, remaining_ms) };
+        // `select`, NOT `poll`: macOS `poll()` is broken on tty/pty devices and
+        // returns `POLLNVAL` for a valid terminal fd, which would make every
+        // non-`$COLORTERM` terminal read nothing and falsely warn. `select` works
+        // on ttys on both macOS and Linux. The fd is opened early so it's well
+        // under `FD_SETSIZE`.
+        // SAFETY: a zeroed `fd_set` with our single valid fd registered.
+        let mut rfds: libc::fd_set = unsafe { std::mem::zeroed() };
+        unsafe { libc::FD_SET(fd, &mut rfds) };
+        // SAFETY: one read fd, null write/error sets, a valid timeval.
+        let ready = unsafe {
+            libc::select(
+                fd + 1,
+                &mut rfds,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                &mut tv,
+            )
+        };
         if ready < 0 {
             // A signal (e.g. SIGWINCH at startup) interrupted the wait — retry
             // within the remaining budget rather than give up to a false warn.
@@ -221,7 +236,8 @@ fn read_until_terminator(
             }
             break;
         }
-        if ready == 0 || pfd.revents & libc::POLLIN == 0 {
+        // SAFETY: `rfds` was populated by `select`; checking our fd's membership.
+        if ready == 0 || !unsafe { libc::FD_ISSET(fd, &rfds) } {
             break; // timeout, or not a read-ready event
         }
         match tty.read(&mut chunk) {

--- a/crates/pixtuoid/src/term.rs
+++ b/crates/pixtuoid/src/term.rs
@@ -73,7 +73,9 @@ pub fn warn_zone(
 /// reply (`0$r`, empty, or a timeout) — which the caller treats as "warn", since
 /// a terminal that can't answer DECRQSS is unlikely to be truecolor. Pure
 /// (operates on the captured bytes) so every branch is unit-tested without a real
-/// terminal.
+/// terminal. `#[cfg(unix)]` like the rest of the DECRQSS machinery it serves —
+/// only the unix `query_truecolor` calls it, so it'd be dead code on Windows.
+#[cfg(unix)]
 fn parse_decrqss_truecolor(resp: &[u8]) -> Option<bool> {
     let s = String::from_utf8_lossy(resp);
     // A valid SGR reply is `DCS 1 $ r ... m ST`; `0 $ r` = request not honored.
@@ -316,6 +318,7 @@ mod tests {
         assert!(!warn_zone(true, true, None, Some("1")));
     }
 
+    #[cfg(unix)]
     #[test]
     fn parse_decrqss_distinguishes_truecolor_from_downsample() {
         // A truecolor terminal echoes our exact RGB triple (colon form).
@@ -345,6 +348,9 @@ mod tests {
         assert_eq!(parse_decrqss_truecolor(b""), None);
     }
 
+    // `response_terminated` is `#[cfg(unix)]` (it serves the unix-only read loop),
+    // so its test must be gated too — else `check-windows` fails to compile.
+    #[cfg(unix)]
     #[test]
     fn response_terminated_on_st_or_bel() {
         assert!(response_terminated(b"\x1bP1$r0m\x1b\\"));

--- a/crates/pixtuoid/src/term.rs
+++ b/crates/pixtuoid/src/term.rs
@@ -65,6 +65,84 @@ pub fn warn_zone(
         && !truecolor_warn_suppressed(suppress_env)
 }
 
+/// The pre-flight decision for the terminal TUI's *color* requirement (distinct
+/// from the truecolor *depth* warning above). The pixel-art office is 24-bit
+/// color end to end with no legible monochrome fallback, so when the environment
+/// disables color we refuse to launch the canvas and explain why — mirroring the
+/// Windows VT hard-gate — instead of rendering unreadable block-soup with no hint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColorPreflight {
+    /// Color is available — launch normally.
+    Proceed,
+    /// `$NO_COLOR` is set but `$CLICOLOR_FORCE` overrides it (the BSD precedence).
+    /// The caller MUST `crossterm::style::force_color_output(true)`: crossterm
+    /// strips color under `$NO_COLOR` and does NOT honor `$CLICOLOR_FORCE` itself
+    /// (verified empirically), so without the explicit force the office would
+    /// still render colorless despite the user asking for color.
+    ForceColor,
+    /// `$NO_COLOR` is set (and not force-overridden) → refuse + explain.
+    RefuseNoColor,
+    /// `$TERM=dumb` → the terminal can't render escapes at all → refuse + explain.
+    RefuseDumbTerm,
+}
+
+/// Decide the color preflight from the environment (pure; the caller reads env and
+/// acts — the "policy in term.rs, IO at the call site" pattern). Precedence,
+/// highest first:
+///   1. `$TERM=dumb` — a terminal that can't interpret escape sequences at all;
+///      nothing we emit renders, and forcing color can't fix it, so refuse first.
+///   2. `$NO_COLOR` non-empty — crossterm strips our 24-bit SGR to a bare reset,
+///      so the office would be unreadable blocks. Honor the BSD `$CLICOLOR_FORCE`
+///      \> `$NO_COLOR` precedence: a non-empty `$CLICOLOR_FORCE` is the user
+///      explicitly wanting color, so force it on rather than refuse.
+///   3. otherwise proceed.
+///
+/// `$NO_COLOR` counts as active only when NON-EMPTY — matching crossterm, the
+/// thing that actually strips the color (it ignores an empty `$NO_COLOR`). An
+/// empty value therefore doesn't break the render and must not block launch.
+pub fn color_preflight(
+    no_color: Option<&str>,
+    clicolor_force: Option<&str>,
+    term: Option<&str>,
+) -> ColorPreflight {
+    if matches!(term, Some(t) if t == "dumb") {
+        return ColorPreflight::RefuseDumbTerm;
+    }
+    let no_color_set = matches!(no_color, Some(v) if !v.is_empty());
+    if no_color_set {
+        let forced = matches!(clicolor_force, Some(v) if !v.is_empty());
+        return if forced {
+            ColorPreflight::ForceColor
+        } else {
+            ColorPreflight::RefuseNoColor
+        };
+    }
+    ColorPreflight::Proceed
+}
+
+/// The `pixtuoid doctor` color-availability line, derived from the SAME
+/// `color_preflight` policy the launcher acts on so the diagnostic matches what
+/// `run` would do. `None` when color is available (the `terminal:` row already
+/// covers depth — no extra line needed); `Some(reason)` when color is disabled or
+/// force-overridden, so a "the office is monochrome / won't launch" report is
+/// self-diagnosable. Pure (takes the decision) — covered via `doctor::run`.
+pub fn color_status_row(pf: ColorPreflight) -> Option<&'static str> {
+    match pf {
+        ColorPreflight::Proceed => None,
+        ColorPreflight::ForceColor => {
+            Some("color: forced on ($CLICOLOR_FORCE overrides $NO_COLOR)")
+        }
+        ColorPreflight::RefuseNoColor => Some(
+            "color: DISABLED — $NO_COLOR is set, so colors are stripped and the \
+             office can't render. Unset NO_COLOR, or set CLICOLOR_FORCE=1 to override.",
+        ),
+        ColorPreflight::RefuseDumbTerm => Some(
+            "color: DISABLED — $TERM=dumb; this terminal can't render escape \
+             sequences or color.",
+        ),
+    }
+}
+
 /// Parse a `DECRQSS`-for-SGR reply to our truecolor probe. We set the background
 /// to `48;2;1;2;3`; the reply form is `DCS 1 $ r <SGR> ST` for a valid request
 /// and `DCS 0 $ r ST` when the terminal can't honor it. Returns
@@ -316,6 +394,43 @@ mod tests {
         assert!(!warn_zone(true, false, None, None));
         assert!(!warn_zone(true, true, Some("truecolor"), None));
         assert!(!warn_zone(true, true, None, Some("1")));
+    }
+
+    #[test]
+    fn color_preflight_precedence_and_thresholds() {
+        use ColorPreflight::*;
+        // Healthy: no NO_COLOR, no dumb → launch.
+        assert_eq!(color_preflight(None, None, Some("xterm-256color")), Proceed);
+        // Empty NO_COLOR is ignored (crossterm doesn't strip on it) → still launch.
+        assert_eq!(color_preflight(Some(""), None, None), Proceed);
+        // NO_COLOR set (any non-empty value, value-agnostic) → refuse.
+        assert_eq!(color_preflight(Some("1"), None, None), RefuseNoColor);
+        assert_eq!(color_preflight(Some("anything"), None, None), RefuseNoColor);
+        // CLICOLOR_FORCE overrides NO_COLOR (BSD precedence) → force, don't refuse.
+        assert_eq!(color_preflight(Some("1"), Some("1"), None), ForceColor);
+        // ...but an EMPTY CLICOLOR_FORCE is not a force → still refuse.
+        assert_eq!(color_preflight(Some("1"), Some(""), None), RefuseNoColor);
+        // CLICOLOR_FORCE with no NO_COLOR is a no-op here (nothing to override).
+        assert_eq!(color_preflight(None, Some("1"), None), Proceed);
+        // TERM=dumb outranks everything — even a force can't make dumb render.
+        assert_eq!(color_preflight(None, None, Some("dumb")), RefuseDumbTerm);
+        assert_eq!(
+            color_preflight(Some("1"), Some("1"), Some("dumb")),
+            RefuseDumbTerm
+        );
+    }
+
+    #[test]
+    fn color_status_row_only_speaks_when_color_is_not_plainly_available() {
+        use ColorPreflight::*;
+        assert_eq!(color_status_row(Proceed), None);
+        assert!(color_status_row(ForceColor)
+            .unwrap()
+            .contains("CLICOLOR_FORCE"));
+        assert!(color_status_row(RefuseNoColor)
+            .unwrap()
+            .contains("NO_COLOR"));
+        assert!(color_status_row(RefuseDumbTerm).unwrap().contains("dumb"));
     }
 
     #[cfg(unix)]

--- a/crates/pixtuoid/src/term.rs
+++ b/crates/pixtuoid/src/term.rs
@@ -1,88 +1,40 @@
-//! Terminal capability probes for the truecolor preflight (the pixel-art office
-//! renders 24-bit half-block SGR; a terminal that can't parse those shows
+//! Terminal capability detection for the truecolor preflight (the pixel-art
+//! office renders 24-bit half-block SGR; a terminal that can't parse those shows
 //! approximated/garbled colors with no other hint — the #1 baffling-bug class for
-//! a truecolor-only TUI). Detection is intentionally a WARN signal, never a gate
-//! on Unix: many genuinely-truecolor terminals omit `COLORTERM`, so a hard gate
-//! would false-negative. (Windows is the exception — `tui::mod` hard-gates VT
-//! there because the WinAPI color fallback renders black-on-black.)
+//! a truecolor-only TUI). The warning is a WARN signal, never a gate on Unix.
+//! (Windows is the exception — `tui::mod` hard-gates VT there because the WinAPI
+//! color fallback renders black-on-black.)
 //!
-//! Truecolor is detected from env only — `$COLORTERM` OR a static
-//! `$TERM`/`$TERM_PROGRAM` allowlist, the same signals `supports-color` /
-//! `anstyle-query` use (neither reads terminfo). The deep case whose ONLY
-//! truecolor signal is a terminfo `Tc`/`RGB` override (some tmux/SSH setups) is
-//! deliberately NOT auto-detected: that needs an `infocmp` subprocess or a
-//! terminfo dependency that is absent on musl/alpine/Nix and stale on stock
-//! macOS, far too much for a warn-only nag. It's covered by the
-//! `$PIXTUOID_NO_TRUECOLOR_WARN` escape hatch instead (#397).
+//! We do NOT guess truecolor from a `$TERM` name allowlist. Detection ASKS the
+//! terminal directly: set an unlikely 24-bit background, then `DECRQSS`-query the
+//! SGR back — a truecolor terminal echoes the RGB triple, a 256-color one
+//! downsamples it, and one that can't even parse the query stays silent
+//! (`query_truecolor`, the termstandard/colors method). `$COLORTERM=truecolor`
+//! is honored as an explicit positive (the terminal declaring itself — not a
+//! guess) purely to skip the round-trip, and `$PIXTUOID_NO_TRUECOLOR_WARN` is an
+//! explicit user override; neither is a heuristic. The query is the authority for
+//! everything else (#397).
+
+/// Default round-trip budget for the `DECRQSS` probe: long enough for a laggy SSH
+/// link to answer, short enough that a terminal which never answers (no DECRQSS
+/// support → genuinely suspect) only costs this once at startup. `poll` returns
+/// the instant a reply arrives, so a responsive terminal never waits the full
+/// budget — only non-responders pay it.
+pub const TRUECOLOR_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(100);
 
 /// True iff `$COLORTERM` advertises 24-bit color (`truecolor` or `24bit`) — the
-/// S-Lang / terminfo convention also used by bat, alacritty, and wezterm. Pure
-/// (takes the env value) so the policy is unit-testable without touching the
-/// environment. Case-sensitive on purpose: the advertised tokens are lowercase
-/// by convention, and a loose match would treat unrelated values as truecolor.
-pub fn colorterm_is_truecolor(colorterm: Option<&str>) -> bool {
+/// terminal explicitly declaring itself (the S-Lang convention), honored as a
+/// positive so we can skip the terminal round-trip. Pure (takes the env value).
+/// Case-sensitive on purpose: the advertised tokens are lowercase by convention.
+fn colorterm_is_truecolor(colorterm: Option<&str>) -> bool {
     matches!(colorterm, Some(v) if v.contains("truecolor") || v.contains("24bit"))
 }
 
-/// Terminals that are genuinely truecolor but don't reliably set `$COLORTERM`
-/// (notably over SSH, which forwards `$TERM` via the pty-req but not
-/// `$COLORTERM`), identified by `$TERM` / `$TERM_PROGRAM`. This mirrors the
-/// static allowlist `supports-color` / `anstyle-query` use — neither reads
-/// terminfo. Deliberately does NOT match `*-256color`: that's Apple Terminal.app
-/// (256-color until macOS 26 / Tahoe), a genuinely-non-truecolor terminal that
-/// MUST still get the warning. Pure (takes the env values) for unit-testing.
-fn term_is_truecolor(term: Option<&str>, term_program: Option<&str>) -> bool {
-    // `$TERM` names are lowercase by convention → case-sensitive substring match.
-    let term_advertises = term.is_some_and(|t| {
-        t.ends_with("-direct")
-            || t.ends_with("-truecolor")
-            || [
-                "kitty",
-                "ghostty",
-                "alacritty",
-                "wezterm",
-                "foot",
-                "contour",
-                "rio",
-            ]
-            .iter()
-            .any(|name| t.contains(name))
-    });
-    // `$TERM_PROGRAM` is a proper name (mixed case: `iTerm.app`, `WezTerm`) →
-    // exact, case-insensitive. `Apple_Terminal` is intentionally absent.
-    let program_advertises = term_program.is_some_and(|p| {
-        [
-            "iTerm.app",
-            "WezTerm",
-            "ghostty",
-            "vscode",
-            "Hyper",
-            "rio",
-            "Tabby",
-        ]
-        .iter()
-        .any(|name| p.eq_ignore_ascii_case(name))
-    });
-    term_advertises || program_advertises
-}
-
-/// The single "is this terminal advertising truecolor?" signal, shared by the
-/// warn policy and the `doctor` verdict so the two can NEVER disagree: `true`
-/// when `$COLORTERM` advertises it OR a known-truecolor `$TERM`/`$TERM_PROGRAM`.
-fn truecolor_advertised(
-    colorterm: Option<&str>,
-    term: Option<&str>,
-    term_program: Option<&str>,
-) -> bool {
-    colorterm_is_truecolor(colorterm) || term_is_truecolor(term, term_program)
-}
-
 /// True iff `$PIXTUOID_NO_TRUECOLOR_WARN` is set to a truthy token (`1` / `true`
-/// / `yes` / `on`, case-insensitive, trimmed) — the documented escape hatch for
-/// a user whose terminal is fine but isn't auto-detected (e.g. a tmux/SSH setup
-/// whose only truecolor signal is a terminfo override). Empty / `0` / `false` /
-/// anything else = not suppressed, so a leftover `PIXTUOID_NO_TRUECOLOR_WARN=`
-/// doesn't silently kill the warning. Pure (takes the env value) for testing.
+/// / `yes` / `on`, case-insensitive, trimmed) — the explicit user override for a
+/// terminal we can't auto-detect (e.g. one that's truecolor but doesn't answer
+/// DECRQSS). Empty / `0` / `false` / anything else = not suppressed, so a
+/// leftover `PIXTUOID_NO_TRUECOLOR_WARN=` doesn't silently kill the warning.
 fn truecolor_warn_suppressed(suppress_env: Option<&str>) -> bool {
     matches!(
         suppress_env.map(str::trim),
@@ -93,40 +45,57 @@ fn truecolor_warn_suppressed(suppress_env: Option<&str>) -> bool {
     )
 }
 
-/// Whether to emit the truecolor preflight warning: a TUI `run` (not headless),
-/// attached to a tty, whose terminal does NOT advertise truecolor (`$COLORTERM`
-/// or the `$TERM`/`$TERM_PROGRAM` allowlist) and hasn't set the
-/// `$PIXTUOID_NO_TRUECOLOR_WARN` escape hatch. Pure so the gate LOGIC is
-/// unit-tested over its truth table; `main.rs` keeps the `#[cfg(not(windows))]`,
+/// Whether we're in the zone where the warning *might* fire and so the terminal
+/// query is worth running: a TUI `run` (not headless), attached to a tty, where
+/// `$COLORTERM` didn't already declare truecolor and the escape hatch isn't set.
+/// Pure so the gate is unit-tested; `main.rs` keeps the `#[cfg(not(windows))]`,
 /// the `IsTerminal` probe, and the env reads inline at its (codecov-excluded)
-/// call site — the policy lives here, the untestable env/tty/cfg reads stay there
-/// (the "policy in term.rs" pattern).
-pub fn should_warn_truecolor(
+/// call site, then runs `query_truecolor` only when this is true (the "policy in
+/// term.rs, IO at the call site" pattern). The final decision is: warn unless the
+/// query returns `Some(true)`.
+pub fn warn_zone(
     cmd_is_run_tui: bool,
     is_tty: bool,
     colorterm: Option<&str>,
-    term: Option<&str>,
-    term_program: Option<&str>,
     suppress_env: Option<&str>,
 ) -> bool {
     cmd_is_run_tui
         && is_tty
-        && !truecolor_advertised(colorterm, term, term_program)
+        && !colorterm_is_truecolor(colorterm)
         && !truecolor_warn_suppressed(suppress_env)
 }
 
-/// The `pixtuoid doctor` `terminal:` line — `$TERM` / `$COLORTERM` /
-/// `$TERM_PROGRAM` and the truecolor verdict, naming WHICH signal advertised it
-/// so a "colors look wrong" report is self-diagnosable. Pure (takes the env
-/// values as `Option`s, `None` = unset) so the row logic is unit-testable on its
-/// own (and `doctor::run` returns its report string, so it's covered end-to-end
-/// too). Shares `truecolor_advertised`'s inputs with the warn policy, so the
-/// diagnostic and the startup warning can never disagree. Untrusted env values
-/// are stripped of control chars before display.
+/// Parse a `DECRQSS`-for-SGR reply to our truecolor probe. We set the background
+/// to `48;2;1;2;3`; the reply form is `DCS 1 $ r <SGR> ST` for a valid request
+/// and `DCS 0 $ r ST` when the terminal can't honor it. Returns
+/// `Some(true)` when our exact RGB triple came back (truecolor), `Some(false)`
+/// for a valid-but-downsampled reply (not truecolor), and `None` for no valid
+/// reply (`0$r`, empty, or a timeout) — which the caller treats as "warn", since
+/// a terminal that can't answer DECRQSS is unlikely to be truecolor. Pure
+/// (operates on the captured bytes) so every branch is unit-tested without a real
+/// terminal.
+fn parse_decrqss_truecolor(resp: &[u8]) -> Option<bool> {
+    let s = String::from_utf8_lossy(resp);
+    // A valid SGR reply is `DCS 1 $ r ... m ST`; `0 $ r` = request not honored.
+    if !s.contains("1$r") {
+        return None;
+    }
+    // Tolerate `:` / `;` separators and an optional empty colorspace-id field
+    // (`48:2::1:2:3`) — both are spec-legal ways to echo our triple back.
+    let normalized = s.replace(';', ":");
+    Some(normalized.contains("48:2:1:2:3") || normalized.contains("48:2::1:2:3"))
+}
+
+/// The `pixtuoid doctor` `terminal:` line — `$TERM` / `$COLORTERM` and the
+/// truecolor verdict, naming HOW it was determined so a "colors look wrong"
+/// report is self-diagnosable. `probe` is the `query_truecolor` result (or `None`
+/// when doctor isn't attached to a tty). Pure (takes its inputs) so the row logic
+/// is unit-tested; `doctor::run` returns its report string, so it's covered
+/// end-to-end too. Untrusted env values are stripped of control chars.
 pub fn terminal_diagnostic_row(
     term: Option<&str>,
     colorterm: Option<&str>,
-    term_program: Option<&str>,
+    probe: Option<bool>,
 ) -> String {
     let shown = |v: Option<&str>| match v {
         Some(s) if !s.is_empty() => crate::strip_control_chars(s),
@@ -134,18 +103,154 @@ pub fn terminal_diagnostic_row(
     };
     let verdict = if colorterm_is_truecolor(colorterm) {
         "yes (COLORTERM)"
-    } else if term_is_truecolor(term, term_program) {
-        "yes (TERM/TERM_PROGRAM)"
     } else {
-        "not advertised"
+        match probe {
+            Some(true) => "yes (terminal query)",
+            Some(false) => "no (terminal downsamples)",
+            None => "unknown (terminal did not answer)",
+        }
     };
     format!(
-        "terminal: TERM={} COLORTERM={} TERM_PROGRAM={} truecolor={}",
+        "terminal: TERM={} COLORTERM={} truecolor={}",
         shown(term),
         shown(colorterm),
-        shown(term_program),
         verdict,
     )
+}
+
+/// The probe bytes: set bg to `48;2;1;2;3` — the SEMICOLON 24-bit SGR form the
+/// renderer (crossterm) actually emits, so we test what pixtuoid will output, not
+/// the stricter colon form some truecolor terminals reject — then `DECRQSS`-query
+/// the SGR back (`DCS $ q m ST`) and reset SGR. Echo is off and we write no
+/// printable text, so there's no on-screen effect.
+#[cfg(unix)]
+const DECRQSS_TRUECOLOR_PROBE: &[u8] = b"\x1b[48;2;1;2;3m\x1bP$qm\x1b\\\x1b[0m";
+
+/// Ask the terminal whether it is truecolor by querying it directly (no `$TERM`
+/// allowlist). Opens the controlling terminal (`/dev/tty`, so a piped
+/// `pixtuoid doctor > file` never receives escape codes), switches it to raw so
+/// the reply isn't echoed and arrives un-buffered, writes the probe, reads the
+/// reply with a `poll` timeout, restores the terminal, and parses. Returns `None`
+/// on any I/O failure or no answer — degrading to "warn", unchanged from a
+/// terminal we can't confirm. The IO seam (codecov-excluded); the parser and the
+/// policy around it are the unit-tested pure pieces.
+#[cfg(unix)]
+pub fn query_truecolor(timeout: std::time::Duration) -> Option<bool> {
+    use std::io::Write;
+    use std::os::fd::AsRawFd;
+
+    let mut tty = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open("/dev/tty")
+        .ok()?;
+    let fd = tty.as_raw_fd();
+
+    // SAFETY: `tcgetattr` only fills the zeroed repr(C) `termios` for a valid fd;
+    // all-zero is a valid starting value (overwritten on success).
+    let mut saved: libc::termios = unsafe { std::mem::zeroed() };
+    if unsafe { libc::tcgetattr(fd, &mut saved) } != 0 {
+        return None;
+    }
+    // Restore the saved settings on EVERY exit path (incl. a panic unwinding).
+    let _restore = TermiosRestore { fd, saved };
+
+    let mut raw = saved;
+    // SAFETY: `cfmakeraw` only mutates the termios struct in place.
+    unsafe { libc::cfmakeraw(&mut raw) };
+    // SAFETY: applying a well-formed termios to the open tty fd.
+    if unsafe { libc::tcsetattr(fd, libc::TCSANOW, &raw) } != 0 {
+        return None;
+    }
+
+    tty.write_all(DECRQSS_TRUECOLOR_PROBE).ok()?;
+    tty.flush().ok()?;
+
+    parse_decrqss_truecolor(&read_until_terminator(&mut tty, fd, timeout))
+}
+
+/// RAII restore of the terminal's saved `termios` — fires on return, `?`, and
+/// panic unwinding so a probe can never leave the terminal in raw mode.
+#[cfg(unix)]
+struct TermiosRestore {
+    fd: std::os::fd::RawFd,
+    saved: libc::termios,
+}
+
+#[cfg(unix)]
+impl Drop for TermiosRestore {
+    fn drop(&mut self) {
+        // SAFETY: re-applying the termios we captured from this same fd.
+        unsafe { libc::tcsetattr(self.fd, libc::TCSANOW, &self.saved) };
+    }
+}
+
+/// Read the terminal's reply, bounded by `timeout`, until the `DCS` string
+/// terminator (`ESC \`) or `BEL` arrives (or the budget elapses / the buffer
+/// caps). `poll` returns the instant bytes are ready, so a prompt terminal never
+/// waits the full budget.
+#[cfg(unix)]
+fn read_until_terminator(
+    tty: &mut std::fs::File,
+    fd: std::os::fd::RawFd,
+    timeout: std::time::Duration,
+) -> Vec<u8> {
+    use std::io::Read;
+
+    let start = std::time::Instant::now();
+    let mut buf = Vec::with_capacity(64);
+    let mut chunk = [0u8; 64];
+    loop {
+        let elapsed = start.elapsed();
+        if elapsed >= timeout {
+            break;
+        }
+        let remaining_ms = (timeout - elapsed).as_millis().min(i32::MAX as u128) as i32;
+        let mut pfd = libc::pollfd {
+            fd,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        // SAFETY: `pfd` is a single valid pollfd; `poll` only reads/writes it.
+        let ready = unsafe { libc::poll(&mut pfd, 1, remaining_ms) };
+        if ready < 0 {
+            // A signal (e.g. SIGWINCH at startup) interrupted the wait — retry
+            // within the remaining budget rather than give up to a false warn.
+            if std::io::Error::last_os_error().kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            break;
+        }
+        if ready == 0 || pfd.revents & libc::POLLIN == 0 {
+            break; // timeout, or not a read-ready event
+        }
+        match tty.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(n) => {
+                buf.extend_from_slice(&chunk[..n]);
+                if response_terminated(&buf) || buf.len() > 1024 {
+                    break;
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(_) => break,
+        }
+    }
+    buf
+}
+
+/// A `DCS` reply ends with the string terminator `ESC \` (some terminals use
+/// `BEL`). Seeing either means the reply is complete — stop reading.
+#[cfg(unix)]
+fn response_terminated(buf: &[u8]) -> bool {
+    buf.windows(2).any(|w| w == [0x1b, b'\\']) || buf.contains(&0x07)
+}
+
+/// Non-Unix stub: Windows hard-gates VT separately in `tui::mod`, so there is no
+/// preflight query there. Keeps `doctor` / the call site cross-platform.
+#[cfg(not(unix))]
+pub fn query_truecolor(_timeout: std::time::Duration) -> Option<bool> {
+    None
 }
 
 #[cfg(test)]
@@ -153,55 +258,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn truecolor_tokens_match() {
+    fn colorterm_truecolor_tokens() {
         assert!(colorterm_is_truecolor(Some("truecolor")));
         assert!(colorterm_is_truecolor(Some("24bit")));
-        // A terminal may set a compound value.
         assert!(colorterm_is_truecolor(Some("truecolor:whatever")));
-    }
-
-    #[test]
-    fn term_allowlist_matches_modern_terminals_but_not_256color() {
-        // Direct-color entries + the modern-terminal $TERM family advertise.
-        for t in [
-            "xterm-direct",
-            "tmux-truecolor",
-            "xterm-kitty",
-            "xterm-ghostty",
-            "alacritty",
-            "wezterm",
-            "foot-extra",
-            "contour",
-            "rio",
-        ] {
-            assert!(term_is_truecolor(Some(t), None), "{t} should advertise");
-        }
-        // $TERM_PROGRAM (proper-name, case-insensitive); Apple_Terminal must NOT.
-        for p in [
-            "iTerm.app",
-            "WezTerm",
-            "ghostty",
-            "vscode",
-            "Hyper",
-            "tabby",
-        ] {
-            assert!(
-                term_is_truecolor(None, Some(p)),
-                "{p} program should advertise"
-            );
-        }
-        // The load-bearing exclusion: Apple Terminal.app is genuinely 256-color
-        // (until macOS 26) and MUST still warn — neither its $TERM nor its
-        // $TERM_PROGRAM may match the allowlist.
-        assert!(!term_is_truecolor(
-            Some("xterm-256color"),
-            Some("Apple_Terminal")
-        ));
-        // tmux/screen default $TERM carries no truecolor signal by name (the deep
-        // terminfo-Tc case is the documented residual, covered by the hatch).
-        assert!(!term_is_truecolor(Some("tmux-256color"), None));
-        assert!(!term_is_truecolor(Some("screen-256color"), None));
-        assert!(!term_is_truecolor(None, None));
+        assert!(!colorterm_is_truecolor(None));
+        assert!(!colorterm_is_truecolor(Some("")));
+        assert!(!colorterm_is_truecolor(Some("256color")));
+        // Case-sensitive: only the conventional lowercase tokens count.
+        assert!(!colorterm_is_truecolor(Some("TrueColor")));
     }
 
     #[test]
@@ -222,103 +287,79 @@ mod tests {
     }
 
     #[test]
-    fn should_warn_truecolor_truth_table() {
-        // Warn ONLY for a TUI run, on a tty, with no truecolor signal + no hatch.
-        assert!(should_warn_truecolor(true, true, None, None, None, None));
-        assert!(should_warn_truecolor(
-            true,
-            true,
-            Some("256color"),
-            Some("xterm-256color"),
-            Some("Apple_Terminal"),
-            None
-        ));
-        // Suppressed by ANY of: not a TUI run, not a tty, $COLORTERM truecolor, a
-        // known-truecolor $TERM / $TERM_PROGRAM, or the escape hatch.
-        assert!(!should_warn_truecolor(false, true, None, None, None, None));
-        assert!(!should_warn_truecolor(true, false, None, None, None, None));
-        assert!(!should_warn_truecolor(
-            true,
-            true,
-            Some("truecolor"),
-            None,
-            None,
-            None
-        ));
-        assert!(!should_warn_truecolor(
-            true,
-            true,
-            None,
-            Some("xterm-kitty"),
-            None,
-            None
-        ));
-        assert!(!should_warn_truecolor(
-            true,
-            true,
-            None,
-            None,
-            Some("iTerm.app"),
-            None
-        ));
-        assert!(!should_warn_truecolor(
-            true,
-            true,
-            None,
-            None,
-            None,
-            Some("1")
-        ));
-        // The SSH false-positive #397 targets: $COLORTERM stripped but $TERM
-        // survives the pty-req → no warning.
-        assert!(!should_warn_truecolor(
-            true,
-            true,
-            None,
-            Some("xterm-ghostty"),
-            None,
-            None
-        ));
+    fn warn_zone_truth_table() {
+        // In the zone (→ query the terminal) only for a TUI run, on a tty, with no
+        // COLORTERM truecolor declaration and no escape hatch.
+        assert!(warn_zone(true, true, None, None));
+        assert!(warn_zone(true, true, Some("256color"), None));
+        // Out of the zone (skip the query, never warn): not a run, not a tty,
+        // COLORTERM already truecolor, or the hatch set.
+        assert!(!warn_zone(false, true, None, None));
+        assert!(!warn_zone(true, false, None, None));
+        assert!(!warn_zone(true, true, Some("truecolor"), None));
+        assert!(!warn_zone(true, true, None, Some("1")));
     }
 
     #[test]
-    fn non_truecolor_is_false() {
-        assert!(!colorterm_is_truecolor(None));
-        assert!(!colorterm_is_truecolor(Some("")));
-        assert!(!colorterm_is_truecolor(Some("256color")));
-        // Case-sensitive: only the conventional lowercase tokens count.
-        assert!(!colorterm_is_truecolor(Some("TrueColor")));
+    fn parse_decrqss_distinguishes_truecolor_from_downsample() {
+        // A truecolor terminal echoes our exact RGB triple (colon form).
+        assert_eq!(
+            parse_decrqss_truecolor(b"\x1bP1$r48:2:1:2:3m\x1b\\"),
+            Some(true)
+        );
+        // Semicolon form is normalized to the same triple.
+        assert_eq!(
+            parse_decrqss_truecolor(b"\x1bP1$r0;48;2;1;2;3m\x1b\\"),
+            Some(true)
+        );
+        // Empty colorspace-id field is spec-legal and still truecolor.
+        assert_eq!(
+            parse_decrqss_truecolor(b"\x1bP1$r48:2::1:2:3m\x1b\\"),
+            Some(true)
+        );
+        // A valid reply that downsampled to a 256-color index is NOT truecolor.
+        assert_eq!(
+            parse_decrqss_truecolor(b"\x1bP1$r48;5;16m\x1b\\"),
+            Some(false)
+        );
+        // A bare attribute reply (no color set) — answered, but not our triple.
+        assert_eq!(parse_decrqss_truecolor(b"\x1bP1$r0m\x1b\\"), Some(false));
+        // `0$r` = request not honored → ambiguous; empty/timeout → ambiguous.
+        assert_eq!(parse_decrqss_truecolor(b"\x1bP0$r\x1b\\"), None);
+        assert_eq!(parse_decrqss_truecolor(b""), None);
     }
 
     #[test]
-    fn terminal_row_renders_each_state() {
-        let yes = terminal_diagnostic_row(Some("xterm-256color"), Some("truecolor"), None);
-        assert!(yes.contains("TERM=xterm-256color"));
-        assert!(yes.contains("COLORTERM=truecolor"));
-        assert!(yes.contains("truecolor=yes (COLORTERM)"));
+    fn response_terminated_on_st_or_bel() {
+        assert!(response_terminated(b"\x1bP1$r0m\x1b\\"));
+        assert!(response_terminated(b"\x1bP1$r0m\x07"));
+        assert!(!response_terminated(b"\x1bP1$r0m"));
+    }
 
-        // $COLORTERM unset but a known-truecolor $TERM → the verdict names the
-        // TERM signal (the doctor/warning coherence case).
-        let by_term = terminal_diagnostic_row(Some("xterm-kitty"), None, None);
-        assert!(by_term.contains("TERM=xterm-kitty"), "{by_term}");
+    #[test]
+    fn terminal_row_names_how_truecolor_was_determined() {
+        let by_colorterm = terminal_diagnostic_row(Some("xterm-256color"), Some("truecolor"), None);
+        assert!(by_colorterm.contains("TERM=xterm-256color"));
+        assert!(by_colorterm.contains("COLORTERM=truecolor"));
+        assert!(by_colorterm.contains("truecolor=yes (COLORTERM)"));
+
+        // COLORTERM silent → the verdict reports the terminal-query outcome.
+        assert!(terminal_diagnostic_row(Some("xterm"), None, Some(true))
+            .contains("truecolor=yes (terminal query)"));
+        assert!(terminal_diagnostic_row(Some("xterm"), None, Some(false))
+            .contains("truecolor=no (terminal downsamples)"));
+
+        // No tty / no answer → unknown, and unset values read as "(unset)".
+        let unknown = terminal_diagnostic_row(None, None, None);
+        assert!(unknown.contains("TERM=(unset)"), "{unknown}");
+        assert!(unknown.contains("COLORTERM=(unset)"), "{unknown}");
         assert!(
-            by_term.contains("truecolor=yes (TERM/TERM_PROGRAM)"),
-            "{by_term}"
+            unknown.contains("truecolor=unknown (terminal did not answer)"),
+            "{unknown}"
         );
 
-        // Unset ($COLORTERM = None) and set-but-empty both read as "(unset)" and a
-        // "not advertised" verdict (no $TERM signal either).
-        for ct in [None, Some("")] {
-            let row = terminal_diagnostic_row(None, ct, None);
-            assert!(row.contains("TERM=(unset)"), "{row}");
-            assert!(row.contains("COLORTERM=(unset)"), "{row}");
-            assert!(row.contains("TERM_PROGRAM=(unset)"), "{row}");
-            assert!(row.contains("truecolor=not advertised"), "{row}");
-        }
-
         // Untrusted env values are control-char-stripped before display.
-        let sanitized =
-            terminal_diagnostic_row(Some("a\x1b[31mb"), Some("truecolor"), Some("x\x1by"));
+        let sanitized = terminal_diagnostic_row(Some("a\x1b[31mb"), Some("truecolor"), None);
         assert!(!sanitized.contains('\u{1b}'), "{sanitized}");
     }
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -96,4 +96,25 @@ the query runs only otherwise.) Run `pixtuoid doctor` for the detected
 
 A terminal that's genuinely truecolor but doesn't answer the query (rare) may
 still get warned. If you know your terminal is fine, silence the warning with
-`$PIXTUOID_NO_TRUECOLOR_WARN=1` (any of `1`/`true`/`yes`/`on`).
+`$PIXTUOID_NO_TRUECOLOR_WARN=1` (any of `1`/`true`/`yes`/`on`). Note: `tmux`
+doesn't implement the `DECRQSS` query, so a truecolor tmux session can trip this
+warning — set `$PIXTUOID_NO_TRUECOLOR_WARN=1` (tmux usually advertises
+`$COLORTERM`, which skips the query, so most setups never see it).
+
+### When color is disabled (`$NO_COLOR`, `$TERM=dumb`)
+
+The office has **no legible monochrome mode** — it's color end to end. So rather
+than render unreadable blocks, `pixtuoid run` refuses to launch the canvas and
+explains why when color is turned off:
+
+- **`$NO_COLOR`** (the [no-color.org](https://no-color.org) convention; any
+  non-empty value): the terminal layer strips our 24-bit color, so the office
+  can't render. Unset `NO_COLOR`, or override per the standard precedence with
+  **`$CLICOLOR_FORCE=1`** (forces color on despite `$NO_COLOR`). An *empty*
+  `$NO_COLOR` is ignored (it doesn't actually strip color).
+- **`$TERM=dumb`**: the terminal can't render escape sequences or color at all.
+
+In both cases use a graphical terminal, or `pixtuoid run --headless` for a plain
+text summary (which works fine without color). `pixtuoid doctor` reports the
+active color status. This gate applies only to the terminal `run` TUI —
+`--headless`, `doctor`, `sources`, and the `floating` window are unaffected.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -85,14 +85,15 @@ Non-TUI commands (`--headless`, `validate-pack`, …) log to stderr directly.
 
 ### Truecolor preflight
 
-The pixel-art office renders in 24-bit color. On launch, `pixtuoid run` prints a
-one-line stderr warning if it can't tell your terminal is truecolor-capable —
-i.e. neither `$COLORTERM` (`truecolor`/`24bit`) nor a known-truecolor
-`$TERM`/`$TERM_PROGRAM` (kitty, Ghostty, Alacritty, WezTerm, foot, iTerm2, …) is
-set. It's **warn-only** (never blocks) and scrolls away once the office takes
-over. Run `pixtuoid doctor` for the detected `terminal:` verdict.
+The pixel-art office renders in 24-bit color. On launch, `pixtuoid run`
+**asks your terminal** whether it supports truecolor — it sets an unlikely
+24-bit color and queries it back (a `DECRQSS` probe) — rather than guessing from
+the terminal's name. If the terminal doesn't confirm, it prints a one-line
+stderr warning. It's **warn-only** (never blocks) and scrolls away once the
+office takes over. (`$COLORTERM=truecolor` is taken as a yes and skips the query;
+the query runs only otherwise.) Run `pixtuoid doctor` for the detected
+`terminal:` verdict.
 
-Some genuinely-truecolor setups can't be auto-detected — notably tmux/SSH
-sessions whose only truecolor signal is a terminfo `Tc`/`RGB` override. If you
-know your terminal is fine, silence the warning with
+A terminal that's genuinely truecolor but doesn't answer the query (rare) may
+still get warned. If you know your terminal is fine, silence the warning with
 `$PIXTUOID_NO_TRUECOLOR_WARN=1` (any of `1`/`true`/`yes`/`on`).

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -108,10 +108,10 @@ than render unreadable blocks, `pixtuoid run` refuses to launch the canvas and
 explains why when color is turned off:
 
 - **`$NO_COLOR`** (the [no-color.org](https://no-color.org) convention; any
-  non-empty value): the terminal layer strips our 24-bit color, so the office
-  can't render. Unset `NO_COLOR`, or override per the standard precedence with
-  **`$CLICOLOR_FORCE=1`** (forces color on despite `$NO_COLOR`). An *empty*
-  `$NO_COLOR` is ignored (it doesn't actually strip color).
+  non-empty value): color output is disabled, so the office can't render. Unset
+  `NO_COLOR`, or override per the standard precedence with **`$CLICOLOR_FORCE=1`**
+  (forces color on despite `$NO_COLOR`; a `0` value does not force). An *empty*
+  `$NO_COLOR` is ignored (it doesn't actually disable color).
 - **`$TERM=dumb`**: the terminal can't render escape sequences or color at all.
 
 In both cases use a graphical terminal, or `pixtuoid run --headless` for a plain

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -82,3 +82,17 @@ and the full error is in the log file.
 Crashes are reported separately to `~/.cache/pixtuoid/crash.log`.
 
 Non-TUI commands (`--headless`, `validate-pack`, …) log to stderr directly.
+
+### Truecolor preflight
+
+The pixel-art office renders in 24-bit color. On launch, `pixtuoid run` prints a
+one-line stderr warning if it can't tell your terminal is truecolor-capable —
+i.e. neither `$COLORTERM` (`truecolor`/`24bit`) nor a known-truecolor
+`$TERM`/`$TERM_PROGRAM` (kitty, Ghostty, Alacritty, WezTerm, foot, iTerm2, …) is
+set. It's **warn-only** (never blocks) and scrolls away once the office takes
+over. Run `pixtuoid doctor` for the detected `terminal:` verdict.
+
+Some genuinely-truecolor setups can't be auto-detected — notably tmux/SSH
+sessions whose only truecolor signal is a terminfo `Tc`/`RGB` override. If you
+know your terminal is fine, silence the warning with
+`$PIXTUOID_NO_TRUECOLOR_WARN=1` (any of `1`/`true`/`yes`/`on`).


### PR DESCRIPTION
Fixes #397, and closes a related gap: pixtuoid's terminal color handling now (a) **asks the terminal** whether it's truecolor instead of guessing, and (b) refuses to render rather than emit unreadable garbage when color is disabled.

## Part A — detect truecolor by querying the terminal (DECRQSS), not a `$TERM` allowlist (#397)

On `pixtuoid run` (and `doctor`), when `$COLORTERM` hasn't already declared truecolor, set an unlikely 24-bit background and `DECRQSS`-query the SGR back ([termstandard/colors](https://github.com/termstandard/colors)): a truecolor terminal echoes the RGB triple, a 256-color one downsamples it, one that can't parse the query stays silent. Warn only if the terminal doesn't confirm. No `$TERM`/`$TERM_PROGRAM` allowlist (the "magic variable" smell), no `infocmp` subprocess (absent on musl/alpine/Nix, stale on macOS), no terminfo dependency — the only approach that *knows* instead of guesses.

- **`query_truecolor(timeout)`** — `cfg(unix)` IO seam: opens `/dev/tty`, raw-modes it via an RAII `TermiosRestore` (restores on every path incl. panic), writes the probe, reads via **`libc::select`** (EINTR-retried, 100ms budget — returns the instant a reply lands). `select`, **not `poll`:** PTY dogfooding caught that macOS `poll()` returns `POLLNVAL` on a tty/pty fd, which would have made every non-`$COLORTERM` terminal falsely warn on the primary platform. Windows is a `None` stub (it hard-gates VT separately).
- **`parse_decrqss_truecolor` / `warn_zone`** — pure, unit-tested; tolerant of `:`/`;` separators and the empty-colorspace-id form. The probe uses the **semicolon** SGR form crossterm actually emits.
- `doctor`'s `terminal:` row names *how* truecolor was determined (COLORTERM / terminal query / downsamples / unknown), tty-gated.
- **Verified on a real terminal:** `COLORTERM= pixtuoid doctor` on Ghostty → `truecolor=yes (terminal query)`.

## Part B — refuse the canvas under `$NO_COLOR` / `$TERM=dumb` instead of rendering block-soup

The pixel-art office is 24-bit color end to end with no legible monochrome fallback. crossterm honors `$NO_COLOR` by stripping every SGR to a bare reset (verified against crossterm-0.29 source), so under `$NO_COLOR` the office rendered as unreadable blocks with no hint; `$TERM=dumb` can't render escapes at all. Both were silent gaps next to the truecolor preflight.

`color_preflight(no_color, clicolor_force, term) -> ColorPreflight` (pure policy in `term.rs`) gates the `run` TUI (cross-platform, before the DECRQSS probe so a dumb terminal never gets escapes):

- `$TERM=dumb` → refuse + explain (a force can't fix it; checked first).
- non-empty `$NO_COLOR` → refuse + explain, **unless** `$CLICOLOR_FORCE` (bixense `!= 0`) overrides it → `main.rs` calls `crossterm::style::force_color_output(true)` (crossterm honors `$NO_COLOR` but **not** `$CLICOLOR_FORCE` — verified). `$FORCE_COLOR`/`$CLICOLOR` are deliberately not read (crossterm keys only on `$NO_COLOR`).
- empty `$NO_COLOR` is ignored (matches crossterm — the thing that strips).

Refuse exits 0 with a one-line stderr explanation pointing at the override + `run --headless` (mirrors the Windows VT hard-gate). Only the terminal `run` TUI is gated; `--headless`/`doctor`/`sources` are plain text and `floating` paints real RGB via softbuffer. `doctor` reuses the same policy for a `color:` diagnostic line and skips the probe under `$TERM=dumb`.

## Sharp edges (documented in the crate `CLAUDE.md`)

- A truecolor terminal that doesn't answer DECRQSS (e.g. tmux #4034) false-positives the depth warn → `$PIXTUOID_NO_TRUECOLOR_WARN=1` covers it (tmux usually sets `$COLORTERM`, skipping the query anyway).
- A very-laggy reply past the 100ms budget could leak a few bytes to the TUI's stdin (accepted, rare).

## Review

Two-lens review (correctness + design), both **APPROVE-WITH-NITS**. Both lenses independently re-verified the three load-bearing crossterm-0.29 behavioral claims against the registry source. Findings fixed in the review-round commit: `$CLICOLOR_FORCE=0` no longer forces (bixense `!= 0`); the `$NO_COLOR` message says "color output is disabled" (accurate — the app, not the terminal, disables color); the `$FORCE_COLOR`/`$CLICOLOR` omissions are documented. Exit-0-on-refuse refuted (correct: valid response to the user's env, keeps `&&` chains intact).

## Verification

`just preflight` green (1928→1930 tests), Windows cross-lint green, `unsafe` limited to the `libc` termios/select calls with `// SAFETY:` notes, no `unwrap()` in non-test code.

Closes #397. Supersedes #400 (credit to @mvanhorn for the terminfo investigation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
