### PR TITLE
feat(site): Astro 7 adoption — agent-dev server, hash CSP, hero pause, prefetch/fonts/robots

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -51,6 +51,9 @@ jobs:
       # an orphaned component or stale dep tsc/eslint can't see). Mirrors the
       # `verify` script; runs before build for fast feedback.
       - run: npm run knip
+      # node:test unit tests (config/csp-hashes.test.mjs) — the CSP hash kernel's
+      # edge cases the e2e watchdog can only catch indirectly. Part of `verify`.
+      - run: npm run test:unit
       - run: npm run build
       # e2e smoke suite vs the PRODUCTION build just produced (astro preview,
       # the official Astro testing posture): pins the page's runtime contracts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ scripts/             gen-media.py + media.json (the ONE manifest-driven driver f
                      account/gateway footprint, NOT a CI test),
                      check_upstream_drift.py (weekly wire-format watch),
 site/                Astro landing page → GitHub Pages; self-contained Node project,
-                     own CI; `just site-{setup,dev,check,fmt,e2e}` → see site/README.md
+                     own CI; `just site-{setup,dev,dev-bg,dev-stop,check,fmt,e2e}` → see site/README.md
 integrations/raycast/  Raycast extension (TypeScript, self-contained Node project; NOT Rust):
                      `Manage Sources` (connect/disconnect over `pixtuoid sources|connect|disconnect
                      --json`) + `Start Floating` commands. A thin shell over the CLI `--json`

--- a/justfile
+++ b/justfile
@@ -298,9 +298,39 @@ site-setup:
     npx --prefix site playwright install chromium
 
 [group('site')]
-[doc('Site dev server with HMR → http://localhost:4321/pixtuoid/')]
+[doc('Site dev server with HMR → http://localhost:4321/pixtuoid/ (foreground; agents: site-dev-bg)')]
 site-dev:
     npm --prefix site run dev
+
+# Agent-facing dev-server lifecycle (Astro 7 `--background`): the daemon has no
+# stdin/TTY tie, so it survives the launching shell — the foreground `astro dev`
+# quits on stdin EOF, which killed agent-driven servers between commands.
+# Readiness = the DEV-ONLY /_astro/status health endpoint (preview 404s it);
+# the astro bin is called directly like playwright.config.ts does (same cwd, no
+# npm wrapper layer). NOTE: dev and preview share port 4321 — stop the daemon
+# (site-dev-stop) before `just site-e2e`, or its webServer spawn fails loud.
+[group('site')]
+[doc('Dev server as a background daemon (survives stdin EOF) — waits on /_astro/status; stop: just site-dev-stop')]
+site-dev-bg:
+    #!/usr/bin/env sh
+    set -eu
+    cd site
+    node node_modules/astro/bin/astro.mjs dev --background
+    # 60 × 0.5s = 30s readiness budget
+    for _ in $(seq 1 60); do
+        if curl -fsS -m 2 http://localhost:4321/_astro/status >/dev/null 2>&1; then
+            echo "ready → http://localhost:4321/pixtuoid/  (logs: cd site && npx astro dev logs --follow)"
+            exit 0
+        fi
+        sleep 0.5
+    done
+    echo "site-dev-bg: daemon started but /_astro/status not ready after 30s" >&2
+    exit 1
+
+[group('site')]
+[doc('Stop the background dev server (astro dev stop; no-op if none is running)')]
+site-dev-stop:
+    cd site && node node_modules/astro/bin/astro.mjs dev stop
 
 [group('site')]
 [doc('Full site gate: format-check → lint → astro check → build (mirrors site CI)')]

--- a/justfile
+++ b/justfile
@@ -333,7 +333,7 @@ site-dev-stop:
     cd site && node node_modules/astro/bin/astro.mjs dev stop
 
 [group('site')]
-[doc('Full site gate: format-check → lint → astro check → build (mirrors site CI)')]
+[doc('Site static tier: format-check → lint → astro check → knip → unit tests → build (site CI runs e2e + lighthouse after these)')]
 site-check:
     npm --prefix site run verify
 

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -57,6 +57,34 @@ Mermaid diagram becomes an inline SVG at build via `rehype-mermaid`, which is
   `components/OfficeBackdrop.astro` dynamically `import()`s it at runtime
   (poster-first; any failure keeps the still). Never hand-edit
   (prettier/eslint/knip all ignore it); regenerate from the crate.
+  The backdrop's pause switch (`#office-pause`, WCAG 2.2.2) lives in the same
+  component: pause stops the rAF loop (frozen frame stays on the canvas) and
+  resume subtracts the paused span from the sim clock (`pauseOffset`) so the
+  timeline doesn't lurch-jump; the button stays `hidden` on every poster-only
+  path (reduced motion / no wasm / fetch failure) and is unhidden by the
+  first painted frame.
+
+## CSP (hash-based, two coordinated halves — both in astro.config.mjs)
+
+The `<meta>` CSP is Astro 7's built-in `security.csp` PLUS the
+`cspInlineHashes()` `astro:build:done` hook, deliberately kept in the same
+file: Astro emits the meta into every page's head (404 included) and owns the
+RESOURCE lists; the hook then re-derives the hash sets from the **built
+html**, because (verified vs 7.0.5) Astro does not hash template-level
+`is:inline` scripts — the only script kind this site has — and it appends
+style hashes unconditionally, which would make browsers *ignore*
+`'unsafe-inline'`. Consequences to not "fix":
+
+- **`script-src` carries no `'unsafe-inline'`** — every inline script is
+  whitelisted by content hash, recomputed on each build. Adding/editing an
+  `is:inline` script needs NO manual CSP step.
+- **`style-src` keeps `'unsafe-inline'` and must stay hash-free**: Shiki
+  spans, the build-time mermaid SVG, and the few `style={}` attributes are
+  inline style ATTRIBUTES, which hashes cannot express (one present hash
+  disables `unsafe-inline` for the whole directive).
+- **`astro dev` serves NO CSP** (upstream: the feature is build/preview-only).
+  CSP regressions surface in `just site-e2e`'s console watchdog against the
+  production build, not in dev.
 
 ## Dev-server lifecycle (agent-driving)
 

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -64,8 +64,11 @@ Mermaid diagram becomes an inline SVG at build via `rehype-mermaid`, which is
   path (reduced motion / no wasm / fetch failure) and is unhidden by the
   first painted frame. Pause is **page-scoped**: `setPaused` dispatches
   `pix:paused` and every other >5s auto-motion listens (the statusline feed
-  ticker, the hero dust) — one control governs page motion, and the statusline
-  reads `❚❚ PAUSED`. The wasm fetch is **deferred** off the render-critical
+  ticker, the hero dust) — one control governs the page's *ambient* motion,
+  and the statusline reads `❚❚ PAUSED`. (The Showcase demo clips are the one
+  motion NOT wired to `pix:paused`: they're in-view-gated and carry native
+  `<video>` controls, so 2.2.2 is satisfied there independently — don't add
+  them to the `pix:paused` set.) The wasm fetch is **deferred** off the render-critical
   window (`load` → `requestIdleCallback`) so it doesn't compete with the
   above-fold poster/fonts; a live un-reduce still boots promptly via the mq
   listener.

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -58,9 +58,25 @@ Mermaid diagram becomes an inline SVG at build via `rehype-mermaid`, which is
   (poster-first; any failure keeps the still). Never hand-edit
   (prettier/eslint/knip all ignore it); regenerate from the crate.
 
+## Dev-server lifecycle (agent-driving)
+
+Foreground `astro dev` quits on stdin EOF — under a PTY an AI agent could not
+keep it alive across commands. Astro 7's `--background` mode is the fix:
+**`just site-dev-bg`** daemonizes the server (no stdin/TTY tie) and polls the
+dev-only `/_astro/status` health endpoint (`{"ok":true}`) until ready;
+**`just site-dev-stop`** (= `astro dev stop`) shuts it down and frees the port.
+`astro dev status` / `astro dev logs --follow` inspect the daemon; non-TTY runs
+auto-emit JSON log lines. Two sharp edges: `/_astro/status` and the
+background/stop/status subcommands are **dev-server only** — `astro preview`
+404s the endpoint and has no daemon mode (verified vs 7.0.5), so the e2e
+webServer keeps its URL-poll readiness; and dev/preview share port 4321, so
+**stop the daemon before `just site-e2e`** (its webServer fails loud on a
+squatted port, by design). `just site-dev` stays foreground for humans who
+want HMR logs.
+
 ## Gates
 
-`just site-{setup, dev, check, fmt, e2e}` (see `README.md`). The full-stack gate
+`just site-{setup, dev, dev-bg, dev-stop, check, fmt, e2e}` (see `README.md`). The full-stack gate
 is `just verify` = `preflight` + `site-check` + `gen-check`. For a site-only
 change, `just site-check` is the relevant one; `just site-e2e` (Playwright vs
 the PRODUCTION build via `astro preview` — the official Astro posture) pins the

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -62,18 +62,28 @@ Mermaid diagram becomes an inline SVG at build via `rehype-mermaid`, which is
   resume subtracts the paused span from the sim clock (`pauseOffset`) so the
   timeline doesn't lurch-jump; the button stays `hidden` on every poster-only
   path (reduced motion / no wasm / fetch failure) and is unhidden by the
-  first painted frame.
+  first painted frame. Pause is **page-scoped**: `setPaused` dispatches
+  `pix:paused` and every other >5s auto-motion listens (the statusline feed
+  ticker, the hero dust) — one control governs page motion, and the statusline
+  reads `❚❚ PAUSED`. The wasm fetch is **deferred** off the render-critical
+  window (`load` → `requestIdleCallback`) so it doesn't compete with the
+  above-fold poster/fonts; a live un-reduce still boots promptly via the mq
+  listener.
 
 ## CSP (hash-based, two coordinated halves — both in astro.config.mjs)
 
 The `<meta>` CSP is Astro 7's built-in `security.csp` PLUS the
-`cspInlineHashes()` `astro:build:done` hook, deliberately kept in the same
-file: Astro emits the meta into every page's head (404 included) and owns the
-RESOURCE lists; the hook then re-derives the hash sets from the **built
-html**, because (verified vs 7.0.5) Astro does not hash template-level
-`is:inline` scripts — the only script kind this site has — and it appends
-style hashes unconditionally, which would make browsers *ignore*
-`'unsafe-inline'`. Consequences to not "fix":
+`cspInlineHashes()` `astro:build:done` hook. The **policy** (`security.csp`
+directives) and the **hook registration** stay together in `astro.config.mjs`
+(the anti-drift co-location); the pure per-page transform — `rewriteCspMeta(html)`
+— lives in [`config/csp-hashes.mjs`](config/csp-hashes.mjs), unit-tested by
+`config/csp-hashes.test.mjs` (`npm run test:unit`, in `verify`) so its
+quote-aware script-tag scan can't diverge from the HTML tokenizer. Astro emits
+the meta into every page's head (404 included) and owns the RESOURCE lists; the
+hook then re-derives the hash sets from the **built html**, because (verified
+vs 7.0.5) Astro does not hash template-level `is:inline` scripts — the only
+script kind this site has — and it appends style hashes unconditionally, which
+would make browsers *ignore* `'unsafe-inline'`. Consequences to not "fix":
 
 - **`script-src` carries no `'unsafe-inline'`** — every inline script is
   whitelisted by content hash, recomputed on each build. Adding/editing an

--- a/site/README.md
+++ b/site/README.md
@@ -109,7 +109,11 @@ gates can't see. CI runs it in `site.yml` after the build step.
   19:00–07:00 inline.
 - **FX** (all `prefers-reduced-motion`-safe) — CRT power-on, hero pixel-dust,
   and the dimmer itself. (The old pointer glow + 3D tilt were removed
-  deliberately: perspective transforms smear pixel art.)
+  deliberately: perspective transforms smear pixel art.) The live office has
+  a pixel-style pause switch (`#office-pause`, bottom-right above the
+  statusline — WCAG 2.2.2): pause freezes the frame in place, resume picks
+  the timeline up where it stopped; hidden whenever only the still poster is
+  showing.
 - **Docs shell** — `layouts/Docs.astro` gives /config, /architecture,
   /contributing, /migration a shared sidebar + build-time mini-TOC + pager.
 
@@ -180,7 +184,10 @@ render script all pick it up automatically — no component edits.
 
 Project page today (`base: '/pixtuoid'`). To move to e.g. `pixtuoid.dev`: add
 `public/CNAME` with the domain, set `base: '/'` and `site: 'https://pixtuoid.dev'`
-in `astro.config.mjs`, then point DNS at GitHub Pages.
+in `astro.config.mjs`, then point DNS at GitHub Pages. `robots.txt` and its
+sitemap URL (`src/pages/robots.txt.ts`) derive from that config automatically —
+note that on the project page crawlers never fetch it (they only read the
+ORIGIN root's robots.txt), so it only becomes authoritative on a custom domain.
 
 ## First deploy (one-time)
 

--- a/site/README.md
+++ b/site/README.md
@@ -93,29 +93,39 @@ gates can't see. CI runs it in `site.yml` after the build step.
   "office gaps". Each section is a floor (6F penthouse → 1F front desk);
   `Statusline.astro` is the one piece of fixed chrome (floor readout +
   scrollspy, the build-time merged-PR feed with a canned-reel fallback,
-  `lights %` / clock / `● LIVE`), and the app's literal keys work on the page —
-  digits `1–6` ride between floors, `t` retints the decorative palette (Esc
-  restores). The favicon dims with the night theme; 404 is the office at
-  3 a.m. (`--empty` render).
+  `lights %` / clock / `● LIVE` · `❚❚ PAUSED`), and the app's literal keys work
+  on the page — digits `1–6` ride between floors, `t` retints the decorative
+  palette (Esc restores). Those bare single-char shortcuts are **focus-gated**
+  (WCAG 2.1.4): they fire only from a neutral focus context (page body / a
+  jumped-to section / the statusline), never a focused control — the shared
+  `window.__pixKeys.shortcutContext()` gate. The favicon dims with the night
+  theme; 404 is the office at 3 a.m. (`--empty` render).
 - **Cross-component seams** (what a new section must wire): sections declare
   `data-lit` (dimmer target; `data-lit="fade"` also rises with the darkness)
