### PR TITLE
docs: code-grounded drift sweep — six rendered docs vs the implementation

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -64,7 +64,7 @@ daemon lane below is deliberately `AgentId`-free.
 ```mermaid
 flowchart TB
   accTitle: pixtuoid data flow
-  accDescr: A hook or transcript event flows from a coding agent (Claude Code, Codex) through the pixtuoid-hook shim into pixtuoid-core, where a HookRouter demuxes agent payloads to the Transport-tagged reducer and SceneState.agents. A daemon gateway (OpenClaw) shares the same shim and socket but is routed instead to apply_presence and SceneState.daemons over a sibling channel that bypasses the reducer. The pixtuoid TUI renderer then paints the whole scene through a terminal-agnostic pixel pass and a half-block flush.
+  accDescr: A hook or transcript event flows from a coding agent (Claude Code, Codex) through the pixtuoid-hook shim into pixtuoid-core, where a HookRouter demuxes agent payloads to the Transport-tagged reducer and SceneState.agents. A daemon gateway (OpenClaw) shares the same shim and socket but is routed instead to apply_presence and SceneState.daemons over a sibling channel that bypasses the reducer. The pixtuoid TUI renderer then paints the whole scene through the pixtuoid-scene engine's terminal-agnostic pixel pass and a half-block flush.
   CC["Claude Code / Codex<br/>(agent source)"]
   OC["OpenClaw gateway<br/>(daemon source)"]
 
@@ -91,10 +91,14 @@ flowchart TB
   subgraph bin["pixtuoid (binary · TUI)"]
     W["watch&lt;Arc&lt;SceneState&gt;&gt;"]
     TR["TuiRenderer"]
-    PX["render_to_rgb_buffer<br/>(desks + mascots)"]
     FL["flush · ½-block cells"]
-    W --> TR --> PX --> FL
   end
+
+  subgraph scene["pixtuoid-scene (engine)"]
+    PX["render_to_rgb_buffer<br/>(desks + mascots)"]
+  end
+
+  W --> TR --> PX --> FL
 
   CC -->|hook event| SH
   OC -->|hook event| SH
@@ -147,12 +151,13 @@ sweep), while the gateway's own process pid is armed for instant `ExitWatch`.
 These are load-bearing — see `CLAUDE.md` and the nested guides before changing them.
 
 - **The `Source` trait is the only seam for adding a transcript-bearing agent
-  CLI** (Codex, Copilot CLI, Cursor, …). Per-source format knowledge lives in that source's
+  CLI** (Codex, Copilot CLI, Antigravity, …). Per-source format knowledge lives in that source's
   own decoder functions (injected into `JsonlWatcher` as fn pointers), not in a
-  shared decoder. A hook-only CLI (Reasonix — no watchable transcript) is the
-  documented exception: no `Source` impl and no runtime wiring; its registry
-  row sets `line_decoder: None` and supplies a custom hook decoder, and it
-  ships an install `Target` instead (bound via the in-TUI Sources panel).
+  shared decoder. Hook-only CLIs (Reasonix, opencode, Cursor CLI,
+  CodeWhale — no watchable transcript) are the documented exception: no
+  `Source` impl and no runtime wiring; their registry rows set
+  `line_decoder: None` and supply a custom hook decoder, and each ships an
+  install `Target` instead (bound via the in-TUI Sources panel).
 - **A `Source` is an `Agent` or a `Daemon`** (`SourceKind`). A daemon (the
   OpenClaw gateway is the first) earns a presence-gated wandering mascot, not a
   desk: its deltas ride a **sibling channel** (`PresenceMsg { source, delta }`,

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -28,7 +28,7 @@ kind = "dog"        # name omitted → "Office Dog"
 | Key | Default | Description |
 |-----|---------|-------------|
 | `theme` | `"normal"` | Color theme — `normal`, `cyberpunk`, `dracula`, `tokyo-night`, `catppuccin`, `gruvbox`. |
-| `max-desks` | auto | Cap desks per floor (≥ 1; `0` is ignored with a warning). If unset, auto-computed from terminal size. Excess agents overflow to additional floors. |
+| `max-desks` | auto | Cap desks per floor (≥ 1; `0` is ignored with a warning). If unset, auto-computed from terminal size. Excess agents overflow to additional floors. Applies to the `run` TUI; `pixtuoid floating` sizes its floors from the window. |
 | `pack-dir` | — | Custom sprite pack directory. Supports `~` expansion. See [Custom sprite packs](#custom-sprite-packs). |
 | `[[pets]]` | all kinds, default names | One stanza per pet. `kind` (`"cat"`/`"dog"`) is required; `name` is optional (the hover-tooltip label, default `Office Cat`/`Office Dog`). Omit the section for all pets; `pets = []` for none; an unknown `kind` is skipped without affecting other settings. Keep it last (it's a table section). |
 
@@ -36,8 +36,9 @@ kind = "dog"        # name omitted → "Office Dog"
 
 | Key | Purpose |
 |-----|---------|
-| `last-seen-version` | Tracks the highest version you've launched, so the "what's new" popup only fires once per upgrade. Pixtuoid overwrites this on every launch. |
-| `[sources]` | Per-agent-CLI connection state (`source-id = true/false`), written when you connect/disconnect a source in the in-TUI **Sources panel** (`s`). When a source has no entry, pixtuoid migrates a default on launch: connected if its hooks are already installed (or it has no hooks to install, like Antigravity), else disconnected. A disconnected source's characters are hidden even if its hooks/transcripts are still present. |
+| `last-seen-version` | Tracks the last version whose "what's new" popup you've seen, so the popup only fires once per upgrade. Pixtuoid rewrites it when the popup fires, on first launch, or to repair an unparseable value — not on every launch. |
+| `[sources]` | Per-agent-CLI connection state (`source-id = true/false`), written when you connect/disconnect a source in the in-TUI **Sources panel** (`s`) or via the scriptable CLI (`pixtuoid connect`/`disconnect`/`sources set`/`setup --yes`). When a source has no entry, pixtuoid migrates a default on launch: connected if its hooks are already installed (or it has no hooks to install, like Antigravity), else disconnected. A disconnected source's characters are hidden even if its hooks/transcripts are still present. |
+| `[floating]` | Geometry of the `pixtuoid floating` desktop window (`width`/`height`/`x`/`y`), rewritten when the window closes. Sizes below 240×160 clamp up on load; `x`/`y` are dropped when the OS can't report the position (the next launch is OS-placed). A user-set `opacity` parses (clamped 0.2–1.0) and survives the rewrite, but isn't applied yet. |
 
 ## Themes
 
@@ -59,7 +60,8 @@ pixtuoid run --pack-dir ./my-pack
 ```
 
 A **robot** pack ships as an example at `crates/pixtuoid/sprites/robot/`. See the
