### PR TITLE
refactor(scene): promote CHARACTER_SPRITE_W to a cross-crate layout const

### DIFF
--- a/crates/pixtuoid-scene/src/embedded_pack.rs
+++ b/crates/pixtuoid-scene/src/embedded_pack.rs
@@ -493,4 +493,27 @@ mod tests {
             }
         }
     }
+
+    // `layout::CHARACTER_SPRITE_W` is the width every out-of-pixel_painter site
+    // (hit-test pin box, decor walk-offset, floating label centering) hard-codes
+    // its geometry on, as the width-unknown fallback for the pack's real
+    // `frame.width`. If the embedded pack's character sprite ever grows/shrinks,
+    // the const must move with it — else the pin box drifts off the painted
+    // sprite. `sim.rs` resolves the SAME "standing" reference pose per frame.
+    #[test]
+    fn character_sprite_w_matches_the_embedded_pack() {
+        let pack = test_default_pack();
+        let w = pack
+            .animation("standing")
+            .and_then(|a| a.frames.first())
+            .expect("embedded pack carries a standing pose")
+            .width();
+        assert_eq!(
+            w,
+            crate::layout::CHARACTER_SPRITE_W,
+            "embedded 'standing' sprite is {w}px wide but CHARACTER_SPRITE_W is {} — \
+             update the const so hit-test/decor/label geometry tracks the pack",
+            crate::layout::CHARACTER_SPRITE_W
+        );
+    }
 }

--- a/crates/pixtuoid-scene/src/embedded_pack.rs
+++ b/crates/pixtuoid-scene/src/embedded_pack.rs
@@ -503,17 +503,27 @@ mod tests {
     #[test]
     fn character_sprite_w_matches_the_embedded_pack() {
         let pack = test_default_pack();
-        let w = pack
+        let frame = pack
             .animation("standing")
             .and_then(|a| a.frames.first())
-            .expect("embedded pack carries a standing pose")
-            .width();
+            .expect("embedded pack carries a standing pose");
+        let (w, h) = (frame.width(), frame.height());
         assert_eq!(
             w,
             crate::layout::CHARACTER_SPRITE_W,
             "embedded 'standing' sprite is {w}px wide but CHARACTER_SPRITE_W is {} — \
              update the const so hit-test/decor/label geometry tracks the pack",
             crate::layout::CHARACTER_SPRITE_W
+        );
+        // The px sprite is `H_CELLS` half-block rows tall (2 px per cell); pin
+        // the cell const too so the hit-test box height can't drift from the pack.
+        assert_eq!(
+            h,
+            crate::layout::CHARACTER_SPRITE_H_CELLS * 2,
+            "embedded 'standing' sprite is {h}px tall but CHARACTER_SPRITE_H_CELLS \
+             ({}) implies {}px — update the const so the hit-test box tracks the pack",
+            crate::layout::CHARACTER_SPRITE_H_CELLS,
+            crate::layout::CHARACTER_SPRITE_H_CELLS * 2
         );
     }
 }

--- a/crates/pixtuoid-scene/src/layout/decor.rs
+++ b/crates/pixtuoid-scene/src/layout/decor.rs
@@ -2,7 +2,7 @@
 //! piece of furniture and waypoint kind in the office. Kept separate from
 //! geometry so adding a new sprite kind doesn't churn the layout math.
 
-use super::{Point, Size, DESK_H, DESK_W};
+use super::{Point, Size, CHARACTER_SPRITE_W, DESK_H, DESK_W};
 
 /// Wander destinations the Idle state machine can pick. Each kind controls
 /// the pose + sprite an arriving agent takes. Plants/lamps are decor, not
@@ -595,8 +595,8 @@ pub const SEAT_RENDER_Y_OFF: u16 = 7;
 /// onto its north seat with no arrival pop, just clear of the desk obstacle.
 /// The `walking_anchor(desk_walk_anchor(d)) == seated_anchor(d)` identity is
 /// locked by a tui-side test; if `DESK_W` or those anchors change they move
