### PR TITLE
feat(site): Terminal Habitat redesign — particle-assembly hero, command palette, clock-driven office

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -11,7 +11,6 @@
         "@astrojs/sitemap": "^3.7.3",
         "@fontsource/jersey-10": "^5.2.8",
         "@fontsource/jetbrains-mono": "^5.2.8",
-        "@fontsource/lora": "^5.2.8",
         "astro": "^6.4.7"
       },
       "devDependencies": {
@@ -988,15 +987,6 @@
       "version": "5.2.8",
       "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
       "integrity": "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==",
-      "license": "OFL-1.1",
-      "funding": {
-        "url": "https://github.com/sponsors/ayuhito"
-      }
-    },
-    "node_modules/@fontsource/lora": {
-      "version": "5.2.8",
-      "resolved": "https://registry.npmjs.org/@fontsource/lora/-/lora-5.2.8.tgz",
-      "integrity": "sha512-AQlfsHw4TP1x/eb2IZ6VjQ70ctKa39m9JN9A4zlvDOeKYLrCs+GaYIEQ86Y6YfSPGHn01bErXkRcyktOW0LOPQ==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"

--- a/site/package.json
+++ b/site/package.json
@@ -23,7 +23,6 @@
     "@astrojs/sitemap": "^3.7.3",
     "@fontsource/jersey-10": "^5.2.8",
     "@fontsource/jetbrains-mono": "^5.2.8",
-    "@fontsource/lora": "^5.2.8",
     "astro": "^6.4.7"
   },
   "devDependencies": {

--- a/site/src/components/CommandPalette.astro
+++ b/site/src/components/CommandPalette.astro
@@ -1,0 +1,456 @@
+---
+import { REPO, CRATES, SPONSOR, asset } from '../consts';
+
+// The terminal you run pixtuoid in has a command line — so does the page. `/`,
+// `:` or ⌘K open it; every action here maps to something the page can already
+// do (ride the elevator, switch theme, open a doc), surfaced as one keyboard
+// entry point. Actions render server-side as data-attributed rows; the hoisted
+// (deferred) script reads them, so there's no is:inline parse-order trap.
+const JUMP = [
+  { icon: '↟', label: 'Top — penthouse', target: 'lobby', keys: '6' },
+  { icon: '▮', label: 'Showcase — the studio', target: 'showcase', keys: '5' },
+  { icon: '▮', label: 'Features — the amenities', target: 'features', keys: '4' },
+  { icon: '▮', label: 'How it works — the machine room', target: 'how', keys: '3' },
+  { icon: '▮', label: 'Supported tools — the tenants', target: 'tools', keys: '2' },
+  { icon: '▮', label: 'Install — the front desk', target: 'install', keys: '1' },
+];
+const THEME = [
+  { icon: '☀', label: 'Theme — day (lights on)', target: 'day' },
+  { icon: '☾', label: 'Theme — night (default)', target: 'night' },
+  { icon: '✦', label: 'Theme — dracula', target: 'dracula' },
+];
+const LINK = [
+  { icon: '↗', label: 'GitHub — source & issues', href: REPO, ext: true },
+  { icon: '☰', label: 'Docs — Architecture', href: asset('architecture'), ext: false },
+  { icon: '☰', label: 'Docs — Configuration', href: asset('config'), ext: false },
+  { icon: '⬗', label: 'crates.io — install page', href: CRATES, ext: true },
+  { icon: '☕', label: 'Buy me a coffee', href: SPONSOR, ext: true },
+];
+---
+
+<div id="cmdk" class="cmdk" hidden>
+  <div class="cmdk__scrim" data-cmdk-close></div>
+  <div
+    class="cmdk__panel"
+    role="dialog"
+    aria-modal="true"
+    aria-label="Command palette"
+    id="cmdk-panel"
+  >
+    <div class="cmdk__head">
+      <span class="cmdk__prompt" aria-hidden="true">&rsaquo;</span>
+      <input
+        id="cmdk-input"
+        class="cmdk__input"
+        type="text"
+        role="combobox"
+        aria-controls="cmdk-list"
+        aria-expanded="true"
+        aria-autocomplete="list"
+        placeholder="jump to a floor, switch theme, open a doc…"
+        autocomplete="off"
+        autocorrect="off"
+        autocapitalize="off"
+        spellcheck="false"
+      />
+      <kbd class="cmdk__esc">esc</kbd>
+    </div>
+    <ul id="cmdk-list" class="cmdk__list" role="listbox" aria-label="Commands">
+      {
+        JUMP.map((a) => (
+          <li class="cmdk__item" role="option" data-kind="jump" data-target={a.target}>
+            <span class="cmdk__ico" aria-hidden="true">
+              {a.icon}
+            </span>
+            <span class="cmdk__label">{a.label}</span>
+            <kbd class="cmdk__key">{a.keys}</kbd>
+          </li>
+        ))
+      }
+      {
+        THEME.map((a) => (
+          <li class="cmdk__item" role="option" data-kind="theme" data-target={a.target}>
+            <span class="cmdk__ico" aria-hidden="true">
+              {a.icon}
+            </span>
+            <span class="cmdk__label">{a.label}</span>
+          </li>
+        ))
+      }
+      <li class="cmdk__item" role="option" data-kind="accent">
+        <span class="cmdk__ico" aria-hidden="true">⟳</span>
+        <span class="cmdk__label">Cycle the accent hue</span>
+        <kbd class="cmdk__key">t</kbd>
+      </li>
+      {
+        LINK.map((a) => (
+          <li
+            class="cmdk__item"
+            role="option"
+            data-kind="link"
+            data-href={a.href}
+            data-ext={a.ext ? '1' : '0'}
+          >
+            <span class="cmdk__ico" aria-hidden="true">
+              {a.icon}
+            </span>
+            <span class="cmdk__label">{a.label}</span>
+            {a.ext && (
+              <span class="cmdk__ext" aria-hidden="true">
+                ↗
+              </span>
+            )}
+          </li>
+        ))
+      }
+      <li class="cmdk__item" role="option" data-kind="replay">
+        <span class="cmdk__ico" aria-hidden="true">⏮</span>
+        <span class="cmdk__label">Replay the intro</span>
+      </li>
+      <li class="cmdk__empty" hidden>no commands match — try "theme" or "docs"</li>
+    </ul>
+    <div class="cmdk__foot" aria-hidden="true">
+      <span><kbd>↑</kbd><kbd>↓</kbd> move</span>
+      <span><kbd>↵</kbd> run</span>
+      <span><kbd>esc</kbd> close</span>
+    </div>
+  </div>
+</div>
+
+<button id="cmdk-hint" class="cmdk-hint" type="button" aria-label="Open command palette">
+  <kbd>/</kbd> commands
+</button>
+
+<style>
+  .cmdk {
+    position: fixed;
+    inset: 0;
+    z-index: 100; /* above the sticky nav (50) and the elevator */
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    padding: 14vh 1rem 1rem;
+    background: color-mix(in srgb, var(--bg-tint) 62%, transparent);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+  }
+  .cmdk[hidden] {
+    display: none;
+  }
+  .cmdk__scrim {
+    position: absolute;
+    inset: 0;
+  }
+  .cmdk__panel {
+    position: relative;
+    width: min(560px, 94vw);
+    max-height: 72vh;
+    display: flex;
+    flex-direction: column;
+    background: var(--panel);
+    border: 1px solid var(--line-strong);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-lg);
+    overflow: hidden;
+    font-family: var(--font-mono);
+    animation: cmdk-in 0.14s ease-out both;
+  }
+  @keyframes cmdk-in {
+    from {
+      opacity: 0;
+      transform: translateY(-8px);
+    }
+  }
+  .cmdk__head {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.75rem 0.9rem;
+    border-bottom: 1px solid var(--line);
+  }
+  .cmdk__prompt {
+    color: var(--accent);
+    font-weight: 700;
+  }
+  .cmdk__input {
+    flex: 1;
+    background: none;
+    border: 0;
+    outline: none;
+    color: var(--fg);
+    font: inherit;
+    font-size: 0.95rem;
+  }
+  .cmdk__input::placeholder {
+    color: var(--fg-dim);
+  }
+  .cmdk__esc {
+    font-size: 0.68rem;
+    color: var(--fg-dim);
+    border: 1px solid var(--line-strong);
+    border-radius: 4px;
+    padding: 0.05rem 0.35rem;
+  }
+  .cmdk__list {
+    list-style: none;
+    margin: 0;
+    padding: 0.35rem;
+    overflow-y: auto;
+  }
+  .cmdk__item {
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    padding: 0.5rem 0.6rem;
+    border-radius: var(--radius-sm);
+    border-left: 2px solid transparent;
+    cursor: pointer;
+    font-size: 0.9rem;
+    color: var(--fg-muted);
+  }
+  .cmdk__item[hidden] {
+    display: none;
+  }
+  .cmdk__item.is-sel {
+    background: color-mix(in srgb, var(--accent) 14%, transparent);
+    border-left-color: var(--accent);
+    color: var(--fg);
+  }
+  .cmdk__ico {
+    width: 1.1rem;
+    text-align: center;
+    color: var(--accent-2);
+  }
+  .cmdk__label {
+    flex: 1;
+  }
+  .cmdk__key,
+  .cmdk__foot kbd {
+    font-size: 0.68rem;
+    color: var(--fg-dim);
+    border: 1px solid var(--line-strong);
+    border-radius: 4px;
+    padding: 0.05rem 0.35rem;
+    min-width: 1.1rem;
+    text-align: center;
+  }
+  .cmdk__ext {
+    color: var(--fg-dim);
+    font-size: 0.8rem;
+  }
+  .cmdk__empty {
+    padding: 0.9rem 0.7rem;
+    color: var(--fg-dim);
+    font-size: 0.85rem;
+  }
+  .cmdk__foot {
+    display: flex;
+    gap: 1rem;
+    padding: 0.5rem 0.9rem;
+    border-top: 1px solid var(--line);
+    font-size: 0.72rem;
+    color: var(--fg-dim);
+  }
+  .cmdk__foot kbd {
+    margin-right: 0.15rem;
+  }
+
+  /* discoverability: a quiet corner chip that opens the palette */
+  .cmdk-hint {
+    position: fixed;
+    left: 1rem;
+    bottom: 1rem;
+    z-index: 40;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.35rem 0.6rem;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    color: var(--fg-dim);
+    background: color-mix(in srgb, var(--panel) 80%, transparent);
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    cursor: pointer;
+    opacity: 0.6;
+    transition:
+      opacity 0.15s ease,
+      color 0.15s ease;
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+  }
+  .cmdk-hint:hover,
+  .cmdk-hint:focus-visible {
+    opacity: 1;
+    color: var(--fg);
+  }
+  .cmdk-hint kbd {
+    font-size: 0.68rem;
+    color: var(--fg-muted);
+    border: 1px solid var(--line-strong);
+    border-radius: 4px;
+    padding: 0 0.3rem;
+  }
+  /* the chip is a nicety; on narrow screens it competes with the thumb zone */
+  @media (max-width: 640px) {
+    .cmdk-hint {
+      display: none;
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .cmdk__panel {
+      animation: none;
+    }
+  }
+</style>
+
+{
+  /* is:inline (matches Nav/Hero/Elevator): renders after <slot/>, so its own
+    #cmdk* nodes exist at parse — no ordering trap, and vanilla DOM code skips
+    the strict TS pass the processed-script path would apply. */
+}
+<script is:inline>
+  (function () {
+    const root = document.getElementById('cmdk');
+    const input = document.getElementById('cmdk-input');
+    const list = document.getElementById('cmdk-list');
+    if (!root || !input || !list) return;
+    const hint = document.getElementById('cmdk-hint');
+    const items = Array.prototype.slice.call(list.querySelectorAll('.cmdk__item'));
+    const empty = list.querySelector('.cmdk__empty');
+    let lastFocus = null;
+    let sel = 0;
+
+    const visible = () => items.filter((el) => !el.hidden);
+
+    function paint() {
+      const vis = visible();
+      if (sel < 0) sel = 0;
+      if (sel > vis.length - 1) sel = vis.length - 1;
+      items.forEach((el) => el.classList.remove('is-sel'));
+      const cur = vis[sel];
+      if (cur) {
+        cur.classList.add('is-sel');
+        cur.scrollIntoView({ block: 'nearest' });
+        input.setAttribute('aria-activedescendant', cur.id || '');
+      }
+    }
+
+    function filter() {
+      const q = input.value.trim().toLowerCase();
+      items.forEach((el) => {
+        const label = (el.querySelector('.cmdk__label').textContent || '').toLowerCase();
+        el.hidden = q !== '' && label.indexOf(q) === -1;
+      });
+      const none = visible().length === 0;
+      if (empty) empty.hidden = !none;
+      sel = 0;
+      paint();
+    }
+
+    function open() {
+      if (!root.hidden) return;
+      lastFocus = document.activeElement;
+      root.hidden = false;
+      input.value = '';
+      filter();
+      input.focus();
+    }
+    function close() {
+      if (root.hidden) return;
+      root.hidden = true;
+      if (lastFocus && lastFocus.focus) lastFocus.focus();
+    }
+
+    function run(el) {
+      if (!el) return;
+      const kind = el.dataset.kind;
+      close();
+      if (kind === 'jump') {
+        const sec = document.getElementById(el.dataset.target);
+        if (sec)
+          sec.scrollIntoView({
+            behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches
+              ? 'auto'
+              : 'smooth',
+            block: 'start',
+          });
+      } else if (kind === 'theme') {
+        const r = document.documentElement.style;
+        r.removeProperty('--coral');
+        r.removeProperty('--coral-deep');
+        r.removeProperty('--amber');
+        document.documentElement.dataset.theme = el.dataset.target;
+        try {
+          localStorage.setItem('pix-theme', el.dataset.target);
+        } catch (e) {}
+        document.dispatchEvent(new CustomEvent('pix:theme'));
+      } else if (kind === 'accent') {
+        // reuse the app's `t` retint cycle wired in Base.astro
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 't' }));
+      } else if (kind === 'link') {
+        if (el.dataset.ext === '1') window.open(el.dataset.href, '_blank', 'noopener');
+        else window.location.href = el.dataset.href;
+      } else if (kind === 'replay') {
+        try {
+          sessionStorage.removeItem('pix-assembled');
+        } catch (e) {}
+        window.location.reload();
+      }
+    }
+
+    // pointer: hover selects, click runs
+    items.forEach((el) => {
+      el.addEventListener('mousemove', () => {
+        const vis = visible();
+        const idx = vis.indexOf(el);
+        if (idx !== -1 && idx !== sel) {
+          sel = idx;
+          paint();
+        }
+      });
+      el.addEventListener('click', () => run(el));
+    });
+
+    input.addEventListener('input', filter);
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        sel++;
+        paint();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        sel--;
+        paint();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        run(visible()[sel]);
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        close();
+      } else if (e.key === 'Tab') {
+        e.preventDefault(); // trap focus on the input while open
+      }
+    });
+
+    root.querySelectorAll('[data-cmdk-close]').forEach((el) => el.addEventListener('click', close));
+    if (hint) hint.addEventListener('click', open);
+
+    // global opener: `/` or `:` or ⌘/Ctrl-K — but never while typing in a field
+    document.addEventListener('keydown', (e) => {
+      if (root.hidden) {
+        const t = e.target;
+        const typing =
+          t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable);
+        const metaK = (e.metaKey || e.ctrlKey) && (e.key === 'k' || e.key === 'K');
+        if (
+          metaK ||
+          (!typing && !e.metaKey && !e.ctrlKey && !e.altKey && (e.key === '/' || e.key === ':'))
+        ) {
+          e.preventDefault();
+          open();
+        }
+      }
+    });
+  })();
+</script>

