### PR TITLE
test(site): Playwright e2e smoke suite — the runtime-contract gate

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -52,6 +52,13 @@ jobs:
       # `verify` script; runs before build for fast feedback.
       - run: npm run knip
       - run: npm run build
+      # e2e smoke suite vs the PRODUCTION build just produced (astro preview,
+      # the official Astro testing posture): pins the page's runtime contracts
+      # — wasm office goes live, statusline truth-light, digit-key scrollspy,
+      # dimmer release, Copy→hire wiring, docs-nav variant, reduced-motion
+      # fallback — plus a console-error watchdog (it caught the CSP-blocked
+      # inlined fonts on day one). Chromium is already installed above.
+      - run: npm run e2e
       # Lighthouse CI: gate a11y / SEO / best-practices (perf advisory) against
       # the built pages — serves dist via `astro preview` (honors the /pixtuoid
       # base) and audits each. Replaces the dropped eslint-plugin-jsx-a11y with a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ scripts/             gen-media.py + media.json (the ONE manifest-driven driver f
                      account/gateway footprint, NOT a CI test),
                      check_upstream_drift.py (weekly wire-format watch),
 site/                Astro landing page → GitHub Pages; self-contained Node project,
-                     own CI; `just site-{setup,dev,check,fmt}` → see site/README.md
+                     own CI; `just site-{setup,dev,check,fmt,e2e}` → see site/README.md
 integrations/raycast/  Raycast extension (TypeScript, self-contained Node project; NOT Rust):
                      `Manage Sources` (connect/disconnect over `pixtuoid sources|connect|disconnect
                      --json`) + `Start Floating` commands. A thin shell over the CLI `--json`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,8 @@ live in nested `CLAUDE.md` files**, auto-loaded when you touch those trees:
   - [`crates/pixtuoid/src/tui/CLAUDE.md`](crates/pixtuoid/src/tui/CLAUDE.md) — the terminal painter (over the `pixtuoid-scene` crate): draw_scene flush, harness, widgets, the theme-PICKER ui, Sources panel, dashboard, hit_test, version popup.
 
 The NON-Rust **consumers** of the `--json` contract have their own guides (their
-gates are `tsc`/`eslint` / `just site-check`, NOT cargo — the Rust house rules
+gates are `tsc`/`eslint` / `just site-check` (+ `just site-e2e`, the Playwright
+runtime-contract smoke suite), NOT cargo — the Rust house rules
 above don't apply there):
 - [`integrations/raycast/CLAUDE.md`](integrations/raycast/CLAUDE.md) — the Raycast TS extension.
 - [`site/CLAUDE.md`](site/CLAUDE.md) — the Astro landing page.

--- a/justfile
+++ b/justfile
@@ -291,9 +291,10 @@ deb target:
 # own CI (.github/workflows/site.yml). See site/README.md.
 
 [group('site')]
-[doc('Install the site npm deps (run once per clone)')]
+[doc('Install the site npm deps + the e2e browser (run once per clone)')]
 site-setup:
     npm --prefix site ci
+    npx --prefix site playwright install chromium
 
 [group('site')]
 [doc('Site dev server with HMR → http://localhost:4321/pixtuoid/')]

--- a/justfile
+++ b/justfile
@@ -310,6 +310,15 @@ site-check:
 site-fmt:
     npm --prefix site run format
 
+[group('site')]
+[doc('E2E smoke suite vs the PRODUCTION build (astro preview) — the runtime-contract gate')]
+site-e2e:
+    #!/usr/bin/env sh
+    set -eu
+    cd site
+    npm run build
+    npx playwright test
+
 # ── gen ───────────────────────────────────────────────────────────
 # Regenerate the committed artifacts that derive from a single source of truth:
 # README sections from site/src/*.json (gen-readme), and the office images for

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -11,3 +11,6 @@ node_modules/
 .env.production
 # misc
 .DS_Store
+# playwright e2e artifacts
+test-results/
+playwright-report/

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -60,7 +60,11 @@ Mermaid diagram becomes an inline SVG at build via `rehype-mermaid`, which is
 
 ## Gates
 
-`just site-{setup, dev, check, fmt}` (see `README.md`). The full-stack gate is
-`just verify` = `preflight` + `site-check` + `gen-check`. For a site-only change,
-`just site-check` is the relevant one; CI is `site.yml` / `pages.yml` (NOT the
-Rust `ci.yml`).
+`just site-{setup, dev, check, fmt, e2e}` (see `README.md`). The full-stack gate
+is `just verify` = `preflight` + `site-check` + `gen-check`. For a site-only
+change, `just site-check` is the relevant one; `just site-e2e` (Playwright vs
+the PRODUCTION build via `astro preview` — the official Astro posture) pins the
+page's RUNTIME contracts (`__pixLights`/`pix:onair`/`data-lit` seams, the
+digit-key scrollspy, the docs-nav variant, reduced-motion) plus a console-error
+watchdog, where tsc/knip/build are blind. CI is `site.yml` / `pages.yml` (NOT
+the Rust `ci.yml`).

--- a/site/README.md
+++ b/site/README.md
@@ -25,9 +25,13 @@ npm run lint       # eslint .
 npm run check       # astro check (types + templates)
 npm run knip       # unused files / exports / dependencies
 npm run build      # astro build → dist/
