### PR TITLE
docs(release): complete the 0.13.0 release notes

### DIFF
--- a/crates/pixtuoid/src/version.rs
+++ b/crates/pixtuoid/src/version.rs
@@ -61,6 +61,10 @@ pub fn release_notes(version: &str) -> Option<&'static [&'static str]> {
         "0.13.0" => Some(&[
             "New agent supported — Hermes Agent (Nous Research) sessions now show up as animated pixel-art coworkers in the office, wired in like every other CLI",
             "A living sky — a sun and moon now arc past the office windows over the city skyline as the day turns, and weather became the atmosphere between them and your desk: a clear noon blazes, a storm dusk goes gloomy, fog swallows the sun, and a crescent moon rises at night, all tinted per theme",
+            "See the office at a glance — a new on-screen HUD ties together a status footer, a wall board, and hover tooltips, so who's working, on what, and how busy the floor is are all readable without opening a panel",
+            "Safer on a shared machine — agents now reach pixtuoid through a private per-user socket directory (macOS/Linux) and a peer-identity check on the Windows named pipe, so another user on the same host can't read or spoof your agents' activity",
+            "Steadier across every CLI — an Antigravity session no longer shows up twice and a Cursor sprite no longer lingers \"working\" after a tool fails, and the upstream-wire-drift watch now covers each CLI's payload fields too, so a silent format change upstream is caught before it drops your agents from the office",
+            "Under the hood — a whole-codebase review pass (correctness, security, performance) and a daemon-state refactor that makes illegal states unrepresentable; the office looks the same, just sturdier",
         ]),
         "0.12.0" => Some(&[
             "A sustained whole-codebase cleanup across several review passes — sturdier session tracking (a delegating agent no longer hides its own pending permission; live sessions survive log-content lookalikes), fresher sprites after a project rename, and pathfinding that recovers when a blocked route reopens",


### PR DESCRIPTION
## What

Completes the in-app `release_notes()` arm for **0.13.0**. The version was bumped to 0.13.0 early in the cycle (#465, semver-forced), so its notes arm only had 2 bullets (Hermes + living sky); everything else landed after. This curates it to **6 user-facing highlights** covering the whole `v0.12.0..HEAD` changeset — the last drafting step before cutting the release.

## The 0.13.0 highlights (shown in the in-app version popup)

1. **Hermes Agent** (hm·) — a new supported CLI [#465]
2. **A living sky** — sun/moon arc + weather-as-atmosphere over the cityview [#471]
3. **See the office at a glance** — a unified on-screen HUD (status footer + wall board + tooltips) [#466]
4. **Safer on a shared machine** — per-user private hook socket (macOS/Linux) + Windows named-pipe peer-identity check [#493 / #497]
5. **Steadier across every CLI** — Antigravity double-render + Cursor lingering-after-failed-tool fixes, and the upstream-wire-drift watch now covers each CLI's payload fields [#500]
6. **Under the hood** — a whole-codebase review pass + a daemon-state make-illegal-states-unrepresentable refactor [#488 / #460]

The **VIBING playground (#478)** is a landing-page feature, not an in-app change, so it's intentionally left out of the in-app notes.

## Verification

- `just notes-curated` (release-PR guard) ✓ — no uncurated `TODO` marker.
- `version::tests` (incl. `release_notes_present_for_every_shipped_version`) — 21 passed.
- Docs-only string change; no artifact regen needed (the HUD bakes the version *number*, already 0.13.0 since #465 — the note strings aren't rendered into images).

## Release plan (after merge — the irreversible step stays a human hand)

```
git tag v0.13.0 && git push origin v0.13.0   # → crates.io + homebrew publish
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9paRKBLvcRt3t8bZeSCro