--- a/site/src/components/Elevator.astro
+++ b/site/src/components/Elevator.astro
@@ -90,7 +90,8 @@ const FLOORS = [
 
     // track the floor the viewport is on. rootMargin centers the trigger band
     // so the indicator flips roughly when a floor crosses mid-screen.
-    if ('IntersectionObserver' in window) {
+    function trackFloors() {
+      if (!('IntersectionObserver' in window)) return;
       const io = new IntersectionObserver(
         function (entries) {
           entries.forEach(function (e) {
@@ -102,6 +103,15 @@ const FLOORS = [
       document.querySelectorAll('[data-floor]').forEach(function (s) {
         io.observe(s);
       });
+    }
+    // The [data-floor] sections are OUTSIDE this component and render AFTER it in
+    // index.astro, so this is:inline script runs (at parse position) before they
+    // exist. Wiring the observer now would observe zero elements and leave the
+    // indicator frozen on the server-rendered floor 6 — defer to DOM-ready.
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', trackFloors, { once: true });
+    } else {
+      trackFloors();
     }
   })();
 </script>

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -1,5 +1,8 @@
 ---
 import { REPO, CRATES, SPONSOR, asset } from '../consts';
+import { getStars, formatStars } from '../lib/github';
+
+const stars = await getStars();
 ---
 
 <footer class="footer">
@@ -19,7 +22,9 @@ import { REPO, CRATES, SPONSOR, asset } from '../consts';
       <p class="footer__tag">A terminal pixel-art office for your AI coding agents.</p>
     </div>
     <nav class="footer__links" aria-label="Footer">
-      <a href={REPO} target="_blank" rel="noreferrer">GitHub</a>
+      <a href={REPO} target="_blank" rel="noreferrer"
+        >GitHub{stars != null && <span class="footer__stars"> ★{formatStars(stars)}</span>}</a
+      >
       <a href={CRATES} target="_blank" rel="noreferrer">crates.io</a>
       <a href={`${REPO}/releases`} target="_blank" rel="noreferrer">Releases</a>
       <a href="#install">Install</a>
@@ -83,6 +88,10 @@ import { REPO, CRATES, SPONSOR, asset } from '../consts';
   }
   .footer__links a:hover {
     color: var(--fg);
+  }
+  .footer__stars {
+    color: var(--accent-2);
+    font-variant-numeric: tabular-nums;
   }
   .footer__legal {
     display: flex;

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -56,6 +56,11 @@ import { REPO, asset } from '../consts';
             alt="A pixel-art office with animated coding-agent characters working at their desks"
           />
         </video>
+        {
+          /* The office reconstructs from its own pixels on load, then fades to the
+            live clip beneath — the signature. Sampled from the real poster. */
+        }
+        <canvas id="assemble" class="assemble px" aria-hidden="true"></canvas>
         <span class="terminal__scan" aria-hidden="true"></span>
       </figure>
     </div>
@@ -104,6 +109,15 @@ import { REPO, asset } from '../consts';
   .terminal__screen {
     width: 100%;
     height: auto;
+  }
+  /* particle-assembly overlay — positioned exactly over the video in JS */
+  .assemble {
+    position: absolute;
+    top: 38px;
+    left: 0;
+    z-index: 2;
+    pointer-events: none;
+    image-rendering: pixelated;
   }
 
   /* one orchestrated page-load entrance, staggered */
@@ -299,5 +313,145 @@ import { REPO, asset } from '../consts';
     }
     apply();
     if (mq.addEventListener) mq.addEventListener('change', apply);
+  })();
+</script>
+
+<script is:inline>
+  // SIGNATURE: the office reconstructs from its own pixels. Sample the real
+  // poster on a coarse grid → each cell is a chunky pixel that starts scattered
+  // across the frame and flies to its place, then the canvas fades to reveal the
+  // live clip beneath. prefers-reduced-motion / already-seen → skip, show clip.
+  (function () {
+    const canvas = document.getElementById('assemble');
+    const fig = document.querySelector('.hero .terminal');
+    const video = document.querySelector('.hero video');
+    if (!canvas || !fig || !video) return;
+    const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    let seen = false;
+    try {
+      seen = sessionStorage.getItem('pix-assembled') === '1';
+    } catch (e) {}
+    if (reduce || seen) {
+      canvas.style.display = 'none';
+      return;
+    }
+
+    const ctx = canvas.getContext('2d');
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+    const DUR = 720; // per-particle travel
+    const STAGGER = 440; // spread of start times
+    let parts = [],
+      W = 0,
+      H = 0,
+      GRID = 0,
+      startT = 0,
+      running = false;
+
+    const img = new Image();
+    img.decoding = 'async';
+    img.src = video.getAttribute('poster');
+    img.onload = prep;
+    img.onerror = function () {
+      canvas.style.display = 'none';
+    };
+
+    function prep() {
+      const vb = video.getBoundingClientRect();
+      const fb = fig.getBoundingClientRect();
+      W = vb.width;
+      H = vb.height;
+      if (W < 4 || H < 4) {
+        requestAnimationFrame(prep);
+        return;
+      } // await layout
+      // sit exactly over the video
+      canvas.style.top = vb.top - fb.top + 'px';
+      canvas.style.left = vb.left - fb.left + 'px';
+      canvas.style.width = W + 'px';
+      canvas.style.height = H + 'px';
+      canvas.width = Math.round(W * dpr);
+      canvas.height = Math.round(H * dpr);
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      ctx.imageSmoothingEnabled = false;
+
+      // sample the poster down to a coarse grid → ~5k chunky pixel blocks
+      const TARGET = 5000;
+      GRID = Math.max(6, Math.round(Math.sqrt((W * H) / TARGET)));
+      const cols = Math.ceil(W / GRID),
+        rows = Math.ceil(H / GRID);
+      const off = document.createElement('canvas');
+      off.width = cols;
+      off.height = rows;
+      const octx = off.getContext('2d');
+      octx.drawImage(img, 0, 0, cols, rows);
+      const d = octx.getImageData(0, 0, cols, rows).data;
+      parts = [];
+      for (let j = 0; j < rows; j++) {
+        for (let i = 0; i < cols; i++) {
+          const k = (j * cols + i) * 4;
+          if (d[k + 3] < 8) continue;
+          parts.push({
+            tx: i * GRID,
+            ty: j * GRID,
+            // scatter start over a frame slightly larger than the canvas
+            sx: -0.12 * W + Math.random() * 1.24 * W,
+            sy: -0.12 * H + Math.random() * 1.24 * H,
+            c: 'rgb(' + d[k] + ',' + d[k + 1] + ',' + d[k + 2] + ')',
+            delay: Math.random() * STAGGER,
+          });
+        }
+      }
+      // pix:revealed may fire before the image decodes, so also self-start.
+      document.addEventListener('pix:revealed', begin, { once: true });
+      requestAnimationFrame(begin);
+    }
+
+    function begin() {
+      if (running || !parts.length) return;
+      running = true;
+      startT = performance.now();
+      requestAnimationFrame(frame);
+    }
+
+    function frame(now) {
+      const el = now - startT;
+      ctx.clearRect(0, 0, W, H);
+      let done = true;
+      const g = GRID + 1; // +1 hides seams between blocks
+      for (let n = 0; n < parts.length; n++) {
+        const p = parts[n];
+        let t = (el - p.delay) / DUR;
+        if (t < 0) {
+          done = false;
+          ctx.fillStyle = p.c;
+          ctx.fillRect(p.sx | 0, p.sy | 0, g, g); // scattered, waiting
+          continue;
+        }
+        if (t < 1) done = false;
+        else t = 1;
+        const e = 1 - Math.pow(1 - t, 3); // easeOutCubic
+        ctx.fillStyle = p.c;
+        ctx.fillRect((p.sx + (p.tx - p.sx) * e) | 0, (p.sy + (p.ty - p.sy) * e) | 0, g, g);
+      }
+      if (done) finish();
+      else requestAnimationFrame(frame);
+    }
+
+    function finish() {
+      ctx.clearRect(0, 0, W, H);
+      ctx.drawImage(img, 0, 0, W, H); // crisp final frame
+      try {
+        sessionStorage.setItem('pix-assembled', '1');
+      } catch (e) {}
+      const pr = video.play();
+      if (pr && pr.catch) pr.catch(function () {});
+      canvas.style.transition = 'opacity 0.5s ease';
+      requestAnimationFrame(function () {
+        canvas.style.opacity = '0';
+      });
+      setTimeout(function () {
+        canvas.style.display = 'none';
+      }, 560);
+    }
   })();
 </script>

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -1,5 +1,9 @@
 ---
 import { REPO, asset } from '../consts';
+import { getStars, formatStars } from '../lib/github';
+
+// Baked in at build (CSP blocks a client fetch); hides if the API is unreachable.
+const stars = await getStars();
 ---
 
 <section id="lobby" class="hero" data-floor="6">
@@ -21,7 +25,11 @@ import { REPO, asset } from '../consts';
         <a class="btn btn-primary" href="#install"
           >Install pixtuoid <span aria-hidden="true">→</span></a
         >
-        <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer">★ Star on GitHub</a>
+        <a class="btn btn-ghost" href={REPO} target="_blank" rel="noreferrer"
+          >★ Star on GitHub{
+            stars != null && <span class="hero__stars"> · {formatStars(stars)}</span>
+          }</a
+        >
       </div>
       <p class="hero__avail">macOS · Linux · Windows · crates.io · MIT licensed</p>
     </div>
@@ -106,6 +114,11 @@ import { REPO, asset } from '../consts';
     letter-spacing: 0.04em;
     color: var(--fg-muted);
   }
