### PR TITLE
fix(site): whole-site audit remediation — a11y, responsive, no-JS & cross-browser robustness

### DIFF
--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -70,7 +70,14 @@ Mermaid diagram becomes an inline SVG at build via `rehype-mermaid`, which is
   in normal motion they auto-loop with NO visible controls, so in-view-gating
   alone did not satisfy 2.2.2 — the page pause button is their pause affordance.
   (Under reduced-motion the clips instead pause and show native `<video>`
-  controls, a separate path.) The wasm fetch is **deferred** off the render-critical
+  controls, a separate path.) One caveat: on a **wasm-failure / no-wasm load**
+  `#office-pause` stays `hidden` (the poster-only path unhides it only on the
+  first painted frame), so a NON-reduced-motion visitor whose wasm never loads
+  has no visible pause button for the clips (nor the statusline ticker / hero
+  dust — the same shared, pre-existing dependency). Reduced-motion users are
+  unaffected (native `<video>` controls, wasm-independent). Unhiding the button
+  whenever any >5s auto-motion runs — independent of wasm — is the real fix,
+  tracked as a follow-up. The wasm fetch is **deferred** off the render-critical
   window (`load` → `requestIdleCallback`) so it doesn't compete with the
   above-fold poster/fonts; a live un-reduce still boots promptly via the mq
   listener.

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -65,10 +65,12 @@ Mermaid diagram becomes an inline SVG at build via `rehype-mermaid`, which is
   first painted frame. Pause is **page-scoped**: `setPaused` dispatches
   `pix:paused` and every other >5s auto-motion listens (the statusline feed
   ticker, the hero dust) — one control governs the page's *ambient* motion,
