### PR TITLE
docs(site): fold weather+sky+theme into one Vibing feature card; surface the live playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Press `s` to open the **Sources** panel and connect your agent CLI (Claude Code,
 | 💡 | **Per-tool monitor glow** | Edit = blue, Bash = orange, Read = cyan — scannable at a glance |
 | 🎨 | **Team palette** | Shirt + pants colored by working directory (same repo → same color, a glanceable org-chart); hair/skin per agent. 16 curated outfits |
 | 🦞 | **OpenClaw gateway mascot** | A live OpenClaw gateway shows up as a wandering lobster whose motion tracks gateway health |
-| 🎛️ | **VIBING** | A sun and moon arc the skyline as the day turns, weather rolls past the windows (rain, storm, snow, fog, overcast, wind, smog), and six themes reskin the office |
+| 🎛️ | **VIBING** | A sun and moon arc the skyline as the day turns, weather rolls past the windows (rain, storm, snow, fog, overcast, windy, smog), and six themes reskin the office |
 | 🔎 | **Hover tooltips** | Hover an agent for session duration, tool-call count and active-time %; hover any furniture — desks, sofas, plants, vending machine, printer — for its name |
 | 🐾 | **Office pets** | A cat or dog (one per floor) roams desks, pantry, sofas; sleeps near idle agents. Click to pet — pixel-art hearts float up |
 | 🛡️ | **Hook-safe** | The shim always exits 0 — a stuck visualizer can never block your agent |

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ _\* experimental — limited testing, unsigned binaries._
 
 > Adding a new tool? Implement the [`Source` trait](#contributing) — or, for a hook-only CLI, just a hook decoder + an install `Target` — then add a row to [`site/src/sources.json`](site/src/sources.json) (its `supported` set is pinned to the code by a test). One file, one channel, done.
 
-## Themes & Configuration
+## Configuration
 
 Press `t` to cycle the built-in themes with live preview. Your choice persists across sessions:
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Press `s` to open the **Sources** panel and connect your agent CLI (Claude Code,
 | 💡 | **Per-tool monitor glow** | Edit = blue, Bash = orange, Read = cyan — scannable at a glance |
 | 🎨 | **Team palette** | Shirt + pants colored by working directory (same repo → same color, a glanceable org-chart); hair/skin per agent. 16 curated outfits |
 | 🦞 | **OpenClaw gateway mascot** | A live OpenClaw gateway shows up as a wandering lobster whose motion tracks gateway health |
-| 🎛️ | **VIBING** | A sun and moon arc the skyline as the day turns, weather rolls past the windows (rain, storm, snow, fog, overcast, windy, smog), and six themes reskin the office |
+| 🎛️ | **Vibing** | A sun and moon arc the skyline as the day turns, weather rolls past the windows (rain, storm, snow, fog, overcast, windy, smog), and six themes reskin the office |
 | 🔎 | **Hover tooltips** | Hover an agent for session duration, tool-call count and active-time %; hover any furniture — desks, sofas, plants, vending machine, printer — for its name |
 | 🐾 | **Office pets** | A cat or dog (one per floor) roams desks, pantry, sofas; sleeps near idle agents. Click to pet — pixel-art hearts float up |
 | 🛡️ | **Hook-safe** | The shim always exits 0 — a stuck visualizer can never block your agent |

--- a/README.md
+++ b/README.md
@@ -83,8 +83,7 @@ Press `s` to open the **Sources** panel and connect your agent CLI (Claude Code,
 | 💡 | **Per-tool monitor glow** | Edit = blue, Bash = orange, Read = cyan — scannable at a glance |
 | 🎨 | **Team palette** | Shirt + pants colored by working directory (same repo → same color, a glanceable org-chart); hair/skin per agent. 16 curated outfits |
 | 🦞 | **OpenClaw gateway mascot** | A live OpenClaw gateway shows up as a wandering lobster whose motion tracks gateway health |
-| 🌧️ | **Weather effects** | Rain, storm, snow, fog, overcast, windy, smog — cycling every 10 minutes |
-| 🌅 | **Living sky** | A sun and moon arc over the city skyline through the day; weather is real atmosphere — clouds dim the beam, fog swallows the sun, storms darken the room, and a crescent moon rises at night |
+| 🎛️ | **VIBING** | A sun and moon arc the skyline as the day turns, weather rolls past the windows (rain, storm, snow, fog, overcast, wind, smog), and six themes reskin the office |
 | 🔎 | **Hover tooltips** | Hover an agent for session duration, tool-call count and active-time %; hover any furniture — desks, sofas, plants, vending machine, printer — for its name |
 | 🐾 | **Office pets** | A cat or dog (one per floor) roams desks, pantry, sofas; sleeps near idle agents. Click to pet — pixel-art hearts float up |
 | 🛡️ | **Hook-safe** | The shim always exits 0 — a stuck visualizer can never block your agent |

--- a/README.md
+++ b/README.md
@@ -112,18 +112,21 @@ _\* experimental — limited testing, unsigned binaries._
 
 ## Configuration
 
-Press `t` to cycle the built-in themes with live preview. Your choice persists across sessions:
+Everything lives in `~/.config/pixtuoid/config.toml` (created on first launch;
+every key optional) — theme, desk cap, custom pet names, and sprite packs. CLI
+flags override the file (`pixtuoid run --theme dracula`).
+
+The setting you'll reach for most is the **theme** — press `t` in the TUI for a
+live-preview picker across six built-in palettes; your pick persists across sessions.
 
 <p align="center">
-  <img src="docs/images/themes-composite.png" alt="built-in themes side by side" width="800" />
+  <img src="docs/images/themes-composite.png" alt="the six built-in themes side by side" width="800" />
 </p>
 
-Settings live in `~/.config/pixtuoid/config.toml` — theme, desk cap, custom pet
-names, and sprite packs. CLI flags override the file (`pixtuoid run --theme dracula`).
 See **[docs/CONFIGURATION.md](docs/CONFIGURATION.md)** for the full key reference
 (defaults, system-managed keys), the custom sprite-pack workflow, and **logging /
-troubleshooting** (the TUI writes warnings to `~/.cache/pixtuoid/log`) — or browse it
-live at **[/config](https://ivanwng97.github.io/pixtuoid/config)**.
+troubleshooting** (diagnostics go to `~/.cache/pixtuoid/log`) — or browse it live
+at **[/config](https://ivanwng97.github.io/pixtuoid/config)**.
 
 ## How It Works
 

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -26,6 +26,9 @@ const floor = floorByNumber(6);
       </p>
       <div class="hero__cta">
         <a class="btn btn-primary" href="#install">[ install <span aria-hidden="true">→</span> ]</a>
+        <a class="hero__ghost" href="#showcase-vibing"
+          ><span aria-hidden="true">▸</span> play with it live</a
+        >
         <a class="hero__ghost" href={REPO} target="_blank" rel="noreferrer">star on github ↗</a>
       </div>
       <p class="hero__avail">macOS · Linux · Windows · crates.io · MIT&nbsp;licensed</p>

--- a/site/src/components/Showcase.astro
+++ b/site/src/components/Showcase.astro
@@ -43,8 +43,9 @@ const countWord = COUNT_WORDS[channels.length] ?? String(channels.length);
       <p class="eyebrow">{floor.n}F · {floor.name} — {live.length} channels on air</p>
       <h2 class="statement statement--md">{countWord} channels.<br />One office.</h2>
       <p class="lead">
-        The office, channel by channel — flip a channel to switch the big screen. VIBING runs live:
-        scrub the office's time, weather, and vibe on-screen.
+        This one's live — the same office running in your browser. Drag the time slider, throw a
+        storm at it, flip the vibe. The other channels are recorded; flip a channel to watch them on
+        the big screen.
       </p>
     </div>
 
@@ -62,6 +63,7 @@ const countWord = COUNT_WORDS[channels.length] ?? String(channels.length);
                 aria-pressed={c.id === def.id ? 'true' : 'false'}
               >
                 <span class="dial__num">{c.ch}</span> {c.label}
+                {c.kind === 'live' && <small class="dial__live">live</small>}
               </button>
             ) : (
               <span class="dial__ch dial__ch--soon">
@@ -459,7 +461,7 @@ const countWord = COUNT_WORDS[channels.length] ?? String(channels.length);
   @media (max-width: 480px) {
     /* 3× max-content is ~376px — past a 360/390px phone, so the studio's
        overflow-x:clip would hide the right dial column (03 Dashboard / 06 Spaces,
-       untappable). Wrap to two shrinkable columns so all 8 channels stay on-screen. */
+       untappable). Wrap to two shrinkable columns so all 7 channels stay on-screen. */
     .dial {
       grid-template-columns: repeat(2, minmax(0, 1fr));
       gap: 0.4rem 1rem;
@@ -506,6 +508,14 @@ const countWord = COUNT_WORDS[channels.length] ?? String(channels.length);
   .dial__ch--soon small {
     font-size: 0.72em;
     letter-spacing: 0.08em;
+  }
+  .dial__live {
+    /* marks the one INTERACTIVE channel (kind:"live") apart from the recorded
+       clips — reuses the active-channel LED glow so "live" reads as on-air. */
+    font-size: 0.72em;
+    letter-spacing: 0.08em;
+    color: var(--led);
+    text-shadow: 0 0 6px var(--led-glow);
   }
 
   .showcase {

--- a/site/src/components/Showcase.astro
+++ b/site/src/components/Showcase.astro
@@ -43,9 +43,9 @@ const countWord = COUNT_WORDS[channels.length] ?? String(channels.length);
       <p class="eyebrow">{floor.n}F · {floor.name} — {live.length} channels on air</p>
       <h2 class="statement statement--md">{countWord} channels.<br />One office.</h2>
       <p class="lead">
-        This one's live — the same office running in your browser. Drag the time slider, throw a
-        storm at it, flip the vibe. The other channels are recorded; flip a channel to watch them on
-        the big screen.
+        The channel on screen is live — the same office running in your browser. Drag the clock
+        forward, roll in a storm, switch the vibe. The other channels are recorded; flip a channel
+        to watch them on the big screen.
       </p>
     </div>
 
@@ -505,15 +505,15 @@ const countWord = COUNT_WORDS[channels.length] ?? String(channels.length);
     color: color-mix(in srgb, var(--fg-muted) 55%, transparent);
     cursor: default;
   }
-  .dial__ch--soon small {
+  /* the dial's two small appended status tags share one geometry (pinned here
+     so a size tweak can't drift): "soon" dims a placeholder channel; "live"
+     LED-glows the one INTERACTIVE channel (kind:"live") apart from the clips. */
+  .dial__ch--soon small,
+  .dial__live {
     font-size: 0.72em;
     letter-spacing: 0.08em;
   }
   .dial__live {
-    /* marks the one INTERACTIVE channel (kind:"live") apart from the recorded
-       clips — reuses the active-channel LED glow so "live" reads as on-air. */
-    font-size: 0.72em;
-    letter-spacing: 0.08em;
     color: var(--led);
     text-shadow: 0 0 6px var(--led-glow);
   }

--- a/site/src/consts.ts
+++ b/site/src/consts.ts
@@ -205,8 +205,8 @@ function variantsForRef(ref: 'themes' | 'weather'): ShowcaseVariant[] {
 
 export function showcaseVariants(c: ShowcaseChannel): ShowcaseVariant[] {
   // A channel may carry a manifest-backed `variantsRef` AND extra inline
-  // `variants`, appended after it — e.g. WEATHER folds the day/night lighting
-  // stills in after the weather list (the former standalone NIGHT channel).
+  // `variants`, appended after it (variant-set channels only) — no current
+  // channel exercises the append, but the shape supports it.
   const inline = c.variants ?? [];
   if (c.variantsRef === 'themes' || c.variantsRef === 'weather')
     return [...variantsForRef(c.variantsRef), ...inline];

--- a/site/src/features.json
+++ b/site/src/features.json
@@ -55,7 +55,7 @@
   {
     "icon": "🎛️",
     "name": "VIBING",
-    "desc": "A sun and moon arc the skyline as the day turns, weather rolls past the windows (rain, storm, snow, fog, overcast, wind, smog), and six themes reskin the office",
+    "desc": "A sun and moon arc the skyline as the day turns, weather rolls past the windows (rain, storm, snow, fog, overcast, windy, smog), and six themes reskin the office",
     "card": {
       "blurb": "The office runs on a real day — a sun and moon arc the skyline, weather rolls through, and six themes reskin the room. On the VIBING channel you drive all three: scrub the hour, throw a storm, flip the vibe.",
       "href": "#showcase-vibing"

--- a/site/src/features.json
+++ b/site/src/features.json
@@ -54,10 +54,10 @@
   },
   {
     "icon": "🎛️",
-    "name": "VIBING",
+    "name": "Vibing",
     "desc": "A sun and moon arc the skyline as the day turns, weather rolls past the windows (rain, storm, snow, fog, overcast, windy, smog), and six themes reskin the office",
     "card": {
-      "blurb": "The office runs on a real day — a sun and moon arc the skyline, weather rolls through, and six themes reskin the room. On the VIBING channel you drive all three: scrub the hour, throw a storm, flip the vibe.",
+      "blurb": "The office runs on a real day — a sun and moon arc the skyline, weather rolls through, and six themes reskin the room. On the Vibing channel you drive all three: scrub the hour, throw a storm, flip the vibe.",
       "href": "#showcase-vibing"
     }
   },

--- a/site/src/features.json
+++ b/site/src/features.json
@@ -13,7 +13,7 @@
     "name": "Multi-floor office",
     "desc": "PageUp/PageDown/↑↓/jk to navigate floors with slide transition",
     "card": {
-      "blurb": "Subagents, multiple CLIs and extra floors appear as your swarm grows.",
+      "blurb": "Overflow agents spill onto new floors — ride the elevator (PageUp/PageDown) between them with a slide transition.",
       "href": "#showcase-agents"
     }
   },
@@ -53,20 +53,11 @@
     }
   },
   {
-    "icon": "🌧️",
-    "name": "Weather effects",
-    "desc": "Rain, storm, snow, fog, overcast, windy, smog — cycling every 10 minutes",
+    "icon": "🎛️",
+    "name": "VIBING",
+    "desc": "A sun and moon arc the skyline as the day turns, weather rolls past the windows (rain, storm, snow, fog, overcast, wind, smog), and six themes reskin the office",
     "card": {
-      "blurb": "Lighting tracks your real clock; rain, storms, fog and moonlight roll past the windows.",
-      "href": "#showcase-vibing"
-    }
-  },
-  {
-    "icon": "🌅",
-    "name": "Living sky",
-    "desc": "A sun and moon arc over the city skyline through the day; weather is real atmosphere — clouds dim the beam, fog swallows the sun, storms darken the room, and a crescent moon rises at night",
-    "card": {
-      "blurb": "The office lives on a real day: a sun and moon arc past the windows over the city, and the weather is the atmosphere between them and your desk — a clear noon blazes, a storm dusk goes gloomy, fog dims the sun to a pale smear, and at night a crescent moon and faint stars come out.",
+      "blurb": "The office runs on a real day — a sun and moon arc the skyline, weather rolls through, and six themes reskin the room. On the VIBING channel you drive all three: scrub the hour, throw a storm, flip the vibe.",
       "href": "#showcase-vibing"
     }
   },

--- a/site/src/showcase.json
+++ b/site/src/showcase.json
@@ -6,7 +6,7 @@
     "asset": "multi-floor",
     "w": 1664,
     "h": 1408,
-    "caption": "every session claims a desk across floors — typing, wandering, coffee runs. workflow fleets get desks too: review fleets of 100+ agents have run this repo through this office.",
+    "caption": "every session claims a desk across floors — typing, wandering, coffee runs. big swarms scale too: fleets of 100+ agents have run this repo through this very office.",
     "duration": "0:10",
     "status": "live"
   },
@@ -17,7 +17,7 @@
     "asset": "openclaw",
     "w": 1120,
     "h": 960,
-    "caption": "run an OpenClaw gateway and a lobster scuttles in — its wander encodes the daemon's health: idle ambles, busy shuttles to the backend coders, a failing model flushes it sickly-red, shutdown walks it out.",
+    "caption": "a live OpenClaw gateway walks in as a lobster — its wander is the daemon's pulse: idle ambles, busy shuttles, failing flushes red, shutdown heads for the elevator.",
     "duration": "0:09",
     "status": "live"
   },
@@ -106,7 +106,7 @@
       { "key": "weather", "label": "weather", "variantsRef": "weather" },
       { "key": "theme", "label": "vibe", "variantsRef": "themes", "retint": true }
     ],
-    "caption": "set the mood — scrub the office's time, weather, and vibe",
+    "caption": "live — drag the slider, tap a vibe, roll the weather",
     "status": "live"
   }
 ]

--- a/site/src/showcase.json
+++ b/site/src/showcase.json
@@ -106,7 +106,7 @@
       { "key": "weather", "label": "weather", "variantsRef": "weather" },
       { "key": "theme", "label": "vibe", "variantsRef": "themes", "retint": true }
     ],
-    "caption": "live — drag the slider, tap a vibe, roll the weather",
+    "caption": "live — you're driving this one",
     "status": "live"
   }
 ]


