### PR TITLE
refactor: land the 3 actionable DRY items from the 07-04 audit (#487 3/4/5)

### DIFF
--- a/crates/pixtuoid-scene/src/layout/mod.rs
+++ b/crates/pixtuoid-scene/src/layout/mod.rs
@@ -308,6 +308,15 @@ impl SceneLayout {
     pub fn home_desk(&self, i: FloorLocalDeskIndex) -> Option<Point> {
         self.home_desks.get(i.0).copied()
     }
+
+    /// The visible top window-wall band height in px — the wall strip between the
+    /// buffer top and where the floor begins, `top_margin - WALL_BAND_TO_TOP_MARGIN`
+    /// (the same quantity `compute` names `top_wall_h` at construction; saturates
+    /// to 0 on a degenerate tiny margin). Post-construction render sites (wall sun
+    /// spot, window spill, weather) read it here so the derivation lives once.
+    pub fn wall_band_h(&self) -> u16 {
+        self.top_margin.saturating_sub(WALL_BAND_TO_TOP_MARGIN)
+    }
 }
 
 #[cfg(test)]

--- a/crates/pixtuoid-scene/src/pixel_painter/ambient.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/ambient.rs
@@ -12,7 +12,8 @@ use pixtuoid_core::state::FloorLocalDeskIndex;
 
 use crate::layout::Layout;
 use crate::pixel_painter::background::{
-    beam_strength, sun_on_wall, window_spill_columns, TimeOfDayLook, WallSide,
+    beam_strength, paint_radial_falloff, sun_on_wall, window_spill_columns, RadialFalloff,
+    TimeOfDayLook, WallSide,
 };
 use crate::pixel_painter::palette::blend_rgb;
 use crate::pixel_painter::PaintCtx;
@@ -299,9 +300,7 @@ pub(super) fn paint_sun_spot(
 
     // The top wall band is the visible window wall; East/West sun spots
     // project onto the outer 1-px column at the left/right edge of that band.
-    let wall_band_h = layout
-        .top_margin
-        .saturating_sub(crate::layout::WALL_BAND_TO_TOP_MARGIN);
+    let wall_band_h = layout.wall_band_h();
     if wall_band_h == 0 {
         return;
     }
@@ -338,20 +337,23 @@ pub(super) fn paint_sun_spot(
     let cy = ry as f32 + (h.saturating_sub(1)) as f32 * 0.5;
     let rx_norm = ((w.saturating_sub(1)) as f32 * 0.5).max(1.0);
     let ry_norm = ((h.saturating_sub(1)) as f32 * 0.5).max(1.0);
-    for y in ry..max_y {
-        for x in rx..max_x {
-            // Quadratic radial falloff so the spot reads round, not boxy.
-            let nx = (x as f32 - cx) / rx_norm;
-            let ny = (y as f32 - cy) / ry_norm;
-            let r2 = nx * nx + ny * ny;
-            if r2 > 1.0 {
-                continue;
-            }
-            let t = (1.0 - r2) * tint_strength;
-            let cur = buf.get(x, y);
-            buf.put(x, y, blend_rgb(cur, color, t));
-        }
-    }
+    // Quadratic radial falloff (shared with the ceiling pool / shadow) so the
+    // spot reads round, not boxy.
+    paint_radial_falloff(
+        buf,
+        RadialFalloff {
+            min_x: rx,
+            max_x,
+            min_y: ry,
+            max_y,
+            cx,
+            cy,
+            rx_norm,
+            ry_norm,
+        },
+        tint_strength,
+        color,
+    );
 }
 
 #[cfg(test)]

--- a/crates/pixtuoid-scene/src/pixel_painter/background/lighting.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/background/lighting.rs
@@ -18,22 +18,35 @@ pub(in crate::pixel_painter) struct Ellipse {
     pub half_h: u16,
 }
 
-/// Blend `color` over an elliptical region with a quadratic falloff from the
-/// center (full `strength`) to the edge (0), so it reads as a soft round patch
-/// rather than a stamped oval. Shared by the ceiling light pool and the
-/// furniture shadow — same math, different tint.
-fn paint_ellipse_blend(buf: &mut RgbBuffer, e: Ellipse, strength: f32, color: Rgb) {
-    if e.half_w == 0 || e.half_h == 0 || strength <= 0.0 {
-        return;
-    }
-    let min_x = e.cx.saturating_sub(e.half_w);
-    let max_x = (e.cx + e.half_w).min(buf.width());
-    let min_y = e.cy.saturating_sub(e.half_h);
-    let max_y = (e.cy + e.half_h).min(buf.height());
-    for y in min_y..max_y {
-        for x in min_x..max_x {
-            let nx = (x as f32 - e.cx as f32) / e.half_w as f32;
-            let ny = (y as f32 - e.cy as f32) / e.half_h as f32;
+/// Float ellipse geometry for [`paint_radial_falloff`]: the paint bounds
+/// `[min..max)` per axis, plus the centre + per-axis normalizer — all `f32`, so a
+/// caller can centre on `(w-1)/2` (half-cell correct) as well as an integer cell.
+pub(in crate::pixel_painter) struct RadialFalloff {
+    pub min_x: u16,
+    pub max_x: u16,
+    pub min_y: u16,
+    pub max_y: u16,
+    pub cx: f32,
+    pub cy: f32,
+    pub rx_norm: f32,
+    pub ry_norm: f32,
+}
+
+/// Blend `color` over the region with a quadratic radial falloff from the centre
+/// (full `strength`) to the ellipse edge (`r² > 1` skipped), so it reads as a
+/// soft round patch rather than a stamped oval. THE one falloff-blend: the
+/// ceiling pool / furniture shadow (`paint_ellipse_blend`, integer centre) and
+/// the wall sun spot (`ambient::paint_sun_spot`, `(w-1)/2` float centre) share it.
+pub(in crate::pixel_painter) fn paint_radial_falloff(
+    buf: &mut RgbBuffer,
+    g: RadialFalloff,
+    strength: f32,
+    color: Rgb,
+) {
+    for y in g.min_y..g.max_y {
+        for x in g.min_x..g.max_x {
+            let nx = (x as f32 - g.cx) / g.rx_norm;
+            let ny = (y as f32 - g.cy) / g.ry_norm;
             let r2 = nx * nx + ny * ny;
             if r2 > 1.0 {
                 continue;
@@ -43,6 +56,32 @@ fn paint_ellipse_blend(buf: &mut RgbBuffer, e: Ellipse, strength: f32, color: Rg
             buf.put(x, y, blend_rgb(cur, color, t));
         }
     }
+}
+
+/// Blend `color` over an integer-centred ellipse — the ceiling pool + shadow.
+fn paint_ellipse_blend(buf: &mut RgbBuffer, e: Ellipse, strength: f32, color: Rgb) {
+    if e.half_w == 0 || e.half_h == 0 || strength <= 0.0 {
+        return;
+    }
+    let min_x = e.cx.saturating_sub(e.half_w);
+    let max_x = (e.cx + e.half_w).min(buf.width());
+    let min_y = e.cy.saturating_sub(e.half_h);
+    let max_y = (e.cy + e.half_h).min(buf.height());
+    paint_radial_falloff(
+        buf,
+        RadialFalloff {
+            min_x,
+            max_x,
+            min_y,
+            max_y,
+            cx: e.cx as f32,
+            cy: e.cy as f32,
+            rx_norm: e.half_w as f32,
+            ry_norm: e.half_h as f32,
+        },
+        strength,
+        color,
+    );
 }
 
 /// Elliptical "ceiling fluorescent" pool of pale warm light on the floor.

--- a/crates/pixtuoid-scene/src/pixel_painter/background/mod.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/background/mod.rs
@@ -13,7 +13,7 @@ mod sky;
 // Re-export everything the parent pixel_painter/mod.rs imports.
 pub(super) use lighting::{
     paint_ceiling_pool, paint_clock, paint_corridor_runner, paint_floor_lamp_halo,
-    paint_neon_panel, paint_shadow, Ellipse,
+    paint_neon_panel, paint_radial_falloff, paint_shadow, Ellipse, RadialFalloff,
 };
 pub(super) use sky::{
     beam_strength, daylight_floor_overlay, dim_floor_overlay, hour_is_day, set_weather_override,
@@ -260,9 +260,7 @@ fn skyline_haze(w: Weather) -> Option<(Rgb, f32)> {
 /// guard in `paint_floor_and_walls`. Used by `paint_dust_motes` so the
 /// motes drift through the same warm spill the floor pass paints.
 pub(in crate::pixel_painter) fn window_spill_columns(layout: &Layout) -> Vec<SunbeamColumn> {
-    let top_wall_h = layout
-        .top_margin
-        .saturating_sub(crate::layout::WALL_BAND_TO_TOP_MARGIN);
+    let top_wall_h = layout.wall_band_h();
     let skip = layout.door.map(|d| (d.x, d.x + ELEVATOR_W));
     let mut out = Vec::new();
     let mut x = 3u16;

--- a/crates/pixtuoid-scene/src/pixel_painter/mod.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/mod.rs
@@ -344,10 +344,7 @@ fn paint_frame(
     let look = time_of_day_look(ctx.now, ctx.theme);
     // Wall band height tracks layout.top_margin (which is buf_h/4 with
     // a floor) — leaves a 4-px buffer between wall trim and cubicles.
-    let top_wall_h = ctx
-        .layout
-        .top_margin
-        .saturating_sub(crate::layout::WALL_BAND_TO_TOP_MARGIN);
+    let top_wall_h = ctx.layout.wall_band_h();
     // The elevator door replaces the rightmost window — pass its x-range
     // so `paint_floor_and_walls` skips drawing a window that would
     // otherwise bleed through behind the elevator frame.

--- a/crates/pixtuoid/src/install/claude.rs
+++ b/crates/pixtuoid/src/install/claude.rs
@@ -124,18 +124,15 @@ fn claude_shim_ref(entry: &Value) -> crate::install::verify::ShimRef {
             let c = c.trim();
             if c == "pixtuoid-hook" {
                 ShimRef::BareName
-            } else if c.starts_with('\'') && c.ends_with('\'') {
-                // Unix explicit form: a `shell_single_quote`'d absolute path. Reverse
-                // the POSIX escaping via the SHARED `posix_unquote` — a naive
-                // `trim_matches('\'')` mangles an embedded `'\''` (an apostrophe in the
-                // path), false-flagging the install "broken" (the R0620-364-01
-                // mis-decode class that the shared `shell_shim_ref` already avoids).
-                ShimRef::Absolute(std::path::PathBuf::from(
-                    crate::install::verify::posix_unquote(c),
-                ))
             } else {
-                // Windows exec form (bare absolute `.exe`) or an unquoted path.
-                ShimRef::Absolute(std::path::PathBuf::from(c))
+                // Unix explicit form: a `shell_single_quote`'d absolute path —
+                // reverse the POSIX escaping via the SHARED `posix_unquote_if_quoted`
+                // (a naive `trim_matches('\'')` mangles an embedded `'\''`, the
+                // R0620-364-01 mis-decode class). A Windows exec-form bare `.exe`,
+                // an unquoted path, or a half-quoted string passes through literal.
+                ShimRef::Absolute(std::path::PathBuf::from(
+                    crate::install::verify::posix_unquote_if_quoted(c),
+                ))
             }
         }
     }

--- a/crates/pixtuoid/src/install/hermes.rs
+++ b/crates/pixtuoid/src/install/hermes.rs
@@ -159,11 +159,7 @@ fn exec_shim_ref(command: &str) -> ShimRef {
         .map(|(p, _)| p)
         .unwrap_or(command)
         .trim();
-    let unq = if path.len() >= 2 && path.starts_with('\'') && path.ends_with('\'') {
-        crate::install::verify::posix_unquote(path)
-    } else {
-        path.to_string()
-    };
+    let unq = crate::install::verify::posix_unquote_if_quoted(path);
     if unq.is_empty() {
         ShimRef::Unknown
     } else {

--- a/crates/pixtuoid/src/install/verify.rs
+++ b/crates/pixtuoid/src/install/verify.rs
@@ -244,10 +244,40 @@ pub(crate) fn posix_unquote(span: &str) -> String {
     out
 }
 
+/// If `s` is a whole POSIX single-quoted span (`'…'`, length ≥ 2), reverse the
+/// quoting via [`posix_unquote`]; otherwise return it verbatim. THE one
+/// "whole-span quoted → unquote else literal" decision — the exec-form decoders
+/// (`claude`, `hermes`) route through it so the `len() >= 2` guard (a lone `'` is
+/// NOT a quoted span, and slicing it would strip to nothing) can't drift between
+/// them. A half-quoted `'/opt/x` (no close) is a literal, not unquoted.
+pub(crate) fn posix_unquote_if_quoted(s: &str) -> String {
+    if s.len() >= 2 && s.starts_with('\'') && s.ends_with('\'') {
+        posix_unquote(s)
+    } else {
+        s.to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn posix_unquote_if_quoted_guards_len_and_pairing() {
+        // A whole single-quoted span is unquoted, incl. an embedded `'\''`.
+        assert_eq!(posix_unquote_if_quoted("'/opt/hook'"), "/opt/hook");
+        assert_eq!(posix_unquote_if_quoted(r"'/U/O'\''B/hook'"), "/U/O'B/hook");
+        // Half-quoted (open, no close) → literal, not unquoted.
+        assert_eq!(posix_unquote_if_quoted("'/opt/hook"), "'/opt/hook");
+        // A LONE `'` (len 1) is NOT a quoted span — the `len() >= 2` guard keeps
+        // it literal instead of slicing to "" (the claude/hermes guard drift this
+        // consolidation fixes: claude previously lacked the length check).
+        assert_eq!(posix_unquote_if_quoted("'"), "'");
+        // Empty + plain unquoted pass through verbatim.
+        assert_eq!(posix_unquote_if_quoted(""), "");
+        assert_eq!(posix_unquote_if_quoted("/plain/path"), "/plain/path");
+    }
 
     #[test]
     fn shell_shim_ref_unix_env_prefix_form() {


### PR DESCRIPTION
Closes #487 — the 3 actionable items of the speculative design-debt cluster (item 1 was already done; items 2/6/7/8 stay refuted-deliberate per invariant #3 and are untouched).

**Item 3 — quote-strip guard drift (correctness):** the "whole-span single-quoted → `posix_unquote` else literal" decision was inlined 3 ways with an **inconsistent length guard** — `hermes` had `len() >= 2`, `claude` had none (a lone `'` passes `starts_with && ends_with` on the same char → sliced to `""`). Consolidated claude + hermes onto one `verify::posix_unquote_if_quoted` with the correct guard. `verify`'s env-prefix extraction keeps its own structural `start < end` guard (a different shape — extracts a quoted *substring*). New guard-teeth test; existing apostrophe-round-trip + half-quoted-literal tests still green.

**Item 4 — radial-falloff dup:** `paint_sun_spot`'s quadratic radial-ellipse blend loop duplicated `paint_ellipse_blend`'s. Extracted one `lighting::paint_radial_falloff(RadialFalloff{..}, strength, color)`; both callers delegate. **Byte-identical render** — `just gen-check` pixel-identical across every baseline (day/night/space renders exercise the sun spot + ceiling pool).

**Item 5 — wall-band accessor:** `top_margin.saturating_sub(WALL_BAND_TO_TOP_MARGIN)` re-derived at 3 render sites → `SceneLayout::wall_band_h()`. Construction sites have no `SceneLayout` yet and stay inline.

`just preflight` green (2147 tests); `just gen-check` pixel-identical; no semver surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9paRKBLvcRt3t8bZeSCro