### PR TITLE
ci(gen): pin the committed wasm/glue PAIR with a sha256 manifest

### DIFF
--- a/justfile
+++ b/justfile
@@ -386,7 +386,9 @@ gen-wasm:
     # manifest, verified by gen-wasm-check. Generation-time stamping keeps CI
     # toolchain-free (byte-exact rebuilds drift across rustc versions — the
     # documented reason rebuild comparison is NOT CI'd).
-    (cd site/public/wasm && find . -maxdepth 1 -type f ! -name manifest.sha256 | LC_ALL=C sort | xargs shasum -a 256 > manifest.sha256)
+    # `! -name '.*'` keeps dotfiles out: a Finder-dropped .DS_Store is gitignored,
+    # so stamping it would verify locally and fail CI (missing file) — local-green/CI-red.
+    (cd site/public/wasm && find . -maxdepth 1 -type f ! -name manifest.sha256 ! -name '.*' | LC_ALL=C sort | xargs shasum -a 256 > manifest.sha256)
     ls -la site/public/wasm/
 
 # Bloat + PAIR gate for the committed wasm artifact. Size: the hero must stay
@@ -417,7 +419,8 @@ gen-wasm-check:
     for f in site/public/wasm/*; do
         b=$(basename "$f")
         [ "$b" = manifest.sha256 ] && continue
-        grep -q " ./$b\$" "$M" || { echo "$f is not covered by $M — run 'just gen-wasm'"; exit 1; }
+        awk -v want="./$b" '$2 == want { found = 1 } END { exit !found }' "$M" \
+            || { echo "$f is not covered by $M — run 'just gen-wasm'"; exit 1; }
     done
     echo "gen-wasm-check OK: $W ($SIZE bytes <= $CAP), pair manifest verified"
 

--- a/justfile
+++ b/justfile
@@ -381,26 +381,45 @@ gen-wasm:
     wasm-bindgen --target web --out-dir site/public/wasm \
         target/wasm32-unknown-unknown/release/pixtuoid_web.wasm
     wasm-opt -Oz -o site/public/wasm/pixtuoid_web_bg.wasm site/public/wasm/pixtuoid_web_bg.wasm
+    # Stamp the wasm/glue PAIR (#424): the JS glue's ABI must match the exact
+    # .wasm it was generated with, so every emitted file's sha256 lands in one
+    # manifest, verified by gen-wasm-check. Generation-time stamping keeps CI
+    # toolchain-free (byte-exact rebuilds drift across rustc versions — the
+    # documented reason rebuild comparison is NOT CI'd).
+    (cd site/public/wasm && find . -maxdepth 1 -type f ! -name manifest.sha256 | LC_ALL=C sort | xargs shasum -a 256 > manifest.sha256)
     ls -la site/public/wasm/
 
-# Bloat gate for the committed wasm artifact: the hero must stay a lazy-load
-# behind the poster, so a silent size regression (a dep pulling in formatting
-# machinery, an accidental debug build) fails loudly. 1 MiB raw ≈ ~350-400 KB
-# gzipped over the wire; the artifact is ~700 KB today. Byte-exact
-# rebuild-match is deliberately NOT checked in CI — wasm output drifts across
-# rustc versions, and CI installs latest stable (local `just gen-wasm` +
-# review is the freshness authority, like the committed demo media).
+# Bloat + PAIR gate for the committed wasm artifact. Size: the hero must stay
+# a lazy-load behind the poster, so a silent size regression (a dep pulling in
+# formatting machinery, an accidental debug build) fails loudly — 1 MiB raw ≈
+# ~350-400 KB gzipped; the artifact is ~700 KB today. Pair (#424): the
+# wasm-bindgen JS glue's ABI must match the exact .wasm it was generated with;
+# a one-sided merge resolution or partial regen ships a silent runtime throw,
+# so every committed file must match gen-wasm's sha256 manifest AND every file
+# must be covered by it. Byte-exact rebuild-match is deliberately NOT checked
+# in CI — wasm output drifts across rustc versions, and CI installs latest
+# stable (local `just gen-wasm` + review is the freshness authority, like the
+# committed demo media).
 [group('gen')]
-[doc('Fail if the committed wasm artifact is missing or over the size cap')]
+[doc('Fail if the committed wasm pair is missing, over the size cap, or hash-mismatched')]
 gen-wasm-check:
     #!/usr/bin/env sh
     set -eu
     W=site/public/wasm/pixtuoid_web_bg.wasm
+    M=site/public/wasm/manifest.sha256
     test -f "$W" || { echo "missing $W — run 'just gen-wasm'"; exit 1; }
     CAP=1048576
     SIZE=$(wc -c < "$W" | tr -d ' ')
     test "$SIZE" -le "$CAP" || { echo "$W is $SIZE bytes (> $CAP cap) — investigate the bloat"; exit 1; }
-    echo "gen-wasm-check OK: $W ($SIZE bytes <= $CAP)"
+    test -f "$M" || { echo "missing $M — run 'just gen-wasm' (the wasm/glue pair manifest)"; exit 1; }
+    (cd site/public/wasm && shasum -a 256 --strict -c manifest.sha256 >/dev/null) \
+        || { echo "wasm/glue pair MISMATCH vs $M — a partial regen or one-sided merge; run 'just gen-wasm' and commit all of site/public/wasm/"; exit 1; }
+    for f in site/public/wasm/*; do
+        b=$(basename "$f")
+        [ "$b" = manifest.sha256 ] && continue
+        grep -q " ./$b\$" "$M" || { echo "$f is not covered by $M — run 'just gen-wasm'"; exit 1; }
+    done
+    echo "gen-wasm-check OK: $W ($SIZE bytes <= $CAP), pair manifest verified"
 
 # Drift gate: fail if any committed README section OR rendered still is stale.
 # Pixel-diffs every PNG (threshold 0); video clips + demo.gif are presence-only

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -51,7 +51,8 @@ Mermaid diagram becomes an inline SVG at build via `rehype-mermaid`, which is
   regenerates these in the same change (workspace `CLAUDE.md`).
 - `public/wasm/` is the live-office backdrop's engine — a GENERATED, COMMITTED
   artifact built from the `pixtuoid-web` crate by `just gen-wasm` (wasm +
-  wasm-bindgen JS glue, size-gated by `gen-wasm-check` in the Rust CI).
+  wasm-bindgen JS glue, size- and pair-gated — a sha256 manifest pins the
+  wasm/glue ABI pair — by `gen-wasm-check` in the Rust CI).
   `components/OfficeBackdrop.astro` dynamically `import()`s it at runtime
   (poster-first; any failure keeps the still). Never hand-edit
   (prettier/eslint/knip all ignore it); regenerate from the crate.

--- a/site/public/wasm/manifest.sha256
+++ b/site/public/wasm/manifest.sha256
@@ -1,0 +1,4 @@
+17ab3eee500b872655bb6a3d85c615fb63275120925b2a013c4f8777883c36f0  ./pixtuoid_web.d.ts
+ed56c2f23c5096df741bb4e8a8402b131124c3b2a2b23ea10009f86e78c065a7  ./pixtuoid_web.js
+0a0248bbefff9a36e07ce1fd1f41cffe6bd24d5837f1bc2e968a8f5bf0dd3af7  ./pixtuoid_web_bg.wasm
+0e3490864d2a75344e829b0e46a2b325e9a6acd794ad337c8d18a091c3e38ff8  ./pixtuoid_web_bg.wasm.d.ts


### PR DESCRIPTION
Closes #424.

## What

`site/public/wasm/` commits two coupled artifacts — the `.wasm` and the wasm-bindgen JS glue whose ABI must match the exact binary it was generated with. Nothing pinned the pair: a one-sided merge resolution (binary → "theirs", glue → "ours") or a partial regen ships a silent ABI mismatch that throws at runtime under the live-office backdrop.

- `just gen-wasm` now stamps `site/public/wasm/manifest.sha256` (standard `sha256sum` format) after `wasm-opt`.
- `gen-wasm-check` (already in `gen-check` + ci.yml's `wasm-check` job) verifies every hash (`shasum --strict -c`) **and** that every committed file is covered by the manifest, alongside the existing 1 MiB cap.
- Generation-time stamping keeps CI toolchain-free — byte-exact rebuild comparison stays deliberately un-CI'd (wasm output drifts across rustc versions; the recipe comment carries the WHY).
- The initial manifest is stamped from the **currently committed** pair (the authority), not a fresh regen that would churn bytes under a newer rustc.

## Verification

| Check | Result |
|---|---|
| `just gen-wasm-check` on the real pair | exit 0 |
| Corrupted hash in manifest | MISMATCH, exit 1 |
| Uncovered stray file in `wasm/` | exit 1 |
| Missing manifest | exit 1 |
| `just lint` | exit 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121vF6GrV7TEXC3H8eR5wBw