+  /* live-at-build star count riding the Star CTA */
+  .hero__stars {
+    color: var(--accent-2);
+    font-variant-numeric: tabular-nums;
+  }
   .terminal__screen {
     width: 100%;
     height: auto;
@@ -118,6 +131,29 @@ import { REPO, asset } from '../consts';
     z-index: 2;
     pointer-events: none;
     image-rendering: pixelated;
+  }
+  /* the office lighting follows the visitor's wall clock (data-clock-night is set
+     pre-paint in Base.astro). After hours the office dims to a cool night shift —
+     applied to both the live screen and the assembly canvas so the look is
+     consistent through the reveal. */
+  .terminal__screen,
+  .assemble {
+    transition: filter 0.7s ease;
+  }
+  :global([data-clock-night='1']) .hero .terminal__screen,
+  :global([data-clock-night='1']) .hero .assemble {
+    filter: brightness(0.66) saturate(0.82) contrast(1.06) hue-rotate(-12deg);
+  }
+  /* a faint moonlight wash over the window, gated on the same clock flag */
+  :global([data-clock-night='1']) .hero .terminal::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: 3;
+    pointer-events: none;
+    border-radius: inherit;
+    background: radial-gradient(130% 90% at 72% -10%, rgba(122, 152, 220, 0.16), transparent 58%);
+    mix-blend-mode: screen;
   }
 
   /* one orchestrated page-load entrance, staggered */

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -107,6 +107,15 @@ const jsonLdSafe = jsonLd ? JSON.stringify(jsonLd).replace(/</g, '\\u003c') : nu
           const BG = { day: '#f4eee2', night: '#0e0d0c', dracula: '#21222c' };
           const meta = document.querySelector('meta[name="theme-color"]');
           if (meta && BG[theme]) meta.setAttribute('content', BG[theme]);