-/// together (X tracks `DESK_W`; `8` is the character sprite width).
-pub(crate) const DESK_WALK_X_OFF: u16 = (DESK_W - 8) / 2 + 4;
+/// together (X tracks `DESK_W`; the sprite width is `CHARACTER_SPRITE_W`).
+pub(crate) const DESK_WALK_X_OFF: u16 = (DESK_W - CHARACTER_SPRITE_W) / 2 + 4;
 pub(crate) const DESK_WALK_Y_OFF: u16 = 4;
 
 /// The cell an agent walks to/from for its home `desk` (top-left Point). The

--- a/crates/pixtuoid-scene/src/layout/mod.rs
+++ b/crates/pixtuoid-scene/src/layout/mod.rs
@@ -216,6 +216,21 @@ pub const PANTRY_FOOTPRINT_DEPTH: u16 = 3;
 
 pub const DESK_W: u16 = 12;
 pub const DESK_H: u16 = 6;
+/// Default character sprite width (px). The bundled pack is 8×12; this is the
+/// ONE authority every out-of-pixel_painter consumer centers/hit-tests on
+/// (anchors' LABEL fallback, `layout::decor::DESK_WALK_X_OFF`, the tui hit-test
+/// pin box, the floating label centering) — a bare `8` copied into those sites
+/// drifts from the painted sprite the moment the pack width changes. The sprite
+/// BLIT sites still pass the pack's REAL `frame.width` (a custom pack may be
+/// wider, e.g. the robot pack's 10); this const is the width-unknown fallback.
+/// Lives in `layout` (not `pixel_painter`) so `layout::decor` can read it
+/// without a module cycle. Pinned to the embedded pack by
+/// `character_sprite_w_matches_the_embedded_pack`.
+pub const CHARACTER_SPRITE_W: u16 = 8;
+/// Default character sprite height in terminal CELLS (the 12 px sprite is 6
+/// half-block rows). Used by the tui hit-test pin box (cell space); the pixel
+/// pose offsets (8/12/7 px) are a SEPARATE vertical-anchor concern, NOT this.
+pub const CHARACTER_SPRITE_H_CELLS: u16 = 6;
 /// Elevator-door sprite size in buffer px — the single source for the door's
 /// width (the layout slots the sprite into the back wall and the renderer skips
 /// the window glass it covers) and height (the z-sort anchor row). Both the

--- a/crates/pixtuoid-scene/src/pixel_painter/anchors.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/anchors.rs
@@ -17,10 +17,11 @@ use crate::layout::{Point, WaypointKind, DESK_W};
 pub(crate) use crate::motion::walking_position;
 use crate::pose::{self, Pose};
 
-/// Default character sprite width (the bundled pack is 8×12). Used to anchor
+/// Re-export the ONE cross-crate sprite-width authority (`layout::CHARACTER_SPRITE_W`)
+/// so pixel_painter siblings keep importing it via `super::`. Used to anchor
 /// LABELS (`character_anchor`), where a custom pack's true width isn't threaded
 /// and ±1px doesn't matter; the sprite BLIT sites pass the real `frame.width`.
-pub(super) const CHARACTER_SPRITE_W: u16 = 8;
+pub(super) use crate::layout::CHARACTER_SPRITE_W;
 
 // All anchor fns center the sprite horizontally on `sprite_w` — the pack's
 // character width (8 for the bundled pack, 10 for the robot pack). The vertical

--- a/crates/pixtuoid/src/floating/offscreen.rs
+++ b/crates/pixtuoid/src/floating/offscreen.rs
@@ -164,11 +164,11 @@ pub(crate) fn boot_capacities_for_window(
     })
 }
 