### PR DESCRIPTION
## What

A README + site copy-polish pass, centered on the two overlapping bento cards that survived the living-sky split (#471): **Weather effects** and **Living sky** both described the sky/weather story and both deep-linked the same `#showcase-vibing`.

- **One `🎛️ VIBING` feature card** replaces both — it folds sky + weather + the six office themes (the three axes the live [VIBING](https://…/#showcase-vibing) channel actually drives) into a single card, mirroring what #468 already did to the showcase channels. Also *adds* theme visibility to the feature list (there was no standalone theme card). README Features table regenerated from `features.json`.
- **VIBING surfaced as the one interactive channel** (it read identically to the six recorded clips): a text-weight `▸ play with it live` hero CTA, a `live` LED tag on the dial's `kind:"live"` channel, and an imperative Showcase lead ("The channel on screen is live — … drag the clock forward, roll in a storm, switch the vibe").
- **Copy dedup / de-jargon:** Multi-floor blurb re-scoped to the elevator/PageUp navigation (was overlapping Multi-agent); OpenClaw showcase caption shortened (the card keeps the full "tell"); AGENTS caption de-jargoned ("workflow/review fleets" → "big swarms scale too").
- **Organize sweep:** stale `8→7 channels` comment; stale WEATHER/NIGHT variant-append example dropped from a `consts.ts` comment. `MonitorWall.astro` **left in place** — it's a documented kept-but-unmounted dial fallback (`site/knip.jsonc`, `site/README.md`), not dead code.

No office visuals changed → no `gen`/`gen-check` regen.

## Review (two-lens gate, escalated to three for a public-facing artifact)

- **Correctness / grounding — APPROVE.** Every factual claim verified against source (six themes, 7 channels, the weather list, VIBING's three axes); blast-check clean (zero surviving `Weather effects` / `Living sky` / `#showcase-weather` refs); both gates independently re-run green.
- **Design / blast-radius — APPROVE-WITH-NITS.** No functional break; README/site parity green; the fold removes a genuine duplicate deep-link.
- **Editorial — APPROVE-WITH-NITS.** All numbers check out; caption de-jargoning is a net improvement.

Four accepted nits folded into the review-round commit (lead forward-pronoun, lead↔caption triad echo, `.dial__live` CSS DRY, `wind`→`windy`). Refuted-with-reason: Multi-floor "repeats desc" (different surfaces — README=desc, bento=blurb), `recorded`/`on air` wording (correct CRT diegesis). Both lenses flagged the all-caps **`VIBING`** README-table name as shouting/opaque; resolved by title-casing the feature name to **`Vibing`** — it stays a scannable feature name in the README while the dial channel label keeps its all-caps `VIBING` (part of the CRT label set AGENTS/OPENCLAW/…).

## Gates

`just gen-readme-check` ✓ · `just site-check` (prettier/eslint/tsc/knip/9 unit/build) ✓ · `just site-e2e` (20 passed, incl. showcase deep-link + VIBING live-office contracts) ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017SqmcvjtwBT3PRGmqxjRAr
