### PR TITLE
chore(arc2): kill 2 mutation survivors + doc/safety hygiene (cleanup arc #2)

### DIFF
--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -130,7 +130,14 @@ given change/tree, say so, don't skip it.
   diff that a reader could infer from the code is the smell); manifest-bridge (a
   `site/src/*.json` / generated schema vs its Rust source of truth).
 - **(D) Quality + tooling** — test-coverage gaps (changed/existing code with no
-  exercising test); mutation-teeth (assertions that survive the mutation);
+  exercising test); mutation-teeth (assertions that survive the mutation — and a
+  PROSE CLAIM that a mutant is EQUIVALENT or KILLED is not teeth, it's an
+  unverified assertion: pin an equivalent in `.cargo/mutants.toml`'s `exclude_re`
+  [mechanically re-checked every run] or kill it with a real test, NEVER trust a
+  code comment; arc #2's mutation run found 2 live reducer survivors masked by
+  exactly such comments — one citing a "residuals note in tests" that didn't
+  exist, one whose "this kills the mutant" assertion couldn't distinguish the
+  branches [`duplicate_root_session_start_..._resurrect` + `parent_waiting_..._ends_a_tool` fixed both]);
   isolation & flakiness (real-state writes, wall-clock/order nondeterminism,
   `TEST_ENV_LOCK`, snapshot determinism); CI/build (gate coverage, path-filter
   holes, toolchain skew); gate-teeth & gate liveness (can this check actually

--- a/crates/pixtuoid-core/src/state/reducer.rs
+++ b/crates/pixtuoid-core/src/state/reducer.rs
@@ -878,9 +878,13 @@ impl Reducer {
             // session's start is swallowed and the whole first turn is
             // invisible (every later arm is a no-op once the corpse is
             // GC'd). Gated to root agents on BOTH sides so a late
-            // duplicate can't un-exit a b1-cascaded subagent.
-            // (mutants: `&&`→`||` on the last conjunct is a documented
-            // accepted equivalent — see the residuals note in tests.)
+            // duplicate can't un-exit a b1-cascaded subagent. All three
+            // conjuncts are load-bearing (`resurrect_in_place` has no exiting
+            // guard, so a `&&`→`||` here WOULD reset a LIVE root — NOT an
+            // equivalent mutant): the exiting conjunct is pinned by
+            // `duplicate_root_session_start_does_not_resurrect_a_live_session`,
+            // the two root-gate conjuncts by the exiting-slot / exiting-subagent
+            // resurrect tests.
             if slot.exiting_at.is_some() && slot.parent_id.is_none() && parent_id.is_none() {
                 // Route through fsm so an in-flight Active span is folded
                 // into active_ms before the reset (every other

--- a/crates/pixtuoid-core/tests/CLAUDE.md
+++ b/crates/pixtuoid-core/tests/CLAUDE.md
@@ -59,7 +59,7 @@ tests/
 2. **Only if the CLI has unique behavior** (subagent hooks, custom lifecycle): add
    `tests/sources/<cli>.rs` (or `<cli>/mod.rs` if it needs private fixtures) and
    register `mod <cli>;` in `tests/sources/main.rs`. Plain CLIs (antigravity,
-   reasonix) need none — `decode.rs` + `conformance.rs` cover them.
+   reasonix) need none — `decode/mod.rs` + `conformance.rs` cover them.
 
 ## Known sharp edges
 

--- a/crates/pixtuoid-core/tests/reducer/lifecycle.rs
+++ b/crates/pixtuoid-core/tests/reducer/lifecycle.rs
@@ -363,6 +363,74 @@ fn session_start_on_exiting_subagent_does_not_resurrect() {
     );
 }
 
+// The resurrect gate fires ONLY for EXITING slots (conjunct A of the three).
+// A duplicate root SessionStart on a LIVE (non-exiting) session — the
+// Codex/Reasonix re-emit-a-start-per-prompt path — must refresh liveness WITHOUT
+// resurrect-in-place: resurrecting a live slot resets Active→Idle AND evicts its
+// active_tasks (reducer.rs:916), un-suppressing a delegating parent's subagent
+// leak. This pins that the `&&`→`||` mutant on the LAST conjunct dies — the
+// mutant reads `(exiting && slot_root) || incoming_root`, which on this live root
+// (incoming_root = true) would wrongly resurrect. (The old inline "accepted
+// equivalent" comment was WRONG: resurrect_in_place has no exiting guard.)
+#[test]
+fn duplicate_root_session_start_does_not_resurrect_a_live_session() {
+    let mut scene = SceneState::uniform(8);
+    let mut r = Reducer::new();
+    let root = AgentId::from_transcript_path("/p/live-root.jsonl");
+    let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+    r.apply(
+        &mut scene,
+        AgentEvent::SessionStart {
+            agent_id: root,
+            source: "claude-code".into(),
+            session_id: "r".into(),
+            cwd: PathBuf::from("/repo"),
+            parent_id: None,
+        },
+        t0,
+        Transport::Hook,
+    );
+    // Drive it Active — a live, in-flight session that is NEVER exiting.
+    r.apply(
+        &mut scene,
+        AgentEvent::ActivityStart {
+            agent_id: root,
+            tool_use_id: Some("t1".into()),
+            detail: Some("Edit: foo.rs".into()),
+        },
+        t0 + Duration::from_secs(1),
+        Transport::Hook,
+    );
+    assert!(matches!(
+        scene.agents.get(&root).unwrap().state,
+        ActivityState::Active { .. }
+    ));
+    // A duplicate ROOT SessionStart (re-emitted per prompt) refreshes liveness but
+    // must NOT resurrect: the slot is not exiting, so conjunct A is false.
+    r.apply(
+        &mut scene,
+        AgentEvent::SessionStart {
+            agent_id: root,
+            source: "claude-code".into(),
+            session_id: "r".into(),
+            cwd: PathBuf::from("/repo"),
+            parent_id: None,
+        },
+        t0 + Duration::from_secs(2),
+        Transport::Hook,
+    );
+    let slot = scene.agents.get(&root).unwrap();
+    assert!(
+        slot.exiting_at.is_none(),
+        "the live session was never exiting"
+    );
+    assert!(
+        matches!(slot.state, ActivityState::Active { .. }),
+        "a duplicate root start on a LIVE session must NOT reset it to Idle: a \
+         resurrect here (the surviving mutant) drops Active + evicts active_tasks"
+    );
+}
+
 // Resurrect-in-place must evict the previous life's correlation state: a tuid
 // left in active_tasks by a session that ended mid-delegation can NEVER drain
 // (its End belongs to the dead life), so suppress_subagent_leak would eat

--- a/crates/pixtuoid-core/tests/reducer/tasks.rs
+++ b/crates/pixtuoid-core/tests/reducer/tasks.rs
@@ -132,12 +132,13 @@ fn hook_activity_during_active_task_is_suppressed() {
         matches!(slot.state, ActivityState::Active { .. }),
         "parent must remain Active(Task) while task in flight"
     );
-    // The suppressed subagent End must be DROPPED, not merely state-neutral:
-    // an un-suppressed ActivityEnd arms pending_idle (the grace debounce keeps
-    // the slot Active, so the state check above can't see the leak). A None
-    // pending_idle is what proves the End never reached apply — this is the
-    // assertion that kills the `delete ActivityEnd arm in suppress_subagent_leak`
-    // mutant the state check alone leaves alive.
+    // A None pending_idle confirms the suppressed End didn't nudge the parent
+    // toward Idle. NOTE: this does NOT kill the `delete ActivityEnd arm in
+    // suppress_subagent_leak` mutant — a misattributed End's tuid (`subagent-R`)
+    // doesn't match the parent's active Task span, so even an UN-suppressed
+    // (applied) End leaves pending_idle None; both branches read None here. That
+    // mutant is killed by `parent_waiting_..._resolves_when_the_subagent_ends_a_tool`
+    // (the Waiting-restore is the observable the suppression path uniquely does).
     assert!(
         slot.pending_idle_at.is_none(),
         "a suppressed subagent End must not arm the parent's pending-idle"
@@ -1697,6 +1698,91 @@ fn parent_waiting_on_subagent_permission_resolves_when_the_subagent_resumes() {
         "parent resumes Active(Delegating) once the subagent works again — no stale Waiting"
     );
     assert!(scene.agents.get(&child).unwrap().exiting_at.is_none());
+}
+
+// SIBLING of the test above (which resumes via a child ActivityStart): the
+// Waiting-restore must ALSO fire for a suppressed child ActivityEnd. Deleting
+// the `ActivityEnd` arm of `suppress_subagent_leak` (a surviving mutant) leaves
+// THIS parent stuck on a stale "permission?" Waiting until the 60-min sweep,
+// because the child's End would then neither suppress nor restore. Pins that arm.
+#[test]
+fn parent_waiting_on_subagent_permission_resolves_when_the_subagent_ends_a_tool() {
+    let mut scene = SceneState::uniform(8);
+    let mut r = Reducer::new();
+    let parent = AgentId::from_transcript_path("/p/orch2.jsonl");
+    let child = AgentId::from_parts("claude-code", "/p/orch2/subagents/agent-1.jsonl");
+    let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+    r.apply(
+        &mut scene,
+        AgentEvent::SessionStart {
+            agent_id: parent,
+            source: "claude-code".into(),
+            session_id: "p".into(),
+            cwd: PathBuf::from("/repo"),
+            parent_id: None,
+        },
+        t0,
+        Transport::Hook,
+    );
+    r.apply(
+        &mut scene,
+        AgentEvent::SessionStart {
+            agent_id: child,
+            source: "claude-code".into(),
+            session_id: "c".into(),
+            cwd: PathBuf::from("/repo"),
+            parent_id: Some(parent),
+        },
+        t0 + Duration::from_millis(100),
+        Transport::Jsonl,
+    );
+    // Parent delegates → Active(Delegating), active_tasks[parent] = {task-T}.
+    r.apply(
+        &mut scene,
+        AgentEvent::ActivityStart {
+            agent_id: parent,
+            tool_use_id: Some("task-T".into()),
+            detail: Some("Agent".into()),
+        },
+        t0 + Duration::from_secs(1),
+        Transport::Hook,
+    );
+    // Subagent's permission prompt → Notification misattributed to the parent.
+    r.apply(
+        &mut scene,
+        AgentEvent::Waiting {
+            agent_id: parent,
+            reason: "permission?".into(),
+        },
+        t0 + Duration::from_secs(2),
+        Transport::Hook,
+    );
+    assert!(
+        matches!(
+            scene.agents.get(&parent).unwrap().state,
+            ActivityState::Waiting { .. }
+        ),
+        "parent goes Waiting on the subagent's permission"
+    );
+    // Subagent resumes by ENDING a tool → a misattributed child hook END (a
+    // different tuid, so not the Task's self-end): suppressed, and the
+    // suppression restores Active(Delegating).
+    r.apply(
+        &mut scene,
+        AgentEvent::ActivityEnd {
+            agent_id: parent,
+            tool_use_id: Some("sub-bash".into()),
+        },
+        t0 + Duration::from_secs(3),
+        Transport::Hook,
+    );
+    assert!(
+        matches!(
+            scene.agents.get(&parent).unwrap().state,
+            ActivityState::Active { .. }
+        ),
+        "a suppressed child END must ALSO restore Active(Delegating), not leave a stale Waiting"
+    );
 }
 
 // Regression (adversarial review): a parent Waiting on a permission while a

--- a/crates/pixtuoid-hook/src/paths.rs
+++ b/crates/pixtuoid-hook/src/paths.rs
@@ -29,6 +29,7 @@ pub(crate) fn default_socket_path() -> String {
         // dir THEY pre-squatted makes the daemon's bind fail loudly instead of
         // silently degrading. Parity-pinned to the daemon's branch 3 by
         // `pixtuoid-core/tests/socket_path_parity.rs`.
+        // Safety: getuid is always safe on Unix.
         let uid = unsafe { libc::getuid() };
         format!("/tmp/pixtuoid-{uid}/pixtuoid.sock")
     }


### PR DESCRIPTION
Cleanup arc #2 (#442) closeout — the mutation-testing (leg 6) + doc/hygiene (legs 4/5) findings.

A full-scope mutation run on the state machine (`reducer`+`fsm`+`scope`, **146 mutants**) scored **140/142 caught** with exactly **two survivors** — both real assertion-teeth gaps hiding behind comments that *claimed* coverage:

**1. `reducer.rs:884` `&&`→`||` in `apply_session_start`'s resurrect gate.** The inline comment called it *"a documented accepted equivalent — see the residuals note in tests."* That note doesn't exist, and `resurrect_in_place` has **no exiting guard**, so the mutant `(exiting && slot_root) || incoming_root` would **reset a live root** (drop `Active` + evict `active_tasks`, un-suppressing subagent leaks). New test `duplicate_root_session_start_does_not_resurrect_a_live_session`; comment corrected.

**2. `reducer.rs:1106` delete-`ActivityEnd`-arm in `suppress_subagent_leak`.** The existing `hook_activity_during_active_task_is_suppressed` test's comment claimed its `pending_idle_at.is_none()` assertion killed it — but a misattributed End's tuid doesn't match the parent's Task span, so an *applied* End arms nothing either (both branches read `None`). The real observable is the **Waiting→Delegating restore** the suppression path uniquely performs. New sibling test `parent_waiting_..._resolves_when_the_subagent_ends_a_tool` (the End twin of the existing Start-resume test); misleading comment corrected.

**Doc/hygiene (legs 4/5):** `tests/CLAUDE.md` `decode.rs`→`decode/mod.rs` (matched line 11's own tree); a missing `// Safety:` comment on the shim's lone `getuid` site (the other 4 carry it).

Both new tests pass on `main` and fail on their mutant by construction. `just preflight` green (2150 tests, +2). A background mutation **re-verify** on the fixed tree is running to mechanically confirm 0 survivors.

(Three stale agent-memory files caught by leg 7 were fixed directly — not repo files, not in this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9paRKBLvcRt3t8bZeSCro