-  and the statusline reads `❚❚ PAUSED`. (The Showcase demo clips are the one
-  motion NOT wired to `pix:paused`: they're in-view-gated and carry native
-  `<video>` controls, so 2.2.2 is satisfied there independently — don't add
-  them to the `pix:paused` set.) The wasm fetch is **deferred** off the render-critical
+  and the statusline reads `❚❚ PAUSED`. The Showcase demo clips ARE in the
+  `pix:paused` set (`Showcase.astro` `syncVideos` gates play on `userPaused`):
+  in normal motion they auto-loop with NO visible controls, so in-view-gating
+  alone did not satisfy 2.2.2 — the page pause button is their pause affordance.
+  (Under reduced-motion the clips instead pause and show native `<video>`
+  controls, a separate path.) The wasm fetch is **deferred** off the render-critical
   window (`load` → `requestIdleCallback`) so it doesn't compete with the
   above-fold poster/fonts; a live un-reduce still boots promptly via the mq
   listener.

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -259,7 +259,7 @@ export default defineConfig({
         "default-src 'self'",
         "base-uri 'self'",
         "object-src 'none'",
-        "img-src 'self' data:",
+        "img-src 'self'",
         "media-src 'self'",
         "font-src 'self'",
         "connect-src 'self'",

--- a/site/src/components/Features.astro
+++ b/site/src/components/Features.astro
@@ -87,7 +87,7 @@ const cells = features.flatMap((f) =>
   .ledger__link {
     font-family: var(--font-mono);
     font-size: 0.85rem;
-    color: var(--coral);
+    color: var(--coral-deep); /* AA 5.2:1; plain --coral was ~2.7:1 on day */
     text-decoration: none;
     white-space: nowrap;
   }

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -36,6 +36,7 @@ const floor = floorByNumber(6);
 <style>
   .hero {
     position: relative;
+    min-height: 100vh; /* fallback for Safari < 15.4, which drops the svh line */
     min-height: 100svh;
     display: flex;
     align-items: flex-end;

--- a/site/src/components/HowItWorks.astro
+++ b/site/src/components/HowItWorks.astro
@@ -108,7 +108,7 @@ const steps = [
     font-size: 0.9rem;
   }
   .how__more a {
-    color: var(--coral);
+    color: var(--coral-deep); /* AA 5.2:1; plain --coral was ~2.7:1 on day */
     text-decoration: none;
   }
   .how__more a:hover {

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -163,8 +163,9 @@ import tabs from '../install.json';
     cursor: pointer;
   }
   .install__tab.is-active {
-    color: var(--led);
-    text-shadow: 0 0 6px var(--led-glow);
+    /* --coral-deep (5.2:1 on the day bg); the old --led green was ~1.4:1 and the
+       tab label is the ONLY text conveying which install method is selected */
+    color: var(--coral-deep);
   }
   /* the climax: the active command HUGE in a square --screen block */
   .install__panel {

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -74,7 +74,9 @@ const { floating = false } = Astro.props;
     const btn = document.getElementById('theme-toggle');
     const icon = btn && btn.querySelector('.nav__toggle-icon');
     function sync() {
-      const night = document.documentElement.dataset.theme === 'night';
+      // dracula is a DARK theme too — treat anything but day as "dark" so the
+      // toggle shows ☀️/"Switch to day" while in dracula (not 🌙/"Switch to night")
+      const night = document.documentElement.dataset.theme !== 'day';
       if (icon) icon.textContent = night ? '☀️' : '🌙';
       if (btn) btn.setAttribute('aria-label', night ? 'Switch to day' : 'Switch to night');
     }
@@ -90,7 +92,9 @@ const { floating = false } = Astro.props;
         root.style.removeProperty('--coral');
         root.style.removeProperty('--coral-deep');
         root.style.removeProperty('--amber');
-        const next = root.dataset.theme === 'night' ? 'day' : 'night';
+        // day → night; any dark theme (night OR dracula) → day, matching the
+        // "Switch to day" label so dracula has a one-click path back to day
+        const next = root.dataset.theme === 'day' ? 'night' : 'day';
         root.dataset.theme = next;
         try {
           localStorage.setItem(window.__pixTheme.KEY, next);

--- a/site/src/components/OfficeBackdrop.astro
+++ b/site/src/components/OfficeBackdrop.astro
@@ -472,6 +472,18 @@ import { asset, DIM_RESTING } from '../consts';
     });
     // content below (boot reveal, lazy media) can shift rects after load
     window.addEventListener('load', measure);
+    // A Showcase channel tune swaps stages of different heights, shifting the
+    // page-space top/bottom of the blocks below it (#install) — resize/load alone
+    // miss that. Re-measure (coalesced through rraf) on any body reflow.
+    if ('ResizeObserver' in window) {
+      new ResizeObserver(function () {
+        if (rraf) return;
+        rraf = requestAnimationFrame(function () {
+          rraf = 0;
+          measure();
+        });
+      }).observe(document.body);
+    }
 
     function wire() {
       if (mq.matches) return; // reduced motion: CSS holds the static level
@@ -496,11 +508,15 @@ import { asset, DIM_RESTING } from '../consts';
           // stays STRANDED at inline opacity 0.001 (invisible h1/CTA) with no
           // recovery while reduce stays on — an inline declaration beats the CSS
           // parallel design (mirrors the dimmer reset just above).
-          if (active) {
-            active.style.opacity = '';
-            active.style.transform = '';
-            active = null;
-          }
+          // Reset EVERY faded block, not just `active`: if you scrolled past the
+          // hero into Showcase/Install BEFORE enabling reduce, the hero is parked
+          // at opacity 0.001 but `active` is now #showcase/#install — so resetting
+          // only `active` leaves the hero H1/CTA invisible with no recovery.
+          document.querySelectorAll('[data-lit="fade"]').forEach(function (el) {
+            el.style.opacity = '';
+            el.style.transform = '';
+          });
+          active = null;
         } else if (!mq.matches && !raf) {
           measure();
           raf = requestAnimationFrame(frame);

--- a/site/src/components/Showcase.astro
+++ b/site/src/components/Showcase.astro
@@ -114,8 +114,10 @@ const countWord = COUNT_WORDS[channels.length] ?? String(channels.length);
     }
 
     // ---- play policy: a clip plays iff its stage is the tuned one AND the
-    // studio is in view AND reduced-motion is off (WCAG 2.2.2 — same contract
-    // as the hero video). Under reduced-motion show native controls instead.
+    // studio is in view AND reduced-motion is off AND the office isn't paused
+    // (WCAG 2.2.2 — the #office-pause button governs the clips too via the
+    // pix:paused listener below). Under reduced-motion show native controls.
+    let userPaused = false;
     function syncVideos() {
       stages.forEach(function (st) {
         const v = st.querySelector('video');
@@ -127,7 +129,7 @@ const countWord = COUNT_WORDS[channels.length] ?? String(channels.length);
           return;
         }
         v.removeAttribute('controls');
-        if (!st.hidden && inView && !v.dataset.mp4) {
+        if (!st.hidden && inView && !userPaused && !v.dataset.mp4) {
           const p = v.play();
           if (p && p.catch) p.catch(function () {});
         } else {
@@ -135,14 +137,23 @@ const countWord = COUNT_WORDS[channels.length] ?? String(channels.length);
         }
       });
     }
-    new IntersectionObserver(
-      function (entries) {
-        inView = entries[0].isIntersecting;
-        syncVideos();
-      },
-      { threshold: 0.15 }
-    ).observe(studio);
+    if ('IntersectionObserver' in window) {
+      new IntersectionObserver(
+        function (entries) {
+          inView = entries[0].isIntersecting;
+          syncVideos();
+        },
+        { threshold: 0.15 }
+      ).observe(studio);
+    }
     if (mq.addEventListener) mq.addEventListener('change', syncVideos);
+    // WCAG 2.2.2: the page-wide pause button (#office-pause) stops the looping
+    // demo clips too — one control governs all >5s auto-motion. The clips carry
+    // no visible controls in normal motion, so this IS their pause affordance.
+    document.addEventListener('pix:paused', function (e) {
+      userPaused = !!(e.detail && e.detail.paused);
+      syncVideos();
+    });
     syncVideos();
 
     // ---- channel tuning (hidden-swap; view-transition crossfade when available)
@@ -257,6 +268,15 @@ const countWord = COUNT_WORDS[channels.length] ?? String(channels.length);
     font-family: var(--font-mono);
     font-size: 0.92rem;
   }
+  @media (max-width: 480px) {
+    /* 3× max-content is ~376px — past a 360/390px phone, so the studio's
+       overflow-x:clip would hide the right dial column (03 Dashboard / 06 Spaces,
+       untappable). Wrap to two shrinkable columns so all 8 channels stay on-screen. */
+    .dial {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 0.4rem 1rem;
+    }
+  }
   .dial__ch {
     text-align: left;
   }
@@ -303,6 +323,10 @@ const countWord = COUNT_WORDS[channels.length] ?? String(channels.length);
   }
   .studio {
     display: grid;
+    /* the single mobile column must shrink below its content's min-width (the
+       dial's tracks), or a child drags the grid past the viewport and the
+       section's overflow-x:clip cuts off the overflow with no scroll */
+    grid-template-columns: minmax(0, 1fr);
     gap: 1.4rem;
   }
   @media (min-width: 980px) {

--- a/site/src/components/Showcase.astro
+++ b/site/src/components/Showcase.astro
@@ -149,7 +149,12 @@ const countWord = COUNT_WORDS[channels.length] ?? String(channels.length);
     if (mq.addEventListener) mq.addEventListener('change', syncVideos);
     // WCAG 2.2.2: the page-wide pause button (#office-pause) stops the looping
     // demo clips too — one control governs all >5s auto-motion. The clips carry
-    // no visible controls in normal motion, so this IS their pause affordance.
+    // no visible controls in normal motion, so this IS their pause affordance —
+    // EXCEPT on a wasm-failure/no-wasm load, where #office-pause never unhides
+    // (poster-only path); there the reduced-motion branch above (native <video>
+    // controls) is the independent backstop. Unhiding the button without wasm is
+    // the shared pre-existing gap (statusline ticker + hero dust too) tracked
+    // separately — the clips ride the same page-pause pattern as those.
     document.addEventListener('pix:paused', function (e) {
       userPaused = !!(e.detail && e.detail.paused);
       syncVideos();

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -191,6 +191,22 @@ const jsonLdSafe = jsonLd ? JSON.stringify(jsonLd).replace(/</g, '\\u003c') : nu
         }
       } catch (e) {}
     </script>
+
+    {
+      /* Progressive enhancement: .reveal starts opacity:0 and JS adds .in on
+        scroll. With JS disabled (or a script/CSP failure) every below-hero
+        section would stay invisible — a blank page under the hero. Reduced-motion
+        already shows them via a media query; this rescues the non-reduced no-JS
+        case too. (style-src keeps 'unsafe-inline', so no CSP hash needed.) */
+    }
+    <noscript>
+      <style>
+        .reveal {
+          opacity: 1 !important;
+          transform: none !important;
+        }
+      </style>
+    </noscript>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -313,6 +329,10 @@ const jsonLdSafe = jsonLd ? JSON.stringify(jsonLd).replace(/</g, '\\u003c') : nu
           // don't hijack typing: skip when a field is focused or a modifier is held
           if (e.ctrlKey || e.metaKey || e.altKey) return;
           if (window.__pixKeys.typing(e)) return;
+          // Escape "skips the boot" — during boot it must NOT also run setTheme
+          // (which clears clock-night + fires a spurious pix:theme). The digit
+          // and `t` handlers already bail while booting; match them.
+          if (document.documentElement.dataset.booting === '1') return;
           const T = window.__pixTheme;
           if (e.key === 'Escape') {
             clearRetint();

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -102,7 +102,11 @@
    and --chip-bg goes transparent (light chrome text over the day office drops to
    low contrast). Mirror the load-bearing translucent tokens in rgba() (which
    predates color-mix by a decade); component-level decorative color-mix degrades
-   harmlessly (the color just inherits), so only these tokens need the fallback. */
+   harmlessly — a `color:` use inherits its parent color, a `background:`/
+   `box-shadow:`/gradient-stop use drops to its initial value (transparent/none) —
+   never illegible, so only these load-bearing tokens need the fallback. Every
+   visitor-reachable theme that redefines them in color-mix (day, night, AND the
+   dracula egg) needs an arm here, or its borders vanish on the old engine. */
 @supports not (color: color-mix(in srgb, red, red)) {
   :root {
     --border: rgba(36, 28, 20, 0.12);
@@ -114,6 +118,11 @@
     --border: rgba(244, 238, 226, 0.13);
     --border-strong: rgba(244, 238, 226, 0.24);
     --glow: rgba(227, 132, 95, 0.24);
+  }
+  :root[data-theme='dracula'] {
+    --border: rgba(248, 248, 242, 0.13); /* #f8f8f2 @ 13% */
+    --border-strong: rgba(248, 248, 242, 0.24); /* #f8f8f2 @ 24% */
+    --glow: rgba(189, 147, 249, 0.26); /* --coral #bd93f9 @ 26% */
   }
 }
 
@@ -354,7 +363,11 @@ section {
   box-shadow: 0 8px 20px color-mix(in srgb, #b5592f 42%, transparent);
 }
 .btn-primary:hover {
-  filter: brightness(1.08);
+  /* DARKEN, don't brighten: brightening the coral drops the white label below AA
+     on the light gradient stop (brightness(1.08) → 4.17:1). Darkening deepens the
+     fill AND keeps white ≥5.2:1 in every state; the -2px lift from .btn:hover is
+     the shared interactive cue, so the CTA still reads as hovered. */
+  filter: brightness(0.94);
 }
 .btn-ghost {
   background: transparent;
@@ -774,9 +787,12 @@ code,
 .prose pre code {
   font-family: var(--font-mono);
 }
-/* tables — display:block + overflow-x:auto gives wide markdown tables their OWN
+/* tables — display:block + overflow-x:auto gives a bare markdown <table> its OWN
    horizontal scroll on mobile instead of overflowing the page (which
-   body{overflow-x:hidden} would clip unreachably); mirrors the Tools matrix. */
+   body{overflow-x:hidden} would clip unreachably). Same GOAL as the Tools matrix
+   but a different mechanism: the matrix hangs overflow on a wrapper div and keeps
+   width:100%, whereas markdown has no wrapper — so display:block on the table
+   itself, which drops width:100% (narrow tables shrink to content on desktop). */
 .prose table {
   display: block;
   overflow-x: auto;

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -423,6 +423,13 @@ section {
    radial wash so a stalled scroll never shows low-contrast text. */
 [data-lit] {
   position: relative;
+  /* A full-width lit block's wash (::before, inset -8% horizontal) pokes 8% past
+     the viewport and widens the page (masked only by body's overflow-x:hidden).
+     Clip the horizontal bleed — it's off-screen on a full-bleed section, so zero
+     visual cost — while overflow-y stays visible so the vertical (-12%) glow
+     still washes above/below the text. `clip` (not hidden) adds no scroll
+     container and doesn't force overflow-y to auto. */
+  overflow-x: clip;
 }
 [data-lit]::before {
   content: '';

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -96,6 +96,27 @@
   --chrome-halo: 0 1px 8px rgba(0, 0, 0, 0.45);
 }
 
+/* color-mix() landed in Safari 16.2 (Dec 2022). On an older engine an invalid
+   color-mix() poisons the whole declaration at computed-value time, so
+   `border: 1px solid var(--border)` resets to border-style:none (borders VANISH)
+   and --chip-bg goes transparent (light chrome text over the day office drops to
+   low contrast). Mirror the load-bearing translucent tokens in rgba() (which
+   predates color-mix by a decade); component-level decorative color-mix degrades
+   harmlessly (the color just inherits), so only these tokens need the fallback. */
+@supports not (color: color-mix(in srgb, red, red)) {
+  :root {
+    --border: rgba(36, 28, 20, 0.12);
+    --border-strong: rgba(36, 28, 20, 0.2);
+    --glow: rgba(217, 119, 87, 0.15);
+    --chip-bg: rgba(14, 13, 12, 0.82);
+  }
+  :root[data-theme='night'] {
+    --border: rgba(244, 238, 226, 0.13);
+    --border-strong: rgba(244, 238, 226, 0.24);
+    --glow: rgba(227, 132, 95, 0.24);
+  }
+}
+
 /* Metric-matched fallback for the Lora body face: local Georgia scaled to Lora's
    metrics so the font-display:swap doesn't reflow the docs prose. size-adjust is
    MEASURED against the built pages (rendered Georgia is ~94.5% of Lora's advance
@@ -325,10 +346,12 @@ section {
      the white label stays legible in both day and night. The glow uses a FIXED
      coral (not var(--coral)) so it matches the baked fill in every theme and
      gallery retint instead of drifting to the theme hue. */
-  background: linear-gradient(100deg, #ad5230, #c96a45);
+  /* The light gradient stop is capped at #b5592f so the white label clears WCAG
+     AA (4.5:1) across the WHOLE fill — the old #c96a45 end was ~3.7:1. */
+  background: linear-gradient(100deg, #ad5230, #b5592f);
   color: #fff;
   text-shadow: 0 1px 2px rgba(35, 14, 5, 0.4);
-  box-shadow: 0 8px 20px color-mix(in srgb, #c96a45 42%, transparent);
+  box-shadow: 0 8px 20px color-mix(in srgb, #b5592f 42%, transparent);
 }
 .btn-primary:hover {
   filter: brightness(1.08);
@@ -444,6 +467,7 @@ section {
   );
 }
 .office-gap {
+  min-height: 100vh; /* fallback for Safari < 15.4, which drops the svh line */
   min-height: 100svh;
   position: relative;
 }
@@ -733,6 +757,9 @@ code,
   border: 1px solid var(--border);
   border-radius: 6px;
   padding: 0.08rem 0.34rem;
+  /* long unbreakable tokens (paths, socket names) must wrap, not overflow the
+     mobile viewport — body{overflow-x:hidden} would clip them unreachably */
+  overflow-wrap: anywhere;
 }
 /* fenced code blocks (Shiki sets the colors; we frame them) */
 .prose pre {
@@ -747,9 +774,13 @@ code,
 .prose pre code {
   font-family: var(--font-mono);
 }
-/* tables */
+/* tables — display:block + overflow-x:auto gives wide markdown tables their OWN
+   horizontal scroll on mobile instead of overflowing the page (which
+   body{overflow-x:hidden} would clip unreachably); mirrors the Tools matrix. */
 .prose table {
-  width: 100%;
+  display: block;
+  overflow-x: auto;
+  max-width: 100%;
   border-collapse: collapse;
   margin: 1.2rem 0;
   font-size: 0.95rem;

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -461,6 +461,19 @@ test('showcase studio: deep-links tune, dial and chips swap hydrated stages, the
         .evaluate((v) => !(v as HTMLVideoElement).paused && !v.hasAttribute('controls'))
     )
     .toBe(true);
+  // WCAG 2.2.2: the page pause governs the clip too (it has no controls of its
+  // own in normal motion). Drive the same pix:paused signal #office-pause fires
+  // and assert the clip stops, then resumes.
+  const clipPaused = () =>
+    page.locator('[data-stage="agents"] video').evaluate((v) => (v as HTMLVideoElement).paused);
+  await page.evaluate(() =>
+    document.dispatchEvent(new CustomEvent('pix:paused', { detail: { paused: true } }))
+  );
+  await expect.poll(clipPaused).toBe(true);
+  await page.evaluate(() =>
+    document.dispatchEvent(new CustomEvent('pix:paused', { detail: { paused: false } }))
+  );
+  await expect.poll(clipPaused).toBe(false);
   expect(errors()).toEqual([]);
 });
 
@@ -573,4 +586,42 @@ test('landing fixed chrome: floating nav, statusline readouts, floor popover, da
   await page.locator('[data-floor-btn="1"]').click();
   await expect(page.locator('#sl-floors')).toBeHidden();
   await expect(page.locator('[data-lift-digit]')).toHaveText('1F', { timeout: 10_000 });
+});
+
+test('no horizontal overflow at phone widths (mobile pan guard)', async ({ browser }) => {
+  // `body { overflow-x: hidden }` masks the desktop scrollbar, so a full-width
+  // block whose ::before glow (or any child) pokes past the viewport is
+  // INVISIBLE on desktop yet PANS the visual viewport on mobile — the
+  // [data-lit]::before -8% overflow class (fixed by overflow-x: clip). A
+  // pseudo-element dodges every querySelectorAll('*') element scan, so only a
+  // documentElement scrollWidth<=clientWidth guard catches it. This whole class
+  // slipped the #453 whole-site audit (desktop-eyeballed, no such assertion);
+  // pin index + a docs page at real phone widths so it can't silently regress.
+  for (const [path, width] of [
+    ['./', 360], // Android
+    ['./', 390], // iPhone 12–14
+    ['./', 430], // iPhone Pro Max
+    ['./config', 390], // docs shell: code blocks / mermaid can overflow too
+  ] as const) {
+    const context = await browser.newContext({
+      viewport: { width, height: 820 },
+      isMobile: true,
+      hasTouch: true,
+    });
+    const page = await context.newPage();
+    await page.addInitScript(() => sessionStorage.setItem('pix-booted', '1'));
+    await page.goto(path);
+    // The reported symptom is a left-right drag at the BOTTOM — measure there,
+    // after any late layout settles.
+    await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight));
+    const { scrollW, clientW } = await page.evaluate(() => ({
+      scrollW: document.documentElement.scrollWidth,
+      clientW: document.documentElement.clientWidth,
+    }));
+    expect(
+      scrollW,
+      `${path} at ${width}px is ${scrollW - clientW}px wider than the viewport (horizontal pan)`
+    ).toBeLessThanOrEqual(clientW);
+    await context.close();
+  }
 });


### PR DESCRIPTION
## Origin

Started from a reported hero glitch ("the office is wider on load, then adjusts"). Investigation found two *separate* things, then widened into a full re-audit:

1. **Hero reframe** — the live wasm canvas computed its buffer from the window aspect, so it only matched the fixed 16:9 poster at 16:9 windows; every other aspect reframed on the poster→canvas crossfade. After seeing both options rendered, we **kept native-fit** (best framing, no crop) and accepted the one-time load reframe — so this is intentionally *not* "fixed" here.
2. **A real mobile bug it exposed** — `[data-lit]::before` (the readability glow, `inset -8%`) made full-width `<section>`s ~8% wider than the viewport. `body{overflow-x:hidden}` hid it on desktop, but on **mobile it panned the page left-right**. Fixed with `overflow-x: clip` (commit 1).

That prompted a **6-lens re-audit** (responsive / a11y / JS-correctness / perf-CSP / cross-browser / links-security), since #453's "whole-site review" scanned its own diff, not the pre-existing surface. Commit 2 is the remediation.

## Fixes (commit 2)

**Responsive (WCAG 1.4.10)**
- Studio dial wraps to 2 cols <480px + `.studio` track `minmax(0,1fr)` — all 8 channels stay tappable on phones (03/06 were clipped & unreachable).
- Docs prose tables get their own `overflow-x:auto` + inline-code `overflow-wrap:anywhere` (config was 404px / kb 414px wide at 390px; now 0 page overflow).

**Accessibility**
- **WCAG 2.2.2**: Showcase demo clips now honor `#office-pause` (`pix:paused`). They auto-loop with no controls in normal motion, so in-view-gating didn't satisfy 2.2.2. Corrected the false `CLAUDE.md` claim + added an e2e assertion.
- **WCAG 1.4.3 (day theme)**: install active tab `--led` 1.4:1 → `--coral-deep` 5.2:1; "see it live"/"see how" links `--coral` 2.7:1 → `--coral-deep` 5.2:1; primary CTA gradient light stop `#c96a45` 3.7:1 → `#b5592f` 4.7:1.

**Robustness**
- No-JS content blackout: `<noscript>` keeps `.reveal` sections visible (were `opacity:0` until JS — blank page below the hero with JS off).
- `color-mix()` `@supports` rgba() fallback for `--border`/`--chip-bg`/`--glow` (Safari <16.2 voided the declaration → borders vanished).
- `100vh` fallback before `100svh` (Safari <15.4 collapsed hero/gaps).
- Reduced-motion hero strand: reset **all** `[data-lit=fade]` blocks (hero H1/CTA could stay invisible after a mid-session reduce).
- Escape-during-boot no longer fires a spurious theme change; dimmer re-measures on reflow; Showcase `IntersectionObserver` guarded; dracula shows the day toggle; CSP `img-src` drops unused `data:`.

## Verification
- `just site-check` ✅ (tsc / eslint / knip / unit / build)
- `just site-e2e` ✅ **18/18** — includes a **new mobile horizontal-overflow guard** (index 360/390/430 + docs) and the new video-pause assertion.
- Rendered: mobile dial all-8-reachable @360px, no-JS below-hero visible, docs tables fit @390px, contrast math (CTA 4.74:1, coral-deep 5.21:1; old 1.40/2.70 confirmed failing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)