### PR TITLE
ci: raise the claude-review turn cap 30 → 60

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -47,4 +47,4 @@ jobs:
           prompt: ${{ steps.prompt.outputs.content }}
           track_progress: true
           show_full_output: true
-          claude_args: '--max-turns 30 --max-budget-usd 10 --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Glob,Grep"'
+          claude_args: '--max-turns 60 --max-budget-usd 10 --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Glob,Grep"'


### PR DESCRIPTION
## What

One line: the review bot's `--max-turns` goes 30 → 60. PR #426 (a redesign-scale 12-commit diff) exhausted 30 turns mid-analysis — the action errored "Reached maximum number of turns (30)", a red check with zero findings delivered. `--max-budget-usd 10` is unchanged and remains the real cost bound.

## Why its own PR

The action's anti-tamper token exchange requires a PR's workflow file to match the default branch's content, so a PR that edits `claude-review.yml` can never bot-review itself (401) — the bump only takes effect for other PRs once it lands on main. Expect the `review` check on THIS PR to be red for exactly that reason (the job still triggers; the 401 happens inside the action); every other gate applies normally.

## Note

The `review` check is not in main's required set — this is quality-of-life for big diffs, not an unblocking change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121vF6GrV7TEXC3H8eR5wBw