-[sprite format docs](../crates/pixtuoid/CLAUDE.md) for palette keys and animation requirements.
+[binary guide](../crates/pixtuoid/CLAUDE.md) for pack loading, and the
+[scene engine guide](../crates/pixtuoid-scene/CLAUDE.md) for the recolor palette keys.
 
 ## Logging & troubleshooting
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -38,7 +38,7 @@ kind = "dog"        # name omitted → "Office Dog"
 |-----|---------|
 | `last-seen-version` | Tracks the last version whose "what's new" popup you've seen, so the popup only fires once per upgrade. Pixtuoid rewrites it when the popup fires, on first launch, or to repair an unparseable value — not on every launch. |
 | `[sources]` | Per-agent-CLI connection state (`source-id = true/false`), written when you connect/disconnect a source in the in-TUI **Sources panel** (`s`) or via the scriptable CLI (`pixtuoid connect`/`disconnect`/`sources set`/`setup --yes`). When a source has no entry, pixtuoid migrates a default on launch: connected if its hooks are already installed (or it has no hooks to install, like Antigravity), else disconnected. A disconnected source's characters are hidden even if its hooks/transcripts are still present. |
-| `[floating]` | Geometry of the `pixtuoid floating` desktop window (`width`/`height`/`x`/`y`), rewritten when the window closes. Sizes below 240×160 clamp up on load; `x`/`y` are dropped when the OS can't report the position (the next launch is OS-placed). A user-set `opacity` parses (clamped 0.2–1.0) and survives the rewrite, but isn't applied yet. |
+| `[floating]` | Geometry of the `pixtuoid floating` desktop window (`width`/`height`/`x`/`y`), rewritten when the window closes. Sizes below 240×160 clamp up on load; `x`/`y` are dropped when the OS can't report the position (the next launch is OS-placed). A user-set `opacity` is accepted (clamped 0.2–1.0) and preserved across the rewrite, but isn't applied yet. |
 
 ## Themes
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -19,7 +19,7 @@ git hooks call the same recipes.
 
 ```bash
 just              # list recipes
-just preflight    # full pre-push gate: lint (fmt + machete + deny + arch) → clippy → hack → test
+just preflight    # full pre-push gate: lint (fmt + machete + deny + arch + shfmt + actionlint + links) → clippy → hack → test
 just fmt          # auto-format
 just test         # the whole suite (cargo-nextest if installed, else cargo test)
 ```
