### PR TITLE
refactor(core): derive DaemonPresence Busy from the run set (#460)

### DIFF
--- a/crates/pixtuoid-core/CLAUDE.md
+++ b/crates/pixtuoid-core/CLAUDE.md
@@ -40,7 +40,13 @@ src/
 │                       next event (apply_presence's None-only adopt; driver arms the watch on PidSeen too).
 │                       The 4th state DaemonState::Degraded (#317): agent_end.success:false → RunFailed →
 │                       Degraded (sickly-red sluggish the lobster), healed by the next clean RunEnded / new RunStarted /
-│                       GatewayUp restart),
+│                       GatewayUp restart. `DaemonPresence` STORES only the orthogonal axes `liveness:
+│                       DaemonLiveness{Up{degraded}|Down}` + `in_flight_run_keys` (#460): Busy/Idle are NOT
+│                       stored — they're PROJECTED by `DaemonPresence::display_state()` (in state/mod.rs), the ONE
+│                       place the Degraded>Busy>Idle priority lives (degraded checked BEFORE the run set, so a
+│                       fan-out-with-one-failure renders Degraded not Busy). apply_presence mutates axes; every
+│                       renderer reads `display_state()`/`is_busy()`, never a stored `state` — so Busy can't drift
+│                       from the run set (the 4-site hand-sync is gone)),
 │                       decoder.rs (shared utils + decode_hook_payload, a registry-driven dispatcher;
 │                       short-circuits is_daemon() → zero AgentEvents),
 │                       drift.rs (structured decode-drift breadcrumbs: unknown_event/missing_field/

--- a/crates/pixtuoid-core/src/source/daemon.rs
+++ b/crates/pixtuoid-core/src/source/daemon.rs
@@ -17,7 +17,7 @@
 
 use std::time::SystemTime;
 
-use crate::state::{DaemonPresence, DaemonState, SceneState};
+use crate::state::{DaemonLiveness, DaemonPresence, SceneState};
 
 // The runtime half (the tokio presence side channel + `PresenceExitWatch`) —
 // ONE gate for the whole `native` layer of this module; the re-export keeps
@@ -139,7 +139,7 @@ impl DaemonPresence {
     /// `last_seen`: the `apply_presence` callers ride its top-level stamp, and the
     /// sweep / `mark_presence_down` re-anchor it explicitly for the walk-out timer.
     fn enter_down(&mut self) {
-        self.state = DaemonState::Down;
+        self.liveness = DaemonLiveness::Down;
         self.clear_concurrency();
         self.current_pid = None;
     }
@@ -160,7 +160,7 @@ pub fn apply_presence(
         .daemons_mut()
         .entry(source.to_string())
         .or_insert_with(|| DaemonPresence {
-            state: DaemonState::Idle,
+            liveness: DaemonLiveness::UP,
             active_sessions: 0,
             last_seen: now,
             entered_at: now,
@@ -170,7 +170,7 @@ pub fn apply_presence(
     // A transition out of Down (or a fresh GatewayUp) re-anchors the enter
     // animation — the mascot scuttles back in from the elevator. Idle↔Busy
     // does NOT reset it, so the steady wander clock stays continuous.
-    let was_down = p.state == DaemonState::Down;
+    let was_down = p.liveness == DaemonLiveness::Down;
     p.last_seen = now;
     match update {
         // UP-winning + idempotent. A (re)start resets the multiplexed-session
@@ -179,33 +179,38 @@ pub fn apply_presence(
         GatewayUp { pid } => {
             p.current_pid = pid;
             p.clear_concurrency();
-            p.state = DaemonState::Idle;
+            p.liveness = DaemonLiveness::UP;
         }
         GatewayDown => {
             p.enter_down();
         }
         SessionStarted => {
             p.active_sessions = p.active_sessions.saturating_add(1);
-            if p.state == DaemonState::Down {
-                p.state = DaemonState::Idle; // any event ⇒ up
+            if p.liveness == DaemonLiveness::Down {
+                p.liveness = DaemonLiveness::UP; // any event ⇒ up
             }
         }
         SessionEnded => {
             // saturating: a pre-attach session_start we never saw must not underflow.
             p.active_sessions = p.active_sessions.saturating_sub(1);
-            if p.state == DaemonState::Down {
-                p.state = DaemonState::Idle;
+            if p.liveness == DaemonLiveness::Down {
+                p.liveness = DaemonLiveness::UP;
             }
         }
         RunStarted { run_key } => {
             p.in_flight_run_keys.insert(run_key);
-            p.state = DaemonState::Busy;
+            // A run starting means alive + not degraded (a fresh attempt clears a
+            // prior model-error). Busy itself is DERIVED from the now-non-empty
+            // run set by `display_state()`, never stored.
+            p.liveness = DaemonLiveness::UP;
         }
         RunEnded { run_key } => {
             p.in_flight_run_keys.remove(&run_key);
             if p.in_flight_run_keys.is_empty() {
-                // A successful run ending heals a prior Degraded back to Idle.
-                p.state = DaemonState::Idle;
+                // The set drained: a clean run heals a prior Degraded and, if the
+                // daemon was Down, resurrects it. Idle is the derived projection
+                // of an empty run set, so there is nothing else to set.
+                p.liveness = DaemonLiveness::UP;
             }
         }
         // A FAILED run (#317): the gateway is alive but its model backend broke.
@@ -214,7 +219,9 @@ pub fn apply_presence(
         // (GatewayUp → Idle). Remove this run from the in-flight set (it ended).
         RunFailed { run_key } => {
             p.in_flight_run_keys.remove(&run_key);
-            p.state = DaemonState::Degraded;
+            // Degraded regardless of any OTHER run still in flight — the
+            // projection renders Degraded over Busy (degraded checked first).
+            p.liveness = DaemonLiveness::Up { degraded: true };
         }
         // Pure pid adoption (#318): bootstrap `current_pid` for a live daemon we
         // never saw `gateway_start` for (mid-attach / reconnect-while-alive), so
@@ -242,7 +249,7 @@ pub fn apply_presence(
     }
     // Re-anchor the enter animation on a Down → up resurrection (the entry was
     // not yet TTL-swept). A fresh insert already stamped `entered_at = now`.
-    if was_down && p.state != DaemonState::Down {
+    if was_down && p.liveness != DaemonLiveness::Down {
         p.entered_at = now;
     }
 }
@@ -263,7 +270,7 @@ pub fn sweep_presence_ttl(scene: &mut SceneState, source: &str, ttl: PresenceTtl
             .duration_since(p.last_seen)
             .map(|d| d.as_millis() as u64)
             .unwrap_or(0);
-        if p.state == DaemonState::Down {
+        if p.liveness == DaemonLiveness::Down {
             // Keep the Down entry only until the walk-out has had time to finish.
             idle_ms >= ttl.down_remove_ms
         } else {
@@ -275,8 +282,11 @@ pub fn sweep_presence_ttl(scene: &mut SceneState, source: &str, ttl: PresenceTtl
                 // no walk-out). The apply-path GatewayDown/PidExited ride
                 // `apply_presence`'s top-level stamp instead.
                 p.last_seen = now;
-            } else if p.state == DaemonState::Busy && idle_ms >= ttl.busy_decay_ms {
-                p.state = DaemonState::Idle;
+            } else if p.is_busy() && idle_ms >= ttl.busy_decay_ms {
+                // Drain the stranded run set; Busy → Idle falls out of the
+                // projection (no state field to flip). `is_busy()` is false while
+                // Degraded, so a broken gateway is NOT silently healed here — only
+                // a real RunEnded/RunStarted/GatewayUp does that.
                 p.in_flight_run_keys.clear();
             }
             false
@@ -296,7 +306,7 @@ pub fn sweep_presence_ttl(scene: &mut SceneState, source: &str, ttl: PresenceTtl
 /// reducer's `reconcile_connected` for agents).
 pub fn mark_presence_down(scene: &mut SceneState, source: &str, now: SystemTime) {
     if let Some(p) = scene.daemons_mut().get_mut(source) {
-        if p.state != DaemonState::Down {
+        if p.liveness != DaemonLiveness::Down {
             p.enter_down();
             p.last_seen = now;
         }
@@ -306,6 +316,9 @@ pub fn mark_presence_down(scene: &mut SceneState, source: &str, now: SystemTime)
 #[cfg(test)]
 mod tests {
     use super::*;
+    // The render vocabulary the assertions compare against — projected via
+    // `display_state()`; production daemon.rs now mutates only `DaemonLiveness`.
+    use crate::state::DaemonState;
 
     // The presence state machine is daemon-AGNOSTIC: every assertion runs
     // against TWO synthetic sources to PROVE a 2nd daemon needs zero new
@@ -329,7 +342,7 @@ mod tests {
         SystemTime::UNIX_EPOCH + std::time::Duration::from_millis(m)
     }
     fn st(s: &SceneState, src: &str) -> DaemonState {
-        s.daemons()[src].state
+        s.daemons()[src].display_state()
     }
     fn sessions(s: &SceneState, src: &str) -> u32 {
         s.daemons()[src].active_sessions

--- a/crates/pixtuoid-core/src/state/mod.rs
+++ b/crates/pixtuoid-core/src/state/mod.rs
@@ -379,12 +379,40 @@ pub enum DaemonState {
     Down,
 }
 
+/// The two ORTHOGONAL liveness axes a daemon mascot actually STORES, so that
+/// "busy" can never drift from the run set (#460). `Up { degraded }` is the
+/// alive gateway (healthy, or `degraded` = its model backend is failing every
+/// run, #317); `Down` is seen-then-died. The remaining render distinction —
+/// Idle vs Busy — is deliberately NOT a field here: it is a pure function of
+/// [`DaemonPresence::in_flight_run_keys`], projected by
+/// [`DaemonPresence::display_state`]. Storing `Busy`/`Idle` separately was the
+/// hand-synced duplication this split removes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DaemonLiveness {
+    /// The gateway is alive. `degraded` (#317): alive-but-broken (auth revoked /
+    /// provider down), rendered distressed; healed by the next clean run / new
+    /// attempt / restart.
+    Up { degraded: bool },
+    /// The gateway was seen and then died (the mascot walks out). Distinct from
+    /// *absent* (no map entry = never configured / plugin not loaded).
+    Down,
+}
+
+impl DaemonLiveness {
+    /// The healthy alive state (`Up { degraded: false }`) — the common case,
+    /// named once so construction sites don't repeat the struct literal.
+    pub const UP: DaemonLiveness = DaemonLiveness::Up { degraded: false };
+}
+
 /// Per-daemon presence for the gateway mascot (the P-A representation): lives on
 /// `SceneState` so the serializable scene snapshot the renderer reads carries
 /// the mascot's state + concurrency (bubble) intensity.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DaemonPresence {
-    pub state: DaemonState,
+    /// The stored liveness axes ([`DaemonLiveness`]). The 4-way render state
+    /// (incl. Idle/Busy) is PROJECTED via [`display_state`](Self::display_state),
+    /// never stored — Busy is derived from `in_flight_run_keys`.
+    pub liveness: DaemonLiveness,
     /// Concurrent sessions the gateway is multiplexing (bubble intensity).
     pub active_sessions: u32,
     /// Last time ANY presence event arrived — drives the busy→idle decay and
@@ -406,6 +434,35 @@ pub struct DaemonPresence {
     /// The gateway pid currently armed for `ExitWatch` (None until first seen).
     /// Kept for debug dumps + the restart pid-rebind guard; not a wire contract.
     pub current_pid: Option<i32>,
+}
+
+impl DaemonPresence {
+    /// The 4-way render vocabulary ([`DaemonState`]) projected from the stored
+    /// axes — the SINGLE place the `Degraded > Busy > Idle` priority is encoded.
+    /// Every renderer reads this instead of a stored `state` field, so Busy can't
+    /// drift from the run set: a `Degraded` gateway renders Degraded even with
+    /// runs still in flight (the fan-out-with-one-failure case), because
+    /// `degraded` is checked BEFORE the run set.
+    pub fn display_state(&self) -> DaemonState {
+        match self.liveness {
+            DaemonLiveness::Down => DaemonState::Down,
+            DaemonLiveness::Up { degraded: true } => DaemonState::Degraded,
+            DaemonLiveness::Up { degraded: false } => {
+                if self.in_flight_run_keys.is_empty() {
+                    DaemonState::Idle
+                } else {
+                    DaemonState::Busy
+                }
+            }
+        }
+    }
+
+    /// Whether the mascot renders as Busy (alive, not degraded, ≥1 run in flight).
+    /// Derived from [`display_state`](Self::display_state) so the Degraded-first
+    /// priority has exactly one definition.
+    pub fn is_busy(&self) -> bool {
+        self.display_state() == DaemonState::Busy
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -595,12 +652,16 @@ mod tests {
 
     #[test]
     fn daemon_presence_round_trips_and_skips_in_flight_keys() {
-        // The openclaw daemon-presence (mascot) state lives on SceneState (P-A) so
-        // the geometry pass can read it. It serializes like the rest of the tree
+        // The openclaw daemon-presence (mascot) lives on SceneState (P-A) so the
+        // geometry pass can read it. It serializes like the rest of the tree
         // (#279). `in_flight_run_keys` is transient process state — a daemon
         // restart resets it — so it is `#[serde(skip)]` and restores empty.
-        let mut p = DaemonPresence {
-            state: DaemonState::Busy,
+        // Consequence of the #460 split: since Busy is DERIVED from the run set
+        // (never a serialized field), a restored dump with a drained run set reads
+        // Idle, NOT Busy — the correct fix for the old "restore strands a
+        // perpetual Busy" drift (this test used to assert the stranded Busy).
+        let p = DaemonPresence {
+            liveness: DaemonLiveness::UP,
             active_sessions: 3,
             last_seen: SystemTime::now(),
             entered_at: SystemTime::now(),
@@ -609,13 +670,23 @@ mod tests {
                 .collect(),
             current_pid: Some(4242),
         };
+        assert_eq!(
+            p.display_state(),
+            DaemonState::Busy,
+            "a non-empty run set reads Busy before serialization"
+        );
         let json = serde_json::to_string(&p).expect("serialize");
         assert!(
             !json.contains("run-1"),
             "in_flight_run_keys must be skipped on the wire: {json}"
         );
         let back: DaemonPresence = serde_json::from_str(&json).expect("deserialize");
-        assert_eq!(back.state, DaemonState::Busy);
+        assert_eq!(back.liveness, DaemonLiveness::UP);
+        assert_eq!(
+            back.display_state(),
+            DaemonState::Idle,
+            "skipped run set restores empty ⇒ Idle, never a stranded Busy"
+        );
         assert_eq!(back.active_sessions, 3);
         assert_eq!(back.current_pid, Some(4242));
         assert!(
@@ -623,12 +694,18 @@ mod tests {
             "skipped field restores empty"
         );
 
-        for st in [DaemonState::Idle, DaemonState::Busy, DaemonState::Down] {
-            p.state = st;
-            let j = serde_json::to_string(&p).unwrap();
+        // Every liveness value round-trips (it IS the serialized axis).
+        let mut q = back;
+        for liveness in [
+            DaemonLiveness::UP,
+            DaemonLiveness::Up { degraded: true },
+            DaemonLiveness::Down,
+        ] {
+            q.liveness = liveness;
+            let j = serde_json::to_string(&q).unwrap();
             assert_eq!(
-                serde_json::from_str::<DaemonPresence>(&j).unwrap().state,
-                st
+                serde_json::from_str::<DaemonPresence>(&j).unwrap().liveness,
+                liveness
             );
         }
     }
@@ -641,7 +718,7 @@ mod tests {
         s.daemons.insert(
             "openclaw".to_string(),
             DaemonPresence {
-                state: DaemonState::Idle,
+                liveness: DaemonLiveness::UP,
                 active_sessions: 0,
                 last_seen: SystemTime::now(),
                 entered_at: SystemTime::now(),
@@ -656,8 +733,55 @@ mod tests {
             serde_json::to_string(&back).expect("re-serialize"),
             "round-trip must be byte-stable"
         );
-        assert_eq!(back.daemons["openclaw"].state, DaemonState::Idle);
+        assert_eq!(back.daemons["openclaw"].liveness, DaemonLiveness::UP);
         assert_eq!(back.daemons["openclaw"].current_pid, Some(900));
+    }
+
+    fn presence_at(liveness: DaemonLiveness) -> DaemonPresence {
+        DaemonPresence {
+            liveness,
+            active_sessions: 0,
+            last_seen: SystemTime::UNIX_EPOCH,
+            entered_at: SystemTime::UNIX_EPOCH,
+            in_flight_run_keys: Default::default(),
+            current_pid: None,
+        }
+    }
+
+    #[test]
+    fn display_state_derives_busy_from_the_run_set_not_a_stored_flag() {
+        // Busy is a pure function of `in_flight_run_keys`, never a separately
+        // stored field that could drift from the set (the #460 invariant).
+        let mut p = presence_at(DaemonLiveness::Up { degraded: false });
+        assert_eq!(p.display_state(), DaemonState::Idle);
+        assert!(!p.is_busy());
+        p.in_flight_run_keys.insert("r".into());
+        assert_eq!(p.display_state(), DaemonState::Busy);
+        assert!(p.is_busy());
+        p.in_flight_run_keys.clear();
+        assert_eq!(p.display_state(), DaemonState::Idle, "drained ⇒ Idle");
+    }
+
+    #[test]
+    fn display_state_degraded_wins_over_busy_with_a_run_still_in_flight() {
+        // The reachable fan-out-with-one-failure case: one run FAILED (degraded)
+        // while ANOTHER is still in flight. Degraded must render over Busy — this
+        // is exactly why the projection checks `degraded` BEFORE the run set (a
+        // naive `Up && !empty ⇒ Busy` would regress it).
+        let mut p = presence_at(DaemonLiveness::Up { degraded: true });
+        p.in_flight_run_keys.insert("still-running".into());
+        assert_eq!(p.display_state(), DaemonState::Degraded);
+        assert!(!p.is_busy(), "a degraded daemon never reads as Busy");
+    }
+
+    #[test]
+    fn display_state_down_wins_over_a_stray_run_key() {
+        // Down is terminal for the projection; a defensively non-empty run set
+        // (enter_down clears it, but the type permits it) can't read as Busy.
+        let mut p = presence_at(DaemonLiveness::Down);
+        p.in_flight_run_keys.insert("stray".into());
+        assert_eq!(p.display_state(), DaemonState::Down);
+        assert!(!p.is_busy());
     }
 
     #[test]

--- a/crates/pixtuoid-scene/src/floor.rs
+++ b/crates/pixtuoid-scene/src/floor.rs
@@ -741,13 +741,13 @@ mod tests {
         // daemons onto floor 0 ONLY, so a multi-floor office renders the lobster
         // exactly once (a regression dropping the gate / flipping the index would
         // duplicate him on every floor).
-        use pixtuoid_core::state::{DaemonPresence, DaemonState};
+        use pixtuoid_core::state::{DaemonLiveness, DaemonPresence};
         let mut scene = SceneState::uniform(16);
         scene.floor_capacities[1] = 16; // a second floor exists
         scene.daemons_mut().insert(
             pixtuoid_core::source::openclaw::SOURCE_NAME.to_string(),
             DaemonPresence {
-                state: DaemonState::Idle,
+                liveness: DaemonLiveness::UP,
                 active_sessions: 0,
                 last_seen: SystemTime::UNIX_EPOCH,
                 entered_at: SystemTime::UNIX_EPOCH,

--- a/crates/pixtuoid-scene/src/pixel_painter/drawable.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/drawable.rs
@@ -20,7 +20,7 @@ use std::time::SystemTime;
 use pixtuoid_core::sprite::blit::blit_frame;
 use pixtuoid_core::sprite::format::Pack;
 use pixtuoid_core::sprite::{Rgb, RgbBuffer};
-use pixtuoid_core::state::{DaemonPresence, DaemonState, FloorLocalDeskIndex};
+use pixtuoid_core::state::{DaemonLiveness, DaemonPresence, DaemonState, FloorLocalDeskIndex};
 use pixtuoid_core::AgentSlot;
 
 use super::effects::{
@@ -539,7 +539,7 @@ pub(super) fn mascot_position(
     const MASCOT_ANIM_FRAME_MS: u64 = 200;
     let frame = ((epoch_ms(now) / MASCOT_ANIM_FRAME_MS) % 2) as usize;
 
-    if presence.state == DaemonState::Down {
+    if presence.liveness == DaemonLiveness::Down {
         // Walk-out: from where the lobster was at the instant of Down, to the elevator.
         let down_age = now.duration_since(presence.last_seen).ok()?.as_millis() as u64;
         if down_age >= MASCOT_LEAVE_MS {
@@ -575,12 +575,12 @@ pub(super) fn mascot_position(
     }
 
     // Steady wander, styled by state.
-    let cycle_ms = match presence.state {
+    let cycle_ms = match presence.display_state() {
         DaemonState::Busy => MASCOT_BUSY_CYCLE_MS,
         DaemonState::Degraded => MASCOT_DEGRADED_CYCLE_MS,
         _ => MASCOT_IDLE_CYCLE_MS,
     };
-    let spots = mascot_spots(layout, presence.state, home);
+    let spots = mascot_spots(layout, presence.display_state(), home);
     let (pos, walking) = mascot_wander(layout, age - MASCOT_ENTER_MS, seed, &spots, home, cycle_ms);
     if walking {
         Some((pos, walk_anim, frame))
@@ -1460,7 +1460,8 @@ mod tests {
 
     fn idle_presence(now: SystemTime, age_ms: u64) -> DaemonPresence {
         DaemonPresence {
-            state: DaemonState::Idle,
+            // Up with an empty run set ⇒ Idle (the derived projection).
+            liveness: DaemonLiveness::UP,
             active_sessions: 0,
             last_seen: now,
             entered_at: now - std::time::Duration::from_millis(age_ms),
@@ -1525,9 +1526,11 @@ mod tests {
         let entered_at = SystemTime::UNIX_EPOCH;
         let seed = 0u64;
 
-        // Both presences identical except `state`; both well past the enter window.
-        let mk = |state: DaemonState, now: SystemTime| DaemonPresence {
-            state,
+        // Both presences identical except degraded-ness (Idle vs Degraded — the
+        // only two this test exercises); both well past the enter window. Empty
+        // run set, so `degraded: false` ⇒ Idle and `true` ⇒ Degraded.
+        let mk = |degraded: bool, now: SystemTime| DaemonPresence {
+            liveness: DaemonLiveness::Up { degraded },
             active_sessions: 0,
             last_seen: now,
             entered_at,
@@ -1552,8 +1555,8 @@ mod tests {
         }
         let now = found.expect("a tick where idle vs degraded phases diverge must exist");
 
-        let idle = mk(DaemonState::Idle, now);
-        let degraded = mk(DaemonState::Degraded, now);
+        let idle = mk(false, now);
+        let degraded = mk(true, now);
         let (_, idle_anim, _) =
             mascot_position(&layout, &idle, "lobster_walk", "lobster_rest", now, seed)
                 .expect("idle pos");

--- a/crates/pixtuoid-scene/src/pixel_painter/mod.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/mod.rs
@@ -913,15 +913,15 @@ fn enqueue_gateway_mascot<'a>(
                 anim_name,
                 frame_idx,
                 run_count,
-                degraded: presence.state == pixtuoid_core::state::DaemonState::Degraded,
+                degraded: presence.display_state() == pixtuoid_core::state::DaemonState::Degraded,
             },
         });
         // First present gateway wins the hover frame (single-gateway today).
         hover.get_or_insert(MascotFrame {
             pos,
             name: def.display_name,
-            busy: presence.state == pixtuoid_core::state::DaemonState::Busy,
-            degraded: presence.state == pixtuoid_core::state::DaemonState::Degraded,
+            busy: presence.is_busy(),
+            degraded: presence.display_state() == pixtuoid_core::state::DaemonState::Degraded,
             active_sessions: presence.active_sessions,
         });
     }

--- a/crates/pixtuoid-web/src/lib.rs
+++ b/crates/pixtuoid-web/src/lib.rs
@@ -543,22 +543,22 @@ mod tests {
         );
         // 30s: up + idle amble.
         o.step(T0_MS + 30_000.0, 160, 96);
-        assert_eq!(o.scene.daemons()[src].state, DaemonState::Idle);
+        assert_eq!(o.scene.daemons()[src].display_state(), DaemonState::Idle);
         // 45s: run 1 in flight → busy shuttle.
         o.step(T0_MS + 45_000.0, 160, 96);
-        assert_eq!(o.scene.daemons()[src].state, DaemonState::Busy);
+        assert_eq!(o.scene.daemons()[src].display_state(), DaemonState::Busy);
         assert_eq!(o.scene.daemons()[src].in_flight_run_keys.len(), 1);
         // 100s (the wide poster's instant): both runs done → idle.
         o.step(T0_MS + 100_000.0, 160, 96);
-        assert_eq!(o.scene.daemons()[src].state, DaemonState::Idle);
+        assert_eq!(o.scene.daemons()[src].display_state(), DaemonState::Idle);
         // 115s: walked out (Down ≠ absent — the leave animation anchors on it).
         o.step(T0_MS + 115_000.0, 160, 96);
-        assert_eq!(o.scene.daemons()[src].state, DaemonState::Down);
+        assert_eq!(o.scene.daemons()[src].display_state(), DaemonState::Down);
         // Next loop, 30s in: the wrap reset the presence cursor; GatewayUp
         // resurrects Down → Idle and re-anchors the enter walk.
         let wrap30 = T0_MS + LOOP_MS as f64 + 30_000.0;
         o.step(wrap30, 160, 96);
-        assert_eq!(o.scene.daemons()[src].state, DaemonState::Idle);
+        assert_eq!(o.scene.daemons()[src].display_state(), DaemonState::Idle);
     }
 
     #[test]

--- a/crates/pixtuoid/examples/snapshot.rs
+++ b/crates/pixtuoid/examples/snapshot.rs
@@ -914,21 +914,21 @@ fn sample_scene(now: SystemTime, max_desks: usize, n_agents: usize) -> SceneStat
 /// the wandering lobster mascot. `state` ∈ {idle, busy, down}; off the gen-media
 /// path so baselines hold.
 fn inject_openclaw_presence(s: &mut SceneState, state: &str, now: SystemTime) -> Result<()> {
-    use pixtuoid_core::state::{DaemonPresence, DaemonState};
-    // Busy carries in-flight RUN keys (two, for a lively demo stream) — the
-    // bubble tell keys on runs, not the persistent single session.
-    let (state, active_sessions, runs) = match state {
-        "idle" => (DaemonState::Idle, 1, Vec::new()),
+    use pixtuoid_core::state::{DaemonLiveness, DaemonPresence};
+    // Busy carries in-flight RUN keys (two, for a lively demo stream) — Busy is
+    // DERIVED from the run set (#460), so "busy" = UP + runs, not a stored state.
+    let (liveness, active_sessions, runs) = match state {
+        "idle" => (DaemonLiveness::UP, 1, Vec::new()),
         "busy" => (
-            DaemonState::Busy,
+            DaemonLiveness::UP,
             1,
             vec!["run-a".to_string(), "run-b".to_string()],
         ),
         // #317: the gateway is up but its model backend is failing every run —
         // a sickly-red, sluggishly-wandering lobster (no in-flight runs: the last
         // one FAILED out of the set).
-        "degraded" => (DaemonState::Degraded, 1, Vec::new()),
-        "down" => (DaemonState::Down, 0, Vec::new()),
+        "degraded" => (DaemonLiveness::Up { degraded: true }, 1, Vec::new()),
+        "down" => (DaemonLiveness::Down, 0, Vec::new()),
         other => {
             anyhow::bail!("unknown --openclaw {other:?}; valid: idle | busy | degraded | down")
         }
@@ -942,7 +942,7 @@ fn inject_openclaw_presence(s: &mut SceneState, state: &str, now: SystemTime) ->
     s.daemons_mut().insert(
         pixtuoid_core::source::openclaw::SOURCE_NAME.to_string(),
         DaemonPresence {
-            state,
+            liveness,
             active_sessions,
             last_seen: now,
             entered_at,

--- a/crates/pixtuoid/src/floating/window.rs
+++ b/crates/pixtuoid/src/floating/window.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
 
 use pixtuoid_core::sprite::format::Pack;
-use pixtuoid_core::state::{DaemonState, SceneState, MAX_FLOORS};
+use pixtuoid_core::state::{DaemonLiveness, SceneState, MAX_FLOORS};
 use tokio::sync::watch;
 use winit::application::ApplicationHandler;
 use winit::dpi::{LogicalSize, PhysicalPosition};
@@ -374,7 +374,7 @@ impl ApplicationHandler<FloatingEvent> for FloatingApp {
             && scene
                 .daemons()
                 .values()
-                .all(|d| d.state == DaemonState::Down);
+                .all(|d| d.liveness == DaemonLiveness::Down);
         let next_tick = if office_idle {
             Duration::from_millis(1000 / IDLE_AMBIENT_FPS)
         } else {

--- a/crates/pixtuoid/src/runtime/mod.rs
+++ b/crates/pixtuoid/src/runtime/mod.rs
@@ -170,7 +170,7 @@ fn summarize(scene: &SceneState) -> String {
         .daemons()
         .iter()
         .map(|(source, p)| {
-            let state = match p.state {
+            let state = match p.display_state() {
                 DaemonState::Idle => "idle",
                 DaemonState::Busy => "busy",
                 DaemonState::Degraded => "degraded",

--- a/crates/pixtuoid/src/tui/tui_renderer/harness.rs
+++ b/crates/pixtuoid/src/tui/tui_renderer/harness.rs
@@ -1179,18 +1179,19 @@ fn version_popup_interrupt_continues_from_edge() {
 /// A scene carrying an OpenClaw gateway presence (and nothing else, so the only
 /// lobster-red pixels on the floor are the lobster's).
 fn gateway_scene(
-    state: pixtuoid_core::state::DaemonState,
+    liveness: pixtuoid_core::state::DaemonLiveness,
     entered_at: SystemTime,
     last_seen: SystemTime,
     sessions: u32,
 ) -> SceneState {
-    gateway_scene_runs(state, entered_at, last_seen, sessions, &[])
+    gateway_scene_runs(liveness, entered_at, last_seen, sessions, &[])
 }
 
 /// As `gateway_scene`, with in-flight RUN keys (the busy bubble tell keys on
-/// runs, not sessions).
+/// runs, not sessions). Busy is DERIVED: pass `DaemonLiveness::UP` + ≥1 run
+/// (#460), not a stored Busy state.
 fn gateway_scene_runs(
-    state: pixtuoid_core::state::DaemonState,
+    liveness: pixtuoid_core::state::DaemonLiveness,
     entered_at: SystemTime,
     last_seen: SystemTime,
     sessions: u32,
@@ -1200,7 +1201,7 @@ fn gateway_scene_runs(
     s.daemons_mut().insert(
         pixtuoid_core::source::openclaw::SOURCE_NAME.to_string(),
         pixtuoid_core::state::DaemonPresence {
-            state,
+            liveness,
             active_sessions: sessions,
             last_seen,
             entered_at,
@@ -1279,7 +1280,7 @@ fn no_gateway_mascot_without_presence() {
 fn gateway_mascot_present_when_up() {
     // entered_at well in the past ⇒ steady wander (past the walk-in).
     let scene = gateway_scene(
-        pixtuoid_core::state::DaemonState::Idle,
+        pixtuoid_core::state::DaemonLiveness::UP,
         t0() - Duration::from_secs(20),
         t0(),
         0,
@@ -1299,10 +1300,10 @@ fn gateway_mascot_busy_bubbles_track_runs_not_sessions() {
     let entered = t0() - Duration::from_secs(20);
 
     // Idle with a live session (sessions=1, NO runs) ⇒ no bubbles.
-    let idle = gateway_scene(pixtuoid_core::state::DaemonState::Idle, entered, t0(), 1);
-    // Busy with two in-flight runs ⇒ bubbles.
+    let idle = gateway_scene(pixtuoid_core::state::DaemonLiveness::UP, entered, t0(), 1);
+    // Busy with two in-flight runs ⇒ bubbles (Busy derives from the runs, UP).
     let busy = gateway_scene_runs(
-        pixtuoid_core::state::DaemonState::Busy,
+        pixtuoid_core::state::DaemonLiveness::UP,
         entered,
         t0(),
         1,
@@ -1330,7 +1331,7 @@ fn gateway_mascot_walks_out_then_is_gone() {
     let mut r = build(160, 80, vec![]);
     // Just after going Down ⇒ still walking out, visible.
     let leaving = gateway_scene(
-        pixtuoid_core::state::DaemonState::Down,
+        pixtuoid_core::state::DaemonLiveness::Down,
         t0() - Duration::from_secs(20),
         t0() - Duration::from_millis(400),
         0,
@@ -1343,7 +1344,7 @@ fn gateway_mascot_walks_out_then_is_gone() {
 
     // Well past the walk-out window ⇒ gone (back to a normal office).
     let gone = gateway_scene(
-        pixtuoid_core::state::DaemonState::Down,
+        pixtuoid_core::state::DaemonLiveness::Down,
         t0() - Duration::from_secs(30),
         t0() - Duration::from_secs(10),
         0,
@@ -1361,7 +1362,7 @@ fn gateway_mascot_wanders_over_time() {
     // Same scene rendered across a wander cycle ⇒ the lobster changes position
     // (proves the motion is live, not a fixed sticker).
     let scene = gateway_scene(
-        pixtuoid_core::state::DaemonState::Idle,
+        pixtuoid_core::state::DaemonLiveness::UP,
         t0() - Duration::from_secs(20),
         t0(),
         0,
@@ -1446,7 +1447,7 @@ fn lobster_red_bbox(buf: &RgbBuffer) -> Option<(u16, u16, u16, u16)> {
 fn gateway_mascot_tooltip_on_hover() {
     // entered_at well in the past ⇒ steady wander (a stable lobster to aim at).
     let scene = gateway_scene(
-        pixtuoid_core::state::DaemonState::Idle,
+        pixtuoid_core::state::DaemonLiveness::UP,
         t0() - Duration::from_secs(20),
         t0(),
         0,

--- a/crates/pixtuoid/src/tui/widgets/mod.rs
+++ b/crates/pixtuoid/src/tui/widgets/mod.rs
@@ -132,7 +132,7 @@ pub(crate) fn gateway_rollup(daemons: &BTreeMap<String, DaemonPresence>) -> Opti
     }
     daemons
         .values()
-        .map(|p| p.state)
+        .map(|p| p.display_state())
         .max_by_key(|s| severity(*s))
 }
 
@@ -567,13 +567,29 @@ mod tests {
 
     // --- office-wide plumbing (per-floor + gateway rollup) ------------------
 
+    // Maps a desired render `DaemonState` to the stored axes. Busy needs a
+    // (placeholder) in-flight run key because Busy is DERIVED from the run set,
+    // never stored (#460) — so `gateway_rollup_is_worst_of` still exercises a
+    // genuinely-Busy fixture rather than a silently-Idle one.
     fn daemon(state: pixtuoid_core::state::DaemonState) -> pixtuoid_core::state::DaemonPresence {
+        use pixtuoid_core::state::{DaemonLiveness, DaemonState};
+        let (liveness, in_flight_run_keys) = match state {
+            DaemonState::Idle => (DaemonLiveness::UP, Default::default()),
+            DaemonState::Busy => (
+                DaemonLiveness::UP,
+                ["fixture-run".to_string()]
+                    .into_iter()
+                    .collect::<std::collections::HashSet<String>>(),
+            ),
+            DaemonState::Degraded => (DaemonLiveness::Up { degraded: true }, Default::default()),
+            DaemonState::Down => (DaemonLiveness::Down, Default::default()),
+        };
         pixtuoid_core::state::DaemonPresence {
-            state,
+            liveness,
             active_sessions: 0,
             last_seen: SystemTime::UNIX_EPOCH,
             entered_at: SystemTime::UNIX_EPOCH,
-            in_flight_run_keys: Default::default(),
+            in_flight_run_keys,
             current_pid: None,
         }
     }

--- a/crates/pixtuoid/tests/wire_to_pixels.rs
+++ b/crates/pixtuoid/tests/wire_to_pixels.rs
@@ -559,8 +559,8 @@ fn openclaw_presence_envelope_renders_a_lobster() {
         .get(pixtuoid_core::source::openclaw::SOURCE_NAME)
         .expect("openclaw presence must be populated");
     assert_ne!(
-        presence.state,
-        pixtuoid_core::state::DaemonState::Down,
+        presence.liveness,
+        pixtuoid_core::state::DaemonLiveness::Down,
         "the in-session presence stream must leave the gateway UP"
     );
 


### PR DESCRIPTION
## What

`DaemonPresence` stored `state: DaemonState` where `Busy` also equalled `!in_flight_run_keys.is_empty()`, hand-synced at 4 sites in `apply_presence` (RunStarted / RunEnded / RunFailed / busy-decay) — the two could drift.

This stores the **orthogonal axes** and **derives** the render state instead:
- `liveness: DaemonLiveness { Up { degraded: bool }, Down }` + the existing `in_flight_run_keys`.
- `DaemonState { Idle, Busy, Degraded, Down }` stays the render vocabulary, projected by one method `DaemonPresence::display_state()` — the single place the **Degraded > Busy > Idle** priority lives (degraded checked *before* the run set, so a fan-out-with-one-failure renders Degraded, not Busy). `is_busy()` derives from it.

Busy is never stored ⇒ it can't drift. The 4-site hand-sync is gone.

## Notable decisions
- Deviated from the issue's literal "read sites match `liveness`/`is_busy()`" sketch: the ~10 renderers consume the full 4-way, so a projection keeps every read site's logic unchanged (`.state` → `.display_state()`) and keeps the priority in one place. Three genuinely *structural* liveness gates read `.liveness == Down` directly (walk-out, ambient-tick, an assertion).
- Fixture param types moved `DaemonState` → `DaemonLiveness`, so a "Busy" fixture must carry a run key (pushes the invariant into the test surface); the `widgets` `daemon()` helper synthesizes one for Busy.
- **One intentional behavior change:** a *deserialized* debug dump now reads Idle, not Busy (`in_flight_run_keys` is `#[serde(skip)]` → restores empty). This fixes the old "restore strands a perpetual Busy" drift; documented in the round-trip test. Debug/snapshot only, not a wire contract (#279).
- No version bump — rides the unreleased **0.13.0** (breaking `pixtuoid-core` field rename).

## Verification
- 2098/2098 workspace tests pass (new `fanout_with_one_failure_renders_degraded_not_busy` + projection tests; the ~20 daemon state-machine tests unchanged bar the `st()` helper → `display_state()`).
- `clippy -D warnings` clean · **`gen-check` zero pixel diff** (render byte-identical) · wasm subset compiles · pre-push `preflight` green.
- Two-lens adversarial review (correctness/behavior-preservation + design/semver/blast-radius): 0 confirmed findings.

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqUwYZoRVwhTb55c2vi2DN
