### PR TITLE
test(scene): reference shared disc visibility threshold

### DIFF
--- a/crates/pixtuoid-scene/src/pixel_painter/background/celestial.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/background/celestial.rs
@@ -67,7 +67,7 @@ const HORIZON_FRAC: f32 = 0.55; // horizon_y = top_wall_h * HORIZON_FRAC
 const ARC_RISE_FRAC: f32 = 0.80; // apex lifts top_wall_h * ARC_RISE_FRAC above horizon
 /// Below this atmo `disc` visibility, thick cloud swallows the disc entirely
 /// (no point painting a body no one can see through the murk).
-const MIN_DISC_VIS: f32 = 0.08;
+pub(super) const MIN_DISC_VIS: f32 = 0.08;
 
 /// This frame's disc placement, or `None` under thick cloud (`atmo(weather).disc`
 /// below [`MIN_DISC_VIS`]). `cx`/`cy` are absolute buffer coordinates derived

--- a/crates/pixtuoid-scene/src/pixel_painter/background/sky.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/background/sky.rs
@@ -885,7 +885,7 @@ mod tests {
         // show MORE of the disc than a thinner one (Rain), matching the
         // direct/diffuse ordering `storm_transmits_less_than_rain_overall`
         // already pins.
-        let min_disc_vis = super::celestial::MIN_DISC_VIS;
+        let min_disc_vis = crate::pixel_painter::background::celestial::MIN_DISC_VIS;
         let overcast = atmo(Weather::Overcast).disc;
         let rain = atmo(Weather::Rain).disc;
         let storm = atmo(Weather::Storm).disc;

--- a/crates/pixtuoid-scene/src/pixel_painter/background/sky.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/background/sky.rs
@@ -878,13 +878,14 @@ mod tests {
 
     #[test]
     fn thick_cloud_hides_the_disc_uniformly() {
-        // `MIN_DISC_VIS` (background/celestial.rs `compute_disc`'s hide gate) is
-        // 0.08 — Overcast/Rain/Storm must all sit at or below it, so thick
+        // `MIN_DISC_VIS` (background/celestial.rs `compute_disc`'s hide gate)
+        // is the authoritative threshold — Overcast/Rain/Storm must all sit at
+        // or below it, so thick
         // cloud hides the disc uniformly: a THICKER cloud (Storm) must never
         // show MORE of the disc than a thinner one (Rain), matching the
         // direct/diffuse ordering `storm_transmits_less_than_rain_overall`
         // already pins.
-        const MIN_DISC_VIS: f32 = 0.08;
+        let min_disc_vis = super::celestial::MIN_DISC_VIS;
         let overcast = atmo(Weather::Overcast).disc;
         let rain = atmo(Weather::Rain).disc;
         let storm = atmo(Weather::Storm).disc;
@@ -894,8 +895,8 @@ mod tests {
              overcast={overcast} rain={rain} storm={storm}"
         );
         assert!(
-            overcast < MIN_DISC_VIS && rain < MIN_DISC_VIS && storm < MIN_DISC_VIS,
-            "overcast/rain/storm should all hide the disc (below MIN_DISC_VIS={MIN_DISC_VIS}): \
+            overcast < min_disc_vis && rain < min_disc_vis && storm < min_disc_vis,
+            "overcast/rain/storm should all hide the disc (below MIN_DISC_VIS={min_disc_vis}): \
              overcast={overcast} rain={rain} storm={storm}"
         );
     }


### PR DESCRIPTION
## Summary
- expose the celestial disc visibility threshold within the background module
- update the sky test to assert against that shared threshold instead of a duplicated literal

Fixes #473

## Test plan
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p pixtuoid-scene thick_cloud_hides_the_disc_uniformly` (blocked: linker `cc` is not installed in this environment)

Co-Authored-By: Claude <noreply@anthropic.com>