@@ -52,7 +52,7 @@ Recipes are grouped by intent — run `just --list` to see them:
 
 | To… | Run | What it touches |
 | --- | --- | --- |
-| **cut a release** | `just bump X.Y.Z` | every version number (workspace + the `pixtuoid`→`pixtuoid-core` path-dep + `Cargo.lock`) · drafts the in-app release notes · `just preflight` · commits on `release/vX.Y.Z` |
+| **cut a release** | `just bump X.Y.Z` | every version number (workspace + the inter-crate path-deps — `pixtuoid`/`pixtuoid-web` → `pixtuoid-scene` → `pixtuoid-core` — + `Cargo.lock`) · drafts the in-app release notes · `just preflight` · commits on `release/vX.Y.Z` |
 | **regenerate doc art** | `just gen` (or `just gen-media` for images only) | `docs/images/*` + `site/public/demos/*` (screenshots + `demo.gif`) from a release build, driven by `scripts/media.json` |
 
 `just bump` rewrites every version number in one shot via `cargo set-version`
@@ -89,7 +89,7 @@ configured before the tag is pushed, or that target's publish step fails. See
 
 ## Architecture invariants (don't break these)
 
-1. `pixtuoid-core` has **no terminal dependencies** (no `ratatui`/`crossterm`/`stdout`).
+1. `pixtuoid-core` and `pixtuoid-scene` (the render+sim engine crate) have **no terminal or window dependencies** (no `ratatui`/`crossterm`/`winit`/`softbuffer`/`stdout` — `just arch` enforces both; terminal/window code lives in the binary's `tui/` and `floating/` painters).
 2. Events flow through **one** channel typed `mpsc::Sender<(Transport, AgentEvent)>`; the `Transport` tag is load-bearing (hook-wins dedup).
 3. The **`Source` trait** is the only seam for adding a transcript-bearing agent CLI (hook-only CLIs like Reasonix instead ship a hook decoder + an install `Target` — see `crates/pixtuoid-core/CLAUDE.md`).
 4. Hook install (`install::install_target`) writes through symlinks (`resolve_symlink`) — don't replace with `fs::rename`.
@@ -159,9 +159,15 @@ TUI), `gh skill` (install Agent Skills, incl. into `.claude/skills/`).
 
 ## Adding a new agent CLI
 