+          // The office LIGHTING follows the visitor's wall clock — independent of
+          // the dark-first page theme. After hours (19:00–07:00) the hero office
+          // dims to a night shift and the footer says so. Only the clock turns
+          // this on; an explicit theme choice ends its authority (the FX script
+          // below clears the flag on pix:theme). Set pre-paint so there's no FOUC.
+          if (!ok(pick)) {
+            const hr = new Date().getHours();
+            if (hr >= 19 || hr < 7) document.documentElement.dataset.clockNight = '1';
+          }
         } catch (e) {
           document.documentElement.dataset.theme = 'day';
         }

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -7,8 +7,6 @@ import '@fontsource/jersey-10/400.css';
 import '@fontsource/jetbrains-mono/400.css';
 import '@fontsource/jetbrains-mono/500.css';
 import '@fontsource/jetbrains-mono/700.css';
-import '@fontsource/lora/400.css';
-import '@fontsource/lora/500.css';
 import '../styles/global.css';
 import { asset, THEMES } from '../consts';
 
@@ -34,7 +32,6 @@ const ogImage = new URL(asset('demos/hero-poster.png'), SITE).href;
 // Per-page canonical/og:url — Astro.url.pathname includes the /pixtuoid base in
 // the static build, so /config no longer self-declares the homepage as canonical.
 const canonical = new URL(Astro.url.pathname, SITE).href;
-const version = __PIXTUOID_VERSION__; // from the workspace Cargo.toml at build
 
 // Escape `<` so no string value can break out of the <script> block (a `</script`
 // or `<!--` in serialized JSON would otherwise close it). Defense-in-depth: every
@@ -43,7 +40,7 @@ const jsonLdSafe = jsonLd ? JSON.stringify(jsonLd).replace(/</g, '\\u003c') : nu
 ---
 
 <!doctype html>
-<html lang="en" data-theme="day">
+<html lang="en" data-theme="night">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -69,8 +66,8 @@ const jsonLdSafe = jsonLd ? JSON.stringify(jsonLd).replace(/</g, '\\u003c') : nu
     <link rel="icon" type="image/png" sizes="180x180" href={asset('apple-touch-icon.png')} />
     <link rel="apple-touch-icon" href={asset('apple-touch-icon.png')} />
     <link rel="canonical" href={canonical} />
-    {/* default = day --bg; the theme-init script below updates it for night/dracula */}
-    <meta name="theme-color" content="#f4eee2" />
+    {/* default = dark terminal --bg; the theme-init script below updates it for day/dracula */}
+    <meta name="theme-color" content="#0e0d0c" />
     {preloadImage && <link rel="preload" as="image" href={preloadImage} fetchpriority="high" />}
 
     <!-- Open Graph / Twitter -->
@@ -101,20 +98,12 @@ const jsonLdSafe = jsonLd ? JSON.stringify(jsonLd).replace(/</g, '\\u003c') : nu
           };
           const forced = new URLSearchParams(location.search).get('theme');
           const pick = ok(forced) ? forced : localStorage.getItem('pix-theme');
-          // The app's office lighting follows the wall clock; until the visitor
-          // chooses a theme, so does the site — arriving after dark means the
-          // night office. The clock only ever turns night ON: a dark-preference
-          // user keeps night at noon via the system fallback below.
-          const hour = new Date().getHours();
-          const afterHours = hour >= 19 || hour < 7;
-          const sys = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'night' : 'day';
-          const theme = ok(pick) ? pick : afterHours ? 'night' : sys;
-          // clock-forced (not chosen, not system) → the footer explains itself
-          if (!ok(pick) && afterHours && sys === 'day')
-            document.documentElement.dataset.clockNight = '1';
+          // Terminal Habitat is dark-first: the page IS a terminal, so it opens
+          // dark unless the visitor explicitly chose the daylight theme.
+          const theme = ok(pick) ? pick : 'night';
           document.documentElement.dataset.theme = theme;
           // keep the mobile browser-chrome tint in sync with the resolved theme
-          const BG = { day: '#f4eee2', night: '#1d1813', dracula: '#282a36' };
+          const BG = { day: '#f4eee2', night: '#0e0d0c', dracula: '#21222c' };
           const meta = document.querySelector('meta[name="theme-color"]');
           if (meta && BG[theme]) meta.setAttribute('content', BG[theme]);
         } catch (e) {
@@ -122,32 +111,9 @@ const jsonLdSafe = jsonLd ? JSON.stringify(jsonLd).replace(/</g, '\\u003c') : nu
         }
       })();
     </script>
-
-    <!-- show the boot intro once per session (skip for reduced-motion) -->
-    <script is:inline>
-      try {
-        if (
-          !window.matchMedia('(prefers-reduced-motion: reduce)').matches &&
-          !sessionStorage.getItem('pix-booted')
-        ) {
-          document.documentElement.dataset.booting = '1';
-        }
-      } catch (e) {}
-    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
-
-    <div id="boot" class="boot" role="status" aria-label="Loading pixtuoid">
-      <div class="boot__log">
-        <div class="boot__line">pixtuoid <b>v{version}</b></div>
-        <div class="boot__line">▸ booting office… <span class="boot__ok">ok</span></div>
-        <div class="boot__line">▸ loading themes… <span class="boot__ok">ok</span></div>
-        <div class="boot__line">▸ spawning agents… <span class="boot__ok">ok</span></div>
-        <div class="boot__line">▸ ready<span class="cursor" aria-hidden="true"></span></div>
-      </div>
-      <div class="boot__hint">press any key to skip</div>
-    </div>
 
     <slot />
 
@@ -195,7 +161,7 @@ const jsonLdSafe = jsonLd ? JSON.stringify(jsonLd).replace(/</g, '\\u003c') : nu
         const reduce = reduceMQ.matches;
 
         // keep the mobile browser-chrome tint in sync on every theme change
-        const BG = { day: '#f4eee2', night: '#1d1813', dracula: '#282a36' };
+        const BG = { day: '#f4eee2', night: '#0e0d0c', dracula: '#21222c' };
         const themeMeta = document.querySelector('meta[name="theme-color"]');
         // …and the tab icon: the little coworker turns the lights off after
         // dark (path derived from the day href so the Pages base-path holds)
@@ -268,18 +234,10 @@ const jsonLdSafe = jsonLd ? JSON.stringify(jsonLd).replace(/</g, '\\u003c') : nu
               saved = localStorage.getItem('pix-theme');
             } catch (e2) {}
             // validate like the no-FOUC init — a stale/garbage stored id must not
-            // land in data-theme — and restore through the SAME fallback chain
-            // the init uses (clock, then system), or an after-hours visitor with
-            // no saved choice would get snapped to day by the Escape that merely
-            // closed the Docs dropdown.
-            const hour = new Date().getHours();
-            const fallback =
-              hour >= 19 || hour < 7 || window.matchMedia('(prefers-color-scheme: dark)').matches
-                ? 'night'
-                : 'day';
-            setTheme(
-              saved === 'night' || saved === 'dracula' || saved === 'day' ? saved : fallback
-            );
+            // land in data-theme — and restore through the SAME dark-first default
+            // the init uses, so Escape (e.g. closing the Docs dropdown) never snaps
+            // a visitor with no saved choice away from the dark terminal.
+            setTheme(saved === 'night' || saved === 'dracula' || saved === 'day' ? saved : 'night');
             return;
           }
           if (e.key && e.key.length === 1) {
@@ -317,72 +275,11 @@ const jsonLdSafe = jsonLd ? JSON.stringify(jsonLd).replace(/</g, '\\u003c') : nu
       })();
     </script>
 
-    <!-- boot intro sequence → dispatches `pix:revealed` (immediately if skipped/disabled) -->
+    <!-- Terminal Habitat has no boot overlay: the hero's particle-assembly is the
+         intro. Fire pix:revealed immediately so the reveal-on-scroll, hero command
+         typing, and CRT power-on observers (registered above) start right away. -->
     <script is:inline>