-  and `data-floor` (scrollspy) — a new floor needs both plus a `FLOORS` row in
-  `Statusline.astro`. The backdrop publishes `window.__pixLights` (per-frame
-  dim value; the statusline polls it) and `pix:onair` + the `.backdrop.is-live`
-  class (discrete live flip; event for changes, class for late-attach seeding),
-  plus `window.__pixHire()` (walk one extra sprite in; the install Copy
-  buttons call it). `window.__pixNight()` (defined in `Base.astro`'s head
-  boot) is the ONE client-side day/night boundary — never re-derive
-  19:00–07:00 inline.
+  and `data-floor` (scrollspy) — a new floor is a `FLOORS` row in `consts.ts`
+  (the ONE source the statusline lift AND each section's `data-floor`/id/eyebrow
+  derive from), then `data-lit` on the section. The backdrop publishes
+  `window.__pixLights` (per-frame dim value; the statusline polls it), `pix:onair`
+  - the `.backdrop.is-live` class (discrete live flip; event for changes, class
+    for late-attach seeding), and `pix:paused` (the office pause switch — see FX)
+    — every >5s auto-motion listens, so ONE control governs page motion. Plus
+    `window.__pixHire()` (walk one extra sprite in; the install Copy buttons call
+    it). `window.__pixNight()` and `window.__pixTheme` / `window.__pixKeys`
+    (defined parse-first in `Base.astro`'s head) are the ONE day/night boundary /
+    theme-constants source / key-shortcut helpers — never re-derive 19:00–07:00,
+    the theme BG map, or the typing guard inline.
 - **FX** (all `prefers-reduced-motion`-safe) — CRT power-on, hero pixel-dust,
   and the dimmer itself. (The old pointer glow + 3D tilt were removed
   deliberately: perspective transforms smear pixel art.) The live office has
   a pixel-style pause switch (`#office-pause`, bottom-right above the
-  statusline — WCAG 2.2.2): pause freezes the frame in place, resume picks
-  the timeline up where it stopped; hidden whenever only the still poster is
-  showing.
+  statusline — WCAG 2.2.2): pause freezes the office frame in place AND, via the
+  `pix:paused` event, stops every other >5s auto-motion (the statusline feed
+  ticker, the hero dust) — the statusline reads `❚❚ PAUSED`; resume picks the
+  timeline up where it stopped. Hidden whenever only the still poster is showing.
 - **Docs shell** — `layouts/Docs.astro` gives /config, /architecture,
-  /contributing, /migration a shared sidebar + build-time mini-TOC + pager.
+  /contributing, /migration a shared sidebar + build-time mini-TOC + pager,
+  driven by the one `DOCS` manifest in `consts.ts` (the Nav dropdown reads the
+  same source).
 
 ## Demo art
 

--- a/site/README.md
+++ b/site/README.md
@@ -15,6 +15,22 @@ npm install        # or: just site-setup   (from the repo root)
 npm run dev        # http://localhost:4321/pixtuoid/   ·  just site-dev
 ```
 
+**Agent-driven (non-TTY) dev server** — foreground `astro dev` exits on stdin
+EOF, so it dies between an agent's shell commands. Astro 7's background mode
+fixes this (dev-server only; `astro preview` has none of it):
+
+```sh
+just site-dev-bg       # astro dev --background, then polls /_astro/status until ready
+just site-dev-stop     # astro dev stop (frees port 4321; no-op if not running)
+npx astro dev status   # from site/: is the daemon up? · logs: npx astro dev logs --follow
+```
+
+Readiness/liveness is the dev-only `/_astro/status` endpoint (`{"ok":true}`,
+served at the root and under the base path). In a non-TTY context astro
+auto-switches to JSON log lines — no logger config needed. Stop the daemon
+before `just site-e2e`: dev and preview share port 4321, and the e2e webServer
+fails loud on a squatted port by design.
+
 ## Quality gates
 
 ```sh

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -1,12 +1,12 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
 import { readFileSync, existsSync, writeFileSync, readdirSync } from 'node:fs';
-import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import { posix, join } from 'node:path';
 import sitemap from '@astrojs/sitemap';
 import rehypeMermaid from 'rehype-mermaid';
 import { unified } from '@astrojs/markdown-remark';
+import { rewriteCspMeta } from './config/csp-hashes.mjs';
 
 // Single-source the displayed version from the workspace Cargo.toml so the boot
 // intro never goes stale on a release bump. Scope the match to the