-Step by step. The registration steps (4–6) are test-forced — skipping one
-fails `just test`; steps 1–3 and 7–9 are on you (7, the runtime wiring, is the
-historically-missed one):
+Step by step. The registration steps (4–7 and 9) are test-forced — skipping
+one fails `just test` (the runtime wiring by
+`build_source_set_wires_every_transcript_bearing_source_plus_the_hook_router`
+in `runtime/driver.rs`; the manifest row by `supported_sources_manifest.rs`).
+Step 8 is forced only for hook-only sources
+(`every_hook_only_source_has_an_install_target`) — a transcript-bearing CLI
+that ALSO has hooks still needs you to remember its install target. Step 10
+(the badge hue) is forced by the theme guards. Steps 1–3 and 11 (docs) are on
+you:
 
 1. **Verify the wire format against the CLI's actual source/releases first.**
    Where does it write transcripts, what does a line look like, does it have
@@ -200,9 +206,12 @@ historically-missed one):
 
 4. **Add ONE `SourceDescriptor` row** in `crates/pixtuoid-core/src/source/registry.rs`
    — label prefix (2 chars), the line decoder, hook keying (`IdKey` + an
-   optional custom hook decoder), and truthful capability flags (`has_exit_signal`,
-   `resurrects_on_prompt`, `delegations_are_hook_silent`). Lifecycle policy
-   derives from the flags; you do **not** edit the reducer.
+   optional custom hook decoder), truthful capability flags (`has_exit_signal`,
+   `resurrects_on_prompt`, `delegations_are_hook_silent`), plus
+   `verified_version` ("unknown" until a byte-real capture anchors it — pinned
+   non-empty by `every_descriptor_has_a_verified_version`) and `version_probe`
+   (the `<cli> --version` argv for `pixtuoid doctor`, or `None`). Lifecycle
+   policy derives from the flags; you do **not** edit the reducer.
 5. **Add the name to `source::REGISTERED_SOURCES`** — a bridge test pins
    table↔list equality, and the conformance suite then REQUIRES a fixture.
 6. **Drop a sanitized real-capture fixture** under
@@ -218,8 +227,10 @@ historically-missed one):
 7. **Wire it into `runtime/driver.rs::run_async`** (`crates/pixtuoid/src/runtime/driver.rs`) —
    the runtime spawns sources by hand; the registry gates tests, not spawning.
 8. **If the CLI has hooks**, add an `install/` target (`Target` registry row +
-   a `merge_install`/`merge_uninstall` pair + a registered-events↔decoder-arms
-   guard test) so connecting `<name>` in the in-TUI Sources panel (`s`) wires
+   a `merge_install`/`merge_uninstall` pair + a `verify_schema` fn mirroring
+   the target's own config format — pinned by
+   `verify_target_is_sound_after_a_real_install_for_every_target` — + a
+   registered-events↔decoder-arms guard test) so connecting `<name>` in the in-TUI Sources panel (`s`) wires
    the shim.
 9. **Add a row to [`site/src/sources.json`](../site/src/sources.json)** — the
    single source of truth for the README "Supported Tools" glimpse AND the
@@ -228,7 +239,14 @@ historically-missed one):
    the README. The `supported` set is pinned to `REGISTERED_SOURCES` by
    `crates/pixtuoid-core/tests/supported_sources_manifest.rs`, so a newly
    registered source FAILS that test until its manifest row exists.
-10. **Other docs in the same PR**: the nested `crates/pixtuoid-core/CLAUDE.md`
+10. **Add the per-source badge hue** — a new field on `SourceColors` in
+    `crates/pixtuoid-scene/src/theme/mod.rs` (wired into `SourceColors::all()`
+    and the `by_prefix` match) plus its value in EVERY theme file under
+    `crates/pixtuoid-scene/src/theme/`, and a `badge_color` in the
+    `sources.json` row. `source_colors_cover_every_registered_source`,
+    the per-theme legibility/distinctness guards, and the site bridge test
+    (`pixtuoid-scene/tests/site_badge_colors.rs`) all fail until it exists.
+11. **Other docs in the same PR**: the nested `crates/pixtuoid-core/CLAUDE.md`
     entry, and — if the upstream is open source — a
     `scripts/check_upstream_drift.py` check so a silent rename pages us weekly.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -225,12 +225,12 @@ you:
    and the full add-a-CLI test steps are in
    [`crates/pixtuoid-core/tests/CLAUDE.md`](../crates/pixtuoid-core/tests/CLAUDE.md).
 7. **Wire it into `runtime/driver.rs::run_async`** (`crates/pixtuoid/src/runtime/driver.rs`) —