-      (function () {
-        const root = document.documentElement;
-        const boot = document.getElementById('boot');
-        function reveal() {
-          document.dispatchEvent(new Event('pix:revealed'));
-        }
-        if (root.dataset.booting !== '1' || !boot) {
-          reveal();
-          return;
-        }
-        // make the page behind the opaque overlay inert + hidden from AT, so a
-        // keyboard / screen-reader user can't reach controls obscured under it
-        const bg = [];
-        Array.prototype.forEach.call(document.body.children, function (el) {
-          if (el !== boot) {
-            el.setAttribute('inert', '');
-            el.setAttribute('aria-hidden', 'true');
-            bg.push(el);
-          }
-        });
-        const lines = boot.querySelectorAll('.boot__line');
-        let i = 0,
-          done = false;
-        function finish() {
-          if (done) return;
-          done = true;
-          boot.classList.add('is-done');
-          try {
-            sessionStorage.setItem('pix-booted', '1');
-          } catch (e) {}
-          bg.forEach(function (el) {
-            el.removeAttribute('inert');
-            el.removeAttribute('aria-hidden');
-          });
-          setTimeout(function () {
-            root.removeAttribute('data-booting');
-          }, 460);
-          boot.removeEventListener('click', skip);
-          document.removeEventListener('keydown', onKey);
-          reveal();
-          // leave focus at the document start (don't focus #main: it would scroll
-          // the page and skip keyboard users past the nav/skip-link). The bg is
-          // no longer inert, so Tab flows skip-link -> nav -> content as normal.
-        }
-        function step() {
-          if (i < lines.length) {
-            lines[i].classList.add('in');
-            i++;
-            setTimeout(step, 260);
-          } else {
-            setTimeout(finish, 520);
-          }
-        }
-        function skip() {
-          for (let j = 0; j < lines.length; j++) lines[j].classList.add('in');
-          finish();
-        }
-        function onKey() {
-          skip();
-        }
-        setTimeout(step, 220);
-        boot.addEventListener('click', skip);
-        document.addEventListener('keydown', onKey);
-      })();
+      document.dispatchEvent(new Event('pix:revealed'));
     </script>
   </body>
 </html>

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -8,6 +8,7 @@ import '@fontsource/jetbrains-mono/400.css';
 import '@fontsource/jetbrains-mono/500.css';
 import '@fontsource/jetbrains-mono/700.css';
 import '../styles/global.css';
+import CommandPalette from '../components/CommandPalette.astro';
 import { asset, THEMES } from '../consts';
 
 interface Props {
@@ -116,6 +117,8 @@ const jsonLdSafe = jsonLd ? JSON.stringify(jsonLd).replace(/</g, '\\u003c') : nu
     <a class="skip-link" href="#main">Skip to content</a>
 
     <slot />
+
+    <CommandPalette />
 
     <!-- reveal-on-scroll: one orchestrated entrance per section -->
     <script is:inline>

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -230,6 +230,41 @@ const jsonLdSafe = jsonLd ? JSON.stringify(jsonLd).replace(/</g, '\\u003c') : nu
           document.documentElement.dataset.theme = t;
           document.dispatchEvent(new CustomEvent('pix:theme'));
         };
+        // 🦞 easter egg: type "lobster" and the OpenClaw mascot scuttles across
+        // the floor (the ok· lobster is the gateway's coding sprite). One at a
+        // time; reduced-motion gets a brief static cameo instead of the scuttle.
+        let lobBusy = false;
+        const spawnLobster = function () {
+          if (lobBusy) return;
+          lobBusy = true;
+          const el = document.createElement('div');
+          el.textContent = '🦞';
+          el.setAttribute('aria-hidden', 'true');
+          el.style.cssText =
+            'position:fixed;left:0;bottom:5vh;font-size:2.4rem;z-index:9998;pointer-events:none;will-change:transform;';
+          document.body.appendChild(el);
+          const done = function () {
+            el.remove();
+            lobBusy = false;
+          };
+          if (reduce) {
+            el.style.transform = 'translateX(2rem)';
+            setTimeout(done, 1400);
+            return;
+          }
+          const span = window.innerWidth + 120;
+          const start = performance.now();
+          const DUR = 3200;
+          const step = function (now) {
+            const p = Math.min(1, (now - start) / DUR);
+            const x = -60 + p * span;
+            const bob = Math.sin(p * Math.PI * 11) * 7; // a little scuttle bob
+            el.style.transform = 'translate(' + x + 'px,' + bob + 'px)';
+            if (p < 1) requestAnimationFrame(step);
+            else done();
+          };
+          requestAnimationFrame(step);
+        };
         document.addEventListener('keydown', function (e) {
           // don't hijack typing: skip when a field is focused or a modifier is held
           const tgt = e.target;
@@ -258,6 +293,7 @@ const jsonLdSafe = jsonLd ? JSON.stringify(jsonLd).replace(/</g, '\\u003c') : nu
               clearRetint();
               setTheme('dracula');
             }
+            if (buf.indexOf('lobster') !== -1) spawnLobster();
           }
         });
       })();