+npm run e2e        # Playwright smoke suite (tests/e2e/) vs the PRODUCTION build
 ```
 
-From the repo root the same gate is `just site-check` (and `just site-fmt`).
+From the repo root the same gate is `just site-check` (and `just site-fmt`);
+`just site-e2e` builds then runs the Playwright suite — the runtime-contract
+tier (window seams, scrollspy keys, dimmer, reduced-motion) that the static
+gates can't see. CI runs it in `site.yml` after the build step.
 
 > **Cross-boundary build inputs.** The site reads seven files from _outside_ `site/`
 > at build time: the workspace `Cargo.toml` (displayed version, via `vite.define` in
@@ -82,9 +86,11 @@ From the repo root the same gate is `just site-check` (and `just site-fmt`).
   and `data-floor` (scrollspy) — a new floor needs both plus a `FLOORS` row in
   `Statusline.astro`. The backdrop publishes `window.__pixLights` (per-frame
   dim value; the statusline polls it) and `pix:onair` + the `.backdrop.is-live`
-  class (discrete live flip; event for changes, class for late-attach seeding).
-  `window.__pixNight()` (defined in `Base.astro`'s head boot) is the ONE
-  client-side day/night boundary — never re-derive 19:00–07:00 inline.
+  class (discrete live flip; event for changes, class for late-attach seeding),
+  plus `window.__pixHire()` (walk one extra sprite in; the install Copy
+  buttons call it). `window.__pixNight()` (defined in `Base.astro`'s head
+  boot) is the ONE client-side day/night boundary — never re-derive
+  19:00–07:00 inline.
 - **FX** (all `prefers-reduced-motion`-safe) — CRT power-on, hero pixel-dust,
   and the dimmer itself. (The old pointer glow + 3D tilt were removed
   deliberately: perspective transforms smear pixel art.)

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -182,5 +182,13 @@ export default defineConfig({
   // project page, so a repo-local robots.txt would serve under /pixtuoid/ and
   // crawlers only read robots.txt from the origin root — see the PR notes).
   integrations: [sitemap()],
-  vite: { define: { __PIXTUOID_VERSION__: JSON.stringify(version) } },
+  vite: {
+    define: { __PIXTUOID_VERSION__: JSON.stringify(version) },
+    // Never inline assets as data: URLs. Vite's default 4KiB inlining turned
+    // the small @fontsource unicode-range subsets into data: fonts, which the
+    // hand-rolled CSP (font-src 'self', Base.astro) silently BLOCKED in
+    // production — caught by the e2e suite's console-error watchdog. Keeping
+    // the CSP strict and the assets as files is the fix, not `data:` in CSP.
+    build: { assetsInlineLimit: 0 },
+  },
 });

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -18,6 +18,7 @@
         "@astrojs/check": "^0.9.4",
         "@eslint/js": "^10.0.1",
         "@lhci/cli": "^0.15.1",
+        "@playwright/test": "^1.61.1",
         "@types/node": "^22.19.21",
         "eslint": "^10.5.0",
         "eslint-config-prettier": "^10.1.8",
@@ -2736,6 +2737,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@puppeteer/browsers": {
@@ -10387,13 +10404,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
-      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.0"
+        "playwright-core": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -10406,9 +10423,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
-      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/site/package.json
+++ b/site/package.json
@@ -17,7 +17,8 @@
     "format:check": "prettier --check .",
     "knip": "knip",
     "verify": "npm run format:check && npm run lint && npm run check && npm run knip && npm run build",
-    "lighthouse": "lhci autorun"
+    "lighthouse": "lhci autorun",
+    "e2e": "playwright test"
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.7.3",
@@ -30,6 +31,7 @@
     "@astrojs/check": "^0.9.4",
     "@eslint/js": "^10.0.1",
     "@lhci/cli": "^0.15.1",
+    "@playwright/test": "^1.61.1",
     "@types/node": "^22.19.21",
     "eslint": "^10.5.0",
     "eslint-config-prettier": "^10.1.8",

--- a/site/playwright.config.ts
+++ b/site/playwright.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// The e2e smoke suite runs against the PRODUCTION build via `astro preview`
+// (the official Astro testing posture: "run your tests against your production
+// code" — the dev server's Vite cache has twice masqueraded as a site bug in
+// this repo). `dist/` must exist: `just site-e2e` builds first; in CI the
+// build step precedes the e2e step. Port 4321 (astro's default) deliberately
+// differs from the local dev habit (4399) so the suite never grabs a live dev
+// server through `reuseExistingServer`.
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? 'github' : 'list',
+  timeout: 45_000,
+  use: {
+    baseURL: 'http://localhost:4321/pixtuoid/',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    // Chromium only: it's the browser CI already installs (rehype-mermaid),
+    // and the suite gates cross-component CONTRACTS, not engine differences.
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+  webServer: {
+    // The astro bin DIRECTLY — an `npm run` wrapper leaves an orphaned astro
+    // child holding the port when Playwright kills the tree, and
+    // reuseExistingServer would then silently test the ORPHAN'S stale build
+    // (caught by this suite's own teeth test). reuse stays false for the same
+    // reason: a squatted port must fail loud, never quietly test old bytes.
+    command: 'node node_modules/astro/bin/astro.mjs preview --port 4321',
+    url: 'http://localhost:4321/pixtuoid/',
+    reuseExistingServer: false,
+    timeout: 30_000,
+  },
+});

--- a/site/playwright.config.ts
+++ b/site/playwright.config.ts
@@ -4,9 +4,9 @@ import { defineConfig, devices } from '@playwright/test';
 // (the official Astro testing posture: "run your tests against your production
 // code" — the dev server's Vite cache has twice masqueraded as a site bug in
 // this repo). `dist/` must exist: `just site-e2e` builds first; in CI the
-// build step precedes the e2e step. Port 4321 (astro's default) deliberately
-// differs from the local dev habit (4399) so the suite never grabs a live dev
-// server through `reuseExistingServer`.
+// build step precedes the e2e step. Port 4321 is astro's default for dev AND
+// preview — a live dev server squatting it makes the webServer spawn fail
+// LOUD (reuseExistingServer stays false below), never quietly test dev bytes.
 export default defineConfig({
   testDir: './tests/e2e',
   fullyParallel: true,

--- a/site/src/env.d.ts
+++ b/site/src/env.d.ts
@@ -1,2 +1,15 @@
 // Injected at build time from the workspace Cargo.toml (see astro.config.mjs).
 declare const __PIXTUOID_VERSION__: string;
+
+// The page's cross-component runtime contracts (producers/consumers documented
+// in README.md "Cross-component seams"; existence pinned by tests/e2e). All
+// optional: each consumer guards, and reduced-motion / pre-boot states leave
+// some unset.
+interface Window {
+  /** THE site clock boundary (7/19) — defined in Base.astro's head boot. */
+  __pixNight?: () => boolean;
+  /** Per-frame dimmer opacity — written by OfficeBackdrop's controller. */
+  __pixLights?: number;
+  /** Hire a coworker into the live office — set once the wasm office boots. */
+  __pixHire?: () => void;
+}

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -11,7 +11,11 @@ import { expect, test, type Page } from '@playwright/test';
 //   - a wasm/glue ABI mismatch throwing at runtime under the hero
 // Runs against the PRODUCTION build (see playwright.config.ts).
 
-/** Fail the calling test if the page logs an uncaught error or console.error. */
+/**
+ * Fail the calling test if the page logs an uncaught error or console.error.
+ * Attached once per DISTINCT code path (index live boot, copy/hire, docs
+ * shell, reduced-motion) rather than every test — keeps failures pointed.
+ */
 function watchErrors(page: Page): () => string[] {
   const errors: string[] = [];
   page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`));
