### PR TITLE
fix(site): stop docs-table code columns collapsing to 1ch

### DIFF
--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -822,9 +822,13 @@ code,
    redundant (the table's own overflow-x:auto handles wide content) and harmful:
    `anywhere` shrinks min-content to 1ch, so table auto-layout collapses a
    code-only column and wraps its token letter-by-letter. nowrap also stops the
-   hyphen-break (`max-` / `desks`) a squeezed column would otherwise take. */
-.prose th code,
-.prose td code {
+   hyphen-break (`max-` / `desks`) a squeezed column would otherwise take.
+   Tradeoff: a genuinely long, break-point-free token in a cell now scrolls the
+   table rather than wrapping — such tokens belong in a fenced block, not a
+   table cell. (`table` in the selector lifts specificity to (0,1,3) so the
+   override beats the (0,1,2) guard above by weight, not source order.) */
+.prose table th code,
+.prose table td code {
   overflow-wrap: normal;
   white-space: nowrap;
 }

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -818,6 +818,16 @@ code,
   font-weight: 400;
   font-synthesis: none;
 }
+/* inside tables, the inline-code `overflow-wrap:anywhere` guard above is both
+   redundant (the table's own overflow-x:auto handles wide content) and harmful:
+   `anywhere` shrinks min-content to 1ch, so table auto-layout collapses a
+   code-only column and wraps its token letter-by-letter. nowrap also stops the
+   hyphen-break (`max-` / `desks`) a squeezed column would otherwise take. */
+.prose th code,
+.prose td code {
+  overflow-wrap: normal;
+  white-space: nowrap;
+}
 /* architecture diagram (```mermaid → build-time inline SVG): frame it in a fixed
    light "terminal screen" so the day-palette SVG stays legible on night/dracula,
    and make it responsive (the SVG keeps its viewBox aspect). */

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -769,3 +769,33 @@ test('no horizontal overflow at phone widths (mobile pan guard)', async ({ brows
     await context.close();
   }
 });
+
+test('docs-table code cells render single-line (column-collapse guard)', async ({ browser }) => {
+  // `.prose :not(pre) > code`'s overflow-wrap:anywhere feeds its soft-wrap
+  // opportunities into MIN-CONTENT intrinsic sizing (unlike break-word), so
+  // table auto-layout crushed the /config Key column to ~1ch and wrapped
+  // `theme` letter-by-letter. The pan guard above is blind to it — a column
+  // collapse never widens the page — so pin the `.prose table th/td code`
+  // exemption directly: every table code token renders as ONE line box.
+  const context = await browser.newContext({
+    viewport: { width: 390, height: 820 },
+    isMobile: true,
+    hasTouch: true,
+  });
+  const page = await context.newPage();
+  await page.addInitScript(() => sessionStorage.setItem('pix-booted', '1'));
+  await page.goto('./config');
+  const cells = await page.evaluate(() => {
+    const code = [...document.querySelectorAll('.prose table th code, .prose table td code')];
+    return {
+      total: code.length,
+      wrapped: code.filter((c) => c.getClientRects().length > 1).map((c) => c.textContent),
+    };
+  });
+  expect(
+    cells.total,
+    'the /config tables rendered no code cells — selector drifted?'
+  ).toBeGreaterThan(0);
+  expect(cells.wrapped, 'code tokens inside table cells wrapped mid-token').toEqual([]);
+  await context.close();
+});


### PR DESCRIPTION
## Problem

On the rendered docs pages (e.g. `/config` "User settings"), a markdown table column whose cells are bare code tokens collapses to ~1 character wide — `theme` wraps letter-by-letter, each fragment drawing its own inline-code pill.

## Root cause

`global.css` gives inline code `overflow-wrap: anywhere` so long paths can't overflow the mobile viewport (`body{overflow-x:hidden}` would clip them unreachably). Unlike `break-word`, `anywhere` feeds its soft-wrap opportunities into **intrinsic sizing**: the code span's min-content contribution drops to 1ch, and table auto-layout crushes the code-only Key column while the long Description prose takes all the width.

## Fix

Exempt code inside table cells (`.prose th code, .prose td code { overflow-wrap: normal; white-space: nowrap }`). Inside tables the guard is redundant — `.prose table` already has `display:block; overflow-x:auto`, so wide content scrolls within the table. `nowrap` additionally prevents the hyphen-break (`max-` / `desks`) a squeezed column would otherwise take.

## Verification

- Live render at 1440px + 375px across all five doc routes: zero code spans line-wrap (`getClientRects().length > 1` sweep), no page-level overflow, keys render as single pills.
- Worst-case token (28ch `$XDG_STATE_HOME/pixtuoid/log`, logging table) fits with ~12px of internal scroll at 375px.
- `just site-check` green; prettier clean.
- Pre-existing, unrelated: `/parallel-delivery` reports ~1px body overflow at 375px from a Shiki ASCII-diagram `pre` (scrolls internally; no tables on that page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019JojEsdMrzu5VVt4vhyBvC