-/// The bundled character sprite width (px). `CHARACTER_SPRITE_W` is `pub(super)` to
-/// `scene::pixel_painter` (not re-exported through `scene::layout`), so the floating
-/// painter uses the literal — labels only center ±half a glyph, so ±1px on a non-8-wide
-/// custom pack is cosmetically irrelevant (same rationale as `character_anchor`).
-const FLOATING_SPRITE_W: i32 = 8;
+/// The bundled character sprite width (px), from the ONE cross-crate authority
+/// `scene::layout::CHARACTER_SPRITE_W`. Labels only center ±half a glyph, so the
+/// default width (not a custom pack's real `frame.width`) is fine here — ±1px on
+/// a non-8-wide pack is cosmetically irrelevant (same rationale as `character_anchor`).
+const FLOATING_SPRITE_W: i32 = pixtuoid_scene::layout::CHARACTER_SPRITE_W as i32;
 
 /// Paint name badges into the upscaled `u32` surface (`0x00RRGGBB`). Each label's `anchor_px`
 /// is office-buffer space → multiply by `scale` for screen space; the badge is centered

--- a/crates/pixtuoid/src/tui/hit_test.rs
+++ b/crates/pixtuoid/src/tui/hit_test.rs
@@ -25,11 +25,11 @@ pub(crate) fn hit_test_agent(
     mx: u16,
     my: u16,
 ) -> Option<AgentId> {
-    // Width-in-cells (sprite is 8 px wide; we don't divide x by 2 because
-    // each pixel column is one cell column in the half-block grid).
-    const SPRITE_W_CELLS: u16 = 8;
-    // Height-in-cells: sprite is 12 px tall = 6 cells.
-    const SPRITE_H_CELLS: u16 = 6;
+    // Width-in-cells: the sprite width in px IS the cell width — we don't divide
+    // x by 2, since each pixel column is one cell column in the half-block grid.
+    const SPRITE_W_CELLS: u16 = pixtuoid_scene::layout::CHARACTER_SPRITE_W;
+    // Height-in-cells: the 12 px sprite is 6 half-block cells.
+    const SPRITE_H_CELLS: u16 = pixtuoid_scene::layout::CHARACTER_SPRITE_H_CELLS;
     for agent in scene.agents.values() {
         let Some(anchor) = character_anchor(agent, layout, now, rctx) else {
             continue;
@@ -58,8 +58,8 @@ pub(crate) fn hit_test_agent(
 /// `GlobalDeskIndex` newtype exists to prevent: while viewing floor ≥ 1 it
 /// could pin an invisible agent from another floor.)
 pub fn hit_test_from_tui(scene: &SceneState, layout: &Layout, mx: u16, my: u16) -> Option<AgentId> {
-    const SPRITE_W: u16 = 8;
-    const SPRITE_H_CELLS: u16 = 6;
+    const SPRITE_W: u16 = pixtuoid_scene::layout::CHARACTER_SPRITE_W;
+    const SPRITE_H_CELLS: u16 = pixtuoid_scene::layout::CHARACTER_SPRITE_H_CELLS;
     for agent in scene.agents.values() {
         // `single_floor_local()` (the projected-scene identity), NOT the
         // arithmetic bridge: on an out-of-range desk the bridge would wrap onto
@@ -549,7 +549,10 @@ mod tests {
         // Computed FROM the painter's seated-anchor geometry (DESK_W-centered
         // 8px sprite, 8px above the desk) — NOT a mirror of the impl's own
         // literals, so a drift from the painted sprite reddens here.
-        let cx = d.x + pixtuoid_scene::layout::DESK_W.saturating_sub(8) / 2;
+        let cx = d.x
+            + pixtuoid_scene::layout::DESK_W
+                .saturating_sub(pixtuoid_scene::layout::CHARACTER_SPRITE_W)
+                / 2;
         let cy = d.y.saturating_sub(8) / 2;
         assert_eq!(hit_test_from_tui(&scene, &layout, cx, cy), Some(id));
     }
@@ -584,8 +587,8 @@ mod tests {
 
         let (ax, ay) = (anchor.x, anchor.y / 2);
         // Every cell of the painted 8x6 sprite box pins…
-        for dx in 0..8u16 {
-            for dy in 0..6u16 {
+        for dx in 0..pixtuoid_scene::layout::CHARACTER_SPRITE_W {
+            for dy in 0..pixtuoid_scene::layout::CHARACTER_SPRITE_H_CELLS {
                 assert_eq!(
                     hit_test_from_tui(&scene, &layout, ax + dx, ay + dy),
                     Some(id),
@@ -598,12 +601,28 @@ mod tests {
             hit_test_from_tui(&scene, &layout, ax.wrapping_sub(1), ay),
             None
         );
-        assert_eq!(hit_test_from_tui(&scene, &layout, ax + 8, ay), None);
+        assert_eq!(
+            hit_test_from_tui(
+                &scene,
+                &layout,
+                ax + pixtuoid_scene::layout::CHARACTER_SPRITE_W,
+                ay
+            ),
+            None
+        );
         assert_eq!(
             hit_test_from_tui(&scene, &layout, ax, ay.wrapping_sub(1)),
             None
         );
-        assert_eq!(hit_test_from_tui(&scene, &layout, ax, ay + 6), None);
+        assert_eq!(
+            hit_test_from_tui(
+                &scene,
+                &layout,
+                ax,
+                ay + pixtuoid_scene::layout::CHARACTER_SPRITE_H_CELLS
+            ),
+            None
+        );
     }
 
     #[test]
@@ -640,11 +659,14 @@ mod tests {
         // Scan desk 0's whole sprite box — the wrapped bridge would hit here.
         let desk0 = layout.home_desks[0];
         let (ax, ay) = (
-            desk0.x + pixtuoid_scene::layout::DESK_W.saturating_sub(8) / 2,
+            desk0.x
+                + pixtuoid_scene::layout::DESK_W
+                    .saturating_sub(pixtuoid_scene::layout::CHARACTER_SPRITE_W)
+                    / 2,
             desk0.y.saturating_sub(8) / 2,
         );
-        for dx in 0..8u16 {
-            for dy in 0..6u16 {
+        for dx in 0..pixtuoid_scene::layout::CHARACTER_SPRITE_W {
+            for dy in 0..pixtuoid_scene::layout::CHARACTER_SPRITE_H_CELLS {
                 assert_eq!(
                     hit_test_from_tui(&scene, &layout, ax + dx, ay + dy),
                     None,


### PR DESCRIPTION
Closes #484.

`CHARACTER_SPRITE_W = 8` was `pub(super)` to `pixel_painter`, so out-of-module consumers hardcoded a bare `8`: the tui hit-test pin box, `layout::decor::DESK_WALK_X_OFF`, and floating's `FLOATING_SPRITE_W`. A sprite resize (or a non-8-wide pack) would drift hit/pin geometry from painted geometry.

**Change:** one `pub const CHARACTER_SPRITE_W: u16 = 8` in `scene::layout` (beside `DESK_W`/`DESK_H`; `layout→pixel_painter` would be a module cycle for `decor.rs`). `anchors.rs` re-exports it (`pub(super) use`) so pixel_painter siblings are untouched; `decor.rs`, both `hit_test` fns + their pin tests, and `offscreen.rs` reference it. Also added `CHARACTER_SPRITE_H_CELLS = 6` for the paired hit-test height literals. New pin test `character_sprite_w_matches_the_embedded_pack` ties the const to the embedded `standing` frame width.

**The trap (not conflated):** the seat *vertical* offset `desk.y.saturating_sub(8)` (8px above the desk) in `seated_anchor` + its two hit-test mirrors is a **distinct** concern and stays a bare literal — it is not the sprite width.

`just preflight` green (2137 tests, +1 pin test); no semver bump (adding a `pub const` is non-breaking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9paRKBLvcRt3t8bZeSCro