@@ -99,9 +103,10 @@ test('the install Copy click hires without breaking the page', async ({ page, co
 
 test('docs pages keep the sticky nav with section links', async ({ page }) => {
   // The floating-nav treatment is index-ONLY; the docs pages have no office
-  // backdrop or statusline, so they keep the sticky bar (the #429-review
+  // backdrop or statusline, so they keep the sticky bar (the #426-review
   // regression: `nav--floating` leaked here — absolute, transparent, links
   // hidden — and every scroll offset went stale).
+  const errors = watchErrors(page);
   await page.goto('./config');
   const nav = page.locator('.nav');
   await expect(nav).not.toHaveClass(/nav--floating/);
@@ -109,6 +114,9 @@ test('docs pages keep the sticky nav with section links', async ({ page }) => {
     .poll(() => page.evaluate(() => getComputedStyle(document.querySelector('.nav')!).position))
     .toBe('sticky');
   await expect(page.locator('.nav__section-link').first()).toBeVisible();
+  // The docs shell has its own script surface (sidebar scrollspy, pager,
+  // inline mermaid SVG) the index tests never visit — keep it error-free too.
+  expect(errors()).toEqual([]);
 });
 
 test('reduced motion stays on the still poster without errors', async ({ browser }) => {
@@ -118,11 +126,17 @@ test('reduced motion stays on the still poster without errors', async ({ browser
   const context = await browser.newContext({ reducedMotion: 'reduce' });
   const page = await context.newPage();
   const errors = watchErrors(page);
+  const wasmRequests: string[] = [];
+  page.on('request', (r) => {
+    if (r.url().includes('/wasm/')) wasmRequests.push(r.url());
+  });
   await page.addInitScript(() => sessionStorage.setItem('pix-booted', '1'));
   await page.goto('./');
   await expect(page.locator('.backdrop__poster')).toBeVisible();
-  // Give a would-be wasm boot time to (wrongly) start, then assert it didn't.
-  await page.waitForTimeout(2_000);
+  // Deterministic (no fixed wait): by network-idle a would-be boot would have
+  // fetched the wasm glue and published __pixHire — assert neither happened.
+  await page.waitForLoadState('networkidle');
+  expect(wasmRequests).toEqual([]);
   await expect(page.locator('.backdrop.is-live')).not.toBeAttached();
   expect(errors()).toEqual([]);
   await context.close();

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -3,8 +3,8 @@ import { expect, test, type Page } from '@playwright/test';
 // The smoke suite: one assertion per cross-component CONTRACT of the OPEN
 // FLOOR page — the seams that only exist at runtime (window globals, custom
 // events, data-attribute wiring) where tsc/eslint/knip/astro-build are blind.
-// Every test here is a regression pin for a bug class a human review actually
-// caught on this site:
+// The first seven tests are regression pins for bug classes a human review
+// actually caught on this site:
 //   - the missed one-shot `pix:onair` event (statusline read STILL forever)
 //   - the `is:inline` parse-position trap (scrollspy frozen on floor 6)
 //   - the floating-nav variant leaking onto the docs pages
@@ -40,6 +40,14 @@ test('the office goes live and the statusline truth-light agrees', async ({ page
   // The on-air readout must say LIVE — covers BOTH orderings of the one-shot
   // pix:onair event vs the statusline's listener (the seed-from-class fix).
   await expect(page.locator('[data-sl-onair]')).toHaveText('● LIVE', { timeout: 10_000 });
+  // Resize re-aspects the render buffer (rAF-throttled sizeBuffer): the buffer
+  // height is fixed at 180, so width = min(640, max(64, round(w/h · 180))) —
+  // 320 at the 1280×720 default, 100 at a 500×900 portrait.
+  const bufW = () =>
+    page.evaluate(() => (document.getElementById('office-live') as HTMLCanvasElement).width);
+  expect(await bufW()).toBe(320);
+  await page.setViewportSize({ width: 500, height: 900 });
+  await expect.poll(bufW).toBe(100);
   expect(errors()).toEqual([]);
 });
 
@@ -84,6 +92,19 @@ test('the dimmer darkens statements and releases in office gaps', async ({ page 
     document.querySelector('.office-gap')!.scrollIntoView({ block: 'center', behavior: 'instant' })
   );
   await expect.poll(dim).toBeLessThan(0.15);
+  // The hero is a data-lit="fade" block: while a statement owns the viewport
+  // center it parks at 0.001 (the invisible-headline class), and rises back
+  // when the office scrolls up again.
+  const heroOp = () =>
+    page.evaluate(() =>
+      parseFloat((document.querySelector('.hero__copy') as HTMLElement).style.opacity || '1')
+    );
+  await page.evaluate(() =>
+    document.getElementById('features')!.scrollIntoView({ block: 'center', behavior: 'instant' })
+  );
+  await expect.poll(heroOp).toBeLessThan(0.01);
+  await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'instant' }));
+  await expect.poll(heroOp).toBeGreaterThan(0.5);
 });
 
 test('the install Copy click hires without breaking the page', async ({ page, context }) => {
@@ -138,6 +159,286 @@ test('reduced motion stays on the still poster without errors', async ({ browser
   await page.waitForLoadState('networkidle');
   expect(wasmRequests).toEqual([]);
   await expect(page.locator('.backdrop.is-live')).not.toBeAttached();
+  // Reduced motion also strips the showcase clip's autoplay: native controls
+  // appear and the video stays paused (WCAG 2.2.2).
+  const video = page.locator('[data-stage="agents"] video');
+  await expect(video).toHaveAttribute('controls', '');
+  await expect.poll(() => video.evaluate((v) => (v as HTMLVideoElement).paused)).toBe(true);
   expect(errors()).toEqual([]);
   await context.close();
+});
+
+// ---------------------------------------------------------------------------
+// The tests below came out of the sitewide interaction audit (91 catalogued
+// listeners/globals/observers → these six): every runtime contract with
+// med+ user impact and low flake risk that the tests above didn't already pin.
+
+test('first visit: boot intro auto-runs, reveals the page, seeds the gate', async ({ page }) => {
+  await page.goto('./'); // NO pix-booted seed — the real first visit
+  await expect(page.locator('#boot')).toBeVisible();
+  // The auto-run finishes in ~2.5s of sequenced timeouts — poll, no fixed wait.
+  await expect(page.locator('html')).not.toHaveAttribute('data-booting', '1', { timeout: 8_000 });
+  await expect.poll(() => page.evaluate(() => sessionStorage.getItem('pix-booted'))).toBe('1');
+  expect(await page.evaluate(() => document.getElementById('main')!.hasAttribute('inert'))).toBe(
+    false
+  );
+  // finish() dispatched pix:revealed, arming the reveal-on-scroll observer —
+  // opacity:0 still counts as "visible" to Playwright, so assert the CLASS.
+  await page.evaluate(() =>
+    document.getElementById('features')!.scrollIntoView({ block: 'center', behavior: 'instant' })
+  );
+  await expect(page.locator('#features .section-head.reveal')).toHaveClass(/\bin\b/);
+  // Gate round-trip: a seeded session skips the overlay, and the IMMEDIATE
+  // pix:revealed path must arm the reveal observer just the same.
+  await page.reload();
+  await expect(page.locator('#boot')).not.toBeVisible();
+  await page.evaluate(() =>
+    document.getElementById('features')!.scrollIntoView({ block: 'center', behavior: 'instant' })
+  );
+  await expect(page.locator('#features .section-head.reveal')).toHaveClass(/\bin\b/);
+});
+
+test('theme chain: saved choice, URL override, toggle persist, Escape restore, system dark', async ({
+  page,
+}) => {
+  // Only the boot gate goes in addInitScript — an init-script THEME seed would
+  // re-run on every navigation and clobber the later steps' seeds; theme
+  // choices are planted via localStorage + reload instead.
+  await page.addInitScript(() => sessionStorage.setItem('pix-booted', '1'));
+  await page.goto('./');
+  await page.evaluate(() => localStorage.setItem('pix-theme', 'dracula'));
+  await page.reload(); // the saved-choice branch — never consults the clock
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'dracula');
+  // The theme-color meta syncs from the same init read (mobile chrome tint).
+  await expect(page.locator('meta[name="theme-color"]')).toHaveAttribute('content', '#282a36');
+  // A ?theme= URL override outranks the saved choice.
+  await page.goto('./?theme=night');
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'night');
+  // Toggle round-trip (seed 'day' so the flip lands 'night' — wall-clock-proof):
+  // flip + persist + the pix:theme dispatch → listener → sync() icon/aria chain.
+  await page.evaluate(() => localStorage.setItem('pix-theme', 'day'));
+  await page.goto('./');
+  await page.locator('#theme-toggle').click();
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'night');
+  expect(await page.evaluate(() => localStorage.getItem('pix-theme'))).toBe('night');
+  await expect(page.locator('#theme-toggle .nav__toggle-icon')).toHaveText('☀️');
+  await expect(page.locator('#theme-toggle')).toHaveAttribute('aria-label', 'Switch to day');
+  await page.reload(); // persistence read-back + the parse-time sync() seed
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'night');
+  await expect(page.locator('#theme-toggle .nav__toggle-icon')).toHaveText('☀️');
+  // Escape restore: t retints inline, Escape clears it and restores the SAVED
+  // theme (validated read — never the clock).
+  await page.evaluate(() => localStorage.setItem('pix-theme', 'dracula'));
+  await page.reload();
+  await page.keyboard.press('t');
+  await expect
+    .poll(() => page.evaluate(() => document.documentElement.style.getPropertyValue('--coral')))
+    .not.toBe('');
+  await page.keyboard.press('Escape');
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'dracula');
+  await expect
+    .poll(() => page.evaluate(() => document.documentElement.style.getPropertyValue('--coral')))
+    .toBe('');
+  // System-dark fallback: no saved pick + a dark scheme lands 'night' — and
+  // after-hours wall clocks ALSO land night, so this is TZ-proof.
+  await page.emulateMedia({ colorScheme: 'dark' });
+  await page.evaluate(() => localStorage.removeItem('pix-theme'));
+  await page.reload();
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'night');
+});
+
+test('install: tabs swap panels and both clipboard branches deliver', async ({ page, context }) => {
+  await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+  await page.addInitScript(() => sessionStorage.setItem('pix-booted', '1'));
+  await page.goto('./'); // no live-office wait — tabs/copy are wasm-independent
+  await page.locator('.install__tab[data-tab="cargo"]').click();
+  await expect(page.locator('.install__tab[data-tab="cargo"]')).toHaveAttribute(
+    'aria-pressed',
+    'true'
+  );
+  await expect(page.locator('#install-panel-cargo')).toBeVisible();
+  await expect(page.locator('#install-panel-brew')).toBeHidden(); // really swapped out
+  // The happy path SPECIFICALLY (the hire test's regex tolerates the fallback):
+  // the flash label AND the clipboard payload round-trip.
+  const copy = page.locator('.install__panel.is-active .install__copy');
+  await copy.click();
+  await expect(copy).toHaveText('Copied ✓');
+  expect(await page.evaluate(() => navigator.clipboard.readText())).toBe(
+    await copy.getAttribute('data-copy')
+  );
+  // Force the manual branch on a fresh load (brew is the default active panel):
+  // no Clipboard API → the <code> contents get SELECTED for a manual ⌘C.
+  await page.addInitScript(() =>
+    Object.defineProperty(navigator, 'clipboard', { value: undefined })
+  );
+  await page.reload();
+  const brewCopy = page.locator('.install__panel.is-active .install__copy');
+  await brewCopy.click();
+  await expect(brewCopy).toHaveText('Select & copy');
+  expect(await page.evaluate(() => String(getSelection()))).toContain('brew install');
+});
+
+test('showcase studio: deep-links tune, dial and chips swap hydrated stages, the clip plays', async ({
+  page,
+}) => {
+  const errors = watchErrors(page);
+  await page.addInitScript(() => sessionStorage.setItem('pix-booted', '1'));
+  await page.goto('./#themes'); // the legacy anchor maps to the themes channel
+  await expect(page.locator('[data-stage="themes"]')).toBeVisible();
+  await expect(page.locator('button.mon[data-ch="themes"]')).toHaveAttribute(
+    'aria-pressed',
+    'true'
+  );
+  // First tune hydrated the stage: data-src promoted to a real src.
+  await expect(page.locator('[data-stage="themes"] img.terminal__screen')).toHaveAttribute(
+    'src',
+    /theme_/
+  );
+  // An in-page hashchange re-tunes.
+  await page.evaluate(() => {
+    location.hash = '#showcase-weather';
+  });
+  await expect(page.locator('[data-stage="weather"]')).toBeVisible();
+  // Dial click: exactly-one-visible-stage swap + aria radio + URL tracking.
+  await page.locator('button.mon[data-ch="spaces"]').click();
+  await expect(page.locator('[data-stage="spaces"]')).toBeVisible();
+  await expect(page.locator('[data-stage="weather"]')).toBeHidden();
+  await expect(page.locator('button.mon[data-ch="spaces"]')).toHaveAttribute(
+    'aria-pressed',
+    'true'
+  );
+  await expect(page).toHaveURL(/#showcase-spaces$/);
+  // OSD chip: variant swap inside the stage.
+  const chip = page.locator('[data-stage="spaces"] .osd__chip', { hasText: 'Pantry' });
+  await chip.click();
+  await expect(chip).toHaveAttribute('aria-pressed', 'true');
+  await expect(page.locator('[data-stage="spaces"] img.terminal__screen')).toHaveAttribute(
+    'src',
+    /space_pantry\.png/
+  );
+  // Play policy: back on the default channel with #studio in view, the clip
+  // plays inline (muted autoplay is gesture-free in chromium) — no controls.
+  await page.locator('button.mon[data-ch="agents"]').click();
+  await page.evaluate(() =>
+    document.getElementById('studio')!.scrollIntoView({ block: 'center', behavior: 'instant' })
+  );
+  await expect
+    .poll(() =>
+      page
+        .locator('[data-stage="agents"] video')
+        .evaluate((v) => !(v as HTMLVideoElement).paused && !v.hasAttribute('controls'))
+    )
+    .toBe(true);
+  expect(errors()).toEqual([]);
+});
+
+test('nav menus + docs: dropdown, TOC scrollspy, 404, mobile burger', async ({ page, browser }) => {
+  const errors = watchErrors(page);
+  await page.goto('./config#themes'); // arrival-by-hash: the rail lights unscrolled
+  await expect(page.locator('[data-toc-link="themes"]')).toHaveAttribute(
+    'aria-current',
+    'location'
+  );
+  // The Docs dropdown is the ONLY route to the six doc pages.
+  const btn = page.locator('#docs-btn');
+  await btn.click();
+  await expect(page.locator('#docs-menu')).toHaveClass(/is-open/);
+  await expect(btn).toHaveAttribute('aria-expanded', 'true');
+  await page.locator('#docs-menu a').first().focus(); // focus INSIDE, or the return branch is skipped
+  await page.keyboard.press('Escape');
+  await expect(page.locator('#docs-menu')).not.toHaveClass(/is-open/);
+  await expect(btn).toBeFocused();
+  // TOC click sync + the anchored heading clears the 60px sticky nav.
+  await page.locator('[data-toc-link="custom-sprite-packs"]').click();
+  await expect(page.locator('[data-toc-link="custom-sprite-packs"]')).toHaveAttribute(
+    'aria-current',
+    'location'
+  );
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => document.getElementById('custom-sprite-packs')!.getBoundingClientRect().top
+      )
+    )
+    .toBeGreaterThan(60);
+  // Scrollspy proper: park a heading at 20% viewport — inside the -15%/-75%
+  // reading band — and the rail follows.
+  await page.evaluate(() => {
+    const h = document.getElementById('themes')!;
+    window.scrollTo({
+      top: h.getBoundingClientRect().top + window.scrollY - window.innerHeight * 0.2,
+      behavior: 'instant',
+    });
+  });
+  await expect(page.locator('[data-toc-link="themes"]')).toHaveAttribute(
+    'aria-current',
+    'location'
+  );
+  // Unknown routes land on the office at 3 a.m. with a way home. The document
+  // request itself logs a resource-404 console error — filter that one line;
+  // everything else must stay clean.
+  await page.goto('./no-such-desk');
+  await expect(page.locator('.lost h1')).toContainText('Session not');
+  await expect
+    .poll(() =>
+      page
+        .locator('.lost__scene .terminal__screen')
+        .evaluate((img) => (img as HTMLImageElement).naturalWidth)
+    )
+    .toBeGreaterThan(0);
+  await expect(page.locator('.lost__cta .btn-primary')).toHaveAttribute('href', '/pixtuoid/');
+  expect(errors().filter((e) => !e.includes('Failed to load resource'))).toEqual([]);
+  // Mobile burger: below 760px the link panel is display:none until .is-open —
+  // a dead burger means no navigation at all on phones. Same Esc-focus-return
+  // contract as the Docs dropdown (WCAG 2.4.3).
+  const ctx = await browser.newContext({ viewport: { width: 480, height: 800 } });
+  const m = await ctx.newPage();
+  await m.addInitScript(() => sessionStorage.setItem('pix-booted', '1'));
+  await m.goto('./config');
+  await m.locator('#nav-burger').click();
+  await expect(m.locator('#nav-links')).toHaveClass(/is-open/);
+  await expect(m.locator('#nav-burger')).toHaveAttribute('aria-expanded', 'true');
+  await m.locator('#nav-links a').first().focus();
+  await m.keyboard.press('Escape');
+  await expect(m.locator('#nav-links')).not.toHaveClass(/is-open/);
+  await expect(m.locator('#nav-burger')).toBeFocused();
+  await ctx.close();
+});
+
+test('landing fixed chrome: floating nav, statusline readouts, floor popover, day/night gap', async ({
+  page,
+}) => {
+  await page.addInitScript(() => sessionStorage.setItem('pix-booted', '1'));
+  await page.goto('./'); // no live-office wait — everything here is wasm-independent
+  // The load-bearing half of the floating variant: no live blur filter over a
+  // 30fps canvas (the compositor-flicker class).
+  await expect(page.locator('.nav')).toHaveClass(/nav--floating/);
+  expect(
+    await page.evaluate(() => getComputedStyle(document.querySelector('.nav')!).backdropFilter)
+  ).toBe('none');
+  // The statusline consumes the globals (the 250ms poll shows the 0.55
+  // fallback pre-wasm, so no live wait is needed); clock is format-only — TZ-agnostic.
+  await expect(page.locator('[data-sl-lights]')).toHaveText(/lights \d+%/);
+  await expect(page.locator('[data-sl-clock]')).toHaveText(/^\d{2}:\d{2} (day|night)$/);
+  // Gap-2's claim must AGREE with the one clock boundary — consistency, not a
+  // fixed value, so it's green at any hour.
+  const s = await page.evaluate(() => ({
+    night: window.__pixNight!(),
+    word: document.querySelector('[data-gap-daynight]')!.textContent,
+    src: (document.querySelector('[data-gap-still]') as HTMLImageElement).src,
+  }));
+  expect(s.word).toBe(s.night ? 'night' : 'day');
+  expect(s.src).toContain(s.night ? 'night.png' : 'day.png');
+  // Floor popover: toggle → Esc closes → reopen → a floor jump closes AND
+  // rides the lift (the same scrollspy round-trip as the digit-keys test).
+  const toggle = page.locator('[data-floor-toggle]');
+  await toggle.click();
+  await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+  await expect(page.locator('#sl-floors')).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(page.locator('#sl-floors')).toBeHidden();
+  await toggle.click();
+  await page.locator('[data-floor-btn="1"]').click();
+  await expect(page.locator('#sl-floors')).toBeHidden();
+  await expect(page.locator('[data-lift-digit]')).toHaveText('1F', { timeout: 10_000 });
 });

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -1,0 +1,129 @@
+import { expect, test, type Page } from '@playwright/test';
+
+// The smoke suite: one assertion per cross-component CONTRACT of the OPEN
+// FLOOR page — the seams that only exist at runtime (window globals, custom
+// events, data-attribute wiring) where tsc/eslint/knip/astro-build are blind.
+// Every test here is a regression pin for a bug class a human review actually
+// caught on this site:
+//   - the missed one-shot `pix:onair` event (statusline read STILL forever)
+//   - the `is:inline` parse-position trap (scrollspy frozen on floor 6)
+//   - the floating-nav variant leaking onto the docs pages
+//   - a wasm/glue ABI mismatch throwing at runtime under the hero
+// Runs against the PRODUCTION build (see playwright.config.ts).
+
+/** Fail the calling test if the page logs an uncaught error or console.error. */
+function watchErrors(page: Page): () => string[] {
+  const errors: string[] = [];
+  page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`));
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') errors.push(`console.error: ${msg.text()}`);
+  });
+  return () => errors;
+}
+
+/** Load the landing page with the boot intro pre-skipped and the office live. */
+async function gotoLive(page: Page): Promise<void> {
+  await page.addInitScript(() => sessionStorage.setItem('pix-booted', '1'));
+  await page.goto('./');
+  // The wasm office must come up: poster → live canvas. 15s is generous — a
+  // timeout here is the ABI-mismatch / loader-regression signal.
+  await expect(page.locator('.backdrop.is-live')).toBeAttached({ timeout: 15_000 });
+}
+
+test('the office goes live and the statusline truth-light agrees', async ({ page }) => {
+  const errors = watchErrors(page);
+  await gotoLive(page);
+  // The on-air readout must say LIVE — covers BOTH orderings of the one-shot
+  // pix:onair event vs the statusline's listener (the seed-from-class fix).
+  await expect(page.locator('[data-sl-onair]')).toHaveText('● LIVE', { timeout: 10_000 });
+  expect(errors()).toEqual([]);
+});
+
+test('the cross-component window contracts exist', async ({ page }) => {
+  await gotoLive(page);
+  // The runtime seams every component wires against (documented in
+  // site/README.md "Cross-component seams") — a rename breaks consumers
+  // silently, so pin their existence + shapes here.
+  await expect
+    .poll(async () =>
+      page.evaluate(() => ({
+        night: typeof window.__pixNight === 'function' && typeof window.__pixNight() === 'boolean',
+        hire: typeof window.__pixHire === 'function',
+        lights: typeof window.__pixLights,
+      }))
+    )
+    .toEqual({ night: true, hire: true, lights: 'number' });
+});
+
+test('digit keys ride between floors (scrollspy round-trip)', async ({ page }) => {
+  await gotoLive(page);
+  // Key "3" → the machine-room floor. Covers the is:inline parse-position
+  // trap (an observer wired before <main> parses sees zero [data-floor]
+  // sections and the readout freezes on 6F).
+  await page.keyboard.press('3');
+  await expect(page.locator('[data-lift-digit]')).toHaveText('3F', { timeout: 10_000 });
+  await page.keyboard.press('1');
+  await expect(page.locator('[data-lift-digit]')).toHaveText('1F', { timeout: 10_000 });
+});
+
+test('the dimmer darkens statements and releases in office gaps', async ({ page }) => {
+  await gotoLive(page);
+  const dim = () =>
+    page.evaluate(() => parseFloat(document.getElementById('dimmer')!.style.opacity || '0'));
+  // A statement at viewport center pulls the darkness in…
+  await page.evaluate(() =>
+    document.getElementById('features')!.scrollIntoView({ block: 'center', behavior: 'instant' })
+  );
+  await expect.poll(dim).toBeGreaterThan(0.5);
+  // …and the first observation gap releases it (the office IS the content).
+  await page.evaluate(() =>
+    document.querySelector('.office-gap')!.scrollIntoView({ block: 'center', behavior: 'instant' })
+  );
+  await expect.poll(dim).toBeLessThan(0.15);
+});
+
+test('the install Copy click hires without breaking the page', async ({ page, context }) => {
+  await context.grantPermissions(['clipboard-write']);
+  const errors = watchErrors(page);
+  await gotoLive(page);
+  await page.evaluate(() =>
+    document.getElementById('install')!.scrollIntoView({ block: 'center', behavior: 'instant' })
+  );
+  const copy = page.locator('.install__panel.is-active .install__copy');
+  await copy.click();
+  // The copy flash proves the click handler ran to completion — i.e. the
+  // pre-copy __pixHire() call (the #436 wiring) didn't throw.
+  await expect(copy).toHaveText(/Copied|Select & copy/);
+  expect(errors()).toEqual([]);
+});
+
+test('docs pages keep the sticky nav with section links', async ({ page }) => {
+  // The floating-nav treatment is index-ONLY; the docs pages have no office
+  // backdrop or statusline, so they keep the sticky bar (the #429-review
+  // regression: `nav--floating` leaked here — absolute, transparent, links
+  // hidden — and every scroll offset went stale).
+  await page.goto('./config');
+  const nav = page.locator('.nav');
+  await expect(nav).not.toHaveClass(/nav--floating/);
+  await expect
+    .poll(() => page.evaluate(() => getComputedStyle(document.querySelector('.nav')!).position))
+    .toBe('sticky');
+  await expect(page.locator('.nav__section-link').first()).toBeVisible();
+});
+
+test('reduced motion stays on the still poster without errors', async ({ browser }) => {
+  // A complete parallel design: no wasm fetch, the poster is the office, the
+  // dimmer holds a constant CSS level. Must be error-free — reduced-motion
+  // visitors see this forever.
+  const context = await browser.newContext({ reducedMotion: 'reduce' });
+  const page = await context.newPage();
+  const errors = watchErrors(page);
+  await page.addInitScript(() => sessionStorage.setItem('pix-booted', '1'));
+  await page.goto('./');
+  await expect(page.locator('.backdrop__poster')).toBeVisible();
+  // Give a would-be wasm boot time to (wrongly) start, then assert it didn't.
+  await page.waitForTimeout(2_000);
+  await expect(page.locator('.backdrop.is-live')).not.toBeAttached();
+  expect(errors()).toEqual([]);
+  await context.close();
+});


### PR DESCRIPTION
## What

A **13-test Playwright smoke suite** pinning the page's **runtime contracts** — the window globals, custom events, and data-attribute wiring where tsc/eslint/knip/build (and the Rust bridge + pixel gates) are all blind.

Two tiers:
- **7 regression pins** for bug classes a human review actually caught this arc: the `pix:onair` race, the `is:inline` parse-position trap, the `nav--floating` docs leak (#426), the `__pixHire` wiring, the dimmer mechanic, the reduced-motion parallel design — plus a console-error watchdog per distinct code path.
- **6 audit-driven tests** (+3 line-level extensions) from a 7-surface sitewide interaction audit that catalogued **91 runtime interactions** and adjudicated each: boot intro first-visit + session gate, the full theme chain (saved/URL/toggle/Escape/system-dark — every step wall-clock-proof), install tabs + both clipboard branches, the showcase studio (deep-links, dial, hydration, chips, play policy), nav menus + docs TOC scrollspy + 404 + mobile burger, and the landing's fixed chrome (floating nav, statusline readouts, floor popover, gap-2 day/night agreement). 49 interactions deliberately skipped with recorded reasons (wall-clock flake, ops-only, easter eggs, covered-elsewhere).

Per the official Astro posture: runs against the **production build** via `astro preview` (never the dev server, whose Vite cache has twice masqueraded as a site bug here).

## Two real catches before it even merged

1. **A production CSP bug (day-one watchdog catch)**: Vite's default 4KiB inlining turned small @fontsource subsets into `data:` fonts — silently blocked by the hand-rolled `font-src 'self'` in production (24 of 154 woff2 files were affected). Fixed strict-side: `assetsInlineLimit: 0` (assets stay files; CSP stays `data:`-free; post-fix dist has zero `url(data:)`).
2. **The orphaned-preview trap (caught by the suite's own teeth test)**: `npm run preview` as the webServer leaves an orphaned astro child squatting the port when Playwright kills the wrapper; `reuseExistingServer` then silently tests the orphan's **stale build**. The config runs the astro bin directly + pins `reuseExistingServer: false` — a squatted port fails loud.

## Wiring

`just site-e2e` (build + test) · `just site-setup` installs the Chromium browser · site.yml runs e2e after the build step · artifacts gitignored · window contracts declared in `env.d.ts` (load-bearing: without it the spec fails 4× TS2339) · gates documented in site/README.md, site/CLAUDE.md + the workspace map.

## Review

Two-lens local review (correctness/flake-audit + design/blast-radius briefs): both **APPROVE-WITH-NITS**, all 9 findings fixed in `e90342c3` — dispositions in the PR thread.

## Verification

| Check | Result |
|---|---|
| Playwright suite (×2 consecutive — no orphan, no port clash) | 13/13 both, ~8s |
| Teeth (mutate `__pixHire` in dist) | contracts test reds |
| `just site-check` | exit 0 |
| `just preflight` (pre-push hook) | 1951/1951 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121vF6GrV7TEXC3H8eR5wBw