@@ -163,13 +163,11 @@ function rehypeRepoLinks() {
 // this site has — and it unconditionally appends style hashes, which would make
 // browsers IGNORE the 'unsafe-inline' that Shiki/mermaid style attributes need.
 // This build:done hook closes both gaps from the BUILT html itself, so the
-// hashes are mechanically derived and can never drift from the content:
-//   - script-src: drop Astro's hashes (its client-directive bootstraps — no
-//     islands here; anything real is in the html and gets re-hashed), then add
-//     a sha256 for every inline <script> actually on that page. External
-//     scripts keep riding 'self'.
-//   - style-src: drop ALL hashes so the configured 'unsafe-inline' stays
-//     honored (CSP ignores it the moment any hash is present).
+// hashes are mechanically derived and can never drift from the content
+// (script-src re-hashed per page, style-src stripped of hashes). The delicate
+// per-page HTML→hashes→rewrite transform lives in ./config/csp-hashes.mjs so it
+// is unit-testable (config/csp-hashes.test.mjs) and its script-tag scan can't
+// diverge from the HTML tokenizer; this hook only walks dist/ and applies it.
 function cspInlineHashes() {
   return {
     name: 'csp-inline-hashes',
@@ -185,37 +183,9 @@ function cspInlineHashes() {
             else if (e.name.endsWith('.html')) htmlFiles.push(p);
           }
         })(fileURLToPath(dir));
-        const HASH = /^'sha(256|384|512)-/;
         for (const file of htmlFiles) {
-          const html = readFileSync(file, 'utf8');
-          // The browser hashes the exact bytes between the tags — extract them
-          // verbatim. Scripts with src= ride 'self'; ld+json data blocks never
-          // execute, but hashing them too is free cross-engine insurance.
-          const hashes = new Set();
-          for (const m of html.matchAll(/<script(\s[^>]*)?>([\s\S]*?)<\/script>/gi)) {
-            if (/\ssrc\s*=/i.test(m[1] ?? '')) continue;
-            hashes.add(`'sha256-${createHash('sha256').update(m[2], 'utf8').digest('base64')}'`);
-          }
-          let rewrote = false;
-          const updated = html.replace(
-            /(<meta http-equiv="content-security-policy" content=")([^"]*)(")/i,
-            (_, pre, /** @type {string} */ content, post) => {
-              rewrote = true;
-              const out = content
-                .split(';')
-                .map((d) => {
-                  const toks = d.trim().split(/\s+/).filter(Boolean);
-                  if (toks[0] !== 'script-src' && toks[0] !== 'style-src') return d.trim();
-                  const resources = toks.slice(1).filter((t) => !HASH.test(t));
-                  const add = toks[0] === 'script-src' ? [...hashes] : [];
-                  return [toks[0], ...resources, ...add].join(' ');
-                })
-                .filter(Boolean)
-                .join('; ');
-              return pre + out + post;
-            }
-          );
-          if (!rewrote) {
+          const updated = rewriteCspMeta(readFileSync(file, 'utf8'));
+          if (updated === null) {
             throw new Error(
               `csp-inline-hashes: no CSP <meta> found in ${file} — did security.csp get disabled?`
             );
@@ -300,6 +270,17 @@ export default defineConfig({
     },
   },
   prefetch: { prefetchAll: true, defaultStrategy: 'hover' },
+  build: {
+    // ALWAYS inline the page stylesheets. Astro's default 'auto' inlines only
+    // sheets smaller than vite's assetsInlineLimit — pinned to 0 below for the
+    // CSP-font posture — so 'auto' would inline NOTHING and every page would
+    // render-block on two external CSS requests (~592ms RTT on simulated
+    // mobile, on the FCP/LCP critical path). 'always' bypasses assetsInlineLimit
+    // entirely; woff2 fonts are not stylesheets so they stay hashed files under
+    // font-src 'self', and inline <style> is allowed (style-src keeps
+    // 'unsafe-inline', kept hash-free by the cspInlineHashes hook).
+    inlineStylesheets: 'always',
+  },
   vite: {
     define: { __PIXTUOID_VERSION__: JSON.stringify(version) },
     // Never inline assets as data: URLs. Vite's default 4KiB inlining turned

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -1,8 +1,9 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync, writeFileSync, readdirSync } from 'node:fs';
+import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
-import { posix } from 'node:path';
+import { posix, join } from 'node:path';
 import sitemap from '@astrojs/sitemap';
 import rehypeMermaid from 'rehype-mermaid';
 import { unified } from '@astrojs/markdown-remark';
@@ -156,6 +157,76 @@ function rehypeRepoLinks() {
   return transform;
 }
 
+// CSP, part 2 of 2 (part 1 is `security.csp` below): Astro 7's built-in CSP
+// emits the <meta> on every page and owns the RESOURCE lists, but (verified vs
+// 7.0.5) it does NOT hash template-level `is:inline` scripts — the only kind
+// this site has — and it unconditionally appends style hashes, which would make
+// browsers IGNORE the 'unsafe-inline' that Shiki/mermaid style attributes need.
+// This build:done hook closes both gaps from the BUILT html itself, so the
+// hashes are mechanically derived and can never drift from the content:
+//   - script-src: drop Astro's hashes (its client-directive bootstraps — no
+//     islands here; anything real is in the html and gets re-hashed), then add
+//     a sha256 for every inline <script> actually on that page. External
+//     scripts keep riding 'self'.
+//   - style-src: drop ALL hashes so the configured 'unsafe-inline' stays
+//     honored (CSP ignores it the moment any hash is present).
+function cspInlineHashes() {
+  return {
+    name: 'csp-inline-hashes',
+    hooks: {
+      /** @param {{ dir: URL }} opts */
+      'astro:build:done': ({ dir }) => {
+        /** @type {string[]} */
+        const htmlFiles = [];
+        (function walk(/** @type {string} */ d) {
+          for (const e of readdirSync(d, { withFileTypes: true })) {
+            const p = join(d, e.name);
+            if (e.isDirectory()) walk(p);
+            else if (e.name.endsWith('.html')) htmlFiles.push(p);
+          }
+        })(fileURLToPath(dir));
+        const HASH = /^'sha(256|384|512)-/;
+        for (const file of htmlFiles) {
+          const html = readFileSync(file, 'utf8');
+          // The browser hashes the exact bytes between the tags — extract them
+          // verbatim. Scripts with src= ride 'self'; ld+json data blocks never
+          // execute, but hashing them too is free cross-engine insurance.
+          const hashes = new Set();
+          for (const m of html.matchAll(/<script(\s[^>]*)?>([\s\S]*?)<\/script>/gi)) {
+            if (/\ssrc\s*=/i.test(m[1] ?? '')) continue;
+            hashes.add(`'sha256-${createHash('sha256').update(m[2], 'utf8').digest('base64')}'`);
+          }
+          let rewrote = false;
+          const updated = html.replace(
+            /(<meta http-equiv="content-security-policy" content=")([^"]*)(")/i,
+            (_, pre, /** @type {string} */ content, post) => {
+              rewrote = true;
+              const out = content
+                .split(';')
+                .map((d) => {
+                  const toks = d.trim().split(/\s+/).filter(Boolean);
+                  if (toks[0] !== 'script-src' && toks[0] !== 'style-src') return d.trim();
+                  const resources = toks.slice(1).filter((t) => !HASH.test(t));
+                  const add = toks[0] === 'script-src' ? [...hashes] : [];
+                  return [toks[0], ...resources, ...add].join(' ');
+                })
+                .filter(Boolean)
+                .join('; ');
+              return pre + out + post;
+            }
+          );
+          if (!rewrote) {
+            throw new Error(
+              `csp-inline-hashes: no CSP <meta> found in ${file} — did security.csp get disabled?`
+            );
+          }
+          writeFileSync(file, updated);
+        }
+      },
+    },
+  };
+}
+
 // Project page → https://ivanwng97.github.io/pixtuoid/
 // If a custom domain is later added, set base back to '/' (and update CNAME).
 export default defineConfig({
@@ -192,10 +263,43 @@ export default defineConfig({
     }),
   },
   // Sitemap respects `site` + `base`, so emitted URLs carry the /pixtuoid
-  // prefix → submit /pixtuoid/sitemap-index.xml to Search Console (this is a
-  // project page, so a repo-local robots.txt would serve under /pixtuoid/ and
-  // crawlers only read robots.txt from the origin root — see the PR notes).
-  integrations: [sitemap()],
+  // prefix → submit /pixtuoid/sitemap-index.xml to Search Console. A
+  // robots.txt pointing at it is prerendered by src/pages/robots.txt.ts —
+  // note it serves under /pixtuoid/ while crawlers only read robots.txt from
+  // the origin root, so it becomes authoritative only on a custom domain.
+  integrations: [sitemap(), cspInlineHashes()],
+  // Prefetch same-site links on hover — the docs pages are tiny static HTML,
+  // so hover-to-tap latency covers the fetch. The injected prefetch client is
+  // a BUNDLED external script (script-src 'self' covers it under the CSP).
+  // CSP, part 1 of 2: Astro's built-in CSP emits the <meta> into EVERY page's
+  // head (404 included) and owns the resource lists — the one thing it can't
+  // compute for this site is the is:inline script hashes, which the
+  // cspInlineHashes() integration above derives from the built html.
+  // script-src carries NO 'unsafe-inline' (hashes instead — the point of the
+  // exercise); 'wasm-unsafe-eval' permits WebAssembly.instantiate for the
+  // live-office hero (wasm compilation ONLY, not JS eval). style-src KEEPS
+  // 'unsafe-inline': Shiki spans, the mermaid inline SVG, and a few style={}
+  // attributes are inline STYLE ATTRIBUTES, which hashes cannot express (and
+  // any present hash would make browsers ignore 'unsafe-inline').
+  // frame-ancestors and SRI need HTTP headers GitHub Pages can't set. NOTE:
+  // security.csp is build/preview-only by design — `astro dev` serves no CSP.
+  security: {
+    csp: {
+      directives: [
+        "default-src 'self'",
+        "base-uri 'self'",
+        "object-src 'none'",
+        "img-src 'self' data:",
+        "media-src 'self'",
+        "font-src 'self'",
+        "connect-src 'self'",
+        "form-action 'self'",
+      ],
+      scriptDirective: { resources: ["'self'", "'wasm-unsafe-eval'"] },
+      styleDirective: { resources: ["'self'", "'unsafe-inline'"] },
+    },
+  },
+  prefetch: { prefetchAll: true, defaultStrategy: 'hover' },
   vite: {
     define: { __PIXTUOID_VERSION__: JSON.stringify(version) },
     // Never inline assets as data: URLs. Vite's default 4KiB inlining turned

--- a/site/config/csp-hashes.mjs
+++ b/site/config/csp-hashes.mjs
@@ -1,0 +1,70 @@
+// The CSP hash-rewrite kernel, extracted from astro.config.mjs so its delicate
+// string surgery is unit-testable (config/csp-hashes.test.mjs) and can't
+// silently diverge from the HTML tokenizer. astro.config.mjs's astro:build:done
+// hook walks dist/ and calls rewriteCspMeta() per page; the emitted policy is
+// byte-identical to the previous inline implementation on every current page
+// (proven by the e2e console-error watchdog against the production build). Only
+// the pathological future inputs the hardened regex now handles differ.
+import { createHash } from 'node:crypto';
+
+const HASH = /^'sha(256|384|512)-/;
+
+// Quote-aware opening tag: it ends at the first `>` that is NOT inside a quoted
+// attribute value. The old `<script(\s[^>]*)?>` truncated on `data-x="a>b"` and
+// hashed the wrong bytes, so a legal is:inline script would be CSP-blocked in
+// production only. Group 1 = the raw attribute list; group 2 = the exact bytes
+// between the tags (what the browser hashes).
+const SCRIPT_RE = /<script\b((?:[^>"']|"[^"]*"|'[^']*')*)>([\s\S]*?)<\/script>/gi;
+
+// A real `src` ATTRIBUTE (external script → rides 'self', no hash). Strip quoted
+// values first so a `src=` sitting inside another attribute's VALUE (e.g.
+// data-cmd="ffmpeg src=in.mp4") can't be mistaken for the attribute; the
+// `(?:^|\s)` boundary keeps `data-src=` from matching `src=`.
+function hasSrcAttr(attrs) {
+  return /(?:^|\s)src\s*=/i.test(attrs.replace(/"[^"]*"|'[^']*'/g, ''));
+}
+
+/**
+ * The set of `'sha256-…'` tokens for every inline <script> in `html`.
+ * @param {string} html
+ * @returns {Set<string>}
+ */
+export function inlineScriptHashes(html) {
+  const hashes = new Set();
+  for (const m of html.matchAll(SCRIPT_RE)) {
+    if (hasSrcAttr(m[1] ?? '')) continue;
+    hashes.add(`'sha256-${createHash('sha256').update(m[2], 'utf8').digest('base64')}'`);
+  }
+  return hashes;
+}
+
+/**
+ * Rewrite the CSP <meta>: re-derive script-src's inline-script hashes from the
+ * built HTML and strip ALL style-src hashes so the configured 'unsafe-inline'
+ * stays honored (one present hash disables it for the whole directive).
+ * @param {string} html
+ * @returns {string | null} the rewritten html, or null if no CSP <meta> exists
+ */
+export function rewriteCspMeta(html) {
+  const hashes = inlineScriptHashes(html);
+  let rewrote = false;
+  const updated = html.replace(
+    /(<meta http-equiv="content-security-policy" content=")([^"]*)(")/i,
+    (_, pre, /** @type {string} */ content, post) => {
+      rewrote = true;
+      const out = content
+        .split(';')
+        .map((d) => {
+          const toks = d.trim().split(/\s+/).filter(Boolean);
+          if (toks[0] !== 'script-src' && toks[0] !== 'style-src') return d.trim();
+          const resources = toks.slice(1).filter((t) => !HASH.test(t));
+          const add = toks[0] === 'script-src' ? [...hashes] : [];
+          return [toks[0], ...resources, ...add].join(' ');
+        })
+        .filter(Boolean)
+        .join('; ');
+      return pre + out + post;
+    }
+  );
+  return rewrote ? updated : null;
+}

--- a/site/config/csp-hashes.mjs
+++ b/site/config/csp-hashes.mjs
@@ -13,8 +13,11 @@ const HASH = /^'sha(256|384|512)-/;
 // attribute value. The old `<script(\s[^>]*)?>` truncated on `data-x="a>b"` and
 // hashed the wrong bytes, so a legal is:inline script would be CSP-blocked in
 // production only. Group 1 = the raw attribute list; group 2 = the exact bytes
-// between the tags (what the browser hashes).
-const SCRIPT_RE = /<script\b((?:[^>"']|"[^"]*"|'[^']*')*)>([\s\S]*?)<\/script>/gi;
+// between the tags (what the browser hashes). The end tag tolerates the
+// spec-legal trailing whitespace (`</script >`, `</script\n>`) — an unmatched
+// close would silently drop that script's hash → a prod-only CSP block
+// (CodeQL js/bad-tag-filter; the HTML tokenizer accepts `</script\s*>`).
+const SCRIPT_RE = /<script\b((?:[^>"']|"[^"]*"|'[^']*')*)>([\s\S]*?)<\/script\s*>/gi;
 
 // A real `src` ATTRIBUTE (external script → rides 'self', no hash). Strip quoted
 // values first so a `src=` sitting inside another attribute's VALUE (e.g.

--- a/site/config/csp-hashes.mjs
+++ b/site/config/csp-hashes.mjs
@@ -13,11 +13,14 @@ const HASH = /^'sha(256|384|512)-/;
 // attribute value. The old `<script(\s[^>]*)?>` truncated on `data-x="a>b"` and
 // hashed the wrong bytes, so a legal is:inline script would be CSP-blocked in
 // production only. Group 1 = the raw attribute list; group 2 = the exact bytes
-// between the tags (what the browser hashes). The end tag tolerates the
-// spec-legal trailing whitespace (`</script >`, `</script\n>`) — an unmatched
-// close would silently drop that script's hash → a prod-only CSP block
-// (CodeQL js/bad-tag-filter; the HTML tokenizer accepts `</script\s*>`).
-const SCRIPT_RE = /<script\b((?:[^>"']|"[^"]*"|'[^']*')*)>([\s\S]*?)<\/script\s*>/gi;
+// between the tags (what the browser hashes). The end tag matches everything a
+// browser treats as a script close — not just `</script>` but the parser-error
+// forms `</script >`, `</script\n>`, and `</script foo="bar">` (a browser ends
+// the script there anyway). An unmatched close would silently drop that
+// script's hash → a prod-only CSP block, and leaving content past a fake-strict
+// `</script>` unhashed is the CodeQL js/bad-tag-filter primitive; `[^>]*`
+// swallows the garbage up to the real `>`.
+const SCRIPT_RE = /<script\b((?:[^>"']|"[^"]*"|'[^']*')*)>([\s\S]*?)<\/script[^>]*>/gi;
 
 // A real `src` ATTRIBUTE (external script → rides 'self', no hash). Strip quoted
 // values first so a `src=` sitting inside another attribute's VALUE (e.g.

--- a/site/config/csp-hashes.test.mjs
+++ b/site/config/csp-hashes.test.mjs
@@ -18,6 +18,11 @@ test('a > inside a quoted attribute value does not truncate the content', () => 
   assert.ok(!h.has(sha('b">doWork()')));
 });
 
+test('a spec-legal whitespace end tag </script > still matches (js/bad-tag-filter)', () => {
+  assert.ok(inlineScriptHashes('<script>doWork()</script >').has(sha('doWork()')));
+  assert.ok(inlineScriptHashes('<script>doWork()</script\n>').has(sha('doWork()')));
+});
+
 test('src= inside another attribute value is not treated as a real src', () => {
   const h = inlineScriptHashes('<script data-cmd="ffmpeg src=in.mp4">go()</script>');
   assert.ok(h.has(sha('go()')), 'the inline script must still be hashed');

--- a/site/config/csp-hashes.test.mjs
+++ b/site/config/csp-hashes.test.mjs
@@ -18,9 +18,13 @@ test('a > inside a quoted attribute value does not truncate the content', () => 
   assert.ok(!h.has(sha('b">doWork()')));
 });
 
-test('a spec-legal whitespace end tag </script > still matches (js/bad-tag-filter)', () => {
+test('parser-error end tags a browser still honors match (js/bad-tag-filter)', () => {
+  // A browser ends the script at each of these; if our regex didn't, the
+  // trailing content would ship unhashed → prod-only CSP block.
   assert.ok(inlineScriptHashes('<script>doWork()</script >').has(sha('doWork()')));
   assert.ok(inlineScriptHashes('<script>doWork()</script\n>').has(sha('doWork()')));
+  assert.ok(inlineScriptHashes('<script>doWork()</script foo="bar">').has(sha('doWork()')));
+  assert.ok(inlineScriptHashes('<script>doWork()</script\t\n bar>').has(sha('doWork()')));
 });
 
 test('src= inside another attribute value is not treated as a real src', () => {

--- a/site/config/csp-hashes.test.mjs
+++ b/site/config/csp-hashes.test.mjs
@@ -1,0 +1,47 @@
+// Unit tests for the CSP hash kernel — the edge cases the e2e watchdog can only
+// catch indirectly (and only on pages the smoke suite exercises). `node --test`
+// runs .mjs natively; wired into `npm run verify` (→ `just site-check`).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { inlineScriptHashes, rewriteCspMeta } from './csp-hashes.mjs';
+
+const sha = (s) => `'sha256-${createHash('sha256').update(s, 'utf8').digest('base64')}'`;
+
+test('hashes inline script content verbatim', () => {
+  assert.ok(inlineScriptHashes('<script>doWork()</script>').has(sha('doWork()')));
+});
+
+test('a > inside a quoted attribute value does not truncate the content', () => {
+  const h = inlineScriptHashes('<script is:inline data-note="a>b">doWork()</script>');
+  assert.ok(h.has(sha('doWork()')), 'must hash the real content, not b">doWork()');
+  assert.ok(!h.has(sha('b">doWork()')));
+});
+
+test('src= inside another attribute value is not treated as a real src', () => {
+  const h = inlineScriptHashes('<script data-cmd="ffmpeg src=in.mp4">go()</script>');
+  assert.ok(h.has(sha('go()')), 'the inline script must still be hashed');
+});
+
+test('a real src attribute skips the script (external, rides self)', () => {
+  assert.equal(inlineScriptHashes('<script src="/app.js"></script>').size, 0);
+});
+
+test('data-src is not mistaken for src', () => {
+  assert.ok(inlineScriptHashes('<script data-src="x">run()</script>').has(sha('run()')));
+});
+
+test('rewriteCspMeta injects script hashes and strips style hashes', () => {
+  const html =
+    '<meta http-equiv="content-security-policy" content="script-src \'self\'; ' +
+    "style-src 'self' 'unsafe-inline' 'sha256-OLD'\">" +
+    '<script>x()</script>';
+  const out = rewriteCspMeta(html);
+  assert.ok(out.includes(sha('x()')), 'script-src gains the inline hash');
+  assert.ok(!out.includes("'sha256-OLD'"), 'style-src hashes are dropped');
+  assert.ok(out.includes("style-src 'self' 'unsafe-inline'"), "'unsafe-inline' survives hash-free");
+});
+
+test('rewriteCspMeta returns null when no CSP meta is present', () => {
+  assert.equal(rewriteCspMeta('<html></html>'), null);
+});

--- a/site/config/theme-bg.test.mjs
+++ b/site/config/theme-bg.test.mjs
@@ -1,0 +1,58 @@
+// THEME_BG (consts.ts, seeded into __pixTheme.BG for the mobile browser-chrome
+// <meta theme-color>) MIRRORS global.css's per-theme `--bg`, a CSS↔JS pairing
+// that can't share a literal. Rule-2 (magic values that cross a boundary get a
+// match-test, not just a "retune together" comment): this asserts they agree,
+// so a one-sided retune fails `just site-check` instead of shipping a mobile
+// chrome tint that disagrees with the painted background.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const read = (rel) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)), 'utf8');
+const consts = read('../src/consts.ts');
+const css = read('../src/styles/global.css');
+
+/** THEME_BG = { day: '#f4eee2', ... } → Map(id → hex). */
+function themeBg() {
+  const body = consts.match(/THEME_BG\s*:\s*Record<[^>]*>\s*=\s*\{([\s\S]*?)\}/);
+  assert.ok(body, 'THEME_BG object literal not found in consts.ts');
+  const map = new Map();
+  for (const m of body[1].matchAll(/(\w+)\s*:\s*'(#[0-9a-fA-F]{3,8})'/g))
+    map.set(m[1], m[2].toLowerCase());
+  return map;
+}
+
+/** The value a `--bg` resolves to for a theme, following one `var(--x)` hop. */
+function cssBg(varDecls, raw) {
+  const v = raw.trim();
+  const hop = v.match(/^var\((--[\w-]+)\)$/);
+  return (hop ? varDecls.get(hop[1]) : v)?.toLowerCase();
+}
+
+test('THEME_BG mirrors global.css --bg for every theme', () => {
+  // collect every `--name: value;` custom-prop declaration (last wins, as in CSS)
+  const decls = new Map();
+  for (const m of css.matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g)) decls.set(m[1], m[2].trim());
+
+  // per-theme --bg: day from the BASE `:root {` block (not the flat last-wins
+  // map — `--bg` is redefined per theme), each other from its
+  // `:root[data-theme='x']` block.
+  const base = css.match(/:root\s*\{([\s\S]*?)\}/);
+  assert.ok(base, 'base :root block not found');
+  const dayBg = base[1].match(/--bg\s*:\s*([^;]+);/);
+  assert.ok(dayBg, 'base :root has no --bg');
+  const bgFor = { day: cssBg(decls, dayBg[1]) };
+  for (const m of css.matchAll(/\[data-theme=['"](\w+)['"]\]\s*\{([\s\S]*?)\}/g)) {
+    const inner = m[2].match(/--bg\s*:\s*([^;]+);/);
+    if (inner) bgFor[m[1]] = cssBg(decls, inner[1]);
+  }
+
+  for (const [id, hex] of themeBg()) {
+    assert.equal(
+      bgFor[id],
+      hex,
+      `THEME_BG.${id} (${hex}) must equal global.css --bg for ${id} (${bgFor[id]})`
+    );
+  }
+});

--- a/site/package.json
+++ b/site/package.json
@@ -16,7 +16,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "knip": "knip",
-    "verify": "npm run format:check && npm run lint && npm run check && npm run knip && npm run build",
+    "test:unit": "node --test \"config/**/*.test.mjs\"",
+    "verify": "npm run format:check && npm run lint && npm run check && npm run knip && npm run test:unit && npm run build",
     "lighthouse": "lhci autorun",
     "e2e": "playwright test"
   },

--- a/site/playwright.config.ts
+++ b/site/playwright.config.ts
@@ -29,6 +29,10 @@ export default defineConfig({
     // reuseExistingServer would then silently test the ORPHAN'S stale build
     // (caught by this suite's own teeth test). reuse stays false for the same
     // reason: a squatted port must fail loud, never quietly test old bytes.
+    // Readiness stays Playwright's URL poll: Astro 7's /_astro/status health
+    // endpoint is DEV-SERVER-ONLY — verified vs 7.0.5, `astro preview` 404s it
+    // (and preview has no --background/stop either; those are `astro dev`
+    // subcommands, adopted in `just site-dev-bg`/`site-dev-stop`).
     command: 'node node_modules/astro/bin/astro.mjs preview --port 4321',
     url: 'http://localhost:4321/pixtuoid/',
     reuseExistingServer: false,

--- a/site/src/components/ChannelStage.astro
+++ b/site/src/components/ChannelStage.astro
@@ -27,6 +27,15 @@ const imgAlt = defVariant ? `pixtuoid office — ${defVariant.name} (${c.label.t
     <span class="terminal__title" data-stage-title>{title}</span>
   </div>
   {
+    /* No `autoplay`: it overrides preload="metadata" and eagerly downloads the
+      whole (below-the-fold) webm at page load. The IntersectionObserver play
+      policy in Showcase.astro already play()s the tuned+visible clip, so
+      autoplay bought nothing for JS visitors while costing ~294KB. Trade-off: a
+      no-JS visitor sees the poster instead of a playing clip (acceptable — the
+      dial/OSD are JS-only anyway). Hidden channels defer their poster too
+      (data-poster → hydrate()), so only the active poster is fetched at load. */
+  }
+  {
     isClip ? (
       <video
         class="terminal__screen px"
@@ -36,8 +45,8 @@ const imgAlt = defVariant ? `pixtuoid office — ${defVariant.name} (${c.label.t
         loop
         playsinline
         preload={active ? 'metadata' : 'none'}
-        autoplay={active}
-        poster={asset(`demos/${c.asset}-poster.png`)}
+        poster={active ? asset(`demos/${c.asset}-poster.png`) : undefined}
+        data-poster={active ? undefined : asset(`demos/${c.asset}-poster.png`)}
         data-mp4={active ? undefined : asset(`demos/${c.asset}.mp4`)}
         data-webm={active ? undefined : asset(`demos/${c.asset}.webm`)}
         aria-label={`pixtuoid demo: ${c.caption}`}

--- a/site/src/components/Features.astro
+++ b/site/src/components/Features.astro
@@ -1,5 +1,8 @@
 ---
 import features from '../features.json';
+import { floorByNumber } from '../consts';
+
+const floor = floorByNumber(4);
 
 // Single source of truth: site/src/features.json — the SAME list the README
 // Features table is generated from (scripts/gen-readme.mjs), so the
@@ -19,10 +22,10 @@ const cells = features.flatMap((f) =>
 );
 ---
 
-<section id="features" class="features" data-lit data-floor="4">
+<section id={floor.id} class="features" data-lit data-floor={floor.n}>
   <div class="container">
     <div class="section-head reveal">
-      <p class="eyebrow">4F · amenities — the office is alive</p>
+      <p class="eyebrow">{floor.n}F · {floor.name} — the office is alive</p>
       <h2 class="statement statement--md">Not a dashboard.<br />A little world.</h2>
       <p class="lead">
         pixtuoid renders your agents as coworkers in a top-down pixel office — with the small

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -1,8 +1,10 @@
 ---
-import { REPO } from '../consts';
+import { REPO, floorByNumber } from '../consts';
+
+const floor = floorByNumber(6);
 ---
 
-<section id="lobby" class="hero" data-floor="6">
+<section id={floor.id} class="hero" data-floor={floor.n}>
   {
     /* The title card: the live office (page-wide backdrop) is fully lit at
       scroll-0; the statement sits bottom-left, film-title style, and pulls
@@ -13,7 +15,7 @@ import { REPO } from '../consts';
   <canvas id="dust" class="dust" aria-hidden="true"></canvas>
   <div class="container hero__frame">
     <div class="hero__copy" data-lit="fade">
-      <p class="eyebrow">6F · penthouse — terminal-native, open&nbsp;source</p>
+      <p class="eyebrow">{floor.n}F · {floor.name} — terminal-native, open&nbsp;source</p>
       <h1 class="statement">
         Your agents<br />
         <span class="hl">work here</span><span class="cursor" aria-hidden="true"></span>
@@ -163,7 +165,8 @@ import { REPO } from '../consts';
     }
     let raf = 0,
       on = false,
-      visible = false;
+      visible = false,
+      userPaused = false;
     function frame() {
       ctx.clearRect(0, 0, W, H);
       for (let i = 0; i < motes.length; i++) {
@@ -183,7 +186,7 @@ import { REPO } from '../consts';
       raf = requestAnimationFrame(frame);
     }
     function start() {
-      if (on || mq.matches || !visible) return;
+      if (on || mq.matches || !visible || userPaused) return;
       on = true;
       raf = requestAnimationFrame(frame);
     }
@@ -222,5 +225,11 @@ import { REPO } from '../consts';
         if (mq.matches) stop();
         else start();
       });
+    // the office pause switch governs page motion (WCAG 2.2.2) — hold the dust too
+    document.addEventListener('pix:paused', function (e) {
+      userPaused = !!(e.detail && e.detail.paused);
+      if (userPaused) stop();
+      else start();
+    });
   })();
 </script>

--- a/site/src/components/HowItWorks.astro
+++ b/site/src/components/HowItWorks.astro
@@ -1,6 +1,7 @@
 ---
-import { asset } from '../consts';
+import { asset, floorByNumber } from '../consts';
 
+const floor = floorByNumber(3);
 const steps = [
   {
     n: '01',
@@ -23,10 +24,10 @@ const steps = [
 ];
 ---
 
-<section id="how" class="how" data-lit data-floor="3">
+<section id={floor.id} class="how" data-lit data-floor={floor.n}>
   <div class="container">
     <div class="section-head reveal">
-      <p class="eyebrow">3F · machine room — launch, connect, code</p>
+      <p class="eyebrow">{floor.n}F · {floor.name} — launch, connect, code</p>
       <h2 class="statement statement--md">Up and running<br />in a minute.</h2>
     </div>
     <ol class="how__steps">

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -1,6 +1,8 @@
 ---
 import { Code } from 'astro:components';
-import { REPO, CRATES } from '../consts';
+import { REPO, CRATES, floorByNumber } from '../consts';
+
+const floor = floorByNumber(1);
 // Single source of truth for install commands → site/src/install.json. The README
 // regenerates its install block from the same file (gen-readme-check), so the site and
 // README can't drift — the site shows every method, the README only the ones
@@ -8,10 +10,10 @@ import { REPO, CRATES } from '../consts';
 import tabs from '../install.json';
 ---
 
-<section id="install" class="install" data-lit data-floor="1">
+<section id={floor.id} class="install" data-lit data-floor={floor.n}>
   <div class="container">
     <div class="section-head reveal">
-      <p class="eyebrow">1F · front desk — get it</p>
+      <p class="eyebrow">{floor.n}F · {floor.name} — get it</p>
       <h2 class="statement statement--md">Move them in.</h2>
       <p class="lead">
         macOS, Linux &amp; Windows. Install, run <code>pixtuoid</code>, and the office opens.
@@ -42,9 +44,14 @@ import tabs from '../install.json';
             data-panel={t.id}
           >
             <Code code={t.cmds.join('\n')} lang="bash" theme="vesper" />
-            <button class="install__copy" data-copy={t.cmds.join('\n')} aria-label="Copy command">
+            {/* no aria-label: the visible "Copy" text IS the accessible name, so
+              the textContent swap stays exposed. The role=status sibling
+              ANNOUNCES the outcome to screen readers (a name change alone isn't
+              announced) — WCAG 4.1.3. */}
+            <button class="install__copy" data-copy={t.cmds.join('\n')}>
               Copy
             </button>
+            <span class="sr-only" role="status" data-copy-status />
           </div>
         ))
       }
@@ -79,11 +86,15 @@ import tabs from '../install.json';
       // capture the resting label ONCE — not after a click, or a rapid second
       // click would capture 'Copied ✓' and the button would stick on it
       const LABEL = (btn.textContent || 'Copy').trim();
-      function flash(msg) {
-        btn.textContent = msg;
+      const status = btn.parentElement && btn.parentElement.querySelector('[data-copy-status]');
+      // visible label swap (sighted) + a role=status announcement (screen reader)
+      function flash(label, announce) {
+        btn.textContent = label;
+        if (status) status.textContent = announce;
         clearTimeout(restore); // a fresh click cancels the previous restore timer
         restore = setTimeout(function () {
           btn.textContent = LABEL;
+          if (status) status.textContent = '';
         }, 1600);
       }
       function manual() {
@@ -97,7 +108,7 @@ import tabs from '../install.json';
           sel.removeAllRanges();
           sel.addRange(range);
         }
-        flash('Select & copy');
+        flash('Select & copy', 'Press Ctrl+C to copy the selected command');
       }
       btn.addEventListener('click', function () {
         // #434: hiring is the click's diegetic echo — a new coworker walks
@@ -110,7 +121,7 @@ import tabs from '../install.json';
         navigator.clipboard
           .writeText(btn.dataset.copy)
           .then(function () {
-            flash('Copied ✓');
+            flash('Copied ✓', 'Copied to clipboard');
           })
           .catch(manual);
       });
@@ -119,6 +130,17 @@ import tabs from '../install.json';
 </script>
 
 <style>
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
   .install__box {
     max-width: 860px;
   }

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -1,5 +1,5 @@
 ---
-import { REPO, SPONSOR, asset } from '../consts';
+import { REPO, SPONSOR, asset, DOCS } from '../consts';
 // Absolute home so the section anchors work from any page (e.g. /config).
 const home = asset('');
 // `floating` = the OPEN FLOOR index treatment (corner chrome over the live
@@ -39,12 +39,7 @@ const { floating = false } = Astro.props;
           Docs <span aria-hidden="true">▾</span>
         </button>
         <div id="docs-menu" class="nav__menu">
-          <a href={asset('architecture')}>Architecture</a>
-          <a href={asset('config')}>Config</a>
-          <a href={asset('contributing')}>Contributing</a>
-          <a href={asset('knowledge-base')}>Knowledge engineering</a>
-          <a href={asset('parallel-delivery')}>Parallel delivery</a>
-          <a href={asset('migration')}>Migration</a>
+          {DOCS.map((d) => <a href={asset(d.route)}>{d.label}</a>)}
         </div>
       </div>
       <a href={REPO} target="_blank" rel="noreferrer">GitHub ↗</a>
@@ -98,72 +93,68 @@ const { floating = false } = Astro.props;
         const next = root.dataset.theme === 'night' ? 'day' : 'night';
         root.dataset.theme = next;
         try {
-          localStorage.setItem('pix-theme', next);
+          localStorage.setItem(window.__pixTheme.KEY, next);
         } catch (e) {}
         // notify listeners (Nav icon sync, gallery chip reset, theme-color meta)
         // — the same event the dracula egg / Escape dispatch from Base.astro
         document.dispatchEvent(new CustomEvent('pix:theme'));
       });
 
-    // mobile hamburger → toggle the nav-links dropdown
-    const burger = document.getElementById('nav-burger');
-    const links = document.getElementById('nav-links');
-    const bicon = burger && burger.querySelector('.nav__burger-icon');
-    if (burger && links) {
-      const setMenu = function (open) {
-        links.classList.toggle('is-open', open);
-        burger.setAttribute('aria-expanded', open ? 'true' : 'false');
-        if (bicon) bicon.textContent = open ? '✕' : '☰';
+    // One disclosure wiring for both the burger menu and the Docs dropdown (the
+    // 5-part toggle/close/Escape-focus-return pattern was duplicated). `icon*`
+    // flips the burger glyph; `focusFirst` moves focus into the revealed panel
+    // so a menu that renders BELOW its trigger still follows it in tab order
+    // (WCAG 2.4.3) — the Escape branch returns focus to the trigger either way.
+    function wireDisclosure(trigger, panel, opts) {
+      opts = opts || {};
+      const isOpen = function () {
+        return panel.classList.contains('is-open');
       };
-      burger.addEventListener('click', function (e) {
+      const set = function (open) {
+        panel.classList.toggle('is-open', open);
+        trigger.setAttribute('aria-expanded', open ? 'true' : 'false');
+        if (opts.icon) opts.icon.textContent = open ? opts.iconOpen : opts.iconClosed;
+        if (open && opts.focusFirst) {
+          const first = panel.querySelector('a, button');
+          if (first) first.focus();
+        }
+      };
+      trigger.addEventListener('click', function (e) {
         e.stopPropagation();
-        setMenu(!links.classList.contains('is-open'));
+        set(!isOpen());
       });
-      links.querySelectorAll('a').forEach(function (a) {
+      panel.querySelectorAll('a').forEach(function (a) {
         a.addEventListener('click', function () {
-          setMenu(false);
+          set(false);
         });
       });
       document.addEventListener('keydown', function (e) {
-        if (e.key !== 'Escape' || !links.classList.contains('is-open')) return;
-        // if focus was inside the menu, return it to the burger so closing the
-        // dropdown (display:none) doesn't drop focus to <body> (WCAG 2.4.3)
-        const focusInMenu = links.contains(document.activeElement);
-        setMenu(false);
-        if (focusInMenu) burger.focus();
+        if (e.key !== 'Escape' || !isOpen()) return;
+        // if focus was inside the panel, return it to the trigger so closing the
+        // panel (display:none) doesn't drop focus to <body> (WCAG 2.4.3)
+        const inside = panel.contains(document.activeElement);
+        set(false);
+        if (inside) trigger.focus();
       });
       document.addEventListener('click', function (e) {
-        if (!links.contains(e.target) && !burger.contains(e.target)) setMenu(false);
+        if (!panel.contains(e.target) && !trigger.contains(e.target)) set(false);
       });
     }
 
-    // desktop "Docs" dropdown (on mobile its items render flat in the burger panel)
+    // mobile hamburger → the nav-links dropdown; desktop "Docs" dropdown (on
+    // mobile the Docs items render flat inside the burger panel)
+    const burger = document.getElementById('nav-burger');
+    const links = document.getElementById('nav-links');
+    if (burger && links)
+      wireDisclosure(burger, links, {
+        icon: burger.querySelector('.nav__burger-icon'),
+        iconOpen: '✕',
+        iconClosed: '☰',
+        focusFirst: true,
+      });
     const docsBtn = document.getElementById('docs-btn');
     const docsMenu = document.getElementById('docs-menu');
-    if (docsBtn && docsMenu) {
-      const setDocs = function (open) {
-        docsMenu.classList.toggle('is-open', open);
-        docsBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      };
-      docsBtn.addEventListener('click', function (e) {
-        e.stopPropagation();
-        setDocs(!docsMenu.classList.contains('is-open'));
-      });
-      docsMenu.querySelectorAll('a').forEach(function (a) {
-        a.addEventListener('click', function () {
-          setDocs(false);
-        });
-      });
-      document.addEventListener('keydown', function (e) {
-        if (e.key !== 'Escape' || !docsMenu.classList.contains('is-open')) return;
-        const inMenu = docsMenu.contains(document.activeElement);
-        setDocs(false);
-        if (inMenu) docsBtn.focus(); // don't drop focus to <body> (WCAG 2.4.3)
-      });
-      document.addEventListener('click', function (e) {
-        if (!docsMenu.contains(e.target) && !docsBtn.contains(e.target)) setDocs(false);
-      });
-    }
+    if (docsBtn && docsMenu) wireDisclosure(docsBtn, docsMenu);
   })();
 </script>
 

--- a/site/src/components/OfficeBackdrop.astro
+++ b/site/src/components/OfficeBackdrop.astro
@@ -34,6 +34,32 @@ import { asset } from '../consts';
      style.opacity write), never pauses the canvas. */
 }
 <div id="dimmer" aria-hidden="true"></div>
+{
+  /* THE PAUSE SWITCH (WCAG 2.2.2) — a real, keyboard-reachable <button> for
+     the auto-playing office; hidden until the canvas actually goes live (the
+     poster-only paths — reduced motion, no wasm, fetch failure — have nothing
+     to pause). aria-pressed carries the state; the label stays constant
+     (toggle-button convention). Icons are inline pixel SVGs on an 8×8 grid
+     (crispEdges — no anti-aliased glyph fonts near the office's pixels). */
+}
+<button
+  id="office-pause"
+  class="office-ctl"
+  hidden
+  aria-pressed="false"
+  aria-label="Pause the office animation"
+>
+  <svg class="office-ctl__pause" viewBox="0 0 8 8" shape-rendering="crispEdges" aria-hidden="true">
+    <rect x="1" y="1" width="2" height="6"></rect>
+    <rect x="5" y="1" width="2" height="6"></rect>
+  </svg>
+  <svg class="office-ctl__play" viewBox="0 0 8 8" shape-rendering="crispEdges" aria-hidden="true">
+    <rect x="2" y="1" width="1" height="7"></rect>
+    <rect x="3" y="2" width="1" height="5"></rect>
+    <rect x="4" y="3" width="1" height="3"></rect>
+    <rect x="5" y="4" width="1" height="1"></rect>
+  </svg>
+</button>
 
 <style is:global>
   /* The fixed canvas sits at z:-1; the body's opaque background would hide
@@ -84,6 +110,64 @@ import { asset } from '../consts';
       opacity: 0.55 !important;
     }
   }
+  /* The pause switch: 8-bit hardware — square, hard edges, a 1px offset
+     "casing" shadow, icons at an integer 3x of their 8×8 grid. Sits just
+     above the statusline, out of the dimmer's reach (fixed chrome, like the
+     statusline itself). Translucent at rest so it reads as part of the
+     office; solid on hover/focus and while paused (a frozen office must
+     announce why). */
+  /* the class display beats [hidden]'s UA rule — restate it (same trap as
+     the statusline's .sl__floors[hidden]) */
+  .office-ctl[hidden] {
+    display: none;
+  }
+  .office-ctl {
+    position: fixed;
+    right: 10px;
+    bottom: calc(2rem + env(safe-area-inset-bottom, 0px) + 10px);
+    z-index: 50;
+    width: 36px;
+    height: 36px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    background: var(--screen);
+    border: 2px solid var(--chip-line);
+    border-radius: 0;
+    box-shadow: 2px 2px 0 rgba(0, 0, 0, 0.45);
+    color: var(--chip-bright);
+    cursor: pointer;
+    opacity: 0.45;
+    transition: opacity 0.15s ease;
+  }
+  .office-ctl:hover,
+  .office-ctl:focus-visible,
+  .office-ctl[aria-pressed='true'] {
+    opacity: 1;
+  }
+  .office-ctl:focus-visible {
+    outline: 2px solid var(--focus-ring);
+    outline-offset: 2px;
+    border-radius: 0; /* the global :focus-visible rounds 3px — keep the pixel edge */
+  }
+  .office-ctl:active {
+    transform: translate(1px, 1px);
+    box-shadow: 1px 1px 0 rgba(0, 0, 0, 0.45);
+  }
+  .office-ctl svg {
+    width: 24px;
+    height: 24px;
+    fill: currentColor;
+  }
+  .office-ctl .office-ctl__play,
+  .office-ctl[aria-pressed='true'] .office-ctl__pause {
+    display: none;
+  }
+  .office-ctl[aria-pressed='true'] .office-ctl__play {
+    display: block;
+    color: var(--led);
+  }
 </style>
 
 <script is:inline define:vars={{ wasmJsUrl: asset('wasm/pixtuoid_web.js') }}>
@@ -110,6 +194,18 @@ import { asset } from '../consts';
     let raf = 0;
     let last = 0;
     let live = false;
+    // The pause switch (#office-pause). While paused the rAF loop is simply
+    // not scheduled — the last frame stays on the canvas. `pauseOffset` is the
+    // total user-paused time: the sim clock runs `Date.now() - pauseOffset`,
+    // so resuming continues from the frozen moment instead of lurch-jumping
+    // the timeline forward. (Tab-hidden stops take NO offset on purpose — the
+    // office keeps living while you're away; only an explicit pause freezes
+    // its clock. Cost: the engine's wall-clock day/night lags by the total
+    // paused time — invisible at human pause scales.)
+    const pauseBtn = document.getElementById('office-pause');
+    let paused = false;
+    let pauseOffset = 0;
+    let pausedAt = 0;
 
     function sizeBuffer() {
       const w = window.innerWidth;
@@ -121,6 +217,27 @@ import { asset } from '../consts';
       img = new ImageData(bufW, BUF_H);
     }
 
+    function paint(nowMs) {
+      office.step(nowMs, bufW, BUF_H);
+      // Re-read ptr/len EVERY frame (resize reallocates; memory.grow
+      // invalidates views) and copy into the reusable ImageData.
+      const view = new Uint8ClampedArray(
+        wasm.memory.buffer,
+        office.frame_ptr(),
+        office.frame_len()
+      );
+      if (view.length === img.data.length) {
+        img.data.set(view);
+        ctx2d.putImageData(img, 0, 0);
+        if (!live) {
+          live = true;
+          wrap.classList.add('is-live');
+          if (pauseBtn) pauseBtn.hidden = false; // there is now something to pause
+          document.dispatchEvent(new CustomEvent('pix:onair', { detail: { live: true } }));
+        }
+      }
+    }
+
     function frame(t) {
       raf = 0;
       if (document.hidden) return;
@@ -128,34 +245,34 @@ import { asset } from '../consts';
         last = t;
         // Date.now(), NOT the rAF timestamp: the engine decodes now_ms as
         // calendar time (browser-local day/night + wall clock).
-        office.step(Date.now(), bufW, BUF_H);
-        // Re-read ptr/len EVERY frame (resize reallocates; memory.grow
-        // invalidates views) and copy into the reusable ImageData.
-        const view = new Uint8ClampedArray(
-          wasm.memory.buffer,
-          office.frame_ptr(),
-          office.frame_len()
-        );
-        if (view.length === img.data.length) {
-          img.data.set(view);
-          ctx2d.putImageData(img, 0, 0);
-          if (!live) {
-            live = true;
-            wrap.classList.add('is-live');
-            document.dispatchEvent(new CustomEvent('pix:onair', { detail: { live: true } }));
-          }
-        }
+        paint(Date.now() - pauseOffset);
       }
       raf = requestAnimationFrame(frame);
     }
     function start() {
-      if (!raf && office && !document.hidden && !mq.matches) {
+      if (!raf && office && !document.hidden && !mq.matches && !paused) {
         raf = requestAnimationFrame(frame);
       }
     }
     function stop() {
       if (raf) cancelAnimationFrame(raf);
       raf = 0;
+    }
+    function setPaused(p) {
+      paused = p;
+      if (pauseBtn) pauseBtn.setAttribute('aria-pressed', String(p));
+      if (p) {
+        pausedAt = Date.now();
+        stop();
+      } else {
+        pauseOffset += Date.now() - pausedAt;
+        start();
+      }
+    }
+    if (pauseBtn) {
+      pauseBtn.addEventListener('click', function () {
+        setPaused(!paused);
+      });
     }
 
     // Reduced motion defers the wasm fetch entirely (still poster only) —
@@ -198,6 +315,9 @@ import { asset } from '../consts';
       rraf = requestAnimationFrame(function () {
         rraf = 0;
         sizeBuffer();
+        // Setting canvas.width WIPES the bitmap: while paused no loop will
+        // repaint it, so re-render the ONE frozen frame at its frozen time.
+        if (paused && live) paint(pausedAt - pauseOffset);
       });
     });
     document.addEventListener('visibilitychange', function () {
@@ -208,6 +328,15 @@ import { asset } from '../consts';
       mq.addEventListener('change', function () {
         if (mq.matches) {
           stop();
+          // Reduced motion takes over as the poster-still design: the pause
+          // switch has nothing left to pause — reset it and hide it (a later
+          // un-reduce re-boots into the PLAYING state, button re-shown by the
+          // first painted frame).
+          paused = false;
+          if (pauseBtn) {
+            pauseBtn.setAttribute('aria-pressed', 'false');
+            pauseBtn.hidden = true;
+          }
           wrap.classList.remove('is-live');
           live = false;
           document.dispatchEvent(new CustomEvent('pix:onair', { detail: { live: false } }));

--- a/site/src/components/OfficeBackdrop.astro
+++ b/site/src/components/OfficeBackdrop.astro
@@ -1,5 +1,5 @@
 ---
-import { asset } from '../consts';
+import { asset, DIM_RESTING } from '../consts';
 ---
 
 {
@@ -33,7 +33,12 @@ import { asset } from '../consts';
      when a statement owns the viewport center. Compositor-only (a single
      style.opacity write), never pauses the canvas. */
 }
-<div id="dimmer" aria-hidden="true"></div>
+{
+  /* --dim-rest single-sources the resting opacity with consts DIM_RESTING (also
+   the statusline's 'lights N%' readout) — a JS↔CSS value that can't share a
+   literal, so it rides an inline custom property both #dimmer rules read. */
+}
+<div id="dimmer" aria-hidden="true" style={`--dim-rest:${DIM_RESTING}`}></div>
 {
   /* THE PAUSE SWITCH (WCAG 2.2.2) — a real, keyboard-reachable <button> for
      the auto-playing office; hidden until the canvas actually goes live (the
@@ -99,7 +104,7 @@ import { asset } from '../consts';
     inset: 0;
     z-index: -1;
     background: var(--bg);
-    opacity: 0.55; /* pre-JS / reduced-motion resting level: constant AA */
+    opacity: var(--dim-rest); /* pre-JS / reduced-motion resting level (consts DIM_RESTING) */
     pointer-events: none;
   }
   /* Reduced motion is a complete parallel design: the office is the still
@@ -107,7 +112,7 @@ import { asset } from '../consts';
      animates. (The controller also early-returns.) */
   @media (prefers-reduced-motion: reduce) {
     #dimmer {
-      opacity: 0.55 !important;
+      opacity: var(--dim-rest) !important;
     }
   }
   /* The pause switch: 8-bit hardware — square, hard edges, a 1px offset
@@ -261,6 +266,10 @@ import { asset } from '../consts';
     function setPaused(p) {
       paused = p;
       if (pauseBtn) pauseBtn.setAttribute('aria-pressed', String(p));
+      // fan the pause out to every OTHER >5s auto-motion surface — the statusline
+      // feed ticker and the hero dust — so ONE control governs page motion
+      // (WCAG 2.2.2 covers the whole page, not just this canvas).
+      document.dispatchEvent(new CustomEvent('pix:paused', { detail: { paused: p } }));
       if (p) {
         pausedAt = Date.now();
         stop();
@@ -307,7 +316,23 @@ import { asset } from '../consts';
           /* the still poster stays — the building simply doesn't go live */
         });
     }
-    if (!mq.matches) boot();
+    // Defer the ~740KB wasm fetch OUT of the render-critical window: kick it
+    // after `load`, at idle, so it stops competing with the above-fold poster /
+    // fonts / CSS (LCP is the H1 text). The poster is the instant layer; the
+    // canvas crossfades in whenever the first frame lands (~0.5–1s later on fast
+    // links — no visual change). Reduced motion still defers entirely; a live
+    // un-reduce boots promptly via the mq listener below.
+    function deferBoot() {
+      if (mq.matches) return;
+      (
+        window.requestIdleCallback ||
+        function (fn) {
+          return setTimeout(fn, 200);
+        }
+      )(boot);
+    }
+    if (document.readyState === 'complete') deferBoot();
+    else window.addEventListener('load', deferBoot, { once: true });
 
     let rraf = 0;
     window.addEventListener('resize', function () {
@@ -337,6 +362,10 @@ import { asset } from '../consts';
             pauseBtn.setAttribute('aria-pressed', 'false');
             pauseBtn.hidden = true;
           }
+          // clear any user-pause so the statusline feed / hero dust aren't stuck
+          // paused after a later un-reduce (they hold their OWN reduced-motion
+          // stop; this only keeps the pause flag in sync across surfaces)
+          document.dispatchEvent(new CustomEvent('pix:paused', { detail: { paused: false } }));
           wrap.classList.remove('is-live');
           live = false;
           document.dispatchEvent(new CustomEvent('pix:onair', { detail: { live: false } }));
@@ -427,20 +456,27 @@ import { asset } from '../consts';
       raf = requestAnimationFrame(frame);
     }
 
+    // Re-measure listeners are registered UNCONDITIONALLY (not behind the
+    // reduced-motion gate): a page loaded reduced then un-reduced mid-session
+    // must not run the controller forever on the single stale snapshot the
+    // un-reduce branch measured — every subsequent resize/rotation/late layout
+    // shift has to re-measure the page-space rects. (measure() is a cheap
+    // getBoundingClientRect sweep; harmless when no loop is running.)
+    let rraf = 0;
+    window.addEventListener('resize', function () {
+      if (rraf) return;
+      rraf = requestAnimationFrame(function () {
+        rraf = 0;
+        measure();
+      });
+    });
+    // content below (boot reveal, lazy media) can shift rects after load
+    window.addEventListener('load', measure);
+
     function wire() {
-      if (mq.matches) return; // reduced motion: CSS holds the static 0.55
+      if (mq.matches) return; // reduced motion: CSS holds the static level
       measure();
       raf = requestAnimationFrame(frame);
-      let rraf = 0;
-      window.addEventListener('resize', function () {
-        if (rraf) return;
-        rraf = requestAnimationFrame(function () {
-          rraf = 0;
-          measure();
-        });
-      });
-      // content below (boot reveal, lazy media) can shift rects after load
-      window.addEventListener('load', measure);
     }
     // DEFERRED: this is:inline script renders BEFORE <main> — a parse-time
     // querySelectorAll sees zero [data-lit] blocks (the documented
@@ -456,6 +492,15 @@ import { asset } from '../consts';
           cancelAnimationFrame(raf);
           raf = 0;
           dimmer.style.opacity = ''; // CSS reduced-motion rule takes over
+          // also release the faded [data-lit="fade"] block, or the hero copy
+          // stays STRANDED at inline opacity 0.001 (invisible h1/CTA) with no
+          // recovery while reduce stays on — an inline declaration beats the CSS
+          // parallel design (mirrors the dimmer reset just above).
+          if (active) {
+            active.style.opacity = '';
+            active.style.transform = '';
+            active = null;
+          }
         } else if (!mq.matches && !raf) {
           measure();
           raf = requestAnimationFrame(frame);

--- a/site/src/components/Showcase.astro
+++ b/site/src/components/Showcase.astro
@@ -1,7 +1,8 @@
 ---
-import { SHOWCASE, showcaseVariants } from '../consts';
+import { SHOWCASE, showcaseVariants, floorByNumber } from '../consts';
 import ChannelStage from './ChannelStage.astro';
 
+const floor = floorByNumber(5);
 const channels = SHOWCASE.map((c, i) => ({
   ...c,
   ch: String(i + 1).padStart(2, '0'),
@@ -31,14 +32,14 @@ const COUNT_WORDS = [
 const countWord = COUNT_WORDS[channels.length] ?? String(channels.length);
 ---
 
-<section id="showcase" class="showcase" data-lit data-floor="5">
+<section id={floor.id} class="showcase" data-lit data-floor={floor.n}>
   {
     /* the legacy #themes/#weather anchor spans + their hash map were removed in
       0.12.0 — #showcase-<id> is the one deep-link form (see fromHash below) */
   }
   <div class="container">
     <div class="section-head reveal">
-      <p class="eyebrow">5F · studio — {live.length} channels on air</p>
+      <p class="eyebrow">{floor.n}F · {floor.name} — {live.length} channels on air</p>
       <h2 class="statement statement--md">{countWord} channels.<br />One office.</h2>
       <p class="lead">
         The office, channel by channel — flip a channel to switch the big screen. Themes and weather
@@ -90,6 +91,12 @@ const countWord = COUNT_WORDS[channels.length] ?? String(channels.length);
         img.removeAttribute('data-src');
       });
       stage.querySelectorAll('video[data-mp4]').forEach(function (v) {
+        // hidden channels defer their poster too (browsers fetch poster even on
+        // [hidden] videos) — promote it alongside the sources on first tune/hover
+        if (v.dataset.poster) {
+          v.poster = v.dataset.poster;
+          v.removeAttribute('data-poster');
+        }
         if (v.dataset.webm) {
           const sw = document.createElement('source');
           sw.src = v.dataset.webm;

--- a/site/src/components/Statusline.astro
+++ b/site/src/components/Statusline.astro
@@ -10,6 +10,7 @@
 // office — with canned office-life beats interleaved; falls back to the
 // canned reel when the API is unreachable so the build never fails.
 import sources from '../sources.json';
+import { FLOORS, DIM_RESTING } from '../consts';
 
 const FALLBACK = [
   { state: 'active', who: 'claude-code', what: 'editing src/reducer.rs' },
@@ -66,14 +67,9 @@ try {
   // offline / timeout → FALLBACK already in place
 }
 
-const FLOORS = [
-  { n: 6, id: 'lobby', name: 'penthouse' },
-  { n: 5, id: 'showcase', name: 'studio' },
-  { n: 4, id: 'features', name: 'amenities' },
-  { n: 3, id: 'how', name: 'machine room' },
-  { n: 2, id: 'tools', name: 'tenants' },
-  { n: 1, id: 'install', name: 'front desk' },
-];
+// FLOORS (number ↔ section id ↔ name) is single-sourced in consts.ts; each
+// narrative section stamps its own data-floor/id/eyebrow from the SAME manifest,
+// so the scrollspy can't desync from the sections it drives.
 
 // per-CLI hue for a feed credit like "cc·pixtuoid" — the same manifest colors
 // the tools-matrix chips use (badge includes the trailing '·')
@@ -301,7 +297,7 @@ const badgeColor = (who: string): string | undefined => {
   }
 </style>
 
-<script is:inline>
+<script is:inline define:vars={{ dimResting: DIM_RESTING }}>
   (function () {
     const bar = document.getElementById('statusline');
     if (!bar) return;
@@ -347,7 +343,12 @@ const badgeColor = (who: string): string | undefined => {
         if (!bar.contains(e.target)) closeList();
       });
       document.addEventListener('keydown', function (e) {
-        if (e.key === 'Escape') closeList();
+        if (e.key !== 'Escape' || list.hidden) return;
+        // if focus was inside the popup, return it to the toggle so closing it
+        // (display:none) doesn't drop focus to <body> (WCAG 2.4.3) — mirrors Nav
+        const inside = list.contains(document.activeElement);
+        closeList();
+        if (inside) toggle.focus();
       });
     }
     btns.forEach(function (b) {
@@ -355,13 +356,14 @@ const badgeColor = (who: string): string | undefined => {
         go(b);
       });
     });
-    // the app's literal floor keys: bare digits 1–6 ride the elevator (skipped
-    // while typing in a field, holding a modifier, or during the boot intro)
+    // the app's literal floor keys: bare digits 1–6 ride the elevator. WCAG
+    // 2.1.4: fire only from a neutral focus context (page body / a section a
+    // jump parked focus on / the statusline), never a focused control or field,
+    // and never during the boot intro.
     document.addEventListener('keydown', function (e) {
       if (e.ctrlKey || e.metaKey || e.altKey) return;
       if (document.documentElement.dataset.booting === '1') return;
-      const t = e.target;
-      if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
+      if (window.__pixKeys.typing(e) || !window.__pixKeys.shortcutContext()) return;
       const btn = btns.find(function (b) {
         return b.dataset.floorBtn === e.key;
       });
@@ -390,16 +392,27 @@ const badgeColor = (who: string): string | undefined => {
       observeFloors();
     }
 
+    // ── page-level pause (WCAG 2.2.2): the office pause switch governs EVERY
+    // >5s auto-motion, so it also holds the feed ticker (the hero dust listens
+    // too). Reduced motion holds the same surfaces. Both drive ONE stop path. ──
+    let userPaused = false;
+
     // ── the feed: one item at a time, sequenced fade-out → fade-in (the items
     // are absolutely stacked, so a simultaneous swap double-exposes two lines
-    // mid-transition; reduced motion: static) ──
+    // mid-transition; reduced motion / user pause: static) ──
     const feedItems = Array.prototype.slice.call(bar.querySelectorAll('.sl__item'));
-    if (feedItems.length > 1 && !mq.matches) {
-      let on = 0;
-      setInterval(function () {
-        feedItems[on].classList.remove('is-on');
-        on = (on + 1) % feedItems.length;
-        const next = feedItems[on];
+    let feedTimer = 0;
+    let feedOn = 0;
+    function stopFeed() {
+      if (feedTimer) clearInterval(feedTimer);
+      feedTimer = 0;
+    }
+    function startFeed() {
+      if (feedTimer || feedItems.length <= 1 || mq.matches || userPaused) return;
+      feedTimer = setInterval(function () {
+        feedItems[feedOn].classList.remove('is-on');
+        feedOn = (feedOn + 1) % feedItems.length;
+        const next = feedItems[feedOn];
         setTimeout(function () {
           next.classList.add('is-on');
         }, 350);
@@ -422,38 +435,73 @@ const badgeColor = (who: string): string | undefined => {
     tickClock();
     setInterval(tickClock, 60000);
     if (lights) {
+      // the resting readout derives from the ONE dimmer const (was a baked
+      // 'lights 55%' that disagreed with the live 100·(1−0.55)=45% math)
+      const rest = 'lights ' + Math.round((1 - dimResting) * 100) + '%';
       if (mq.matches) {
-        lights.textContent = 'lights 55%';
+        lights.textContent = rest;
       } else {
         // 250ms: fast enough that the readout tracks the dimmer's ease instead
         // of contradicting a fully-lit gap for a visible beat
         setInterval(function () {
-          // a mid-session reduce-ON pins the dimmer at the CSS 0.55 while
+          // a mid-session reduce-ON pins the dimmer at the resting level while
           // __pixLights goes stale — report the pinned value, not the ghost
           const v = mq.matches
-            ? 0.55
+            ? dimResting
             : typeof window.__pixLights === 'number'
               ? window.__pixLights
-              : 0.55;
+              : dimResting;
           lights.textContent = 'lights ' + Math.round((1 - v) * 100) + '%';
         }, 250);
       }
     }
-    if (onair) {
-      // not-live copy follows the motion mode: reduced motion shows the still
-      // POSTER (a frame), live-capable mode shows a paused feed (STILL)
-      const setAir = function (live) {
-        onair.textContent = live ? '● LIVE' : mq.matches ? '□ STILL FRAME' : '○ STILL';
-        onair.classList.toggle('is-live', !!live);
-      };
-      if (mq.matches) onair.textContent = '□ STILL FRAME';
-      // seed from the backdrop's class: the one-shot pix:onair event can fire
-      // before this script attaches (fast wasm load), and a missed event would
-      // read STILL forever
-      if (!mq.matches && document.querySelector('.backdrop.is-live')) setAir(true);
-      document.addEventListener('pix:onair', function (e) {
-        setAir(e.detail && e.detail.live);
+    // the on-air readout reflects LIVE / user-PAUSED / STILL (poster) — the
+    // paused state is what makes the fixed bar read as paused, not '● LIVE'
+    let isLive = false;
+    function renderAir() {
+      if (!onair) return;
+      let text, live;
+      if (userPaused) {
+        text = '❚❚ PAUSED';
+        live = false;
+      } else if (isLive) {
+        text = '● LIVE';
+        live = true;
+      } else {
+        // reduced motion shows the still POSTER (a frame); live-capable mode
+        // shows a paused feed (STILL)
+        text = mq.matches ? '□ STILL FRAME' : '○ STILL';
+        live = false;
+      }
+      onair.textContent = text;
+      onair.classList.toggle('is-live', live);
+    }
+    // seed from the backdrop's class: the one-shot pix:onair event can fire
+    // before this script attaches (fast wasm load), and a missed event would
+    // read STILL forever
+    if (!mq.matches && document.querySelector('.backdrop.is-live')) isLive = true;
+    renderAir();
+    document.addEventListener('pix:onair', function (e) {
+      isLive = !!(e.detail && e.detail.live);
+      renderAir();
+    });
+
+    // ONE control, ONE stop path: the office pause switch fans out here (the
+    // feed ticker) and to the hero dust; the reduced-motion flip drives the SAME
+    // paths, so a mid-session reduce-ON freezes the ticker too (not just at load).
+    document.addEventListener('pix:paused', function (e) {
+      userPaused = !!(e.detail && e.detail.paused);
+      if (userPaused) stopFeed();
+      else startFeed();
+      renderAir();
+    });
+    if (mq.addEventListener) {
+      mq.addEventListener('change', function () {
+        if (mq.matches) stopFeed();
+        else startFeed();
+        renderAir();
       });
     }
+    startFeed();
   })();
 </script>

--- a/site/src/components/SupportedTools.astro
+++ b/site/src/components/SupportedTools.astro
@@ -1,6 +1,8 @@
 ---
 import sources from '../sources.json';
-import { asset } from '../consts';
+import { asset, floorByNumber } from '../consts';
+
+const floor = floorByNumber(2);
 
 // Single source of truth → site/src/sources.json. The README "Supported Tools"
 // glimpse is generated from the SAME file (scripts/gen-readme.mjs), and the
@@ -45,10 +47,10 @@ const legend = (['yes', 'experimental', 'planned', 'no'] as OsState[])
   .join(' · ');
 ---
 
-<section id="tools" class="tools" data-lit data-floor="2">
+<section id={floor.id} class="tools" data-lit data-floor={floor.n}>
   <div class="container">
     <div class="section-head reveal">
-      <p class="eyebrow">2F · tenants — the resident CLIs</p>
+      <p class="eyebrow">{floor.n}F · {floor.name} — the resident CLIs</p>
       <h2 class="statement statement--md">Whichever CLI<br />they run.</h2>
       <p class="lead">
         Each coding agent shows up as a coworker. Support is per-tool <em>and</em> per-OS — the same matrix
@@ -205,19 +207,24 @@ const legend = (['yes', 'experimental', 'planned', 'no'] as OsState[])
     font-size: 0.72rem;
     text-transform: uppercase;
     letter-spacing: 0.06em;
-    opacity: 0.55;
+    /* informative (the only shipped-vs-planned divider): a muted AA color, NOT
+       opacity — element opacity sat at ~3.6:1 in day, below WCAG 1.4.3. */
+    color: var(--fg-muted);
     padding-top: 0.9rem;
     border-bottom: none;
   }
   .tools__planned tbody:last-child tr:last-child th,
   .tools__planned tr th,
   .tools__planned tr td {
-    opacity: 0.62;
+    /* de-emphasize planned rows with a muted color, not opacity (which dropped
+       the informative tool names below AA) */
+    color: var(--fg-muted);
   }
   .tools__legend {
     margin: 0.7rem 0.2rem 0.3rem;
     font-size: 0.78rem;
-    opacity: 0.6;
+    /* the sole decode key for the ✅/🧪/🔜 glyphs — AA muted color, not opacity */
+    color: var(--fg-muted);
   }
   /* The transport column is supplementary — drop it before the grid gets cramped. */
   @media (max-width: 560px) {

--- a/site/src/consts.ts
+++ b/site/src/consts.ts
@@ -12,6 +12,75 @@ export const SPONSOR = 'https://buymeacoffee.com/IvanWng97';
 const BASE = import.meta.env.BASE_URL;
 export const asset = (p: string): string => `${BASE.replace(/\/$/, '')}/${p.replace(/^\//, '')}`;
 
+// ── Theme constants (single source for the Base/Nav inline-script family) ──
+// Seeded parse-first into window.__pixTheme (Base.astro head) via define:vars so
+// the theme init, the Escape restore, the FX theme-color sync, and Nav's toggle
+// all read ONE storage key + valid set + BG map and can't drift. THEME_BG is the
+// mobile browser-chrome tint per theme; its hexes MIRROR global.css's per-theme
+// --bg (day #f4eee2 / night #1d1813 / dracula #282a36) — a CSS↔JS pairing that
+// can't share a literal, so it's pinned here by comment (retune both together).
+export const THEME_STORAGE_KEY = 'pix-theme';
+export const VALID_THEMES = ['day', 'night', 'dracula'] as const;
+export type ThemeId = (typeof VALID_THEMES)[number];
+export const THEME_BG: Record<ThemeId, string> = {
+  day: '#f4eee2',
+  night: '#1d1813',
+  dracula: '#282a36',
+};
+
+// ── Floor identity: number ↔ section id ↔ name, single-sourced ──
+// Statusline builds its lift registry from this AND every narrative section
+// stamps its own data-floor + id + eyebrow prefix from its entry (via
+// floorByNumber), so a renumber / rename / add can't silently desync the
+// digit-key scrollspy or the lift readout (load-bearing runtime contracts).
+// Reading order = top floor down (the page scrolls 6F → 1F).
+export interface Floor {
+  n: number;
+  id: string; // section id + the digit-key jump target (getElementById)
+  name: string; // eyebrow + lift readout name
+}
+export const FLOORS: Floor[] = [
+  { n: 6, id: 'lobby', name: 'penthouse' },
+  { n: 5, id: 'showcase', name: 'studio' },
+  { n: 4, id: 'features', name: 'amenities' },
+  { n: 3, id: 'how', name: 'machine room' },
+  { n: 2, id: 'tools', name: 'tenants' },
+  { n: 1, id: 'install', name: 'front desk' },
+];
+export const floorByNumber = (n: number): Floor => {
+  const f = FLOORS.find((x) => x.n === n);
+  if (!f) throw new Error(`consts: no FLOORS entry for floor ${n}`);
+  return f;
+};
+
+// The dimmer's resting opacity — the single source for FIVE former copies that
+// straddle a JS↔CSS boundary. OfficeBackdrop emits it into #dimmer's CSS via an
+// inline `--dim-rest` custom property (its base + reduced-motion rules read it);
+// Statusline derives its 'lights N%' readout from it (100·(1 − DIM_RESTING)).
+// Both read THIS value at build time, so the pre-JS/reduced-motion dim level and
+// the statusline readout can never drift (they had already drifted: 55% vs 45%).
+export const DIM_RESTING = 0.55;
+
+// ── Rendered docs pages: one manifest the Nav dropdown, the Docs sidebar/pager,
+// and each page's `current` type all derive from (was triple-scattered). Fixed
+// reading order = the prev/next sequence AND the Nav dropdown order. Adding a
+// rendered doc still needs its content collection + page file (see
+// site/CLAUDE.md), but the menu/sidebar/pager come free from this one edit.
+export interface DocPage {
+  id: string;
+  route: string; // base-path-relative slug (asset(route))
+  label: string;
+}
+export const DOCS = [
+  { id: 'config', route: 'config', label: 'Configuration' },
+  { id: 'architecture', route: 'architecture', label: 'Architecture' },
+  { id: 'knowledge-base', route: 'knowledge-base', label: 'Knowledge engineering' },
+  { id: 'parallel-delivery', route: 'parallel-delivery', label: 'Parallel delivery' },
+  { id: 'contributing', route: 'contributing', label: 'Contributing' },
+  { id: 'migration', route: 'migration', label: 'Migration' },
+] as const satisfies readonly DocPage[];
+export type DocId = (typeof DOCS)[number]['id'];
+
 export interface ThemeShot {
   id: string;
   name: string;

--- a/site/src/env.d.ts
+++ b/site/src/env.d.ts
@@ -12,4 +12,18 @@ interface Window {
   __pixLights?: number;
   /** Hire a coworker into the live office — set once the wasm office boots. */
   __pixHire?: () => void;
+  /** THE theme registry + fallback, seeded parse-first in Base.astro's head. */
+  __pixTheme?: {
+    KEY: string;
+    VALID: readonly string[];
+    BG: Record<string, string>;
+    ok: (_v: string) => boolean;
+    fallback: () => string;
+  };
+  /** Key-shortcut guards (Base.astro): the typing-surface check + the WCAG
+   * 2.1.4 focus gate for the bare single-char shortcuts (digits 1–6, t). */
+  __pixKeys?: {
+    typing: (_e: Event) => boolean;
+    shortcutContext: () => boolean;
+  };
 }

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -14,7 +14,7 @@ import '@fontsource/jetbrains-mono/700.css';
 import '@fontsource/lora/400.css';
 import '@fontsource/lora/500.css';
 import '../styles/global.css';
-import { asset, THEMES } from '../consts';
+import { asset, THEMES, THEME_BG, THEME_STORAGE_KEY, VALID_THEMES } from '../consts';
 
 interface Props {
   title?: string;
@@ -67,8 +67,11 @@ const jsonLdSafe = jsonLd ? JSON.stringify(jsonLd).replace(/</g, '\\u003c') : nu
     <link rel="icon" type="image/png" sizes="180x180" href={asset('apple-touch-icon.png')} />
     <link rel="apple-touch-icon" href={asset('apple-touch-icon.png')} />
     <link rel="canonical" href={canonical} />
-    {/* default = day --bg; the theme-init script below updates it for night/dracula */}
-    <meta name="theme-color" content="#f4eee2" />
+    {
+      /* default = day --bg (single-sourced with the JS theme map); the theme-init
+      script below updates it for night/dracula */
+    }
+    <meta name="theme-color" content={THEME_BG.day} />
     {
       /* The above-fold display face (hero headline, statements, boot intro's
         version line): preload the latin subset so the pixel type doesn't
@@ -98,7 +101,10 @@ const jsonLdSafe = jsonLd ? JSON.stringify(jsonLd).replace(/</g, '\\u003c') : nu
     }
 
     <!-- No-FOUC theme init: ?theme= override → saved choice → system → day -->
-    <script is:inline>
+    <script
+      is:inline
+      define:vars={{ themeKey: THEME_STORAGE_KEY, validThemes: VALID_THEMES, themeBG: THEME_BG }}
+    >
       // THE site clock boundary (7/19) — the one client-side source of truth,
       // defined parse-first so every later consumer (this init, the Escape
       // fallback below, the statusline clock, the gap-2 window swap) reads the
@@ -109,28 +115,65 @@ const jsonLdSafe = jsonLd ? JSON.stringify(jsonLd).replace(/</g, '\\u003c') : nu
         const h = new Date().getHours();
         return h >= 19 || h < 7;
       };
+      // Parse-first theme constants (seeded from consts.ts via define:vars): ONE
+      // storage key + valid set + BG map + clock→system fallback, so the init
+      // below, the Escape restore, the FX theme-color sync, and Nav's toggle all
+      // read the SAME source and can't drift (the __pixNight single-source idiom).
+      window.__pixTheme = {
+        KEY: themeKey,
+        VALID: validThemes,
+        BG: themeBG,
+        ok: function (v) {
+          return validThemes.indexOf(v) !== -1;
+        },
+        // clock, then system — the ONE fallback both init and Escape restore use
+        fallback: function () {
+          return window.__pixNight() || window.matchMedia('(prefers-color-scheme: dark)').matches
+            ? 'night'
+            : 'day';
+        },
+      };
+      // Parse-first key helpers: the typing-surface guard (was copied 3×) and the
+      // WCAG 2.1.4 focus gate for the bare single-char shortcuts (digits 1–6, t).
+      // A shortcut fires only when a NEUTRAL surface holds focus — the page body,
+      // a section a floor-jump parked focus on, or the statusline — never a real
+      // interactive control (link/button/field), so voice-control dictation or
+      // stray focus can't trigger floor/theme changes.
+      window.__pixKeys = {
+        typing: function (e) {
+          const t = e && e.target;
+          return !!(
+            t &&
+            (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)
+          );
+        },
+        shortcutContext: function () {
+          const a = document.activeElement;
+          if (!a || a === document.body || a === document.documentElement) return true;
+          if (a.hasAttribute && a.hasAttribute('data-floor')) return true;
+          const sl = document.getElementById('statusline');
+          return !!(sl && sl.contains(a));
+        },
+      };
       (function () {
         try {
-          const ok = function (v) {
-            return v === 'day' || v === 'night' || v === 'dracula';
-          };
+          const T = window.__pixTheme;
           const forced = new URLSearchParams(location.search).get('theme');
-          const pick = ok(forced) ? forced : localStorage.getItem('pix-theme');
+          const pick = T.ok(forced) ? forced : localStorage.getItem(T.KEY);
           // The app's office lighting follows the wall clock; until the visitor
           // chooses a theme, so does the site — arriving after dark means the
           // night office. The clock only ever turns night ON: a dark-preference
-          // user keeps night at noon via the system fallback below.
+          // user keeps night at noon via the system fallback (see T.fallback).
           const afterHours = window.__pixNight();
-          const sys = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'night' : 'day';
-          const theme = ok(pick) ? pick : afterHours ? 'night' : sys;
+          const sysDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+          const theme = T.ok(pick) ? pick : T.fallback();
           // clock-forced (not chosen, not system) → the footer explains itself
-          if (!ok(pick) && afterHours && sys === 'day')
+          if (!T.ok(pick) && afterHours && !sysDark)
             document.documentElement.dataset.clockNight = '1';
           document.documentElement.dataset.theme = theme;
           // keep the mobile browser-chrome tint in sync with the resolved theme
-          const BG = { day: '#f4eee2', night: '#1d1813', dracula: '#282a36' };
           const meta = document.querySelector('meta[name="theme-color"]');
-          if (meta && BG[theme]) meta.setAttribute('content', BG[theme]);
+          if (meta && T.BG[theme]) meta.setAttribute('content', T.BG[theme]);
         } catch (e) {
           document.documentElement.dataset.theme = 'day';
         }
@@ -208,8 +251,7 @@ const jsonLdSafe = jsonLd ? JSON.stringify(jsonLd).replace(/</g, '\\u003c') : nu
         const reduceMQ = window.matchMedia('(prefers-reduced-motion: reduce)');
         const reduce = reduceMQ.matches;
 
-        // keep the mobile browser-chrome tint in sync on every theme change
-        const BG = { day: '#f4eee2', night: '#1d1813', dracula: '#282a36' };
+        // browser-chrome tint per theme comes from the parse-first single source
         const themeMeta = document.querySelector('meta[name="theme-color"]');
         // …and the tab icon: the little coworker turns the lights off after
         // dark (path derived from the day href so the Pages base-path holds)
@@ -223,7 +265,8 @@ const jsonLdSafe = jsonLd ? JSON.stringify(jsonLd).replace(/</g, '\\u003c') : nu
         syncFavicon();
         document.addEventListener('pix:theme', function () {
           const t = document.documentElement.dataset.theme;
-          if (themeMeta && BG[t]) themeMeta.setAttribute('content', BG[t]);
+          if (themeMeta && window.__pixTheme.BG[t])
+            themeMeta.setAttribute('content', window.__pixTheme.BG[t]);
           syncFavicon();
           // any explicit theme act ends the clock's authority (and its footer line)
           delete document.documentElement.dataset.clockNight;
@@ -268,31 +311,21 @@ const jsonLdSafe = jsonLd ? JSON.stringify(jsonLd).replace(/</g, '\\u003c') : nu
         };
         document.addEventListener('keydown', function (e) {
           // don't hijack typing: skip when a field is focused or a modifier is held
-          const tgt = e.target;
           if (e.ctrlKey || e.metaKey || e.altKey) return;
-          if (
-            tgt &&
-            (tgt.tagName === 'INPUT' || tgt.tagName === 'TEXTAREA' || tgt.isContentEditable)
-          )
-            return;
+          if (window.__pixKeys.typing(e)) return;
+          const T = window.__pixTheme;
           if (e.key === 'Escape') {
             clearRetint();
             let saved = null;
             try {
-              saved = localStorage.getItem('pix-theme');
+              saved = localStorage.getItem(T.KEY);
             } catch (e2) {}
             // validate like the no-FOUC init — a stale/garbage stored id must not
             // land in data-theme — and restore through the SAME fallback chain
             // the init uses (clock, then system), or an after-hours visitor with
             // no saved choice would get snapped to day by the Escape that merely
             // closed the Docs dropdown.
-            const fallback =
-              window.__pixNight() || window.matchMedia('(prefers-color-scheme: dark)').matches
-                ? 'night'
-                : 'day';
-            setTheme(
-              saved === 'night' || saved === 'dracula' || saved === 'day' ? saved : fallback
-            );
+            setTheme(T.ok(saved) ? saved : T.fallback());
             return;
           }
           if (e.key && e.key.length === 1) {
@@ -318,9 +351,9 @@ const jsonLdSafe = jsonLd ? JSON.stringify(jsonLd).replace(/</g, '\\u003c') : nu
           // "press any key to skip" the boot must not also retint (inert blocks
           // focus/clicks, not document-level keydown)
           if (document.documentElement.dataset.booting === '1') return;
-          const t = e.target;
-          if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable))
-            return;
+          // WCAG 2.1.4: fire only from a neutral focus context (never a focused
+          // control or text field), so dictation / stray focus can't retint.
+          if (window.__pixKeys.typing(e) || !window.__pixKeys.shortcutContext()) return;
           i = (i + 1) % accents.length;
           const s = document.documentElement.style;
           s.setProperty('--coral', accents[i].a);

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -4,6 +4,10 @@
 // font origins, no third-party tracking, and they actually load behind the GFW.
 // Family names ('Jersey 10' / 'JetBrains Mono' / 'Lora') match global.css as-is.
 import '@fontsource/jersey-10/400.css';
+// The hero/statement display face, preloaded (below): resolve the LATIN subset
+// woff2 through Vite (?url) so the <link> carries the same hashed asset URL the
+// @fontsource CSS resolves to — rebuild-proof, no hardcoded hash.
+import jerseyLatinWoff2 from '@fontsource/jersey-10/files/jersey-10-latin-400-normal.woff2?url';
 import '@fontsource/jetbrains-mono/400.css';
 import '@fontsource/jetbrains-mono/500.css';
 import '@fontsource/jetbrains-mono/700.css';
@@ -48,19 +52,11 @@ const jsonLdSafe = jsonLd ? JSON.stringify(jsonLd).replace(/</g, '\\u003c') : nu
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     {
-      /* CSP: lock down origins / object-src / base-uri. 'unsafe-inline' stays for
-        script + style because the no-FOUC theme-init and boot must run inline
-        before paint (a strict hashed CSP would need every inline script
-        externalized — and there is no script-injection vector: the only dynamic
-        content is the trusted, scheme-sanitized /config markdown). frame-ancestors
-        and SRI need HTTP headers that GitHub Pages can't set. 'wasm-unsafe-eval'
-        permits WebAssembly.instantiate for the live-office hero (wasm compilation
-        ONLY — unlike 'unsafe-eval' it does not enable JS eval). */
+      /* CSP: injected here by Astro's built-in security.csp (astro.config.mjs)
+        — hash-based script-src (NO 'unsafe-inline'), each is:inline script
+        whitelisted by content hash via the cspInlineHashes() build hook.
+        Config + rationale live in astro.config.mjs; build/preview-only. */
     }
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="default-src 'self'; base-uri 'self'; object-src 'none'; img-src 'self' data:; media-src 'self'; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; connect-src 'self'; form-action 'self'"
-    />
     <title>{title}</title>
     <meta name="description" content={description} />
     {
@@ -73,6 +69,13 @@ const jsonLdSafe = jsonLd ? JSON.stringify(jsonLd).replace(/</g, '\\u003c') : nu
     <link rel="canonical" href={canonical} />
     {/* default = day --bg; the theme-init script below updates it for night/dracula */}
     <meta name="theme-color" content="#f4eee2" />
+    {
+      /* The above-fold display face (hero headline, statements, boot intro's
+        version line): preload the latin subset so the pixel type doesn't
+        swap in late. `crossorigin` is required even same-origin — font
+        requests are CORS-mode, and a mismatch double-downloads. */
+    }
+    <link rel="preload" as="font" type="font/woff2" href={jerseyLatinWoff2} crossorigin />
     {preloadImage && <link rel="preload" as="image" href={preloadImage} fetchpriority="high" />}
 
     <!-- Open Graph / Twitter -->

--- a/site/src/layouts/Docs.astro
+++ b/site/src/layouts/Docs.astro
@@ -3,21 +3,16 @@ import type { MarkdownHeading } from 'astro';
 import Base from './Base.astro';
 import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
-import { REPO, asset } from '../consts';
+import { REPO, asset, DOCS, type DocId } from '../consts';
 
 interface Props {
   title: string;
   description: string;
   /** from `await render(entry)` — drives the build-time mini-TOC */
   headings: MarkdownHeading[];
-  /** which doc this page is (sidebar highlight + prev/next) */
-  current:
-    | 'config'
-    | 'architecture'
-    | 'knowledge-base'
-    | 'parallel-delivery'
-    | 'contributing'
-    | 'migration';
+  /** which doc this page is (sidebar highlight + prev/next) — derived from the
+   * one DOCS manifest so it can't fall out of sync with the sidebar/pager */
+  current: DocId;
   /** repo-relative path for the "Source of truth" footer link, e.g. docs/CONFIGURATION.md */
   sourcePath: string;
   /** suffix after the source link (architecture mentions its Mermaid diagram) */
@@ -33,16 +28,7 @@ const {
   sourceNote = 'this page renders it verbatim.',
 } = Astro.props;
 
-// Fixed reading order — also the prev/next sequence.
-const DOCS = [
-  { id: 'config', label: 'Configuration', href: 'config' },
-  { id: 'architecture', label: 'Architecture', href: 'architecture' },
-  { id: 'knowledge-base', label: 'Knowledge engineering', href: 'knowledge-base' },
-  { id: 'parallel-delivery', label: 'Parallel delivery', href: 'parallel-delivery' },
-  { id: 'contributing', label: 'Contributing', href: 'contributing' },
-  { id: 'migration', label: 'Migration', href: 'migration' },
-] as const;
-
+// Reading order / sidebar / pager all come from the one DOCS manifest (consts.ts).
 const idx = DOCS.findIndex((d) => d.id === current);
 const prev = idx > 0 ? DOCS[idx - 1] : undefined;
 const next = idx >= 0 && idx < DOCS.length - 1 ? DOCS[idx + 1] : undefined;
@@ -64,7 +50,7 @@ const toc = raw.map((h) => ({ ...h, text: h.text.replace(/\s*\([^)]*\)\s*$/, '')
         {
           DOCS.map((d) => (
             <li>
-              <a href={asset(d.href)} aria-current={d.id === current ? 'page' : undefined}>
+              <a href={asset(d.route)} aria-current={d.id === current ? 'page' : undefined}>
                 {d.label}
               </a>
             </li>
@@ -81,7 +67,7 @@ const toc = raw.map((h) => ({ ...h, text: h.text.replace(/\s*\([^)]*\)\s*$/, '')
       <nav class="docs__pager" aria-label="Docs pagination">
         {
           prev ? (
-            <a class="docs__pager-link" href={asset(prev.href)} rel="prev">
+            <a class="docs__pager-link" href={asset(prev.route)} rel="prev">
               <span class="docs__pager-dir" aria-hidden="true">
                 ← previous
               </span>
@@ -93,7 +79,7 @@ const toc = raw.map((h) => ({ ...h, text: h.text.replace(/\s*\([^)]*\)\s*$/, '')
         }
         {
           next && (
-            <a class="docs__pager-link docs__pager-link--next" href={asset(next.href)} rel="next">
+            <a class="docs__pager-link docs__pager-link--next" href={asset(next.route)} rel="next">
               <span class="docs__pager-dir" aria-hidden="true">
                 next →
               </span>

--- a/site/src/pages/robots.txt.ts
+++ b/site/src/pages/robots.txt.ts
@@ -1,0 +1,17 @@
+import type { APIRoute } from 'astro';
+
+// robots.txt, prerendered to dist/robots.txt. The sitemap URL is DERIVED from
+// the one canonical origin (`site` in astro.config.mjs) + BASE_URL, so a
+// custom-domain move (README "Custom domain") can't leave a stale hardcoded
+// origin behind. Note the project-page caveat: GitHub Pages serves this at
+// /pixtuoid/robots.txt, while crawlers only fetch robots.txt from the ORIGIN
+// root — it becomes fully authoritative the day the site moves to its own
+// domain (base '/'); until then the sitemap is submitted directly to Search
+// Console (see the sitemap() note in astro.config.mjs).
+export const GET: APIRoute = ({ site }) => {
+  const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+  const sitemap = new URL(`${base}/sitemap-index.xml`, site);
+  return new Response(`User-agent: *\nAllow: /\n\nSitemap: ${sitemap.href}\n`, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+};

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -51,7 +51,10 @@
 
   /* Type */
   --font-display: 'Jersey 10', 'Segoe UI', system-ui, sans-serif;
-  --font-body: 'Lora', Georgia, 'Times New Roman', serif;
+  /* 'Lora Fallback' = local Georgia, metric-matched to Lora (below), so the
+     font-display:swap on the text-heavy docs pages is shift-free (was ~0.12 CLS
+     from the Lora swap reflowing .prose). */
+  --font-body: 'Lora', 'Lora Fallback', Georgia, 'Times New Roman', serif;
   --font-mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
 
   /* Scale */
@@ -91,6 +94,21 @@
   --shadow-lg: 0 2px 6px rgba(0, 0, 0, 0.4), 0 24px 60px rgba(0, 0, 0, 0.6);
   --glow: color-mix(in srgb, var(--coral) 24%, transparent);
   --chrome-halo: 0 1px 8px rgba(0, 0, 0, 0.45);
+}
+
+/* Metric-matched fallback for the Lora body face: local Georgia scaled to Lora's
+   metrics so the font-display:swap doesn't reflow the docs prose. size-adjust is
+   MEASURED against the built pages (rendered Georgia is ~94.5% of Lora's advance
+   width, so scale it up ~105.85%); ascent/descent overrides come from the real
+   Lora latin-400 (ascent 1006, descent -274 per 1000 em) divided by size-adjust.
+   Re-measure if the body face changes. */
+@font-face {
+  font-family: 'Lora Fallback';
+  src: local('Georgia');
+  size-adjust: 105.85%;
+  ascent-override: 95.04%;
+  descent-override: 25.88%;
+  line-gap-override: 0%;
 }
 
 /* ---------- reset ---------- */
@@ -660,7 +678,9 @@ code,
 .boot__hint {
   margin-top: 1.4rem;
   font-size: 0.72rem;
-  opacity: 0.55;
+  /* the sole "press any key to skip" instruction — it must stay readable, so the
+     de-emphasis comes from size alone (opacity:0.55 dropped it to ~2.2:1 in day,
+     below WCAG 1.4.3); inherited --fg-muted clears AA in every theme. */
 }
 
 /* ---------- prose: rendered markdown (the /config page) ---------- */

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -141,16 +141,37 @@ test('the hero pause switch freezes the office and resumes it seamlessly', async
   await expect(btn).toHaveAttribute('aria-pressed', 'false');
   const shot = () =>
     page.evaluate(() => (document.getElementById('office-live') as HTMLCanvasElement).toDataURL());
+  const bufW = () =>
+    page.evaluate(() => (document.getElementById('office-live') as HTMLCanvasElement).width);
   await btn.click();
   await expect(btn).toHaveAttribute('aria-pressed', 'true');
   const frozen = await shot();
   await page.waitForTimeout(400); // >10 would-be frames at the 33ms cap
   expect(await shot()).toBe(frozen); // not one new frame painted
+  // Pause-unify (WCAG 2.2.2 covers the whole page): the statusline reflects the
+  // paused office — PAUSED, not '● LIVE'.
+  await expect(page.locator('[data-sl-onair]')).toHaveText('❚❚ PAUSED');
+  // Resize while paused: sizeBuffer() wipes the bitmap and no rAF will repaint
+  // it, so the resize handler must re-render the ONE frozen frame — a blank
+  // var(--bg) void here is the exact regression this branch prevents.
+  await page.setViewportSize({ width: 500, height: 900 });
+  await expect.poll(bufW).toBe(100); // re-aspected
+  expect(await btn.getAttribute('aria-pressed')).toBe('true'); // still paused
+  const painted = await page.evaluate(() => {
+    const c = document.getElementById('office-live') as HTMLCanvasElement;
+    const d = c.getContext('2d')!.getImageData(0, 0, c.width, c.height).data;
+    return d.some((v) => v !== 0);
+  });
+  expect(painted).toBe(true); // the frozen frame, not a void
+  const frozen2 = await shot(); // frozen at the new aspect
+  await page.waitForTimeout(400);
+  expect(await shot()).toBe(frozen2); // pause survives the resize
   // Keyboard operability: the switch is a real button — Enter resumes.
   await btn.focus();
   await page.keyboard.press('Enter');
   await expect(btn).toHaveAttribute('aria-pressed', 'false');
-  await expect.poll(shot, { timeout: 10_000 }).not.toBe(frozen); // animating again
+  await expect.poll(shot, { timeout: 10_000 }).not.toBe(frozen2); // animating again
+  await expect(page.locator('[data-sl-onair]')).toHaveText('● LIVE'); // back to live
   expect(errors()).toEqual([]);
 });
 
@@ -215,6 +236,74 @@ test('reduced motion stays on the still poster without errors', async ({ browser
   await expect.poll(() => video.evaluate((v) => (v as HTMLVideoElement).paused)).toBe(true);
   expect(errors()).toEqual([]);
   await context.close();
+});
+
+test('wasm fetch failure keeps the still poster without an uncaught error', async ({ browser }) => {
+  // The third documented boot path (live / reduced-motion / FAILURE): abort every
+  // wasm request so the dynamic import rejects — the empty .catch must keep the
+  // poster (graceful degradation), never throw or show a dead-canvas pause button.
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  const errors = watchErrors(page);
+  await page.route('**/wasm/**', (r) => r.abort());
+  const wasmTried: string[] = [];
+  page.on('request', (r) => {
+    if (r.url().includes('/wasm/')) wasmTried.push(r.url());
+  });
+  await page.addInitScript(() => sessionStorage.setItem('pix-booted', '1'));
+  await page.goto('./');
+  // the boot is deferred to load+idle — wait until it actually attempted the fetch
+  await expect.poll(() => wasmTried.length, { timeout: 15_000 }).toBeGreaterThan(0);
+  await page.waitForLoadState('networkidle');
+  await expect(page.locator('.backdrop__poster')).toBeVisible();
+  await expect(page.locator('.backdrop.is-live')).not.toBeAttached();
+  await expect(page.locator('#office-pause')).toBeHidden(); // nothing to pause
+  await expect(page.locator('[data-sl-onair]')).toHaveText('○ STILL');
+  // the aborted request logs a resource error; the import rejection must stay
+  // handled — no uncaught pageerror / console.error beyond that one line.
+  expect(errors().filter((e) => !e.includes('Failed to load resource'))).toEqual([]);
+  await context.close();
+});
+
+test('single-char shortcuts are focus-gated to a neutral context (WCAG 2.1.4)', async ({
+  page,
+}) => {
+  await gotoLive(page);
+  // Baseline: from the page body the digit still rides the lift.
+  await page.keyboard.press('3');
+  await expect(page.locator('[data-lift-digit]')).toHaveText('3F', { timeout: 10_000 });
+  // Focus a real interactive control (the fixed pause button — no scroll on
+  // focus): bare digits + `t` must go INERT so voice-control dictation / stray
+  // focus can't trigger floor or theme changes.
+  await page.locator('#office-pause').focus();
+  await page.keyboard.press('1');
+  await expect(page.locator('[data-lift-digit]')).toHaveText('3F'); // unchanged
+  await page.evaluate(() => document.documentElement.style.removeProperty('--coral'));
+  await page.keyboard.press('t');
+  expect(
+    await page.evaluate(() => document.documentElement.style.getPropertyValue('--coral'))
+  ).toBe(''); // no retint from a focused control
+});
+
+test('the clock forces night after hours and clears on an explicit theme act', async ({ page }) => {
+  // The only theme-init path every other test routes around. Playwright's clock
+  // makes it deterministic (fixes Date; timers/rAF stay real).
+  await page.clock.setFixedTime(new Date('2026-01-01T23:00:00'));
+  await page.emulateMedia({ colorScheme: 'light' }); // the clock must win over a light OS
+  await page.addInitScript(() => sessionStorage.setItem('pix-booted', '1'));
+  await page.goto('./');
+  await page.evaluate(() => localStorage.removeItem('pix-theme'));
+  await page.reload();
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'night');
+  await expect(page.locator('html')).toHaveAttribute('data-clock-night', '1');
+  // an explicit theme act ends the clock's authority (and its footer explainer)
+  await page.locator('#theme-toggle').click();
+  await expect(page.locator('html')).not.toHaveAttribute('data-clock-night', '1');
+  // …and the clock NEVER forces day: noon + a light OS lands day, not night.
+  await page.clock.setFixedTime(new Date('2026-01-01T12:00:00'));
+  await page.evaluate(() => localStorage.removeItem('pix-theme'));
+  await page.reload();
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'day');
 });
 
 // ---------------------------------------------------------------------------

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -130,6 +130,30 @@ test('the dimmer darkens statements and releases in office gaps', async ({ page 
   await expect.poll(heroOp).toBeGreaterThan(0.5);
 });
 
+test('the hero pause switch freezes the office and resumes it seamlessly', async ({ page }) => {
+  // WCAG 2.2.2: the auto-playing office backdrop can be paused. Pause must
+  // STOP the rAF loop dead (a frozen canvas, byte-identical snapshots — not
+  // merely a hidden button), and resume must paint new frames again.
+  const errors = watchErrors(page);
+  await gotoLive(page);
+  const btn = page.locator('#office-pause');
+  await expect(btn).toBeVisible(); // unhidden by the first painted frame
+  await expect(btn).toHaveAttribute('aria-pressed', 'false');
+  const shot = () =>
+    page.evaluate(() => (document.getElementById('office-live') as HTMLCanvasElement).toDataURL());
+  await btn.click();
+  await expect(btn).toHaveAttribute('aria-pressed', 'true');
+  const frozen = await shot();
+  await page.waitForTimeout(400); // >10 would-be frames at the 33ms cap
+  expect(await shot()).toBe(frozen); // not one new frame painted
+  // Keyboard operability: the switch is a real button — Enter resumes.
+  await btn.focus();
+  await page.keyboard.press('Enter');
+  await expect(btn).toHaveAttribute('aria-pressed', 'false');
+  await expect.poll(shot, { timeout: 10_000 }).not.toBe(frozen); // animating again
+  expect(errors()).toEqual([]);
+});
+
 test('the install Copy click hires without breaking the page', async ({ page, context }) => {
   await context.grantPermissions(['clipboard-write']);
   const errors = watchErrors(page);
@@ -182,6 +206,8 @@ test('reduced motion stays on the still poster without errors', async ({ browser
   await page.waitForLoadState('networkidle');
   expect(wasmRequests).toEqual([]);
   await expect(page.locator('.backdrop.is-live')).not.toBeAttached();
+  // Poster-only path: nothing is animating, so the pause switch stays hidden.
+  await expect(page.locator('#office-pause')).toBeHidden();
   // Reduced motion also strips the showcase clip's autoplay: native controls
   // appear and the video stays paused (WCAG 2.2.2).
   const video = page.locator('[data-stage="agents"] video');


### PR DESCRIPTION
## What

Two commits executing the Astro 7 feature-gap audit's verdicts (the workflow-audited ADOPT list, user-approved):

1. **Agent-driven dev-server lifecycle**: `just site-dev-bg`/`site-dev-stop` over `astro dev --background` + the `/_astro/status` probe — kills the documented PTY stdin-EOF pain. Capability matrix verified against installed 7.0.5 (preview got NONE of it → e2e keeps URL-polling, WHY in place).
2. **The 5 adopts**: hash-based CSP (script-src loses `'unsafe-inline'`; build-done hook covers 7.0.5's is:inline gap in the same mechanism), hero pause control (WCAG 2.2.2, pixel ⏸/▶ per pinned shape, e2e-pinned), prefetch (hover), Jersey-10 preload (honest metrics: CLS win, no LCP change — animation-gated), robots.txt→sitemap.

## Verification

| Gate | Result |
|---|---|
| just site-check | green |
| just site-e2e | **14/14** (13 + the pause pin; console watchdogs = zero CSP violations) |
| lighthouse | a11y ≥0.96 · BP 1.0 · SEO 1.0 · perf home 0.75 (pre-existing warn) |
| non-TTY dev-server demo | boot → probe 200 → stop → port freed |

Known follow-up (deferred to the whole-site review, next): statusline `● LIVE` while user-paused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121vF6GrV7TEXC3H8eR5wBw