### PR TITLE
docs(release): freshen the in-app 0.12.0 release notes

### DIFF
--- a/crates/pixtuoid/src/version.rs
+++ b/crates/pixtuoid/src/version.rs
@@ -59,9 +59,9 @@ pub fn release_notes(version: &str) -> Option<&'static [&'static str]> {
         // brace would silently break if the indentation ever shifted.
         // [bump-inject-here]
         "0.12.0" => Some(&[
-            "A whole-codebase cleanup: 39 review findings fixed — sturdier session tracking (a delegating agent no longer hides its own pending permission; live sessions survive log-content lookalikes), fresher sprites after a project rename, and pathfinding that recovers when a blocked route reopens",
+            "A sustained whole-codebase cleanup across several review passes — sturdier session tracking (a delegating agent no longer hides its own pending permission; live sessions survive log-content lookalikes), fresher sprites after a project rename, and pathfinding that recovers when a blocked route reopens",
             "The office is more honest under pressure — a full pantry re-steams your coffee, narrow floating windows seat exactly as many agents as fit, and the web hero hires only when a desk is truly free",
-            "Under the hood: the render engine's public API slimmed and semver-gated, per-CLI transcript knowledge fully routed through the source registry, and the daily security-audit signal revived",
+            "Under the hood: a deep architecture pass made illegal states unrepresentable and slimmed the render engine's public API (semver-gated), per-CLI transcript knowledge is fully routed through the source registry, and the daily security-audit signal is revived",
         ]),
         "0.11.1" => Some(&[
             "Maintenance release — the animated office is unchanged from 0.11.0; documentation polish across the site and READMEs, plus a supply-chain hardening of how pixtuoid ships",


### PR DESCRIPTION
Release-prep for **0.12.0** — freshens the in-app release notes only. (The 0.12.0
version bump already landed on `main` during development, so there's no
version-bump commit here; `Cargo.toml` is already `0.12.0` and `version.rs`
already had a curated `"0.12.0"` arm.)

### What changed
The `release_notes("0.12.0")` arm was curated early (the cleanup-arc-#1 bump), so
its **"39 review findings"** count predated the two whole-codebase audits (#457,
#461) and the architecture deep-dive that shipped after. Two string edits, no
claims beyond what shipped:

- **B1:** drop the brittle exact count → *"A sustained whole-codebase cleanup across several review passes …"* (0.12.0 spanned cleanup-arc-#1 + #457 + #461).
- **B3:** fold the arch deep-dive headline into the under-the-hood bullet — *"a deep architecture pass made illegal states unrepresentable and slimmed the render engine's public API (semver-gated) …"*.

### Not touched
- No `CHANGELOG.md` — git-cliff generates the GitHub-release changelog at tag-time (`release.yml`).
- No gen-media regen — no still renders the version popup (the `popup` crop is the agent-tree dashboard), so **0 pixel drift**.

### Gates
`just notes-curated` ✓ · `release_notes` unit tests ✓ · `cargo clippy -p pixtuoid --all-targets` clean.

### Release sequencing (the tag is a human step)
1. This PR + **#462** (the concurrent site hero redesign) merge to `main`.
2. **Then** a human tags: `git tag v0.12.0 && git push origin v0.12.0` → the irreversible crates.io + homebrew + npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BuCo5MJ89A7nLrYv2k5Bys
