### PR TITLE
fix(hook): close #495 — Windows named-pipe server-identity check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2327,6 +2327,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,9 +34,14 @@ The components that handle untrusted or privileged input, and how they're bounde
    `0700` directory `/tmp/pixtuoid-<uid>/pixtuoid.sock`; `PIXTUOID_SOCKET`
    overrides — the socket itself created `0600`, owner-only). The `/tmp` fallback
    dir is created with a TOCTOU-safe `mkdir` + ownership/mode validation, and the
-   shim verifies the connected peer's uid (`getpeereid`) before writing — so
-   another user cannot squat the (formerly flat, predictable) rendezvous path to
-   disable the hook plane, nor intercept the payload by racing a listener onto it.
+   shim verifies the connected peer's uid (`getpeereid`/`SO_PEERCRED`) before
+   writing — so another user cannot squat the (formerly flat, predictable)
+   rendezvous path to disable the hook plane, nor intercept the payload by racing
+   a listener onto it. On **Windows** the transport is a named pipe
+   `\\.\pipe\pixtuoid-<user>` with an owner-only DACL, and the shim likewise
+   verifies the pipe **server's** token user SID matches ours
+   (`GetNamedPipeServerProcessId` → token compare) before writing — closing the
+   same squat-and-intercept vector on the machine-global pipe namespace (#495).
    It is a *local IPC* — there is no network
    listener. The shim is hardened to **never block the agent**: it always exits
    `0`, within a hard ~200 ms watchdog bound, on any error. It does not execute or

--- a/crates/pixtuoid-core/src/source/hook/windows.rs
+++ b/crates/pixtuoid-core/src/source/hook/windows.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result};
 use tokio::net::windows::named_pipe::{NamedPipeServer, PipeMode, ServerOptions};
 use tokio::sync::Semaphore;
 use tracing::warn;
-use windows_sys::Win32::Foundation::LocalFree;
+use windows_sys::Win32::Foundation::{LocalFree, ERROR_ACCESS_DENIED};
 use windows_sys::Win32::Security::Authorization::{
     ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1,
 };
