### PR TITLE
fix(site): #office-pause governs ambient motion independent of wasm (#456)

### DIFF
--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -60,9 +60,7 @@ Mermaid diagram becomes an inline SVG at build via `rehype-mermaid`, which is
   The backdrop's pause switch (`#office-pause`, WCAG 2.2.2) lives in the same
   component: pause stops the rAF loop (frozen frame stays on the canvas) and
   resume subtracts the paused span from the sim clock (`pauseOffset`) so the
-  timeline doesn't lurch-jump; the button stays `hidden` on every poster-only
-  path (reduced motion / no wasm / fetch failure) and is unhidden by the
-  first painted frame. Pause is **page-scoped**: `setPaused` dispatches
+  timeline doesn't lurch-jump. Pause is **page-scoped**: `setPaused` dispatches
   `pix:paused` and every other >5s auto-motion listens (the statusline feed
   ticker, the hero dust) — one control governs the page's *ambient* motion,
   and the statusline reads `❚❚ PAUSED`. The Showcase demo clips ARE in the
@@ -70,17 +68,17 @@ Mermaid diagram becomes an inline SVG at build via `rehype-mermaid`, which is
   in normal motion they auto-loop with NO visible controls, so in-view-gating
   alone did not satisfy 2.2.2 — the page pause button is their pause affordance.
   (Under reduced-motion the clips instead pause and show native `<video>`
-  controls, a separate path.) One caveat: on a **wasm-failure / no-wasm load**
-  `#office-pause` stays `hidden` (the poster-only path unhides it only on the
-  first painted frame), so a NON-reduced-motion visitor whose wasm never loads
-  has no visible pause button for the clips (nor the statusline ticker / hero
-  dust — the same shared, pre-existing dependency). Reduced-motion users are
-  unaffected (native `<video>` controls, wasm-independent). Unhiding the button
-  whenever any >5s auto-motion runs — independent of wasm — is the real fix,
-  tracked as a follow-up. The wasm fetch is **deferred** off the render-critical
-  window (`load` → `requestIdleCallback`) so it doesn't compete with the
-  above-fold poster/fonts; a live un-reduce still boots promptly via the mq
-  listener.
+  controls, a separate path.) Because that ambient motion is **wasm-independent**,
+  `#office-pause` is decoupled from the office canvas (#456): the button is shown
+  whenever motion runs = NOT reduced-motion, and its control (`setPaused` / the
+  click handler) wires up even on a no-wasm engine or a failed fetch — so a
+  non-reduced-motion visitor whose wasm never loads can still pause the ticker /
+  dust / clips. Only the office RENDER path (`boot`/`paint`) is gated on `hasWasm`;
+  `start`/`stop` are no-ops without a live office, so `setPaused` is safe
+  standalone. Reduced-motion hides the button (nothing auto-animates there). The
+  wasm fetch is **deferred** off the render-critical window (`load` →
+  `requestIdleCallback`) so it doesn't compete with the above-fold poster/fonts;
+  a live un-reduce still boots promptly via the mq listener.
 - The **on-page nav + footer logo mark IS the favicon** — `public/favicon-32.png`
   / `favicon-32-night.png` (the head-and-collar bust squircle from #379), one
   brand asset in two roles so there's no second file to drift (the old separate

--- a/site/README.md
+++ b/site/README.md
@@ -121,7 +121,9 @@ gates can't see. CI runs it in `site.yml` after the build step.
   statusline — WCAG 2.2.2): pause freezes the office frame in place AND, via the
   `pix:paused` event, stops every other >5s auto-motion (the statusline feed
   ticker, the hero dust) — the statusline reads `❚❚ PAUSED`; resume picks the
-  timeline up where it stopped. Hidden whenever only the still poster is showing.
+  timeline up where it stopped. Hidden only under reduced motion (nothing
+  auto-animates); on a no-wasm / fetch-failure poster it stays visible, since the
+  ticker / dust / clips still run and it governs them wasm-independently (#456).
 - **Docs shell** — `layouts/Docs.astro` gives /config, /architecture,
   /contributing, /migration a shared sidebar + build-time mini-TOC + pager,
   driven by the one `DOCS` manifest in `consts.ts` (the Nav dropdown reads the

--- a/site/src/components/OfficeBackdrop.astro
+++ b/site/src/components/OfficeBackdrop.astro
@@ -40,12 +40,15 @@ import { asset, DIM_RESTING } from '../consts';
 }
 <div id="dimmer" aria-hidden="true" style={`--dim-rest:${DIM_RESTING}`}></div>
 {
-  /* THE PAUSE SWITCH (WCAG 2.2.2) — a real, keyboard-reachable <button> for
-     the auto-playing office; hidden until the canvas actually goes live (the
-     poster-only paths — reduced motion, no wasm, fetch failure — have nothing
-     to pause). aria-pressed carries the state; the label stays constant
-     (toggle-button convention). Icons are inline pixel SVGs on an 8×8 grid
-     (crispEdges — no anti-aliased glyph fonts near the office's pixels). */
+  /* THE PAUSE SWITCH (WCAG 2.2.2) — a real, keyboard-reachable <button> for the
+     page's auto-motion. Shown whenever motion runs = NOT reduced-motion: it
+     governs the wasm-INDEPENDENT ambient motion (statusline ticker, hero dust,
+     showcase clips) via pix:paused, so it stays reachable even on the no-wasm /
+     fetch-failure poster paths where the office canvas never goes live (#456).
+     Only reduced-motion hides it (nothing auto-animates there). aria-pressed
+     carries the state; the label stays constant (toggle-button convention).
+     Icons are inline pixel SVGs on an 8×8 grid (crispEdges — no anti-aliased
+     glyph fonts near the office's pixels). */
 }
 <button
   id="office-pause"
@@ -179,8 +182,14 @@ import { asset, DIM_RESTING } from '../consts';
   (function () {
     const wrap = document.querySelector('.backdrop');
     const canvas = document.getElementById('office-live');
-    if (!wrap || !canvas || typeof WebAssembly === 'undefined') return;
+    if (!wrap || !canvas) return;
     const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    // The office needs WebAssembly, but the pause CONTROL does not: it governs
+    // the page's wasm-independent ambient motion (statusline ticker, hero dust,
+    // showcase clips) via pix:paused, so it must wire up and stay reachable even
+    // on a no-wasm engine or a failed fetch. Only the office render path is gated
+    // on `hasWasm`. #456
+    const hasWasm = typeof WebAssembly !== 'undefined';
 
     // Render SMALL and let CSS stretch (image-rendering: pixelated): ~180px
     // tall is the app's own chunky-pixel scale (OFFICE_TARGET_H).
@@ -237,7 +246,6 @@ import { asset, DIM_RESTING } from '../consts';
         if (!live) {
           live = true;
           wrap.classList.add('is-live');
-          if (pauseBtn) pauseBtn.hidden = false; // there is now something to pause
           document.dispatchEvent(new CustomEvent('pix:onair', { detail: { live: true } }));
         }
       }
@@ -283,6 +291,14 @@ import { asset, DIM_RESTING } from '../consts';
         setPaused(!paused);
       });
     }