-   the runtime spawns sources by hand; the registry gates tests, not spawning.
-8. **If the CLI has hooks**, add an `install/` target (`Target` registry row +
+   the runtime spawns sources by hand (the registry drives the guard test, not the spawning).
+8. **If the CLI has hooks**, add an `install/` target (a `Target` registry row +
    a `merge_install`/`merge_uninstall` pair + a `verify_schema` fn mirroring
-   the target's own config format — pinned by
-   `verify_target_is_sound_after_a_real_install_for_every_target` — + a
-   registered-events↔decoder-arms guard test) so connecting `<name>` in the in-TUI Sources panel (`s`) wires
+   the target's own config format + a registered-events↔decoder-arms guard
+   test; `verify_target_is_sound_after_a_real_install_for_every_target` pins
+   the schema fn) so connecting `<name>` in the in-TUI Sources panel (`s`) wires
    the shim.
 9. **Add a row to [`site/src/sources.json`](../site/src/sources.json)** — the
    single source of truth for the README "Supported Tools" glimpse AND the

--- a/docs/KNOWLEDGE-ENGINEERING.md
+++ b/docs/KNOWLEDGE-ENGINEERING.md
@@ -12,10 +12,11 @@ the system we ran, the experiments we ran against it, and the honest results
 
 > **Editor's note (2026-06).** The heavy *process* machinery described below —
 > the review-ledger suppression protocol, the disposition sweep's mechanized