@@ -150,7 +150,7 @@ impl Listener {
             // stays fatal.
             Err(e)
                 if e.kind() == std::io::ErrorKind::PermissionDenied
-                    || e.raw_os_error() == Some(5) =>
+                    || e.raw_os_error() == Some(ERROR_ACCESS_DENIED as i32) =>
             {
                 return Err(anyhow::Error::new(super::SocketBusy {
                     path: path.to_path_buf(),

--- a/crates/pixtuoid-hook/Cargo.toml
+++ b/crates/pixtuoid-hook/Cargo.toml
@@ -31,6 +31,13 @@ anyhow     = { workspace = true }
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+# The shim was deliberately Windows-dep-free (constants hand-hardcoded), but the
+# #495 client-side peer-cred check needs Win32 (GetNamedPipeServerProcessId +
+# token-user SID compare) — verified decls beat hand-FFI in the never-panic shim.
+# Pin the SAME major as pixtuoid-core / pixtuoid so the bindings don't double-compile.
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_System_Pipes", "Win32_System_Threading"] }
+
 [target.'cfg(unix)'.dev-dependencies]
 tempfile = "3"
 

--- a/crates/pixtuoid-hook/src/paths.rs
+++ b/crates/pixtuoid-hook/src/paths.rs
@@ -34,17 +34,26 @@ pub(crate) fn default_socket_path() -> String {
     }
     #[cfg(windows)]
     {
-        // The pipe NAME is namespacing only — the security boundary is the
-        // server-side DACL (spec §2). USERNAME is std-only, present in any
-        // login session, and computed identically by shim and daemon
-        // (parity-pinned in pixtuoid-core/tests/socket_path_parity.rs).
-        // Backslashes are sanitized: pipe names can't contain them, and
-        // enterprise boxes do set USERNAME=DOMAIN\user.
-        let user = std::env::var("USERNAME")
-            .unwrap_or_else(|_| "default".into())
-            .replace('\\', "-");
-        format!(r"\\.\pipe\pixtuoid-{user}")
+        default_windows_pipe_name()
     }
+}
+
+/// The default hook pipe name `\\.\pipe\pixtuoid-{USERNAME}` (branch 2/3 on
+/// Windows), WITHOUT the `PIXTUOID_SOCKET` override short-circuit. The security
+/// boundary is the server-side DACL (spec §2), but the NAME is namespacing only —
+/// USERNAME is std-only, present in any login session, and computed identically
+/// by shim and daemon (parity-pinned in pixtuoid-core/tests/socket_path_parity.rs).
+/// Backslashes are sanitized: pipe names can't contain them, and enterprise boxes
+/// set USERNAME=DOMAIN\user. The shim compares the resolved endpoint against this
+/// to SCOPE its #495 peer-cred check to our own predictable rendezvous — an
+/// explicit `PIXTUOID_SOCKET` pipe stays the user's trust decision (parity with
+/// the Unix `owned_tmp_socket_dir` scoping).
+#[cfg(windows)]
+pub(crate) fn default_windows_pipe_name() -> String {
+    let user = std::env::var("USERNAME")
+        .unwrap_or_else(|_| "default".into())
+        .replace('\\', "-");
+    format!(r"\\.\pipe\pixtuoid-{user}")
 }
 
 /// The per-user tmp dir we OWN (`/tmp/pixtuoid-{uid}`) when `endpoint` is the

--- a/crates/pixtuoid-hook/src/transport.rs
+++ b/crates/pixtuoid-hook/src/transport.rs
@@ -139,11 +139,11 @@ pub(crate) fn send_line(endpoint: &str, line: &[u8]) {
     if !spawn_timeout_watchdog() {
         return;
     }
-    // 231 = ERROR_PIPE_BUSY (all named-pipe server instances mid-handshake).
-    // Matched on the raw numeric code — NOT a windows-crate constant — to keep the
-    // shipped shim at ZERO Windows deps (the deliberate reason it's hardcoded, not
-    // imported). The backoff is bounded by the 200ms send watchdog either way.
-    const ERROR_PIPE_BUSY: i32 = 231;
+    // ERROR_PIPE_BUSY = all named-pipe server instances mid-handshake. Now the
+    // windows-sys constant (#495 pulled the crate in for the peer check below),
+    // no longer a hand-hardcoded 231. The backoff is bounded by the 200ms send
+    // watchdog either way.
+    const ERROR_PIPE_BUSY: i32 = windows_sys::Win32::Foundation::ERROR_PIPE_BUSY as i32;
     const PIPE_BUSY_RETRY_BACKOFF_MS: u64 = 10;
     loop {
         match std::fs::OpenOptions::new()
@@ -152,6 +152,17 @@ pub(crate) fn send_line(endpoint: &str, line: &[u8]) {
             .open(endpoint)
         {
             Ok(mut f) => {
+                // #495: before writing, verify the pipe SERVER runs as US — a
+                // co-located user who squatted our predictable default pipe (so
+                // our daemon's create failed → SocketBusy degrade) would else
+                // receive the payload (cwd, tool names). Scoped to our default
+                // rendezvous; an explicit PIXTUOID_SOCKET pipe is the user's
+                // trust call (parity with the Unix owned_tmp_socket_dir scope).
+                // Fail-closed drop, never a panic (invariant #5).
+                if endpoint == crate::paths::default_windows_pipe_name() && !peer::server_is_us(&f)
+                {
+                    return;
+                }
                 let _ = f.write_all(line);
                 return;
             }
@@ -166,9 +177,119 @@ pub(crate) fn send_line(endpoint: &str, line: &[u8]) {
     }
 }
 
-// No in-process tests here ON PURPOSE: send_line spawns a watchdog that
+/// The Windows counterpart of the Unix `peer_is_us` check (#495): verify the
+/// named-pipe SERVER (the process that created the pipe) runs as OUR user before
+/// the shim writes the hook payload. Windows named pipes are a machine-global,
+/// unprivileged namespace, so a co-located user can pre-create our predictable
+/// `\\.\pipe\pixtuoid-{USERNAME}` (making our daemon's create fail → the hook
+/// plane silently degrades) and receive the payload. Comparing the connected
+/// server's token user SID to ours closes that. EVERYTHING here fails CLOSED
+/// (any FFI failure ⇒ `false` ⇒ drop) and never panics — invariant #5.
+#[cfg(windows)]
+mod peer {
+    use std::os::windows::io::AsRawHandle;
+
+    use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
+    use windows_sys::Win32::Security::{
+        EqualSid, GetTokenInformation, TokenUser, PSID, TOKEN_QUERY, TOKEN_USER,
+    };
+    use windows_sys::Win32::System::Pipes::GetNamedPipeServerProcessId;
+    use windows_sys::Win32::System::Threading::{
+        GetCurrentProcess, OpenProcess, OpenProcessToken, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+
+    /// The `TOKEN_USER` blob for `process`'s token, `u64`-backed so the embedded
+    /// `PSID` pointer is properly aligned (a `Vec<u8>` would only guarantee
+    /// align-1). The returned buffer OWNS the SID — keep it alive across the
+    /// `EqualSid` call. `None` on any failure.
+    ///
+    /// SAFETY: `process` is a valid process handle for the call's duration.
+    unsafe fn token_user_blob(process: HANDLE) -> Option<Vec<u64>> {
+        let mut token: HANDLE = std::ptr::null_mut();
+        if OpenProcessToken(process, TOKEN_QUERY, &mut token) == 0 {
+            return None;
+        }
+        // Size probe (returns 0 + sets `len`), then the real read; close the
+        // token on every path.
+        let mut len: u32 = 0;
+        GetTokenInformation(token, TokenUser, std::ptr::null_mut(), 0, &mut len);
+        let blob = if len == 0 {
+            None
+        } else {
+            let mut buf = vec![0u64; (len as usize).div_ceil(8)];
+            if GetTokenInformation(token, TokenUser, buf.as_mut_ptr().cast(), len, &mut len) == 0 {
+                None
+            } else {
+                Some(buf)
+            }
+        };
+        CloseHandle(token);
+        blob
+    }
+
+    /// The `PSID` embedded in a `TOKEN_USER` blob. Valid only while `blob` lives.
+    ///
+    /// SAFETY: `blob` is a `TOKEN_USER` written by `GetTokenInformation`, u64-aligned.
+    unsafe fn sid_of(blob: &[u64]) -> PSID {
+        (*(blob.as_ptr().cast::<TOKEN_USER>())).User.Sid
+    }
+
+    /// True iff the pipe server behind `file` runs as our user. Fail-closed.
+    pub(super) fn server_is_us(file: &std::fs::File) -> bool {
+        let handle = file.as_raw_handle() as HANDLE;
+        // SAFETY: `handle` is a live connected pipe; `server` (from OpenProcess)
+        // is closed exactly once; the two SID buffers outlive the EqualSid call.
+        unsafe {
+            let mut server_pid: u32 = 0;
+            if GetNamedPipeServerProcessId(handle, &mut server_pid) == 0 {
+                return false;
+            }
+            // Our own user SID (GetCurrentProcess is a pseudo-handle — never closed).
+            let Some(ours) = token_user_blob(GetCurrentProcess()) else {
+                return false;
+            };
+            let server = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, server_pid);
+            if server.is_null() {
+                return false;
+            }
+            let theirs = token_user_blob(server);
+            CloseHandle(server);
+            let Some(theirs) = theirs else {
+                return false;
+            };
+            EqualSid(sid_of(&ours), sid_of(&theirs)) != 0
+        }
+    }
+}
+
+// No in-process tests for `send_line` ON PURPOSE: it spawns a watchdog that
 // exit(0)s the whole process ~200ms later (both platforms), which would kill
 // sibling tests under plain `cargo test`'s shared-process runner. All
 // send_line coverage lives at the child-process level — tests/shim.rs
 // (delivery, missing endpoint, stalled listener) and its Windows twin
 // tests/shim_pipe.rs — where exit-is-the-contract is observable, not fatal.
+// `peer::server_is_us` spawns NO watchdog, so it IS unit-testable below.
+
+// The peer-cred check runs only on the `windows-test` CI job (no reachable path
+// on Unix). Both ends of a self-hosted pipe are THIS process → same user → true.
+#[cfg(all(windows, test))]
+mod win_peer_tests {
+    #[tokio::test]
+    async fn server_is_us_for_a_self_hosted_pipe() {
+        // A unique name per run so parallel test processes don't collide.
+        let name = format!(r"\\.\pipe\pixtuoid-peer-selftest-{}", std::process::id());
+        let _server = tokio::net::windows::named_pipe::ServerOptions::new()
+            .create(&name)
+            .expect("create self-hosted pipe server");
+        // A blocking std client — the same handle type `send_line` writes over.
+        let client = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&name)
+            .expect("open client end");
+        assert!(
+            super::peer::server_is_us(&client),
+            "our own process's pipe server must verify as us"
+        );
+    }
+}

--- a/crates/pixtuoid-hook/src/transport.rs
+++ b/crates/pixtuoid-hook/src/transport.rs
@@ -185,6 +185,20 @@ pub(crate) fn send_line(endpoint: &str, line: &[u8]) {
 /// plane silently degrades) and receive the payload. Comparing the connected
 /// server's token user SID to ours closes that. EVERYTHING here fails CLOSED
 /// (any FFI failure ⇒ `false` ⇒ drop) and never panics — invariant #5.
+///
+/// KNOWN SHARP EDGE — pid→token, not fd-atomic (don't "fix" it): unlike Unix
+/// `getpeereid` (which reads the peer off the connected fd atomically), this
+/// resolves the server via `GetNamedPipeServerProcessId` → `OpenProcess`, a
+/// pid→handle pair with an inherent PID-reuse TOCTOU. It is fail-closed AND
+/// effectively unexploitable: for the payload to leak, the squatter's server
+/// process must stay ALIVE to receive the write, so its pid can't have been
+/// recycled; a recycled pid means the squatter exited, its pipe instance died
+/// with it, and the write goes nowhere. There is no atomic Win32 alternative
+/// that ALSO survives elevation — `GetSecurityInfo(OWNER)` reads the pipe object
+/// owner in one call but would false-negative an admin daemon (owner = the
+/// Administrators group, not the user). The `default_windows_pipe_name` re-read
+/// in `send_line`'s scope check is a deliberate one-shot cost (the shim runs once
+/// per hook and exits).
 #[cfg(windows)]
 mod peer {
     use std::os::windows::io::AsRawHandle;


### PR DESCRIPTION
Closes #495 — the N-1-of-N gap the whole-codebase audit caught in my own #485 work: the read-side leak defense was Unix-only.

## Problem
The Windows shim wrote the hook payload to whatever pipe answered `\\.\pipe\pixtuoid-{USERNAME}` (machine-global, predictable name). A co-located user who pre-squats it — making our daemon's `create_hook_pipe(first=true)` fail → `SocketBusy` → silent transcript-only degrade — received cwd + tool names + tool_args.

## Fix
`transport::send_line` (Windows) now verifies the pipe **server** runs as our user before writing:
`GetNamedPipeServerProcessId` → `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION)` → `OpenProcessToken` → `GetTokenInformation(TokenUser)` → `EqualSid` vs our own token user.
- **Fail-CLOSED** on any FFI failure (drop, never panic — invariant #5); u64-backed SID buffers for pointer alignment; handles closed exactly once; `GetCurrentProcess` pseudo-handle not closed.
- **Scoped** to our default pipe name (`paths::default_windows_pipe_name`, factored out of `default_socket_path`) so an explicit `PIXTUOID_SOCKET` pipe stays the user's trust decision — parity with the Unix `owned_tmp_socket_dir` scoping.

## Dep decision
This needed windows-sys on the shim (the one Win32-dep-free crate) — but **core+binary already depend on it** (0.61), verified decls beat hand-FFI in the never-panic shim, and the **same major is pinned** so bindings don't double-compile. Features: `Win32_Foundation` + `Win32_Security` + `Win32_System_Pipes` + `Win32_System_Threading`.

## While there (magic-number → named const)
- shim: hand-hardcoded `231` → `ERROR_PIPE_BUSY`.
- core `hook/windows.rs`: `Some(5)` → `ERROR_ACCESS_DENIED` (free — `Win32_Foundation` already imported).
- (`install/io.rs`'s "os error 32" is a **comment**, not a numeric compare — left as-is.)

## Verification
`just preflight` green on macOS (2148 tests — the windows arms are `cfg`'d out here). The Windows compile is verified by the **`check-windows` CI job**; a new `#[cfg(all(windows,test))]` teeth test asserts `server_is_us` on a self-hosted pipe → us (runs on `windows-test`). API module paths verified against docs.rs (`GetNamedPipeServerProcessId`=Pipes, `OpenProcessToken`=Threading, `EqualSid`/`PSID`/`TOKEN_USER`=Security, `HANDLE`=`*mut c_void`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9paRKBLvcRt3t8bZeSCro