+    // #office-pause is visible whenever the page has ambient auto-motion to pause
+    // — i.e. NOT reduced motion — regardless of whether the wasm office ever goes
+    // live. On a no-wasm / fetch-fail load the ticker + dust + clips still run, so
+    // the button must still offer their pause affordance (WCAG 2.2.2). #456
+    function syncPauseBtn() {
+      if (pauseBtn) pauseBtn.hidden = mq.matches;
+    }
+    syncPauseBtn();
 
     // Reduced motion defers the wasm fetch entirely (still poster only) —
     // but a LIVE un-reduce should still bring the office up, so the fetch
@@ -331,8 +347,10 @@ import { asset, DIM_RESTING } from '../consts';
         }
       )(boot);
     }
-    if (document.readyState === 'complete') deferBoot();
-    else window.addEventListener('load', deferBoot, { once: true });
+    if (hasWasm) {
+      if (document.readyState === 'complete') deferBoot();
+      else window.addEventListener('load', deferBoot, { once: true });
+    }
 
     let rraf = 0;
     window.addEventListener('resize', function () {
@@ -353,15 +371,10 @@ import { asset, DIM_RESTING } from '../consts';
       mq.addEventListener('change', function () {
         if (mq.matches) {
           stop();
-          // Reduced motion takes over as the poster-still design: the pause
-          // switch has nothing left to pause — reset it and hide it (a later
-          // un-reduce re-boots into the PLAYING state, button re-shown by the
-          // first painted frame).
+          // Reduced motion IS the poster-still design: nothing auto-animates, so
+          // reset the pause flag (syncPauseBtn hides the control below).
           paused = false;
-          if (pauseBtn) {
-            pauseBtn.setAttribute('aria-pressed', 'false');
-            pauseBtn.hidden = true;
-          }
+          if (pauseBtn) pauseBtn.setAttribute('aria-pressed', 'false');
           // clear any user-pause so the statusline feed / hero dust aren't stuck
           // paused after a later un-reduce (they hold their OWN reduced-motion
           // stop; this only keeps the pause flag in sync across surfaces)
@@ -369,10 +382,13 @@ import { asset, DIM_RESTING } from '../consts';
           wrap.classList.remove('is-live');
           live = false;
           document.dispatchEvent(new CustomEvent('pix:onair', { detail: { live: false } }));
-        } else {
+        } else if (hasWasm) {
           boot(); // no-op if already booted; a reduced-motion first visit fetches here
           start();
         }
+        // ambient motion stops on reduce and resumes on un-reduce (ticker/dust/
+        // clips) — show/hide the control to match, both directions. #456
+        syncPauseBtn();
       });
     }
   })();