--- a/site/src/lib/github.ts
+++ b/site/src/lib/github.ts
@@ -1,0 +1,41 @@
+// Build-time GitHub star count. The site's CSP is `connect-src 'self'`, so the
+// browser can't call api.github.com — we resolve the count once at build (CI
+// rebuilds on every push keep it fresh) and bake it into the HTML. All failures
+// (offline, 403 rate-limit, shape drift) degrade to null → the count just hides.
+import { REPO } from '../consts';
+
+const API = `https://api.github.com/repos/${REPO.replace('https://github.com/', '')}`;
+const TIMEOUT_MS = 4000; // don't let a slow/hung API stall the whole build
+
+async function fetchOnce(): Promise<number | null> {
+  try {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+    const res = await fetch(API, {
+      headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'pixtuoid-site-build' },
+      signal: ctrl.signal,
+    });
+    clearTimeout(timer);
+    if (!res.ok) return null;
+    const data: unknown = await res.json();
+    const n = (data as { stargazers_count?: unknown }).stargazers_count;
+    return typeof n === 'number' && Number.isFinite(n) ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+// Memoize the PROMISE so concurrent frontmatter callers (Hero, Footer) share a
+// single network round-trip rather than racing to fetch it each.
+let inflight: Promise<number | null> | undefined;
+export function getStars(): Promise<number | null> {
+  if (!inflight) inflight = fetchOnce();
+  return inflight;
+}
+
+// 1234 → "1.2k", 12345 → "12k", 999 → "999" — compact, like a repo badge.
+export function formatStars(n: number): string {
+  if (n < 1000) return String(n);
+  const k = n / 1000;
+  return (n >= 10000 ? Math.round(k) : Math.round(k * 10) / 10) + 'k';
+}

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -1,77 +1,117 @@
 /* ============================================================
-   pixtuoid — "Cozy Terminal" skin
-   Claude warmth (paper #faf9f5 · ink #141413 · coral #d97757) kept as the base,
-   pushed toward terminal/pixel character:
-   Display: Jersey 10  ·  UI/code: JetBrains Mono  ·  Body: Lora
-   coral→amber accent gradient · blinking cursor · ASCII dividers · CRT scanlines
+   pixtuoid — "Terminal Habitat" skin
+   The page IS the terminal you run pixtuoid in: a dark truecolor TUI.
+   Dark-first · all-mono body · pixel display · the office assembles from
+   its own pixels. Accents ARE the product's real agent-sprite hues,
+   used as ANSI colors — not an arbitrary neon.
+   Display: Jersey 10  ·  everything else: JetBrains Mono (no serif)
    ============================================================ */
 
 :root {
-  /* Brand constants */
-  /* Warm "Coworking" palette — cream lightened from the office carpet (#8A765F)
-     + Claude coral. Analogous warm harmony so the office art sits INTO the page. */
-  --paper: #f4eee2; /* warm cream (carpet hue, lifted) */
-  --ink: #241c14; /* deep warm wood */
-  --gray: #b3a892;
-  --coral: #d97757; /* Claude coral */
-  --coral-deep: #a8431f; /* darkened for WCAG AA: ~5:1 on the cream --paper */
-  --amber: #e6a356; /* warm amber — gradient end */
-  --blue: #6a9bcc;
-  --green: #788c5d;
-  --ok: #556b2f; /* AA "ok" green for the boot log — 5.15:1 on cream (raw --green is 3.18:1) */
-  /* Gradient-headline stops, AA-tuned and theme-aware via --grad-2, so the .hl
-     word stays legible (deep coral → deep amber) and — unlike --coral/--amber —
-     is NOT dragged below contrast by the gallery retint. */
-  --grad-2: #9c5a12; /* deep amber — 4.68:1 on the cream --bg */
-  --grad: linear-gradient(100deg, var(--coral-deep), var(--grad-2));
-  /* Focus ring — kept a LITERAL (not `var(--coral-deep)`) and theme-aware, so no
-     retint / theme override can drag the focus affordance below WCAG 1.4.11's
-     3:1 on the cream bg. */
-  --focus-ring: #a8431f;
+  /* ---- Terminal Habitat: dark base (the default identity) ---- */
+  --bg: #0e0d0c; /* near-black terminal ground */
+  --bg-tint: #0a0908; /* deeper wells / status footer */
+  --panel: #16151a; /* raised surface / cards */
+  --panel-2: #1e1c22; /* higher surface / hover */
+  --fg: #f4eee2; /* warm paper text (~17:1 on --bg) */
+  --fg-muted: #b3a890; /* ~8:1 on --bg */
+  --fg-dim: #7d7566; /* captions / inert glyphs */
 
-  /* Semantic tokens — DAY (warm cream) */
-  --bg: var(--paper);
-  --bg-tint: #ede3d1;
-  --surface: #fdf9ef;
-  --surface-2: #ece1cd;
-  --fg: var(--ink);
-  --fg-muted: #6f6453;
-  --border: color-mix(in srgb, var(--ink) 12%, transparent);
-  --border-strong: color-mix(in srgb, var(--ink) 20%, transparent);
-  --shadow: 0 1px 2px rgba(36, 28, 20, 0.05), 0 8px 24px rgba(36, 28, 20, 0.09);
-  --shadow-lg: 0 2px 4px rgba(36, 28, 20, 0.06), 0 20px 50px rgba(36, 28, 20, 0.13);
-  --glow: color-mix(in srgb, var(--coral) 15%, transparent);
+  /* Agent-sprite hues, used as ANSI accents (from the product's night palette) */
+  --coral: #e3845f; /* Claude */
+  --cyan: #6a9bcc; /* Codex */
+  --green: #8bbf6a; /* ok / success */
+  --purple: #bd93f9; /* subagents */
+  --amber: #ecae66; /* warning / gradient end */
+
+  /* The switchable primary — the [t] key / command palette retint this pair,
+     never the raw hues above, so the ANSI legend stays stable. */
+  --accent: var(--coral);
+  --accent-2: var(--amber);
+  --grad: linear-gradient(100deg, var(--accent), var(--accent-2));
+
+  --line: rgba(244, 238, 226, 0.12);
+  --line-strong: rgba(244, 238, 226, 0.22);
+  /* Focus ring — a LITERAL (not var(--accent)) so a palette retint can't drag
+     the focus affordance below WCAG 1.4.11's 3:1 on the dark --bg. */
+  --focus-ring: #e3845f;
+  --glow: color-mix(in srgb, var(--accent) 22%, transparent);
+  --shadow: 0 1px 2px rgba(0, 0, 0, 0.4), 0 12px 34px rgba(0, 0, 0, 0.5);
+  --shadow-lg: 0 2px 6px rgba(0, 0, 0, 0.45), 0 28px 70px rgba(0, 0, 0, 0.62);
 
   /* Type */
   --font-display: 'Jersey 10', 'Segoe UI', system-ui, sans-serif;
-  --font-body: 'Lora', Georgia, 'Times New Roman', serif;
   --font-mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+  --font-body: var(--font-mono); /* all-mono — you're in a terminal */
 
   /* Scale */
-  --maxw: 1120px;
-  --radius: 16px;
-  --radius-sm: 10px;
+  --maxw: 1140px;
+  --radius: 14px;
+  --radius-sm: 9px;
+  /* half-block dividers + TUI chrome measure against this */
+  --cell: 8px;
+
+  /* Back-compat aliases: the old "Cozy Terminal" token names, remapped onto the
+     new Terminal Habitat tokens so existing component scoped-styles render in the
+     dark palette immediately. Each section drops its alias use as it's reskinned;
+     these are the transition scaffold, not the target vocabulary. */
+  --paper: var(--bg);
+  --ink: var(--fg);
+  --gray: var(--fg-dim);
+  --surface: var(--panel);
+  --surface-2: var(--panel-2);
+  --border: var(--line);
+  --border-strong: var(--line-strong);
+  --coral-deep: var(--accent);
+  --grad-2: var(--accent-2);
+  --blue: var(--cyan);
+  --ok: var(--green);
 }
 
-:root[data-theme='night'] {
-  /* warm "after-hours office" dark — pairs with the night-office renders */
-  --coral: #e3845f;
-  --coral-deep: #f0a07f;
-  --amber: #ecae66;
-  --ok: #788c5d; /* 4.79:1 on the night --bg */
-  --grad-2: #ecae66; /* light amber — high contrast on the dark night --bg */
-  --focus-ring: #e3845f; /* literal; matches the night --coral (see :root note) */
-  --bg: #1d1813;
-  --bg-tint: #18130f;
-  --surface: #271f17;
-  --surface-2: #322820;
-  --fg: #f4eee2;
-  --fg-muted: #b3a890;
-  --border: color-mix(in srgb, #f4eee2 13%, transparent);
-  --border-strong: color-mix(in srgb, #f4eee2 24%, transparent);
-  --shadow: 0 1px 2px rgba(0, 0, 0, 0.35), 0 10px 30px rgba(0, 0, 0, 0.45);
-  --shadow-lg: 0 2px 6px rgba(0, 0, 0, 0.4), 0 24px 60px rgba(0, 0, 0, 0.6);
-  --glow: color-mix(in srgb, var(--coral) 24%, transparent);
+/* ---- Light alternate ("daylight terminal") — opt-in via the theme switch ---- */
+:root[data-theme='day'] {
+  --bg: #f4eee2;
+  --bg-tint: #ede3d1;
+  --panel: #fdf9ef;
+  --panel-2: #ece1cd;
+  --fg: #241c14;
+  --fg-muted: #6f6453;
+  --fg-dim: #9a8f7c;
+  --coral: #a8431f; /* AA-tuned on cream */
+  --cyan: #2f6690;
+  --green: #556b2f;
+  --purple: #6a4bb0;
+  --amber: #9c5a12;
+  --accent: #a8431f;
+  --accent-2: #9c5a12;
+  --line: rgba(36, 28, 20, 0.12);
+  --line-strong: rgba(36, 28, 20, 0.2);
+  --focus-ring: #a8431f;
+  --glow: color-mix(in srgb, var(--accent) 15%, transparent);
+  --shadow: 0 1px 2px rgba(36, 28, 20, 0.05), 0 8px 24px rgba(36, 28, 20, 0.09);
+  --shadow-lg: 0 2px 4px rgba(36, 28, 20, 0.06), 0 20px 50px rgba(36, 28, 20, 0.13);
+}
+
+/* ---- Dracula — a dark variant (hidden 'dracula' easter egg + palette) ---- */
+:root[data-theme='dracula'] {
+  --bg: #21222c;
+  --bg-tint: #191a21;
+  --panel: #282a36;
+  --panel-2: #343746;
+  --fg: #f8f8f2;
+  --fg-muted: #9aa0c8;
+  --fg-dim: #6b7194;
+  --coral: #ff79c6;
+  --cyan: #8be9fd;
+  --green: #50fa7b;
+  --purple: #bd93f9;
+  --amber: #f1fa8c;
+  --accent: #bd93f9;
+  --accent-2: #ff79c6;
+  --line: rgba(248, 248, 242, 0.13);
+  --line-strong: rgba(248, 248, 242, 0.24);
+  --focus-ring: #bd93f9;
+  --glow: color-mix(in srgb, var(--accent) 26%, transparent);
 }
 
 /* ---------- reset ---------- */
@@ -89,8 +129,8 @@ body {
   font-family: var(--font-body);
   background: var(--bg);
   color: var(--fg);
-  line-height: 1.7;
-  font-size: clamp(1rem, 0.95rem + 0.2vw, 1.115rem);
+  line-height: 1.65;
+  font-size: clamp(0.95rem, 0.9rem + 0.2vw, 1.04rem);
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
   transition:
@@ -99,7 +139,7 @@ body {
   overflow-x: hidden;
 }
 
-/* warm dawn-glow atmosphere */
+/* faint terminal-phosphor atmosphere: a top glow + a very subtle scanline wash */
 body::before {
   content: '';
   position: fixed;
@@ -107,11 +147,11 @@ body::before {
   z-index: -1;
   pointer-events: none;
   background:
-    radial-gradient(120% 80% at 80% -10%, var(--glow), transparent 60%),
+    radial-gradient(120% 80% at 82% -12%, var(--glow), transparent 58%),
     radial-gradient(
-      90% 60% at 6% 0%,
-      color-mix(in srgb, var(--amber) 9%, transparent),
-      transparent 55%
+      90% 60% at 4% -4%,
+      color-mix(in srgb, var(--cyan) 8%, transparent),
+      transparent 52%
     );
 }
 
@@ -120,22 +160,18 @@ img {
   display: block;
 }
 a {
-  color: var(--coral-deep);
+  color: var(--accent);
   text-underline-offset: 2px;
 }
-:root[data-theme='night'] a {
-  color: var(--coral);
-}
 
-/* Visible keyboard focus on every interactive control (WCAG 2.4.7) — the design
-   defined :hover but had no focus affordance. */
+/* Visible keyboard focus on every interactive control (WCAG 2.4.7) */
 :focus-visible {
   outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
   border-radius: 3px;
 }
 
-/* skip-to-content: off-screen until focused (WCAG 2.4.1 Bypass Blocks) */
+/* skip-to-content: off-screen until focused (WCAG 2.4.1) */
 .skip-link {
   position: fixed;
   top: 0.6rem;
@@ -144,9 +180,9 @@ a {
   transform: translateY(-150%);
   padding: 0.6rem 1rem;
   border-radius: var(--radius-sm);
-  background: var(--surface);
+  background: var(--panel);
   color: var(--fg);
-  border: 1px solid var(--border-strong);
+  border: 1px solid var(--line-strong);
   font-family: var(--font-mono);
   font-size: 0.9rem;
   text-decoration: none;
@@ -161,54 +197,63 @@ h1,
 h2,
 h3 {
   font-family: var(--font-display);
-  /* Jersey 10 ships a single weight — request 400 and forbid synthesis so the
+  /* Jersey 10 ships one weight — request 400 and forbid synthesis so the
      browser never fake-bolds it (faux-bold smears a pixel font's crisp edges). */
   font-weight: 400;
   font-synthesis: none;
-  line-height: 1.04;
-  letter-spacing: 0;
+  line-height: 1.02;
+  letter-spacing: 0.01em;
   color: var(--fg);
 }
 h1 {
-  font-size: clamp(2.5rem, 1.7rem + 3.6vw, 4.6rem);
+  font-size: clamp(2.7rem, 1.8rem + 4vw, 5rem);
 }
 h2 {
-  font-size: clamp(1.9rem, 1.4rem + 2vw, 2.9rem);
+  font-size: clamp(2rem, 1.5rem + 2.1vw, 3rem);
 }
 h3 {
-  font-size: clamp(1.15rem, 1.04rem + 0.5vw, 1.4rem);
-  /* stays 400: Jersey 10 is single-weight, and a 600 here would only be a dead
-     declaration (the h1,h2,h3 font-synthesis:none guard already blocks faux-bold)
-     until someone relaxes that guard — then h3 would smear. Keep them in sync. */
+  font-size: clamp(1.2rem, 1.08rem + 0.5vw, 1.45rem);
   font-weight: 400;
 }
+
 /* terminal-prompt eyebrow */
 .eyebrow {
   font-family: var(--font-mono);
   font-weight: 700;
-  font-size: 0.76rem;
-  letter-spacing: 0.12em;
+  font-size: 0.74rem;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: var(--coral-deep);
+  color: var(--accent);
 }
 .eyebrow::before {
   content: '› ';
-  opacity: 0.7;
-}
-:root[data-theme='night'] .eyebrow {
-  color: var(--coral);
+  opacity: 0.65;
 }
 .lead {
-  font-size: clamp(1.08rem, 1rem + 0.5vw, 1.34rem);
+  font-family: var(--font-mono);
+  font-size: clamp(1rem, 0.94rem + 0.4vw, 1.2rem);
   color: var(--fg-muted);
-  max-width: 42ch;
+  max-width: 46ch;
+  line-height: 1.6;
 }
-/* coral→amber gradient headline word */
+
+/* gradient headline word (accent → accent-2) */
 .hl {
   background: var(--grad);
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
+  background-size: 220% 100%;
+  animation: shimmer 7s ease-in-out infinite;
+}
+@keyframes shimmer {
+  0%,
+  100% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
 }
 
 /* blinking block cursor */
@@ -218,7 +263,7 @@ h3 {
   height: 0.92em;
   margin-left: 0.08em;
   transform: translateY(0.08em);
-  background: var(--coral);
+  background: var(--accent);
   animation: blink 1.05s steps(1) infinite;
 }
 @keyframes blink {
@@ -235,25 +280,29 @@ h3 {
   padding-inline: clamp(1.1rem, 4vw, 2.5rem);
 }
 section {
-  padding-block: clamp(3.2rem, 7vw, 6rem);
+  padding-block: clamp(3.4rem, 7vw, 6.4rem);
 }
 .section-head {
-  max-width: 48ch;
+  max-width: 52ch;
   margin-bottom: clamp(1.8rem, 4vw, 3rem);
 }
 .section-head .lead {
   margin-top: 0.9rem;
 }
 
-/* ASCII pixel divider between sections */
+/* half-block ▀▄ rule between sections — the terminal's own divider glyph */
 .px-rule {
-  height: 6px;
+  height: 10px;
   width: min(100%, var(--maxw));
   margin: 0 auto;
   border: 0;
-  background: repeating-linear-gradient(90deg, var(--coral) 0 6px, transparent 6px 14px);
-  image-rendering: pixelated;
-  opacity: 0.4;
+  color: var(--accent);
+  background:
+    repeating-linear-gradient(90deg, currentColor 0 8px, transparent 8px 16px) top / 100% 5px
+      no-repeat,
+    repeating-linear-gradient(90deg, transparent 0 8px, currentColor 8px 16px) bottom / 100% 5px
+      no-repeat;
+  opacity: 0.32;
   -webkit-mask-image: linear-gradient(90deg, transparent, #000 12%, #000 88%, transparent);
   mask-image: linear-gradient(90deg, transparent, #000 12%, #000 88%, transparent);
 }
@@ -265,9 +314,9 @@ section {
   gap: 0.5rem;
   font-family: var(--font-mono);
   font-weight: 700;
-  font-size: 0.92rem;
+  font-size: 0.9rem;
   padding: 0.72rem 1.3rem;
-  border-radius: 12px;
+  border-radius: 11px;
   border: 1px solid transparent;
   cursor: pointer;
   text-decoration: none;
@@ -281,31 +330,28 @@ section {
   transform: translateY(-2px);
 }
 .btn-primary {
-  /* deep-coral gradient (NOT the light amber end of --grad) + a text-shadow so
-     the white label stays legible in both day and night. The glow uses a FIXED
-     coral (not var(--coral)) so it matches the baked fill in every theme and
-     gallery retint instead of drifting to the theme hue. */
-  background: linear-gradient(100deg, #ad5230, #c96a45);
-  color: #fff;
-  text-shadow: 0 1px 2px rgba(35, 14, 5, 0.4);
-  box-shadow: 0 8px 20px color-mix(in srgb, #c96a45 42%, transparent);
+  background: var(--grad);
+  color: #14100c;
+  text-shadow: none;
+  box-shadow: 0 8px 22px var(--glow);
 }
 .btn-primary:hover {
-  filter: brightness(1.08);
+  filter: brightness(1.06);
 }
 .btn-ghost {
-  background: transparent;
+  background: color-mix(in srgb, var(--fg) 4%, transparent);
   color: var(--fg);
-  border-color: var(--border-strong);
+  border-color: var(--line-strong);
 }
 .btn-ghost:hover {
-  background: color-mix(in srgb, var(--fg) 5%, transparent);
+  background: color-mix(in srgb, var(--fg) 8%, transparent);
+  border-color: var(--accent);
 }
 
 /* ---------- surfaces ---------- */
 .card {
-  background: var(--surface);
-  border: 1px solid var(--border);
+  background: var(--panel);
+  border: 1px solid var(--line);
   border-radius: var(--radius);
   box-shadow: var(--shadow);
 }
@@ -314,8 +360,8 @@ section {
 .terminal {
   position: relative;
   border-radius: var(--radius);
-  border: 1px solid var(--border-strong);
-  background: var(--surface);
+  border: 1px solid var(--line-strong);
+  background: var(--panel);
   box-shadow: var(--shadow-lg);
   overflow: hidden;
 }
@@ -324,14 +370,14 @@ section {
   align-items: center;
   gap: 0.5rem;
   padding: 0.6rem 0.9rem;
-  background: var(--surface-2);
-  border-bottom: 1px solid var(--border);
+  background: var(--panel-2);
+  border-bottom: 1px solid var(--line);
 }
 .terminal__dot {
   width: 11px;
   height: 11px;
   border-radius: 50%;
-  background: var(--gray);
+  background: var(--fg-dim);
 }
 .terminal__dot--r {
   background: #e06a5a;
@@ -351,7 +397,7 @@ section {
 .terminal__screen {
   display: block;
   width: 100%;
-  background: #0e0d0c;
+  background: #0a0908;
 }
 /* scanline overlay — very faint, only reads as CRT texture up close */
 .terminal__scan {
@@ -359,9 +405,9 @@ section {
   left: 0;
   right: 0;
   bottom: 0;
-  top: 38px; /* below the title bar */
+  top: 38px;
   pointer-events: none;
-  background: repeating-linear-gradient(to bottom, rgba(0, 0, 0, 0.05) 0 1px, transparent 1px 3px);
+  background: repeating-linear-gradient(to bottom, rgba(0, 0, 0, 0.16) 0 1px, transparent 1px 3px);
   mix-blend-mode: multiply;
 }
 
@@ -417,21 +463,6 @@ code,
    FX layer — tasteful flair, all reduced-motion-safe above
    ============================================================ */
 
-/* animated shimmer across the gradient headline word */
-.hl {
-  background-size: 220% 100%;
-  animation: shimmer 7s ease-in-out infinite;
-}
-@keyframes shimmer {
-  0%,
-  100% {
-    background-position: 0% 50%;
-  }
-  50% {
-    background-position: 100% 50%;
-  }
-}
-
 /* CRT power-on when a terminal scrolls into view */
 .crt.crt-on .terminal__screen {
   animation: crt-on 0.9s ease-out both;
@@ -478,28 +509,8 @@ code,
   animation: retint-pulse 0.6s ease-out;
 }
 
-/* Dracula — hidden easter-egg theme (type "dracula"; Esc restores) */
-:root[data-theme='dracula'] {
-  --coral: #bd93f9;
-  --coral-deep: #caa6fb;
-  --amber: #ff79c6;
-  --ok: #9db87e; /* 6.50:1 on the dracula --bg */
-  --grad-2: #ff79c6; /* light pink — high contrast on the dark dracula --bg */
-  --focus-ring: #caa6fb; /* literal; matches the dracula --coral-deep (see :root note) */
-  --bg: #282a36;
-  --bg-tint: #21222c;
-  --surface: #343746;
-  --surface-2: #44475a;
-  --fg: #f8f8f2;
-  --fg-muted: #8b92bd;
-  --border: color-mix(in srgb, #f8f8f2 13%, transparent);
-  --border-strong: color-mix(in srgb, #f8f8f2 24%, transparent);
-  --shadow: 0 1px 2px rgba(0, 0, 0, 0.35), 0 10px 30px rgba(0, 0, 0, 0.45);
-  --shadow-lg: 0 2px 6px rgba(0, 0, 0, 0.4), 0 24px 60px rgba(0, 0, 0, 0.6);
-  --glow: color-mix(in srgb, var(--coral) 26%, transparent);
-}
-
-/* ---------- boot intro overlay ---------- */
+/* ---------- boot intro overlay (interim — the particle-assembly hero
+   supersedes this in the hero rebuild) ---------- */
 .boot {
   display: none;
   position: fixed;
@@ -536,7 +547,7 @@ code,
   color: var(--fg);
 }
 .boot__ok {
-  color: var(--ok);
+  color: var(--green);
 }
 .boot__hint {
   margin-top: 1.4rem;
@@ -544,7 +555,7 @@ code,
   opacity: 0.55;
 }
 
-/* ---------- prose: rendered markdown (the /config page) ---------- */
+/* ---------- prose: rendered markdown (the /config etc. doc pages) ---------- */
 .prose {
   line-height: 1.7;
 }
@@ -556,7 +567,7 @@ code,
   font-size: clamp(1.45rem, 1.2rem + 1.3vw, 1.95rem);
   margin: 2.2rem 0 0.8rem;
   padding-top: 1.4rem;
-  border-top: 1px solid var(--border);
+  border-top: 1px solid var(--line);
 }
 .prose h3 {
   margin: 1.6rem 0 0.5rem;
@@ -566,12 +577,8 @@ code,
   color: var(--fg);
 }
 .prose a {
-  color: var(--coral-deep);
+  color: var(--accent);
   font-weight: 600;
-}
-:root[data-theme='night'] .prose a,
-:root[data-theme='dracula'] .prose a {
-  color: var(--coral);
 }
 .prose ul {
   padding-left: 1.3rem;
@@ -579,21 +586,19 @@ code,
 .prose li {
   margin: 0.3rem 0;
 }
-/* inline code */
 .prose :not(pre) > code {
   font-family: var(--font-mono);
   font-size: 0.88em;
-  background: var(--surface-2);
-  border: 1px solid var(--border);
+  background: var(--panel-2);
+  border: 1px solid var(--line);
   border-radius: 6px;
   padding: 0.08rem 0.34rem;
 }
-/* fenced code blocks (Shiki sets the colors; we frame them) */
 .prose pre {
   margin: 1.2rem 0;
   padding: 1rem 1.1rem;
   border-radius: var(--radius-sm);
-  border: 1px solid var(--border-strong);
+  border: 1px solid var(--line-strong);
   overflow-x: auto;
   font-size: 0.9rem;
   line-height: 1.6;
@@ -601,7 +606,6 @@ code,
 .prose pre code {
   font-family: var(--font-mono);
 }
-/* tables */
 .prose table {
   width: 100%;
   border-collapse: collapse;
@@ -612,18 +616,17 @@ code,
 .prose td {
   text-align: left;
   padding: 0.55rem 0.8rem;
-  border: 1px solid var(--border);
+  border: 1px solid var(--line);
   vertical-align: top;
 }
 .prose th {
-  background: var(--surface-2);
+  background: var(--panel-2);
   font-family: var(--font-display);
   font-weight: 400;
   font-synthesis: none;
 }
-/* architecture diagram (```mermaid → build-time inline SVG): frame it in a fixed
-   light "terminal screen" so the day-palette SVG stays legible on night/dracula,
-   and make it responsive (the SVG keeps its viewBox aspect). */
+/* architecture diagram (```mermaid → inline SVG): keep a fixed LIGHT "terminal
+   screen" so the day-palette SVG stays legible on the dark page. */
 .prose svg {
   display: block;
   width: 100%;
@@ -632,16 +635,10 @@ code,
   margin: 1.8rem auto;
   padding: clamp(0.8rem, 2vw, 1.4rem);
   background: #fbfaf6;
-  border: 1px solid var(--border-strong);
+  border: 1px solid var(--line-strong);
   border-radius: var(--radius-sm);
   box-shadow: var(--shadow);
 }
-/* mermaid renders labels as HTML inside <foreignObject> (htmlLabels), so the
-   page's `.prose p{color:var(--fg)}` / `.prose a{color:coral}` / `.prose code
-   {background:surface-2}` cascade leaks in and makes the labels invisible on the
-   light frame in night/dracula. The frame is always light, so pin every label to
-   dark ink on a light backing — readable on all themes. (Scope fill: to text
-   elements only; arrowheads/edges are <path> and keep mermaid's stroke colors.) */
 .prose svg .nodeLabel,
 .prose svg .nodeLabel p,
 .prose svg .edgeLabel,
@@ -664,7 +661,6 @@ code,
   fill: #fbfaf6 !important;
   border-color: transparent !important;
 }
-/* mermaid bakes edge @keyframes into the SVG — keep them inert for reduced motion */
 @media (prefers-reduced-motion: reduce) {
   .prose svg [class*='edge'] {
     animation: none !important;

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -509,52 +509,6 @@ code,
   animation: retint-pulse 0.6s ease-out;
 }
 
-/* ---------- boot intro overlay (interim — the particle-assembly hero
-   supersedes this in the hero rebuild) ---------- */
-.boot {
-  display: none;
-  position: fixed;
-  inset: 0;
-  z-index: 9999;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  background: var(--bg);
-  font-family: var(--font-mono);
-  color: var(--fg-muted);
-  font-size: clamp(0.82rem, 0.74rem + 0.4vw, 1rem);
-  line-height: 1.95;
-  transition: opacity 0.45s ease;
-}
-:root[data-booting='1'] .boot {
-  display: flex;
-}
-.boot.is-done {
-  opacity: 0;
-  pointer-events: none;
-}
-.boot__log {
-  width: min(86vw, 420px);
-}
-.boot__line {
-  opacity: 0;
-  transition: opacity 0.25s ease;
-}
-.boot__line.in {
-  opacity: 1;
-}
-.boot__line b {
-  color: var(--fg);
-}
-.boot__ok {
-  color: var(--green);
-}
-.boot__hint {
-  margin-top: 1.4rem;
-  font-size: 0.72rem;
-  opacity: 0.55;
-}
-
 /* ---------- prose: rendered markdown (the /config etc. doc pages) ---------- */
 .prose {
   line-height: 1.7;


### PR DESCRIPTION
Bold reimagining of the landing page as a **Terminal Habitat**: the page *is* the terminal you run pixtuoid in — dark-first, all-mono, the live pixel office as a full-bleed hero.

## Signature
- **Particle-assembly hero** — on load, the real office reconstructs from a swarm of its own chunky pixels (sampled from the actual poster PNG), coalesces into a mosaic, then the canvas fades to reveal the live clip playing beneath. Once-per-session (`sessionStorage`), `prefers-reduced-motion` → straight to the crisp office.

## Interactive chrome
- **Command palette** (`/`, `:`, or ⌘K) — the page's own command line: ride the elevator (floor keys mirrored), switch theme, cycle the accent, open a doc. Type-to-filter, ↑↓/↵/esc, focus-trapped + restored, discoverable via a quiet bottom-left chip.
- **Day↔night by local clock** — the page chrome stays dark-first, but the hero *office lighting* follows the visitor's wall clock: after hours it dims to a cool night shift and the footer's clock line reappears. An explicit theme choice ends the clock's authority.
- **Live-at-build GitHub stars** — CSP is `connect-src 'self'` so a client fetch is impossible; the count is resolved once at build (promise-memoized, 4s timeout, graceful null) and baked into the Hero CTA + footer.
- **🦞 easter egg** — type "lobster" and the OpenClaw mascot scuttles the office floor (mirrors the hidden "dracula" typed-egg).

## Fix (pre-existing bug)
- **Elevator scrollspy was frozen on floor 6** — the lift's `is:inline` script wired its `IntersectionObserver` at parse position, but `<Elevator />` renders before the `[data-floor]` sections in `index.astro`, so the observer was born watching zero elements. Deferred the observe-wiring to DOM-ready.

## Foundation
Dark-first token system (all-mono body, agent-hue accents, half-block chrome) with back-compat aliases so every section renders dark coherently; boot overlay removed (the particle-assembly is the intro); dead `.boot` CSS dropped. Both the dark default and the day/light alternate verified coherent top-to-bottom.

## Gates
`just site-check` green throughout (astro-check 0 errors, knip, eslint, prettier, build). Verified via Playwright: assembly frames, palette open/filter/close, elevator scrollspy tracking 6F→1F, day/night office delta, lobster scuttle, both full themes.

> AI-generated — labeled `needs-human-verify`; needs the two-lens review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121vF6GrV7TEXC3H8eR5wBw