-> attestation (the old `check_dod`/`.dod` gate — the sweep itself survives as a
-> practice in `pr-review.prompt.md`'s process notes), and the
+> attestation (the old `check_dod`/`.dod` gate), and the
 > `census-reminder` / `review-metrics` / `sharp-edge-inventory` automation —
-> has since been **removed** from the repo as a deliberate simplification. This
+> has since been **removed** from the repo as a deliberate simplification (the
+> disposition sweep itself survives as a practice in `pr-review.prompt.md`'s
+> process notes). This
 > page is kept as a record of what we built and, more to the point, what we
 > *measured*: the null onboarding result and the code-first storage ranking are
 > exactly *why* the prose-and-process layers were cut back to the parts that act

--- a/docs/KNOWLEDGE-ENGINEERING.md
+++ b/docs/KNOWLEDGE-ENGINEERING.md
@@ -11,8 +11,10 @@ the system we ran, the experiments we ran against it, and the honest results
 — including the null ones.
 
 > **Editor's note (2026-06).** The heavy *process* machinery described below —
-> the review-ledger suppression protocol, the merge-time disposition sweep, and
-> the `census-reminder` / `review-metrics` / `sharp-edge-inventory` automation —
+> the review-ledger suppression protocol, the disposition sweep's mechanized
+> attestation (the old `check_dod`/`.dod` gate — the sweep itself survives as a
+> practice in `pr-review.prompt.md`'s process notes), and the
+> `census-reminder` / `review-metrics` / `sharp-edge-inventory` automation —
 > has since been **removed** from the repo as a deliberate simplification. This
 > page is kept as a record of what we built and, more to the point, what we
 > *measured*: the null onboarding result and the code-first storage ranking are
@@ -137,7 +139,7 @@ each gate a versioned file with an automatic reader:
 |---|---|---|
 | plan | [`impl-plan.prompt.md`](../.github/prompts/impl-plan.prompt.md) — 7 sections every non-trivial plan must answer (data-shape identity, named consumers, sibling paths, untrusted-input boundaries, tests-first + negative branches, sharp-edge + ledger sweep, blocking verification) | routed from the workspace context file; the plan lands in the PR body |
 | implement | the 6 recurring pitfalls + the PR template checkbox pointing at them | the template is forced on every author |
-| review | [`pr-review.prompt.md`](../.github/prompts/pr-review.prompt.md) — two differentiated lenses, five hard requirements, escalation triggers, ledger routing | copied verbatim into reviewer prompts; the bot loads its own rules file |
+| review | [`pr-review.prompt.md`](../.github/prompts/pr-review.prompt.md) — two differentiated lenses, five hard requirements, escalation triggers, sharp-edge routing | copied verbatim into reviewer prompts; the bot loads its own rules file |
 | merge | the disposition sweep — every finding ends FIXED / REFUTED-with-trace / ISSUE-FILED / ACCEPTED-residual; plan-misses become `plan-miss:` commit lines | the orchestrator's process notes; commit messages become the data channel |
 | periodic | the history census (the weekly `census-reminder` workflow auto-files its successor as a `census` issue once the merged-PR backlog crosses ~50 past the last window — `scripts/census_reminder.py`, no hand-filed placeholder), ledger-blind calibration, `scripts/review-metrics.py` + the reports below | the issue backlog and the harvest scripts |
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,7 +1,7 @@
 # Migration
 
 Per-version upgrade notes. Most releases need nothing; the entries below cover
-the two that changed something user-visible.
+the releases that changed something user-visible.
 
 ## v0.7.x → v0.8.0
 
@@ -30,6 +30,7 @@ This release also adds two new sources you can connect there: **CodeWhale**
 | `~/.cache/ascii-agents/` | `~/.cache/pixtuoid/` |
 | `/tmp/ascii-agents-{uid}.sock` | `/tmp/pixtuoid-{uid}.sock` |
 | `_ascii_agents` hook key in `settings.json` | `_pixtuoid` |
+| `ASCII_AGENTS_SOCKET` env var | `PIXTUOID_SOCKET` (v0.4.0 also adds `PIXTUOID_LOG`) |
 
 ## Upgrade steps
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -30,7 +30,7 @@ This release also adds two new sources you can connect there: **CodeWhale**
 | `~/.cache/ascii-agents/` | `~/.cache/pixtuoid/` |
 | `/tmp/ascii-agents-{uid}.sock` | `/tmp/pixtuoid-{uid}.sock` |
 | `_ascii_agents` hook key in `settings.json` | `_pixtuoid` |
-| `ASCII_AGENTS_SOCKET` env var | `PIXTUOID_SOCKET` (v0.4.0 also adds `PIXTUOID_LOG`) |
+| `ASCII_AGENTS_SOCKET` / `_HOOK` / `_LOG` env vars | `PIXTUOID_SOCKET` / `PIXTUOID_HOOK` / `PIXTUOID_LOG` |
 
 ## Upgrade steps
 

--- a/docs/PARALLEL-DELIVERY.md
+++ b/docs/PARALLEL-DELIVERY.md
@@ -155,9 +155,11 @@ an incident into a review finding into a checklist into a gate.
 
 ## Worked example: pixtuoid
 
-pixtuoid is a Cargo workspace `pixtuoid-core ← pixtuoid-scene ← pixtuoid` plus an
-Astro **site** and a Raycast **TS extension** — a producer + three consumers in
-one monorepo. The cross-area contract is **`pixtuoid … --json`** (the
+pixtuoid is a Cargo workspace `pixtuoid-core ← pixtuoid-scene ← {pixtuoid,
+pixtuoid-web}` (plus the standalone `pixtuoid-hook` shim), an Astro **site**,
+and a Raycast **TS extension** — one producer chain + its consumers in one
+monorepo (the `pixtuoid-web` wasm painter is itself a site build input:
+`just gen-wasm` → the committed `site/public/wasm/`). The cross-area contract is **`pixtuoid … --json`** (the
 `SourceStatus` / `OutcomeRow` DTOs).
 
 - **Pinning:** the Rust side pins the shape with the `source_status_json_shape`
@@ -188,14 +190,16 @@ runnable shape (Claude Code's Workflow tool):
 // Phase 0 happened already: the --json shape + its pinning test are on the branch.
 phase('Fan out')
 const areas = [
-  { key: 'rust',    dir: 'crates/',             gate: 'just preflight && just semver && just gen-check' },
-  { key: 'site',    dir: 'site/',               gate: 'just site-check' },
-  { key: 'raycast', dir: 'integrations/raycast/', gate: 'cd integrations/raycast && npx tsc --noEmit && npx eslint .' },
+  // guide is explicit: the rust area's house rules live in the ROOT CLAUDE.md
+  // (there is no crates/CLAUDE.md), the consumers' in their own directories
+  { key: 'rust',    dir: 'crates/',             guide: 'CLAUDE.md',                      gate: 'just preflight && just semver && just gen-check' },
+  { key: 'site',    dir: 'site/',               guide: 'site/CLAUDE.md',                 gate: 'just site-check' },
+  { key: 'raycast', dir: 'integrations/raycast/', guide: 'integrations/raycast/CLAUDE.md', gate: 'cd integrations/raycast && npx tsc --noEmit && npx eslint .' },
 ]
 const results = await parallel(areas.map((a) => () =>
   agent(
     `Implement the <feature> in ${a.dir} against the FROZEN pixtuoid --json contract ` +
-    `(SourceStatus/OutcomeRow). Read ${a.dir}CLAUDE.md for this area's house rules. ` +
+    `(SourceStatus/OutcomeRow). Read ${a.guide} for this area's house rules. ` +
     `Run its gate and report the EXIT CODE you observed: ${a.gate}`,
     { label: `area:${a.key}`, isolation: 'worktree' },   // each agent gets its own worktree
   )))


### PR DESCRIPTION
## What

A code-grounded drift sweep of the six rendered docs (`/config`, `/architecture`, `/contributing`, `/migration`, `/knowledge-base`, `/parallel-delivery`): six auditors verified every claim against the authoritative Rust source, findings adversarially verified before any edit — 10 confirmed drifts + 10 accepted nits fixed, 1 skipped (a pets-config migration entry whose version archaeology didn't converge; a wrong migration note is worse than a thin one).

Highlights:
- **The architecture page's headline SVG was wrong**: the mermaid diagram placed `render_to_rgb_buffer` inside the binary and omitted `pixtuoid-scene` entirely (it predates the engine-crate extraction, contradicting the page's own prose). The pixel pass now renders in its own engine subgraph — verified built + rendered.
- **CONFIGURATION**: the system-managed table omitted `[floating]`; the `last-seen-version` description was false twice over (it is NOT rewritten every launch, and tracks the last popup shown, not the highest version launched).
- **CONTRIBUTING**: invariant 1 now covers `pixtuoid-scene` + the winit/softbuffer ban; the add-a-CLI checklist's "steps 4–6 are test-forced" undersold today's gates (4–7 and 9 are forced; 8 for hook-only sources) and gains the test-forced per-source badge-hue step.
- **ARCHITECTURE prose**: Cursor moved out of the transcript-bearing examples (it's hook-only per its registry row); "Reasonix is THE hook-only exception" → the real four-member class.
- **PARALLEL-DELIVERY / MIGRATION / KNOWLEDGE-ENGINEERING**: five-crate DAG in the worked example, v0.4.0 env-var rename row, editor's-note precision on what was actually removed.

## Verification

| Check | Result |
|---|---|
| `just site-check` (docs render verbatim; mermaid → SVG) | exit 0 |
| `just lint` (incl. lychee links) | exit 0 |
| `cargo check --workspace --tests` | exit 0 (docs-only diff) |
| /architecture diagram screenshot | engine subgraph renders |
| Audit provenance | 6 finders + 2 adversarial verifiers; every fix carries file:line evidence |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121vF6GrV7TEXC3H8eR5wBw