--- a/site/src/components/Showcase.astro
+++ b/site/src/components/Showcase.astro
@@ -149,12 +149,12 @@ const countWord = COUNT_WORDS[channels.length] ?? String(channels.length);
     if (mq.addEventListener) mq.addEventListener('change', syncVideos);
     // WCAG 2.2.2: the page-wide pause button (#office-pause) stops the looping
     // demo clips too — one control governs all >5s auto-motion. The clips carry
-    // no visible controls in normal motion, so this IS their pause affordance —
-    // EXCEPT on a wasm-failure/no-wasm load, where #office-pause never unhides
-    // (poster-only path); there the reduced-motion branch above (native <video>
-    // controls) is the independent backstop. Unhiding the button without wasm is
-    // the shared pre-existing gap (statusline ticker + hero dust too) tracked
-    // separately — the clips ride the same page-pause pattern as those.
+    // no visible controls in normal motion, so this IS their pause affordance.
+    // #office-pause is shown whenever motion runs = NOT reduced-motion — including
+    // the no-wasm / fetch-failure poster paths, where it's decoupled from the
+    // office canvas and still governs the ticker / dust / clips (#456). Under
+    // reduced-motion the button is hidden and the clips instead show native
+    // <video> controls (the separate backstop above).
     document.addEventListener('pix:paused', function (e) {
       userPaused = !!(e.detail && e.detail.paused);
       syncVideos();

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -137,7 +137,7 @@ test('the hero pause switch freezes the office and resumes it seamlessly', async
   const errors = watchErrors(page);
   await gotoLive(page);
   const btn = page.locator('#office-pause');
-  await expect(btn).toBeVisible(); // unhidden by the first painted frame
+  await expect(btn).toBeVisible(); // shown at init for any non-reduced-motion visitor (syncPauseBtn), independent of the office going live
   await expect(btn).toHaveAttribute('aria-pressed', 'false');
   const shot = () =>
     page.evaluate(() => (document.getElementById('office-live') as HTMLCanvasElement).toDataURL());
@@ -227,7 +227,9 @@ test('reduced motion stays on the still poster without errors', async ({ browser
   await page.waitForLoadState('networkidle');
   expect(wasmRequests).toEqual([]);
   await expect(page.locator('.backdrop.is-live')).not.toBeAttached();
-  // Poster-only path: nothing is animating, so the pause switch stays hidden.
+  // Reduced motion is the ONLY path that hides the pause switch: nothing
+  // auto-animates here (the wasm-fail poster keeps it visible — ticker/dust/clips
+  // still run there, see the wasm-failure test).
   await expect(page.locator('#office-pause')).toBeHidden();
   // Reduced motion also strips the showcase clip's autoplay: native controls
   // appear and the video stays paused (WCAG 2.2.2).

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -241,7 +241,9 @@ test('reduced motion stays on the still poster without errors', async ({ browser
 test('wasm fetch failure keeps the still poster without an uncaught error', async ({ browser }) => {
   // The third documented boot path (live / reduced-motion / FAILURE): abort every
   // wasm request so the dynamic import rejects — the empty .catch must keep the
-  // poster (graceful degradation), never throw or show a dead-canvas pause button.
+  // poster (graceful degradation) and never throw. The pause control stays present
+  // though: it governs the wasm-independent ambient motion (ticker/dust/clips), so
+  // a failed office must NOT strand that motion uncontrollable (#456).
   const context = await browser.newContext();
   const page = await context.newPage();
   const errors = watchErrors(page);
@@ -257,8 +259,24 @@ test('wasm fetch failure keeps the still poster without an uncaught error', asyn
   await page.waitForLoadState('networkidle');
   await expect(page.locator('.backdrop__poster')).toBeVisible();
   await expect(page.locator('.backdrop.is-live')).not.toBeAttached();
-  await expect(page.locator('#office-pause')).toBeHidden(); // nothing to pause
   await expect(page.locator('[data-sl-onair]')).toHaveText('○ STILL');
+  // #456: the office canvas never went live, but the statusline ticker / hero dust
+  // / showcase clips still auto-animate — so the pause control must be VISIBLE and
+  // actually govern them (WCAG 2.2.2), not hidden as if nothing were animating.
+  // Clicking it fires the page-wide pix:paused even with no live office.
+  const pauseBtn = page.locator('#office-pause');
+  await expect(pauseBtn).toBeVisible();
+  const paused = page.evaluate(
+    () =>
+      new Promise<boolean>((resolve) => {
+        document.addEventListener('pix:paused', (e) => resolve((e as CustomEvent).detail.paused), {
+          once: true,
+        });
+      })
+  );
+  await pauseBtn.click();
+  expect(await paused).toBe(true);
+  await expect(pauseBtn).toHaveAttribute('aria-pressed', 'true');
   // the aborted request logs a resource error; the import rejection must stay
   // handled — no uncaught pageerror / console.error beyond that one line.
   expect(errors().filter((e) => !e.includes('Failed to load resource'))).toEqual([]);


### PR DESCRIPTION
Closes #456.

## Problem
`#office-pause` (the WCAG 2.2.2 pause switch) was unhidden **only by the first painted wasm frame**. On the **no-wasm / fetch-failure** poster paths it stayed hidden — but the statusline feed ticker, hero dust, and (since #455) the Showcase demo clips keep auto-animating there, **independent of wasm**. So a non-reduced-motion visitor whose wasm never loaded had **no visible pause affordance** for that motion. Pre-existing for the ticker/dust; #455 extended the same page-pause pattern to the clips, which is why it was tracked as a follow-up rather than fixed inline.

## Fix — decouple the pause *control* from the office *canvas*
- The early return no longer bails on `typeof WebAssembly === 'undefined'`; only the office **render** path (`boot`/`paint`) is gated on a new `hasWasm`. `setPaused`/`start`/`stop` are no-ops without a live office, so the control is safe standalone.
- `syncPauseBtn()` shows `#office-pause` whenever motion runs = **NOT reduced-motion**, independent of wasm, and hides it under reduced-motion — one rule, called at init and on every reduced-motion change. The wasm-frame unhide is removed.
- Clicking it still fires `pix:paused`, which the ticker / dust / clips already consume, and the statusline reads `❚❚ PAUSED` — even with no live office.
- Reduced-motion is unchanged (button hidden; clips keep native `<video>` controls).

## Verification
- **e2e teeth**: the wasm-fetch-failure test now asserts `#office-pause` is **visible** and a click fires `pix:paused{true}` + flips `aria-pressed` (it previously asserted *hidden* — which encoded the bug). The reduced-motion test still asserts hidden.
- **Rendered** the aborted-wasm poster: button shows bottom-right, click → statusline `○ STILL` → `❚❚ PAUSED`.
- `just site-check` EXIT=0 · `just site-e2e` **18/18**.
- Docs: `site/CLAUDE.md` updated — the old "hidden on every poster-only path" text and the #455 follow-up caveat are both replaced with the decoupled behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)