### PR TITLE
feat(site): wb-5 — lobby + docs: tenant board, star plaque, pantry FAQ, docs join the building (+ hero badges)

### DIFF
--- a/crates/pixtuoid/examples/snapshot/proof.rs
+++ b/crates/pixtuoid/examples/snapshot/proof.rs
@@ -70,6 +70,12 @@ static PROOF_FONT: LazyLock<FontRef<'static>> = LazyLock::new(|| {
 // the burned coda strip — a full-width caption, theme-independent like the panel
 const CODA_LINE_H: u32 = 18;
 const CODA_PAD: u32 = 10;
+// The "captured"/"happened in a terminal" framing (here + the `~ captured
+// claude code session` panel title below) is owner-adjudicated DELIBERATE
+// (PR #512 disposition): the timeline is authored — the statusline-ticker
+// disjointness pin REQUIRES authored strings — and the load-bearing half of
+// the claim is engine truth (the right pane replays through the real
+// decode_cc_line → Reducer → renderer). Don't re-flag as an overclaim.
 const CODA_TEXT: &str = "the left pane happened in a terminal. the right pane is the same \
 event stream, drawn by the same engine -- nothing is mocked.";
 

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -40,8 +40,8 @@ Mermaid diagram becomes an inline SVG at build via `rehype-mermaid`, which is
 **wb-5 (Lobby + Docs):** the five doc routes now mount the Statusline **doc
 variant** (index-only organs — floor lift, PR feed, env readouts, keys hint —
 omitted; the left segment renders `~ pixtuoid docs · /<route>` instead; the
-build-time PR-feed fetch is skipped entirely for doc pages, so the 6 doc
-routes don't each re-hit the GitHub API at build). `Docs.astro`'s sidebar is
+build-time PR-feed fetch is skipped entirely for doc pages, so the doc
+pages (the five routes plus 404) don't each re-hit the GitHub API at build). `Docs.astro`'s sidebar is
 now an elevator panel (`.hw-panel` + `.led-dot`) with a DOCS wing plus a
 building bank of every OTHER floor, both read off the one `FLOORS` manifest in
 `consts.ts`. Every top-level blockquote in a rendered doc promotes to a

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -37,6 +37,28 @@ avoid link rot while the file + display name changed). `ARCHITECTURE.md`'s
 Mermaid diagram becomes an inline SVG at build via `rehype-mermaid`, which is
 **why CI installs Chromium**; break the Mermaid syntax and `astro build` fails.
 
+**wb-5 (Lobby + Docs):** the five doc routes now mount the Statusline **doc
+variant** (index-only organs — floor lift, PR feed, env readouts, keys hint —
+omitted; the left segment renders `~ pixtuoid docs · /<route>` instead; the
+build-time PR-feed fetch is skipped entirely for doc pages, so the 6 doc
+routes don't each re-hit the GitHub API at build). `Docs.astro`'s sidebar is
+now an elevator panel (`.hw-panel` + `.led-dot`) with a DOCS wing plus a
+building bank of every OTHER floor, both read off the one `FLOORS` manifest in
+`consts.ts`. Every top-level blockquote in a rendered doc promotes to a
+terminal-window callout via [`config/rehype-callouts.mjs`](config/rehype-callouts.mjs)
+— a pure hast transform, unit-tested, registered in `astro.config.mjs`'s
+processor AFTER `rehypeRepoLinks` (order matters: it walks the final tree).
+Note its smartypants quirk: Astro's remark-smartypants has already turned a
+straight `'` into a curly U+2019 by the time the transform runs, so the
+imperative-warning sniff normalizes back before matching. Elsewhere in the
+same arc: `src/faq.json` is a NEW single-sourced content manifest (the pantry
+chitchat FAQ copy, every answer citing a repo contract, e.g. the hook-shim
+200ms/exit-0 invariant); the lobby tenant-directory board restyle kept
+`src/sources.json` untouched (bridge tests stay green); and
+[`config/plaque-stars.mjs`](config/plaque-stars.mjs) is the star plaque's
+display-line authority (`starText`), unit-tested on its null-stars arm since
+`__GH_STARS__` is a build-time `vite.define` the e2e suite always overrides.
+
 ## Single-sourced content (don't hand-edit the rendered copy)
 
 - The root `README.md` Features table + install commands are GENERATED from

--- a/site/README.md
+++ b/site/README.md
@@ -66,8 +66,10 @@ gates can't see. CI runs it in `site.yml` after the build step.
 
 > **Generated README sections.** `src/features.json` (feature inventory — also
 > drives the Showcase roster), `src/sources.json` (supported tools — also drives the
-> tool × OS matrix), and `src/install.json` (install methods — also drives the
-> Install tabs) are single sources shared with the **root README**:
+> tool × OS matrix AND the hero's badge row, filtered to `status: "supported"` —
+> a bridge e2e pins the two rendered counts together), and `src/install.json`
+> (install methods — also drives the Install tabs) are single sources shared
+> with the **root README**:
 > `scripts/gen-readme.mjs` regenerates the Features table, the supported-tools
 > glimpse, and the install block between their markers. The install block shows
 > only methods flagged `"readme": true` (Homebrew, npm); the rest (Cargo, GitHub

--- a/site/README.md
+++ b/site/README.md
@@ -177,7 +177,13 @@ gates can't see. CI runs it in `site.yml` after the build step.
 - **Docs shell** — `layouts/Docs.astro` gives /config, /architecture,
   /contributing, /knowledge-base, and /parallel-delivery a shared sidebar + build-time mini-TOC + pager,
   driven by the one `DOCS` manifest in `consts.ts` (the Nav dropdown reads the
-  same source).
+  same source). The sidebar is an elevator panel (`.hw-panel` + `.led-dot`) —
+  a DOCS wing plus a building bank of every other floor, both off the same
+  `FLOORS` manifest the lift/shaft use. Each doc route mounts the Statusline's
+  **doc variant** (`~ pixtuoid docs · /<route>` in place of the index-only
+  organs; the build-time PR-feed fetch is skipped). Top-level blockquotes in
+  the rendered markdown promote to terminal-window callouts via
+  `config/rehype-callouts.mjs`.
 
 ## Demo art
 

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -7,6 +7,7 @@ import sitemap from '@astrojs/sitemap';
 import rehypeMermaid from 'rehype-mermaid';
 import { unified } from '@astrojs/markdown-remark';
 import { rewriteCspMeta } from './config/csp-hashes.mjs';
+import rehypeCallouts from './config/rehype-callouts.mjs';
 import { fetchStarCount } from './config/gh-stars.mjs';
 
 // Single-source the displayed version from the workspace Cargo.toml so the boot
@@ -236,6 +237,7 @@ export default defineConfig({
           },
         ],
         rehypeRepoLinks, // after mermaid so it walks the final tree
+        rehypeCallouts, // last: promote doc blockquotes to terminal-window chrome (§6)
       ],
     }),
   },

--- a/site/config/plaque-stars.mjs
+++ b/site/config/plaque-stars.mjs
@@ -1,0 +1,12 @@
+// The star plaque's display line, extracted so the offline-build null arm
+// (__GH_STARS__ unreachable, see gh-stars.mjs) is unit-testable — the e2e
+// suite always builds with GH_STARS_OVERRIDE set (astro.config.mjs), and a
+// vite `define` can't be flipped per-test, so nothing else exercises it.
+
+/**
+ * @param {string | null} stars the `__GH_STARS__` build-time value
+ * @returns {string} "★ <count>" for a real count, or bare "★" when null
+ */
+export function starText(stars) {
+  return `★ ${stars ?? ''}`.trim();
+}

--- a/site/config/plaque-stars.test.mjs
+++ b/site/config/plaque-stars.test.mjs
@@ -1,0 +1,23 @@
+// Unit tests for the star-plaque's display-line kernel — the offline-build
+// null arm (__GH_STARS__ unreachable) has zero e2e coverage: the suite always
+// builds with GH_STARS_OVERRIDE=842 (astro.config.mjs), and a vite `define`
+// can't be flipped per-test. Same posture as csp-hashes.test.mjs / gh-stars.test.mjs.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { starText } from './plaque-stars.mjs';
+
+test('a real count renders the raw untruncated number', () => {
+  assert.equal(starText('842'), '★ 842');
+});
+
+test('a large count is not truncated or formatted', () => {
+  assert.equal(starText('123456'), '★ 123456');
+});
+
+test('null (offline build) renders a bare star: no "null"/"undefined" leak, no trailing space', () => {
+  const out = starText(null);
+  assert.equal(out, '★');
+  assert.ok(!out.includes('null'));
+  assert.ok(!out.includes('undefined'));
+  assert.equal(out, out.trim());
+});

--- a/site/config/rehype-callouts.mjs
+++ b/site/config/rehype-callouts.mjs
@@ -1,0 +1,86 @@
+// Markdown callouts → terminal-window chrome (spec §6): every top-level
+// blockquote in a rendered doc becomes a small terminal window — "~ note"
+// dark chrome by default, a red-dot "~ warning" window when the quote OPENS
+// with an imperative-warning strong (**Don't …** / **Never …** / **Warning**).
+// Pure hast transform, unit-tested by rehype-callouts.test.mjs and registered
+// in astro.config.mjs's processor (the csp-hashes.mjs co-location pattern).
+// The red dot reuses global.css's .terminal__dot--r — no second red literal.
+
+const WARN_RE = /^(don'?t|never|warning|danger|caution)\b/i;
+
+function textOf(node) {
+  if (!node) return '';
+  if (node.type === 'text') return node.value;
+  return (node.children || []).map(textOf).join('');
+}
+
+// The FIRST <strong> in document order — CONTRIBUTING's "**Don't chain …**"
+// idiom puts the imperative there; a plain editorial quote has none → note.
+function firstStrongText(node) {
+  if (node.type === 'element' && node.tagName === 'strong') return textOf(node);
+  for (const c of node.children || []) {
+    if (c.type !== 'element') continue;
+    const t = firstStrongText(c);
+    if (t) return t;
+  }
+  return '';
+}
+
+function calloutFor(blockquote) {
+  // Astro's default remark-smartypants has already turned a straight "'" into
+  // U+2019 by the time this hast transform runs — normalize back so "Don't"
+  // classifies the same whether the source markdown typed it straight or not.
+  const opener = firstStrongText(blockquote).trim().replace(/’/g, "'");
+  const warn = WARN_RE.test(opener);
+  const kind = warn ? 'warn' : 'note';
+  const barChildren = [];
+  if (warn) {
+    barChildren.push({
+      type: 'element',
+      tagName: 'span',
+      properties: { className: ['terminal__dot', 'terminal__dot--r'] },
+      children: [],
+    });
+  }
+  barChildren.push({
+    type: 'element',
+    tagName: 'span',
+    properties: { className: ['callout__title'] },
+    children: [{ type: 'text', value: warn ? '~ warning' : '~ note' }],
+  });
+  return {
+    type: 'element',
+    tagName: 'div',
+    properties: { className: ['callout', `callout--${kind}`] },
+    children: [
+      {
+        type: 'element',
+        tagName: 'div',
+        properties: { className: ['callout__bar'], ariaHidden: 'true' },
+        children: barChildren,
+      },
+      {
+        ...blockquote,
+        properties: { ...(blockquote.properties || {}), className: ['callout__body'] },
+      },
+    ],
+  };
+}
+
+export default function rehypeCallouts() {
+  return function transform(tree) {
+    (function walk(node) {
+      const kids = node.children || [];
+      for (let i = 0; i < kids.length; i++) {
+        const c = kids[i];
+        if (c.type !== 'element') continue;
+        if (c.tagName === 'blockquote') {
+          // wrap and DON'T descend — a nested quote stays a plain quote
+          kids[i] = calloutFor(c);
+          continue;
+        }
+        walk(c);
+      }
+    })(tree);
+  };
+}

--- a/site/config/rehype-callouts.test.mjs
+++ b/site/config/rehype-callouts.test.mjs
@@ -1,0 +1,83 @@
+// Unit tests for the callout promoter — the doc-blockquote → terminal-window
+// transform (spec §6). Pure hast in/out, same posture as csp-hashes.test.mjs.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import rehypeCallouts from './rehype-callouts.mjs';
+
+const el = (tagName, children = [], properties = {}) => ({
+  type: 'element',
+  tagName,
+  properties,
+  children,
+});
+const txt = (value) => ({ type: 'text', value });
+const p = (...children) => el('p', children);
+const strong = (s) => el('strong', [txt(s)]);
+const quote = (...children) => el('blockquote', children);
+const run = (children) => {
+  const tree = { type: 'root', children };
+  rehypeCallouts()(tree);
+  return tree;
+};
+
+test('a plain blockquote becomes a ~ note terminal window', () => {
+  const tree = run([quote(p(txt('This file is the single source.')))]);
+  const wrap = tree.children[0];
+  assert.equal(wrap.tagName, 'div');
+  assert.deepEqual(wrap.properties.className, ['callout', 'callout--note']);
+  const bar = wrap.children[0];
+  assert.deepEqual(bar.properties.className, ['callout__bar']);
+  const title = bar.children.find((c) => c.properties?.className?.includes('callout__title'));
+  assert.equal(title.children[0].value, '~ note');
+  // a note window carries NO red dot
+  assert.ok(!JSON.stringify(bar).includes('terminal__dot--r'));
+});
+
+test("a **Don't …** opener becomes the red-dot ~ warning window", () => {
+  const tree = run([quote(p(strong("Don't chain `cargo clippy && cargo test`"), txt(' — …')))]);
+  const wrap = tree.children[0];
+  assert.deepEqual(wrap.properties.className, ['callout', 'callout--warn']);
+  const bar = wrap.children[0];
+  const dot = bar.children.find((c) => c.properties?.className?.includes('terminal__dot--r'));
+  assert.ok(dot, 'warning bar carries the terminal red dot');
+  const title = bar.children.find((c) => c.properties?.className?.includes('callout__title'));
+  assert.equal(title.children[0].value, '~ warning');
+});
+
+test("astro's smartypants curly apostrophe (U+2019) still classifies as a warning", () => {
+  // docs/CONTRIBUTING.md's own "**Don't chain …**" idiom — the motivating
+  // example — comes out of remark as "Don’t" (typeset quote), not the
+  // ASCII "Don't" the source markdown was typed with.
+  const tree = run([quote(p(strong('Don’t chain `cargo clippy && cargo test`')))]);
+  assert.deepEqual(tree.children[0].properties.className, ['callout', 'callout--warn']);
+});
+
+test('Never/Warning openers also classify as warnings', () => {
+  for (const opener of ['Never do this', 'Warning: hot', 'Caution — edges']) {
+    const tree = run([quote(p(strong(opener)))]);
+    assert.deepEqual(tree.children[0].properties.className, ['callout', 'callout--warn'], opener);
+  }
+});
+
+test('the original quote children survive verbatim inside .callout__body', () => {
+  const para = p(txt('kept content'));
+  const tree = run([quote(para)]);
+  const body = tree.children[0].children[1];
+  assert.equal(body.tagName, 'blockquote');
+  assert.deepEqual(body.properties.className, ['callout__body']);
+  assert.equal(body.children[0], para);
+});
+
+test('a blockquote nested inside a wrapped quote is not double-wrapped', () => {
+  const tree = run([quote(p(txt('outer')), quote(p(txt('inner'))))]);
+  const body = tree.children[0].children[1];
+  const inner = body.children.find((c) => c.tagName === 'blockquote');
+  assert.ok(inner, 'the inner quote stays a plain blockquote');
+  assert.ok(!(inner.properties?.className || []).includes('callout__body'));
+});
+
+test('non-blockquote content is untouched', () => {
+  const para = p(txt('prose'));
+  const tree = run([para]);
+  assert.equal(tree.children[0], para);
+});

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -1,7 +1,12 @@
 ---
 import { REPO, floorById, floorName } from '../consts';
+import sources from '../sources.json';
 
 const floor = floorById('lobby');
+// Same manifest + supported-filter SupportedTools.astro renders its tools
+// table from — a bridge e2e (smoke.spec.ts) pins this chip count to that
+// table's row count, so the two consumers can't silently diverge.
+const badges = sources.filter((s) => s.status === 'supported');
 ---
 
 <section id={floor.id} class="hero" data-floor={floor.fl} data-floor-label={floor.label}>
@@ -21,9 +26,18 @@ const floor = floorById('lobby');
         <span class="hl">work here</span><span class="cursor" aria-hidden="true"></span>
       </h1>
       <p class="statement-sub lead">
-        Every Claude Code, Codex, or Cursor session walks in, sits down, and gets to work — in a
-        pixel office that lives in your terminal.
+        Every session walks in, sits down, and gets to work — in a pixel office that lives in your
+        terminal.
       </p>
+      <ul class="hero__badges" aria-label={`Works with ${badges.length} coding CLIs`}>
+        {
+          badges.map((s) => (
+            <li class="hero__badge" style={`--badge:${s.badge_color}`}>
+              <span class="hero__badge-code">{s.badge.replace('·', '')}</span> {s.name}
+            </li>
+          ))
+        }
+      </ul>
       <div class="hero__cta">
         <a class="btn btn-primary" href="#install">[ install <span aria-hidden="true">→</span> ]</a>
         <a class="hero__ghost" href="#showcase-vibing"
@@ -88,6 +102,56 @@ const floor = floorById('lobby');
   .hero__ghost:hover {
     color: var(--coral);
   }
+  .hero__badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 1.15rem 0 0;
+    padding: 0;
+    list-style: none;
+  }
+  .hero__badge {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.4em;
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    letter-spacing: 0.02em;
+    padding: 0.32rem 0.6rem;
+    /* DAY default: the light --surface family — a hairline-bordered chip,
+       not the dark hardware panel (the dark chip read too heavy on the light
+       day office, user-caught). NIGHT below switches to the --screen /
+       --chip-line hardware family instead (the mock's look, matching the
+       app's own dark Sources panel). */
+    background: var(--surface);
+    border: 1px solid var(--border-strong);
+    color: var(--fg);
+  }
+  .hero__badge-code {
+    font-weight: 700;
+    /* the app's real per-CLI hue (sources.json badge_color, pinned to
+       theme::NORMAL.source by crates/pixtuoid-scene/tests/site_badge_colors.rs),
+       darkened toward black so it clears WCAG AA (4.5:1) on the light day
+       chip — measured worst case (OpenClaw #ffaa30) 5.37:1 at 45% black; the
+       e2e badge-hue sweep (smoke.spec.ts) pins every hue in both themes. */
+    color: color-mix(in srgb, var(--badge) 55%, black);
+  }
+  :root[data-theme='night'] .hero__badge,
+  :root[data-theme='dracula'] .hero__badge {
+    /* dracula's --bg is dark too (same direction as night — see
+       --office-ink's dracula arm in global.css); it piggybacks on night's
+       already-measured formula rather than a third dedicated sweep. */
+    background: var(--screen);
+    border-color: var(--chip-line);
+    color: var(--chip-ink);
+  }
+  :root[data-theme='night'] .hero__badge-code,
+  :root[data-theme='dracula'] .hero__badge-code {
+    /* lightened toward white so the hue clears 4.5:1 on the dark --screen
+       chip — measured worst case (DeepSeek-Reasonix #9c3cc0) 5.09:1 at 20%
+       white. */
+    color: color-mix(in srgb, var(--badge) 80%, white);
+  }
   .hero__avail {
     margin-top: 1.1rem;
     font-family: var(--font-mono);
@@ -131,11 +195,14 @@ const floor = floorById('lobby');
        shared 0.86 dimmer cap, not this hero's 0.74, and stays --fg-muted). */
     color: var(--office-ink);
   }
+  .hero__copy .hero__badges {
+    animation-delay: 0.32s;
+  }
   .hero__copy .hero__cta {
-    animation-delay: 0.38s;
+    animation-delay: 0.4s;
   }
   .hero__copy .hero__avail {
-    animation-delay: 0.48s;
+    animation-delay: 0.5s;
   }
   @media (prefers-reduced-motion: reduce) {
     .hero__copy > * {

--- a/site/src/components/PantryFaq.astro
+++ b/site/src/components/PantryFaq.astro
@@ -65,10 +65,10 @@ import { asset } from '../consts';
   (function () {
     const chat = document.querySelector('[data-pantry-chat]');
     if (!chat) return;
-    const bubbles = chat.querySelectorAll('.pantry__bubble, .pantry__cite');
+    const animated = chat.querySelectorAll('.pantry__bubble, .pantry__cite');
     document.addEventListener('pix:paused', function (e) {
       const paused = !!(e.detail && e.detail.paused);
-      bubbles.forEach(function (b) {
+      animated.forEach(function (b) {
         b.style.animationPlayState = paused ? 'paused' : 'running';
       });
     });
@@ -85,7 +85,7 @@ import { asset } from '../consts';
      .section-head's own "adjacent chunk in one section" scale (this floor's
      eyebrow-to-content rhythm), not a new value. */
   .pantry {
-    margin-top: clamp(1.1rem, 3vw, 1.8rem);
+    margin-top: var(--rhythm-adjacent);
   }
   .pantry__scene {
     display: flex;

--- a/site/src/components/PantryFaq.astro
+++ b/site/src/components/PantryFaq.astro
@@ -44,7 +44,13 @@ import { asset } from '../consts';
             <p class="pantry__bubble pantry__bubble--a" style={`--turn:${i * 2 + 1}`}>
               {f.a}
             </p>
-            <p class="pantry__cite">— {f.cite}</p>
+            {/* same --turn as the answer above: a citation pops WITH its
+              answer, never before it (review-caught: an un-turned cite has no
+              delay — an unset var() in calc() computes to 0s — so it spoiled
+              the sequence from frame one) */}
+            <p class="pantry__cite" style={`--turn:${i * 2 + 1}`}>
+              — {f.cite}
+            </p>
           </li>
         ))
       }
@@ -59,7 +65,7 @@ import { asset } from '../consts';
   (function () {
     const chat = document.querySelector('[data-pantry-chat]');
     if (!chat) return;
-    const bubbles = chat.querySelectorAll('.pantry__bubble');
+    const bubbles = chat.querySelectorAll('.pantry__bubble, .pantry__cite');
     document.addEventListener('pix:paused', function (e) {
       const paused = !!(e.detail && e.detail.paused);
       bubbles.forEach(function (b) {
@@ -126,11 +132,14 @@ import { asset } from '../consts';
   .pantry__bubble--a {
     margin-left: clamp(1.2rem, 8%, 2.4rem);
   }
+  /* bare text over the dimmed office (not on a bubble's --screen plate) —
+     the wb-3 class: --fg-muted measured 4.26:1 on the day dim, under the
+     4.5:1 floor; --office-ink is THE token for exactly this ground. */
   .pantry__cite {
     margin: 0;
     font-family: var(--font-mono);
     font-size: 0.72rem;
-    color: var(--fg-muted);
+    color: var(--office-ink);
   }
   /* sequential pop, armed by the section reveal ('in'), one turn per beat.
      No-JS never adds .in → bubbles simply show (no opacity:0 base); reduced-
@@ -138,7 +147,8 @@ import { asset } from '../consts';
      pre-delay opacity 0 without leaving a permanently-hidden element behind
      (the animation ends back at the base style, which is already opacity 1). */
   @media (prefers-reduced-motion: no-preference) {
-    .pantry__scene.in .pantry__bubble {
+    .pantry__scene.in .pantry__bubble,
+    .pantry__scene.in .pantry__cite {
       animation: pantry-pop 0.3s ease backwards;
       animation-delay: calc(var(--turn) * 1.6s + 0.3s);
     }

--- a/site/src/components/PantryFaq.astro
+++ b/site/src/components/PantryFaq.astro
@@ -1,0 +1,156 @@
+---
+// The pantry chitchat FAQ (§5): two coworkers at the water cooler answer the
+// audit's objections — every line contract-true (see faq.json's `cite`; the
+// spec's battery question is dropped: no citable code contract). The bubble
+// mirrors the PRODUCT's chitchat bubble (paint_chitchat_bubbles,
+// crates/pixtuoid/src/tui/widgets/tooltip.rs): a flat tooltip_bg-ground
+// one-liner, no border/radius — so it renders here as mono text on --screen
+// with sharp corners. The scene is the gen'd pantry still (space_pantry.png,
+// scripts/media.json — no new media). Mounted inside section#amenities,
+// directly after <ProofSplit /> (index.astro): no root <section>/.container
+// of its own — width comes from the shared 4F .container (ProofSplit's
+// eb12cce precedent), and role="region" restores the landmark a bare div's
+// generic role would otherwise drop its aria-label from (ProofSplit's
+// 4adf9916 precedent).
+import faq from '../faq.json';
+import { asset } from '../consts';
+---
+
+<div
+  class="pantry"
+  id="pantry"
+  role="region"
+  aria-label="pantry FAQ: two coworkers answer common questions"
+>
+  <div class="pantry__scene reveal">
+    <figure class="pantry__still">
+      <img
+        class="px"
+        src={asset('demos/space_pantry.png')}
+        width="800"
+        height="620"
+        alt="the office pantry: pixel-art coworkers by the coffee machine"
+        loading="lazy"
+        decoding="async"
+      />
+    </figure>
+    <ol class="pantry__chat" data-pantry-chat>
+      {
+        faq.map((f, i) => (
+          <li class="pantry__turn">
+            <p class="pantry__bubble pantry__bubble--q" style={`--turn:${i * 2}`}>
+              {f.q}
+            </p>
+            <p class="pantry__bubble pantry__bubble--a" style={`--turn:${i * 2 + 1}`}>
+              {f.a}
+            </p>
+            <p class="pantry__cite">— {f.cite}</p>
+          </li>
+        ))
+      }
+    </ol>
+  </div>
+</div>
+
+<script is:inline>
+  // Bubbles are >5s of auto-motion in aggregate → they JOIN the pix:paused set
+  // (consumer only; #office-pause stays the one dispatcher). Reduced motion
+  // never animates (CSS-gated below), so there's nothing to pause there.
+  (function () {
+    const chat = document.querySelector('[data-pantry-chat]');
+    if (!chat) return;
+    const bubbles = chat.querySelectorAll('.pantry__bubble');
+    document.addEventListener('pix:paused', function (e) {
+      const paused = !!(e.detail && e.detail.paused);
+      bubbles.forEach(function (b) {
+        b.style.animationPlayState = paused ? 'paused' : 'running';
+      });
+    });
+  })();
+</script>
+
+<style>
+  /* margin-top only, not a symmetric padding-block: .pantry is a SECOND block
+     inside section#amenities, after ProofSplit (whose own bottom padding —
+     clamp(3rem, 8vh, 6rem) — already closes ITS side of the gap, and the
+     outer section's own padding-block closes the floor's bottom) — a second
+     full padding-block here would be pure double-spacing (measured cost:
+     ~0.49vh of the scroll-budget pin below). The remaining top margin reuses
+     .section-head's own "adjacent chunk in one section" scale (this floor's
+     eyebrow-to-content rhythm), not a new value. */
+  .pantry {
+    margin-top: clamp(1.1rem, 3vw, 1.8rem);
+  }
+  .pantry__scene {
+    display: flex;
+    flex-wrap: wrap;
+    gap: clamp(1.4rem, 4vw, 3rem);
+    align-items: center;
+  }
+  .pantry__still {
+    margin: 0;
+    flex: 0 1 380px;
+  }
+  .pantry__still img {
+    display: block;
+    width: 100%;
+    height: auto;
+  }
+  .pantry__chat {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    flex: 1 1 300px;
+    min-width: 260px;
+    display: flex;
+    flex-direction: column;
+    gap: 1.1rem;
+  }
+  /* the product's chitchat bubble: flat mono text on the hardware screen,
+     sharp corners (paint_chitchat_bubbles renders exactly this — a
+     tooltip_bg-ground one-liner, no border radius). --screen/--chip-bright
+     are THEME-INDEPENDENT (global.css never redefines them per theme,
+     same as the tenant board/plaque), so this clears WCAG AA identically
+     in day/night/dracula — one measured pair, not a per-theme retune. */
+  .pantry__bubble {
+    width: max-content;
+    max-width: 100%;
+    margin: 0 0 0.35rem;
+    padding: 0.4rem 0.7rem;
+    background: var(--screen);
+    color: var(--chip-bright);
+    font-family: var(--font-mono);
+    font-size: 0.88rem;
+  }
+  /* two speakers: questions hang left, answers step right */
+  .pantry__bubble--a {
+    margin-left: clamp(1.2rem, 8%, 2.4rem);
+  }
+  .pantry__cite {
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    color: var(--fg-muted);
+  }
+  /* sequential pop, armed by the section reveal ('in'), one turn per beat.
+     No-JS never adds .in → bubbles simply show (no opacity:0 base); reduced-
+     motion never enters this media block → static. fill-mode:backwards holds
+     pre-delay opacity 0 without leaving a permanently-hidden element behind
+     (the animation ends back at the base style, which is already opacity 1). */
+  @media (prefers-reduced-motion: no-preference) {
+    .pantry__scene.in .pantry__bubble {
+      animation: pantry-pop 0.3s ease backwards;
+      animation-delay: calc(var(--turn) * 1.6s + 0.3s);
+    }
+  }
+  @keyframes pantry-pop {
+    from {
+      opacity: 0;
+      transform: translateY(4px);
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+</style>

--- a/site/src/components/Statusline.astro
+++ b/site/src/components/Statusline.astro
@@ -180,9 +180,6 @@ const badgeColor = (who: string): string | undefined => {
             ○ STATIC
           </span>
         </div>
-        <span class="sl__keys" aria-hidden="true">
-          keys 1–6
-        </span>
       </>
     )
   }
@@ -212,6 +209,16 @@ const badgeColor = (who: string): string | undefined => {
     </a>
     <span class="sr-only" role="status" data-sl-copy-status></span>
   </div>
+  {
+    /* index-only, and deliberately AFTER #sl-install: the base layout's
+      rightmost-item order (review-caught — bundling keys into the index
+      fragment above had silently swapped the two rightmost items) */
+    !doc && (
+      <span class="sl__keys" aria-hidden="true">
+        keys 1–6
+      </span>
+    )
+  }
 </div>
 
 <style is:global>
@@ -295,7 +302,7 @@ const badgeColor = (who: string): string | undefined => {
   }
   .sl__floorbtn:hover,
   .sl__floorbtn:focus-visible {
-    background: #1c1916;
+    background: var(--hw-hover);
   }
   .sl__floorbtn[aria-current='location'] {
     color: var(--led);

--- a/site/src/components/Statusline.astro
+++ b/site/src/components/Statusline.astro
@@ -20,6 +20,15 @@ import {
 } from '../consts';
 import { GH_FETCH_TIMEOUT_MS } from '../../config/gh-stars.mjs';
 
+interface Props {
+  /** Doc-shell variant (§6): render "~ pixtuoid docs · /<doc>" as the left
+   * segment instead of the index-only organs (floor lift, PR feed, env
+   * readouts, keys hint). wb-1's #sl-install chip block renders in BOTH
+   * variants (it sits outside the conditional). */
+  doc?: string;
+}
+const { doc } = Astro.props;
+
 // Build-time star count (§2): null when the API was unreachable at build —
 // the chip stays, the ★ segment is omitted (offline builds never fail).
 const ghStars: string | null = __GH_STARS__;
@@ -42,41 +51,48 @@ interface TickerItem {
 }
 
 let items: TickerItem[] = FALLBACK;
-try {
-  const headers: Record<string, string> = { accept: 'application/vnd.github+json' };
-  if (process.env.GITHUB_TOKEN) headers.authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
-  const res = await fetch(
-    'https://api.github.com/repos/IvanWng97/pixtuoid/pulls?state=closed&base=main&sort=updated&direction=desc&per_page=12',
-    { headers, signal: AbortSignal.timeout(GH_FETCH_TIMEOUT_MS) }
-  );
-  if (res.ok) {
-    const prs = (await res.json()) as {
-      number: number;
-      title: string;
-      merged_at: string | null;
-      user: { login: string } | null;
-    }[];
-    // bots don't get feed credit — a dependabot bump attributed to the office's
-    // coding agents undercuts the "agents built this" story
-    const merged = prs.filter((p) => p.merged_at && !p.user?.login?.endsWith('[bot]')).slice(0, 6);
-    if (merged.length >= 4) {
-      const human = (title: string) => {
-        const t = title.replace(/^[a-z]+(\([^)]*\))?!?:\s*/, '');
-        if (t.length <= 64) return t;
-        const cut = t.slice(0, 63);
-        return cut.slice(0, Math.max(40, cut.lastIndexOf(' '))) + '…';
-      };
-      const real: TickerItem[] = merged.map((p, i) => ({
-        state: ['active', 'active', 'idle'][i % 3],
-        who: 'cc·pixtuoid',
-        what: `merged #${p.number} · ${human(p.title)}`,
-      }));
-      const flavor = FALLBACK.filter((f) => f.who !== 'cursor');
-      items = real.flatMap((r, i) => (i % 2 === 1 ? [flavor[(i >> 1) % flavor.length], r] : [r]));
+// the fetch feeds only the index ticker (.sl__feed, doc-variant-excluded
+// below) — skip it on the doc variant so the 6 doc pages don't each re-hit
+// the GitHub API at build
+if (!doc) {
+  try {
+    const headers: Record<string, string> = { accept: 'application/vnd.github+json' };
+    if (process.env.GITHUB_TOKEN) headers.authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+    const res = await fetch(
+      'https://api.github.com/repos/IvanWng97/pixtuoid/pulls?state=closed&base=main&sort=updated&direction=desc&per_page=12',
+      { headers, signal: AbortSignal.timeout(GH_FETCH_TIMEOUT_MS) }
+    );
+    if (res.ok) {
+      const prs = (await res.json()) as {
+        number: number;
+        title: string;
+        merged_at: string | null;
+        user: { login: string } | null;
+      }[];
+      // bots don't get feed credit — a dependabot bump attributed to the office's
+      // coding agents undercuts the "agents built this" story
+      const merged = prs
+        .filter((p) => p.merged_at && !p.user?.login?.endsWith('[bot]'))
+        .slice(0, 6);
+      if (merged.length >= 4) {
+        const human = (title: string) => {
+          const t = title.replace(/^[a-z]+(\([^)]*\))?!?:\s*/, '');
+          if (t.length <= 64) return t;
+          const cut = t.slice(0, 63);
+          return cut.slice(0, Math.max(40, cut.lastIndexOf(' '))) + '…';
+        };
+        const real: TickerItem[] = merged.map((p, i) => ({
+          state: ['active', 'active', 'idle'][i % 3],
+          who: 'cc·pixtuoid',
+          what: `merged #${p.number} · ${human(p.title)}`,
+        }));
+        const flavor = FALLBACK.filter((f) => f.who !== 'cursor');
+        items = real.flatMap((r, i) => (i % 2 === 1 ? [flavor[(i >> 1) % flavor.length], r] : [r]));
+      }
     }
+  } catch {
+    // offline / timeout → FALLBACK already in place
   }
-} catch {
-  // offline / timeout → FALLBACK already in place
 }
 
 // FLOORS (id ↔ fl string ↔ label) is single-sourced in consts.ts; each
@@ -92,67 +108,84 @@ const badgeColor = (who: string): string | undefined => {
 ---
 
 <div class="statusline" id="statusline">
-  <nav class="sl__nav" aria-label="Floors">
-    <button
-      class="sl__floor"
-      data-floor-toggle
-      aria-expanded="false"
-      aria-controls="sl-floors"
-      aria-label="Jump to a floor"
-    >
-      <span class="sl__digit" data-lift-digit>{FLOORS[0].fl}</span>
-      <span class="sl__name" data-lift-name>{floorName(FLOORS[0])}</span>
-      <span class="sl__caret" aria-hidden="true">▴</span>
-    </button>
-    <div id="sl-floors" class="sl__floors" hidden>
-      {
-        FLOORS.map((f) => (
+  {
+    doc ? (
+      <span class="sl__path">~ pixtuoid docs · /{doc}</span>
+    ) : (
+      <>
+        <nav class="sl__nav" aria-label="Floors">
           <button
-            class="sl__floorbtn"
-            data-floor-btn={f.fl}
-            data-target={f.id}
-            data-name={floorName(f)}
-            aria-current={f.fl === FLOORS[0].fl ? 'location' : undefined}
+            class="sl__floor"
+            data-floor-toggle
+            aria-expanded="false"
+            aria-controls="sl-floors"
+            aria-label="Jump to a floor"
           >
-            {f.fl} <span class="sl__floorname">{floorName(f)}</span>
+            <span class="sl__digit" data-lift-digit>
+              {FLOORS[0].fl}
+            </span>
+            <span class="sl__name" data-lift-name>
+              {floorName(FLOORS[0])}
+            </span>
+            <span class="sl__caret" aria-hidden="true">
+              ▴
+            </span>
           </button>
-        ))
-      }
-      <div class="sl__keysrow">
-        <span class="sl__keyslabel">keys 1–6</span>
-        <button
-          class="sl__keystoggle"
-          type="button"
-          data-keys-toggle
-          role="switch"
-          aria-checked="true"
-          aria-label="Keyboard shortcuts"
-        >
-          <span data-keys-state>on</span>
-        </button>
-      </div>
-    </div>
-  </nav>
-  <div class="sl__feed" aria-hidden="true">
-    {
-      items.map((it, i) => (
-        <span class:list={['sl__item', { 'is-on': i === 0 }]}>
-          <span class:list={['sl__dot', it.state]} />
-          <span class="sl__text">
-            <b style={badgeColor(it.who) ? `--who:${badgeColor(it.who)}` : undefined}>{it.who}</b> ·{' '}
-            {it.what}
+          <div id="sl-floors" class="sl__floors" hidden>
+            {FLOORS.map((f) => (
+              <button
+                class="sl__floorbtn"
+                data-floor-btn={f.fl}
+                data-target={f.id}
+                data-name={floorName(f)}
+                aria-current={f.fl === FLOORS[0].fl ? 'location' : undefined}
+              >
+                {f.fl} <span class="sl__floorname">{floorName(f)}</span>
+              </button>
+            ))}
+            <div class="sl__keysrow">
+              <span class="sl__keyslabel">keys 1–6</span>
+              <button
+                class="sl__keystoggle"
+                type="button"
+                data-keys-toggle
+                role="switch"
+                aria-checked="true"
+                aria-label="Keyboard shortcuts"
+              >
+                <span data-keys-state>on</span>
+              </button>
+            </div>
+          </div>
+        </nav>
+        <div class="sl__feed" aria-hidden="true">
+          {items.map((it, i) => (
+            <span class:list={['sl__item', { 'is-on': i === 0 }]}>
+              <span class:list={['sl__dot', it.state]} />
+              <span class="sl__text">
+                <b style={badgeColor(it.who) ? `--who:${badgeColor(it.who)}` : undefined}>
+                  {it.who}
+                </b>{' '}
+                · {it.what}
+              </span>
+            </span>
+          ))}
+        </div>
+        <div class="sl__env" aria-hidden="true">
+          <span data-sl-lights>lights ··%</span>
+          <span class="sl__sep">·</span>
+          <span data-sl-clock />
+          <span class="sl__sep">·</span>
+          <span class="sl__onair" data-sl-onair>
+            ○ STATIC
           </span>
+        </div>
+        <span class="sl__keys" aria-hidden="true">
+          keys 1–6
         </span>
-      ))
-    }
-  </div>
-  <div class="sl__env" aria-hidden="true">
-    <span data-sl-lights>lights ··%</span>
-    <span class="sl__sep">·</span>
-    <span data-sl-clock></span>
-    <span class="sl__sep">·</span>
-    <span class="sl__onair" data-sl-onair>○ STATIC</span>
-  </div>
+      </>
+    )
+  }
   <div class="sl__install hw-panel" id="sl-install">
     {
       ghStars && (
@@ -173,13 +206,12 @@ const badgeColor = (who: string): string | undefined => {
       data-sl-install-link
       aria-label="Jump to the install section"
     >
-      <span class="sl__copy-icon" aria-hidden="true">→</span>
-      <span class="sl__copy-icon-flash led-selected" aria-hidden="true">✓</span>
-      <span class="sl__copy-label" aria-hidden="true">install</span>
+      <span class="sl__copy-icon" aria-hidden="true"> → </span>
+      <span class="sl__copy-icon-flash led-selected" aria-hidden="true"> ✓ </span>
+      <span class="sl__copy-label" aria-hidden="true"> install </span>
     </a>
     <span class="sr-only" role="status" data-sl-copy-status></span>
   </div>
-  <span class="sl__keys" aria-hidden="true">keys 1–6</span>
 </div>
 
 <style is:global>
@@ -419,6 +451,14 @@ const badgeColor = (who: string): string | undefined => {
   .sl__keys {
     flex: none;
     color: var(--chip-dim);
+  }
+  .sl__path {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--chip-ink);
   }
   /* The feed alone gets a WIDER hide-breakpoint than .sl__env/.sl__stars/etc
      below: once its available width drops under ~200px (roughly 768-860px,

--- a/site/src/components/Statusline.astro
+++ b/site/src/components/Statusline.astro
@@ -206,9 +206,9 @@ const badgeColor = (who: string): string | undefined => {
       data-sl-install-link
       aria-label="Jump to the install section"
     >
-      <span class="sl__copy-icon" aria-hidden="true"> → </span>
-      <span class="sl__copy-icon-flash led-selected" aria-hidden="true"> ✓ </span>
-      <span class="sl__copy-label" aria-hidden="true"> install </span>
+      <span class="sl__copy-icon" aria-hidden="true">→</span>
+      <span class="sl__copy-icon-flash led-selected" aria-hidden="true">✓</span>
+      <span class="sl__copy-label" aria-hidden="true">install</span>
     </a>
     <span class="sr-only" role="status" data-sl-copy-status></span>
   </div>

--- a/site/src/components/SupportedTools.astro
+++ b/site/src/components/SupportedTools.astro
@@ -20,19 +20,16 @@ const OSES = [
   { key: 'linux', label: 'Linux' },
   { key: 'windows', label: 'Windows' },
 ] as const;
-// In-palette marks replace the OS-native ✅/🧪 emoji — the ✅ grid was the
-// loudest, most-saturated off-system hue on the page (its glossy green belongs
-// to no token; the office greens are --ok/--led). Each state is a distinct 8×8
-// pixel SVG (the same crispEdges idiom as the office pause icon): a green check
-// (supported) vs an amber flask (experimental) — distinct SHAPE, not just hue,
-// so the distinction survives colour-blindness / the dracula pink --amber (WCAG
-// 1.4.1). Planned & absent are muted text. The value still rides the sr-only
-// sibling — these marks are aria-hidden.
+// Tenant-board LEDs replace the pixel check/flask SVGs. The WCAG 1.4.1
+// shape-not-just-hue rule the old marks encoded SURVIVES: supported is a
+// FILLED glowing disc, experimental a HOLLOW ring — distinct silhouette, so
+// the distinction holds under colour-blindness / the dracula pink --amber.
+// The value still rides the sr-only sibling; the LEDs are aria-hidden.
 const MARK = (s: string): string => {
   if (s === 'yes')
-    return `<svg class="tools__mark tools__mark--yes" viewBox="0 0 8 8" shape-rendering="crispEdges" aria-hidden="true"><use href="#tm-check" /></svg>`;
+    return `<span class="led-dot tools__led tools__led--on" aria-hidden="true"></span>`;
   if (s === 'experimental')
-    return `<svg class="tools__mark tools__mark--experimental" viewBox="0 0 8 8" shape-rendering="crispEdges" aria-hidden="true"><use href="#tm-flask" /></svg>`;
+    return `<span class="led-dot tools__led tools__led--exp" aria-hidden="true"></span>`;
   if (s === 'no') return '<span class="tools__mark tools__dash" aria-hidden="true">–</span>';
   return '<span class="tools__mark tools__soon" aria-hidden="true">soon</span>';
 };
@@ -61,32 +58,6 @@ const legendStates = (['yes', 'experimental', 'planned', 'no'] as OsState[]).fil
 ---
 
 <section id={floor.id} class="tools" data-lit data-floor={floor.fl} data-floor-label={floor.label}>
-  {
-    /* pixel check, defined once, referenced by every supported/experimental cell
-     + the legend via <use> (crispEdges → hard pixel edges, like the pause icon) */
-  }
-  <svg width="0" height="0" class="tools__sprite" aria-hidden="true" focusable="false">
-    <symbol id="tm-check" viewBox="0 0 8 8">
-      <rect x="1" y="3" width="1" height="2"></rect>
-      <rect x="2" y="4" width="1" height="2"></rect>
-      <rect x="3" y="5" width="1" height="2"></rect>
-      <rect x="4" y="4" width="1" height="2"></rect>
-      <rect x="5" y="3" width="1" height="2"></rect>
-      <rect x="6" y="2" width="1" height="2"></rect>
-      <rect x="7" y="1" width="1" height="2"></rect>
-    </symbol>
-    {
-      /* experimental gets a distinct SHAPE (a pixel flask, echoing the app's 🧪),
-       not just a hue — so supported-vs-experimental survives colour-blindness
-       and the dracula theme's pink --amber (WCAG 1.4.1) */
-    }
-    <symbol id="tm-flask" viewBox="0 0 8 8">
-      <rect x="1" y="0" width="5" height="1"></rect>
-      <rect x="3" y="1" width="2" height="3"></rect>
-      <rect x="2" y="4" width="4" height="1"></rect>
-      <rect x="1" y="5" width="6" height="2"></rect>
-    </symbol>
-  </svg>
   <div class="container">
     <div class="section-head reveal">
       <p class="eyebrow">{floor.fl} · {floorName(floor)} — the resident CLIs</p>
@@ -98,7 +69,7 @@ const legendStates = (['yes', 'experimental', 'planned', 'no'] as OsState[]).fil
       </p>
     </div>
 
-    <div class="tools__matrix reveal">
+    <div class="tools__matrix tools__board hw-panel reveal">
       <table>
         <caption class="sr-only">Supported coding agents by operating system</caption>
         <thead>
@@ -222,8 +193,14 @@ const legendStates = (['yes', 'experimental', 'planned', 'no'] as OsState[]).fil
     font-size: 0.78rem;
     font-weight: 700;
     /* the app's real per-CLI hue (sources.json badge_color, pinned to
-       theme::NORMAL.source by a scene bridge test); LED green fallback */
-    color: var(--badge, var(--led));
+       theme::NORMAL.source by a scene bridge test); LED green fallback.
+       Lightened toward white so it clears WCAG AA (4.5:1) on this ALWAYS-dark
+       --screen ground — unlike the hero's day/night badge split, this table
+       renders on --screen regardless of page theme, so one lift covers every
+       theme. Same formula + measured worst case as the hero's night-mode arm
+       (DeepSeek-Reasonix #9c3cc0, 5.09:1 at 20% white); the e2e board-hue
+       sweep (smoke.spec.ts) pins every hue in both page themes. */
+    color: color-mix(in srgb, var(--badge, var(--led)) 80%, white);
     background: var(--screen);
     padding: 0.1rem 0.35rem;
     margin-right: 0.5rem;
@@ -246,8 +223,58 @@ const legendStates = (['yes', 'experimental', 'planned', 'no'] as OsState[]).fil
   .tools__cell[data-state='no'] {
     opacity: 0.35;
   }
-  .tools__sprite {
-    position: absolute;
+  /* the lobby directory board (§5): dark hardware screen — ink flips to the
+     chip palette (the statusline's --screen vocabulary) */
+  .tools__board {
+    padding: 0.9rem 0.9rem 0.4rem;
+    color: var(--chip-ink);
+  }
+  .tools__board th,
+  .tools__board td {
+    border-bottom-color: var(--chip-line);
+  }
+  .tools__board thead th {
+    color: var(--chip-dim);
+  }
+  /* row lights on hover — same hardware-hover ground as the statusline's
+     floor buttons (#1c1916 on --screen) */
+  .tools__board tbody tr:hover {
+    background: #1c1916;
+  }
+  .tools__board .tools__badge {
+    background: none;
+    /* the neon: the app's real per-CLI hue, glowing on the dark screen */
+    text-shadow: 0 0 8px color-mix(in srgb, var(--badge, var(--led)) 55%, transparent);
+  }
+  .tools__board td.tools__how {
+    color: var(--chip-dim);
+    opacity: 1;
+  }
+  .tools__board .tools__group td,
+  .tools__board .tools__planned tr th,
+  .tools__board .tools__planned tr td,
+  .tools__board .tools__legend,
+  .tools__board .tools__legend-item:not(:first-child)::before {
+    /* the legend/planned muted ink is --fg-muted, tuned for the light PAGE
+       background — the board is now an ALWAYS-dark --screen ground
+       regardless of page theme, so it needs the same --chip-dim the rest of
+       this block already uses (measured 3.36:1 with --fg-muted, below the
+       4.5:1 AA floor; --chip-dim clears 5.34:1). */
+    color: var(--chip-dim);
+  }
+  :global(.tools__led) {
+    display: inline-block;
+    vertical-align: -0.1em;
+  }
+  :global(.tools__led--on) {
+    background: var(--led);
+    box-shadow: 0 0 6px var(--led-glow);
+  }
+  /* hollow ring = the experimental SHAPE (vs the filled supported disc) */
+  :global(.tools__led--exp) {
+    background: transparent;
+    border: 2px solid var(--amber);
+    box-shadow: none;
   }
   /* the marks are injected via set:html (MARK()), so they carry no scoped
      data-astro hash — scoped selectors would miss them. Style them :global
@@ -257,14 +284,6 @@ const legendStates = (['yes', 'experimental', 'planned', 'no'] as OsState[]).fil
     height: 1.1em;
     fill: currentColor;
     vertical-align: -0.16em;
-  }
-  /* the office's own greens/amber (--ok is the AA "supported" green; the raw
-     bright --led reads too faint on cream), tinting the shared check by state */
-  :global(.tools__mark--yes) {
-    color: var(--ok);
-  }
-  :global(.tools__mark--experimental) {
-    color: var(--amber);
   }
   :global(.tools__dash) {
     color: var(--fg-muted);

--- a/site/src/components/SupportedTools.astro
+++ b/site/src/components/SupportedTools.astro
@@ -1,6 +1,7 @@
 ---
 import sources from '../sources.json';
 import { asset, floorById, floorName, REPO } from '../consts';
+import { starText } from '../../config/plaque-stars.mjs';
 
 const floor = floorById('tools');
 
@@ -151,7 +152,7 @@ const legendStates = (['yes', 'experimental', 'planned', 'no'] as OsState[]).fil
       </div>
       <aside class="tools__plaque hw-panel reveal" aria-label="GitHub stars">
         <p class="tools__plaque-stars">
-          ★ {stars ?? ''}<span class="sr-only">GitHub stars</span>
+          {starText(stars)}<span class="sr-only">GitHub stars</span>
         </p>
         {
           /* the engraving: the SAME claim showcase.json:9 already ships on the

--- a/site/src/components/SupportedTools.astro
+++ b/site/src/components/SupportedTools.astro
@@ -30,6 +30,9 @@ const OSES = [
 // FILLED glowing disc, experimental a HOLLOW ring — distinct silhouette, so
 // the distinction holds under colour-blindness / the dracula pink --amber.
 // The value still rides the sr-only sibling; the LEDs are aria-hidden.
+// PAIRED-COPY PIN: smoke.spec.ts's planned-row probe hand-copies the
+// 'planned'/'soon' branch's markup (this fn is unexported frontmatter it
+// can't call) — change that branch and the probe together.
 const MARK = (s: string): string => {
   if (s === 'yes')
     return `<span class="led-dot is-on tools__led tools__led--on" aria-hidden="true"></span>`;
@@ -287,9 +290,9 @@ const legendStates = (['yes', 'experimental', 'planned', 'no'] as OsState[]).fil
     color: var(--chip-dim);
   }
   /* row lights on hover — same hardware-hover ground as the statusline's
-     floor buttons (#1c1916 on --screen) */
+     floor buttons (--hw-hover on --screen) */
   .tools__board tbody tr:hover {
-    background: #1c1916;
+    background: var(--hw-hover);
   }
   .tools__board .tools__badge {
     background: none;

--- a/site/src/components/SupportedTools.astro
+++ b/site/src/components/SupportedTools.astro
@@ -27,7 +27,7 @@ const OSES = [
 // The value still rides the sr-only sibling; the LEDs are aria-hidden.
 const MARK = (s: string): string => {
   if (s === 'yes')
-    return `<span class="led-dot tools__led tools__led--on" aria-hidden="true"></span>`;
+    return `<span class="led-dot is-on tools__led tools__led--on" aria-hidden="true"></span>`;
   if (s === 'experimental')
     return `<span class="led-dot tools__led tools__led--exp" aria-hidden="true"></span>`;
   if (s === 'no') return '<span class="tools__mark tools__dash" aria-hidden="true">–</span>';
@@ -266,10 +266,10 @@ const legendStates = (['yes', 'experimental', 'planned', 'no'] as OsState[]).fil
     display: inline-block;
     vertical-align: -0.1em;
   }
-  :global(.tools__led--on) {
-    background: var(--led);
-    box-shadow: 0 0 6px var(--led-glow);
-  }
+  /* the lit fill+glow is .led-dot.is-on's authority (global.css) — the
+     supported-state dot carries `is-on` in its class list (MARK()), so no
+     local override is needed; .tools__led--on stays as a selector hook for
+     the docs-lobby e2e count. */
   /* hollow ring = the experimental SHAPE (vs the filled supported disc) */
   :global(.tools__led--exp) {
     background: transparent;
@@ -285,15 +285,17 @@ const legendStates = (['yes', 'experimental', 'planned', 'no'] as OsState[]).fil
     fill: currentColor;
     vertical-align: -0.16em;
   }
+  /* same board-ink swap as the legend/planned block above — these marks
+     render on the always-dark .hw-panel board regardless of page theme. */
   :global(.tools__dash) {
-    color: var(--fg-muted);
+    color: var(--chip-dim);
   }
   :global(.tools__soon) {
     font-family: var(--font-mono);
     font-size: 0.6rem;
     letter-spacing: 0.04em;
     text-transform: uppercase;
-    color: var(--fg-muted);
+    color: var(--chip-dim);
   }
   /* td-qualified: must outrank the `.tools th, .tools td` nowrap above —
      bare .tools__how loses on specificity and the column clips mid-word */

--- a/site/src/components/SupportedTools.astro
+++ b/site/src/components/SupportedTools.astro
@@ -1,8 +1,12 @@
 ---
 import sources from '../sources.json';
-import { asset, floorById, floorName } from '../consts';
+import { asset, floorById, floorName, REPO } from '../consts';
 
 const floor = floorById('tools');
+
+// Build-time star count (wb-1 define; null when the GitHub API was
+// unreachable — the offline build ships the plaque without a number).
+const stars = __GH_STARS__;
 
 // Single source of truth → site/src/sources.json. The README "Supported Tools"
 // glimpse is generated from the SAME file (scripts/gen-readme.mjs), and the
@@ -69,80 +73,95 @@ const legendStates = (['yes', 'experimental', 'planned', 'no'] as OsState[]).fil
       </p>
     </div>
 
-    <div class="tools__matrix tools__board hw-panel reveal">
-      <table>
-        <caption class="sr-only">Supported coding agents by operating system</caption>
-        <thead>
-          <tr>
-            <th scope="col">Tool</th>
-            {OSES.map((o) => <th scope="col">{o.label}</th>)}
-            <th scope="col" class="tools__how-col">How</th>
-          </tr>
-        </thead>
-        <tbody>
-          {
-            supported.map((s) => (
-              <tr>
-                <th scope="row">
-                  {s.badge && (
-                    <span
-                      class="tools__badge"
-                      style={s.badge_color ? `--badge:${s.badge_color}` : undefined}
-                      aria-hidden="true"
-                    >
-                      {s.badge}
-                    </span>
-                  )}
-                  <a href={s.url} target="_blank" rel="noreferrer">
-                    {s.name}
-                  </a>
-                </th>
-                {OSES.map((o) => (
-                  <td class="tools__cell" data-state={s.platforms[o.key]}>
-                    <span class="sr-only">{stateLabel(s.platforms[o.key])}</span>
-                    <Fragment set:html={MARK(s.platforms[o.key])} />
-                  </td>
-                ))}
-                <td class="tools__how">{s.transport}</td>
-              </tr>
-            ))
-          }
-        </tbody>
-        {
-          planned.length > 0 && (
-            <tbody class="tools__planned">
-              <tr class="tools__group">
-                <td colspan={OSES.length + 2}>Planned</td>
-              </tr>
-              {planned.map((s) => (
+    <div class="tools__lobby">
+      <div class="tools__matrix tools__board hw-panel reveal">
+        <table>
+          <caption class="sr-only">Supported coding agents by operating system</caption>
+          <thead>
+            <tr>
+              <th scope="col">Tool</th>
+              {OSES.map((o) => <th scope="col">{o.label}</th>)}
+              <th scope="col" class="tools__how-col">How</th>
+            </tr>
+          </thead>
+          <tbody>
+            {
+              supported.map((s) => (
                 <tr>
                   <th scope="row">
+                    {s.badge && (
+                      <span
+                        class="tools__badge"
+                        style={s.badge_color ? `--badge:${s.badge_color}` : undefined}
+                        aria-hidden="true"
+                      >
+                        {s.badge}
+                      </span>
+                    )}
                     <a href={s.url} target="_blank" rel="noreferrer">
                       {s.name}
                     </a>
                   </th>
-                  {OSES.map(() => (
-                    <td class="tools__cell" data-state="planned">
-                      <span class="sr-only">planned</span>
-                      <Fragment set:html={MARK('planned')} />
+                  {OSES.map((o) => (
+                    <td class="tools__cell" data-state={s.platforms[o.key]}>
+                      <span class="sr-only">{stateLabel(s.platforms[o.key])}</span>
+                      <Fragment set:html={MARK(s.platforms[o.key])} />
                     </td>
                   ))}
                   <td class="tools__how">{s.transport}</td>
                 </tr>
-              ))}
-            </tbody>
-          )
-        }
-      </table>
-      <p class="tools__legend">
+              ))
+            }
+          </tbody>
+          {
+            planned.length > 0 && (
+              <tbody class="tools__planned">
+                <tr class="tools__group">
+                  <td colspan={OSES.length + 2}>Planned</td>
+                </tr>
+                {planned.map((s) => (
+                  <tr>
+                    <th scope="row">
+                      <a href={s.url} target="_blank" rel="noreferrer">
+                        {s.name}
+                      </a>
+                    </th>
+                    {OSES.map(() => (
+                      <td class="tools__cell" data-state="planned">
+                        <span class="sr-only">planned</span>
+                        <Fragment set:html={MARK('planned')} />
+                      </td>
+                    ))}
+                    <td class="tools__how">{s.transport}</td>
+                  </tr>
+                ))}
+              </tbody>
+            )
+          }
+        </table>
+        <p class="tools__legend">
+          {
+            legendStates.map((s) => (
+              <span class="tools__legend-item">
+                <Fragment set:html={MARK(s)} /> {LEGEND_LABEL[s]}
+              </span>
+            ))
+          }
+        </p>
+      </div>
+      <aside class="tools__plaque hw-panel reveal" aria-label="GitHub stars">
+        <p class="tools__plaque-stars">
+          ★ {stars ?? ''}<span class="sr-only">GitHub stars</span>
+        </p>
         {
-          legendStates.map((s) => (
-            <span class="tools__legend-item">
-              <Fragment set:html={MARK(s)} /> {LEGEND_LABEL[s]}
-            </span>
-          ))
+          /* the engraving: the SAME claim showcase.json:9 already ships on the
+             AGENTS channel caption — one sourced sentence, two mounts */
         }
-      </p>
+        <p class="tools__plaque-engraving">
+          fleets of 100+ agents have run this repo through this very office.
+        </p>
+        <a class="tools__plaque-link" href={REPO} target="_blank" rel="noreferrer">star it →</a>
+      </aside>
     </div>
   </div>
 </section>
@@ -158,6 +177,36 @@ const legendStates = (['yes', 'experimental', 'planned', 'no'] as OsState[]).fil
     clip: rect(0, 0, 0, 0);
     white-space: nowrap;
     border: 0;
+  }
+  .tools__lobby {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.6rem;
+    align-items: flex-start;
+  }
+  /* the wall plaque: hardware (sharp + 1px edge via .hw-panel), star count in
+     the display face with the LED glow the statusline digits use */
+  .tools__plaque {
+    max-width: 240px;
+    padding: 1rem 1.1rem;
+    color: var(--chip-ink);
+    font-family: var(--font-mono);
+  }
+  .tools__plaque-stars {
+    font-family: var(--font-display);
+    font-size: 1.6rem;
+    color: var(--led);
+    text-shadow: 0 0 6px var(--led-glow);
+    margin: 0 0 0.5rem;
+  }
+  .tools__plaque-engraving {
+    font-size: 0.82rem;
+    color: var(--chip-dim);
+    margin: 0 0 0.8rem;
+  }
+  .tools__plaque-link {
+    font-size: 0.82rem;
+    color: var(--chip-bright);
   }
   .tools__matrix {
     max-width: 760px;

--- a/site/src/faq.json
+++ b/site/src/faq.json
@@ -1,0 +1,12 @@
+[
+  {
+    "q": "will it slow my agent down?",
+    "a": "never — the hook exits 0 in under 200ms, by contract.",
+    "cite": "the hook-shim contract (CLAUDE.md, architecture invariant 5)"
+  },
+  {
+    "q": "is anything uploaded?",
+    "a": "nothing — read-only local logs; nothing ever leaves your machine.",
+    "cite": "the machine-room copy (HowItWorks, step 02)"
+  }
+]

--- a/site/src/layouts/Docs.astro
+++ b/site/src/layouts/Docs.astro
@@ -56,7 +56,10 @@ const toc = raw.map((h) => ({ ...h, text: h.text.replace(/\s*\([^)]*\)\s*$/, '')
             <li>
               <a href={asset(d.route)} aria-current={d.id === current ? 'page' : undefined}>
                 <span
-                  class:list={['led-dot', { 'led-selected': d.id === current }]}
+                  class:list={[
+                    'led-dot',
+                    { 'led-selected': d.id === current, 'is-on': d.id === current },
+                  ]}
                   aria-hidden="true"
                 />
                 {d.label}
@@ -272,15 +275,6 @@ const toc = raw.map((h) => ({ ...h, text: h.text.replace(/\s*\([^)]*\)\s*$/, '')
     border-left-color: var(--led);
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
-  }
-  /* .led-selected is normally wired via a container/:global(.led-dot) pairing
-     (ElevatorShaft) because that component's dot lives across a scope
-     boundary; here the dot carries the class directly, so it needs its own
-     lit-fill rule — .led-dot.is-on's exact fill+glow, just keyed off the
-     selected-state class this sidebar actually uses. */
-  .docs__sidebar .led-dot.led-selected {
-    background: var(--led);
-    box-shadow: 0 0 6px var(--led-glow);
   }
   .docs__fl {
     font-family: var(--font-display);

--- a/site/src/layouts/Docs.astro
+++ b/site/src/layouts/Docs.astro
@@ -263,15 +263,15 @@ const toc = raw.map((h) => ({ ...h, text: h.text.replace(/\s*\([^)]*\)\s*$/, '')
     gap: 0.55rem;
     color: var(--chip-ink);
   }
-  /* #1c1916: the statusline's floor-button hover ground (Statusline.astro) —
+  /* --hw-hover: the statusline's floor-button hover ground —
      the same hardware-hover tone on the same --screen ground */
   .docs__sidebar a:hover {
     color: var(--chip-bright);
-    background: #1c1916;
+    background: var(--hw-hover);
   }
   .docs__sidebar a[aria-current='page'] {
     color: var(--led);
-    background: #1c1916;
+    background: var(--hw-hover);
     border-left-color: var(--led);
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
@@ -314,7 +314,7 @@ const toc = raw.map((h) => ({ ...h, text: h.text.replace(/\s*\([^)]*\)\s*$/, '')
   }
   .docs :global(.callout__body code) {
     color: var(--chip-bright);
-    background: #1c1916;
+    background: var(--hw-hover);
   }
   /* scrollspy state (#257) — same affordance family as the sidebar's current
      page (--coral-deep is theme-retuned, so no per-theme override needed) */

--- a/site/src/layouts/Docs.astro
+++ b/site/src/layouts/Docs.astro
@@ -3,6 +3,7 @@ import type { MarkdownHeading } from 'astro';
 import Base from './Base.astro';
 import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
+import Statusline from '../components/Statusline.astro';
 import { REPO, asset, DOCS, type DocId } from '../consts';
 
 interface Props {
@@ -32,6 +33,9 @@ const {
 const idx = DOCS.findIndex((d) => d.id === current);
 const prev = idx > 0 ? DOCS[idx - 1] : undefined;
 const next = idx >= 0 && idx < DOCS.length - 1 ? DOCS[idx + 1] : undefined;
+
+// The statusline's left path segment — same DOCS manifest the sidebar uses.
+const routeSlug = idx >= 0 ? DOCS[idx].route : current;
 
 // Mini-TOC: h2 sections; when a doc has few of them, fold in the h3s too.
 // Trailing parentheticals are stripped for the rail — "System-managed (don't
@@ -115,6 +119,7 @@ const toc = raw.map((h) => ({ ...h, text: h.text.replace(/\s*\([^)]*\)\s*$/, '')
     }
   </main>
   <Footer />
+  <Statusline doc={routeSlug} />
 </Base>
 
 <script is:inline>

--- a/site/src/layouts/Docs.astro
+++ b/site/src/layouts/Docs.astro
@@ -5,13 +5,6 @@ import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
 import Statusline from '../components/Statusline.astro';
 import { REPO, asset, DOCS, FLOORS, type DocId } from '../consts';
-import tabs from '../install.json';
-
-// The ONE install-command source (README-synced via gen-readme) — never a
-// second copy of the literal.
-const brew = tabs.find((t) => t.id === 'brew');
-if (!brew) throw new Error('Docs.astro: install.json has no "brew" entry');
-const installCmd = brew.cmds[0];
 
 interface Props {
   title: string;
@@ -128,12 +121,6 @@ const toc = raw.map((h) => ({ ...h, text: h.text.replace(/\s*\([^)]*\)\s*$/, '')
           {sourcePath}
         </a> — {sourceNote}
       </p>
-
-      <div class="docs__install hw-panel">
-        <code class="docs__install-cmd">$ {installCmd}</code>
-        <button class="docs__install-copy" data-docs-copy={installCmd}>copy</button>
-        <span class="sr-only" role="status" data-docs-copy-status></span>
-      </div>
     </div>
 
     {
@@ -196,56 +183,6 @@ const toc = raw.map((h) => ({ ...h, text: h.text.replace(/\s*\([^)]*\)\s*$/, '')
     });
     const fromHash = location.hash.slice(1);
     if (fromHash && bySlug[fromHash]) setActive(fromHash);
-  })();
-</script>
-
-<script is:inline>
-  // The per-doc closing install strip (§6). Fires pix:install-copy
-  // {source:'docs'} AFTER a successful clipboard write (the contract: any
-  // install-copy control dispatches post-write) — wb-1's listeners (hire
-  // receipt, statusline flash) consume it.
-  (function () {
-    const btn = document.querySelector('[data-docs-copy]');
-    if (!btn) return;
-    const status = document.querySelector('[data-docs-copy-status]');
-    let restore = 0;
-    const LABEL = (btn.textContent || 'copy').trim();
-    function flash(label, announce) {
-      btn.textContent = label;
-      if (status) status.textContent = announce;
-      clearTimeout(restore);
-      restore = setTimeout(function () {
-        btn.textContent = LABEL;
-        if (status) status.textContent = '';
-      }, 1600);
-    }
-    btn.addEventListener('click', function () {
-      if (!navigator.clipboard || !navigator.clipboard.writeText) {
-        // no/blocked Clipboard API: select the command for a manual copy — and
-        // do NOT fire pix:install-copy (nothing was written)
-        const code = document.querySelector('.docs__install-cmd');
-        const sel = window.getSelection && window.getSelection();
-        if (code && sel) {
-          const range = document.createRange();
-          range.selectNodeContents(code);
-          sel.removeAllRanges();
-          sel.addRange(range);
-        }
-        flash('select & copy', 'Press Ctrl+C to copy the selected command');
-        return;
-      }
-      navigator.clipboard
-        .writeText(btn.dataset.docsCopy)
-        .then(function () {
-          flash('copied ✓', 'Copied to clipboard');
-          document.dispatchEvent(
-            new CustomEvent('pix:install-copy', { detail: { source: 'docs' } })
-          );
-        })
-        .catch(function () {
-          flash('copy failed', 'Copy failed — copy the command manually');
-        });
-    });
   })();
 </script>
 
@@ -432,55 +369,6 @@ const toc = raw.map((h) => ({ ...h, text: h.text.replace(/\s*\([^)]*\)\s*$/, '')
     font-family: var(--font-mono);
     font-size: 0.84rem;
     color: var(--fg-muted);
-  }
-  .sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-  }
-  .docs__install {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 1rem;
-    margin-top: 1.4rem;
-    padding: 0.8rem 1rem;
-    background: var(--screen);
-    font-family: var(--font-mono);
-  }
-  .docs__install-cmd {
-    color: var(--chip-bright);
-    background: none;
-    padding: 0;
-    overflow-x: auto;
-    white-space: nowrap;
-  }
-  .docs__install-copy {
-    flex: none;
-    font: inherit;
-    font-size: 0.8rem;
-    font-weight: 700;
-    padding: 0.35rem 0.8rem;
-    border: 1px solid var(--chip-line);
-    background: none;
-    color: var(--chip-ink);
-    cursor: pointer;
-  }
-  .docs__install-copy:hover,
-  .docs__install-copy:focus-visible {
-    color: var(--led);
-    border-color: var(--led);
-  }
-  @media (pointer: coarse) {
-    .docs__install-copy {
-      min-height: 44px;
-    }
   }
   /* single column: content first, rails hidden (Nav's Docs dropdown covers them) */
   @media (max-width: 1000px) {

--- a/site/src/layouts/Docs.astro
+++ b/site/src/layouts/Docs.astro
@@ -4,7 +4,7 @@ import Base from './Base.astro';
 import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
 import Statusline from '../components/Statusline.astro';
-import { REPO, asset, DOCS, type DocId } from '../consts';
+import { REPO, asset, DOCS, FLOORS, type DocId } from '../consts';
 
 interface Props {
   title: string;
@@ -48,14 +48,33 @@ const toc = raw.map((h) => ({ ...h, text: h.text.replace(/\s*\([^)]*\)\s*$/, '')
 <Base title={title} description={description}>
   <Nav />
   <main id="main" tabindex="-1" class="docs">
-    <nav class="docs__rail docs__sidebar" aria-label="Docs">
-      <p class="eyebrow docs__eyebrow">docs</p>
+    <nav class="docs__rail docs__sidebar hw-panel" aria-label="Docs">
+      <p class="docs__bank">elevator — docs wing</p>
       <ul class="docs__list">
         {
           DOCS.map((d) => (
             <li>
               <a href={asset(d.route)} aria-current={d.id === current ? 'page' : undefined}>
+                <span
+                  class:list={['led-dot', { 'led-selected': d.id === current }]}
+                  aria-hidden="true"
+                />
                 {d.label}
+              </a>
+            </li>
+          ))
+        }
+      </ul>
+      <p class="docs__bank">the building</p>
+      <ul class="docs__list docs__list--building">
+        {
+          FLOORS.map((f) => (
+            <li>
+              <a href={`${asset('')}#${f.id}`}>
+                <span class="docs__fl" aria-hidden="true">
+                  {f.fl}
+                </span>
+                {f.label}
               </a>
             </li>
           ))
@@ -189,9 +208,6 @@ const toc = raw.map((h) => ({ ...h, text: h.text.replace(/\s*\([^)]*\)\s*$/, '')
     font-family: var(--font-mono);
     font-size: 0.84rem;
   }
-  .docs__eyebrow {
-    margin-bottom: 0.8rem;
-  }
   .docs__toc-label {
     font-weight: 700;
     font-size: 0.76rem;
@@ -220,12 +236,91 @@ const toc = raw.map((h) => ({ ...h, text: h.text.replace(/\s*\([^)]*\)\s*$/, '')
     color: var(--fg);
     background: color-mix(in srgb, var(--fg) 5%, transparent);
   }
+  /* elevator panel (§6): the sidebar is HARDWARE — dark screen, sharp corners,
+     1px light edge (.hw-panel, wb-1). Ink switches to the chip palette; the
+     current doc reads as the lit LED, not the paper-coral current-page tint. */
+  .docs__sidebar {
+    padding: 0.8rem 0.55rem;
+    color: var(--chip-ink);
+  }
+  .docs__bank {
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--chip-dim);
+    margin: 0 0 0.5rem 0.6rem;
+  }
+  .docs__list--building {
+    margin-top: 1.3rem;
+  }
+  .docs__sidebar a {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    color: var(--chip-ink);
+  }
+  /* #1c1916: the statusline's floor-button hover ground (Statusline.astro) —
+     the same hardware-hover tone on the same --screen ground */
+  .docs__sidebar a:hover {
+    color: var(--chip-bright);
+    background: #1c1916;
+  }
   .docs__sidebar a[aria-current='page'] {
-    color: var(--coral-deep);
-    background: var(--surface);
-    border-left-color: var(--coral-deep);
+    color: var(--led);
+    background: #1c1916;
+    border-left-color: var(--led);
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
+  }
+  /* .led-selected is normally wired via a container/:global(.led-dot) pairing
+     (ElevatorShaft) because that component's dot lives across a scope
+     boundary; here the dot carries the class directly, so it needs its own
+     lit-fill rule — .led-dot.is-on's exact fill+glow, just keyed off the
+     selected-state class this sidebar actually uses. */
+  .docs__sidebar .led-dot.led-selected {
+    background: var(--led);
+    box-shadow: 0 0 6px var(--led-glow);
+  }
+  .docs__fl {
+    font-family: var(--font-display);
+    font-size: 0.95rem;
+    color: var(--chip-dim);
+    min-width: 1.5rem;
+  }
+  .docs__sidebar a:hover .docs__fl,
+  .docs__sidebar a[aria-current='page'] .docs__fl {
+    color: inherit;
+  }
+  /* callout chrome (§6, emitted by config/rehype-callouts.mjs): rendered
+     markdown carries no astro scope hash → :global, same as .prose h2 above */
+  .docs :global(.callout) {
+    margin: 1.4rem 0;
+    background: var(--screen);
+    border: 1px solid var(--chip-line);
+  }
+  .docs :global(.callout__bar) {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 0.75rem;
+    border-bottom: 1px solid var(--chip-line);
+    font-family: var(--font-mono);
+    font-size: 0.76rem;
+    color: var(--chip-dim);
+  }
+  .docs :global(.callout__body) {
+    margin: 0;
+    padding: 0.9rem 1.1rem;
+    border: 0;
+    color: var(--chip-ink);
+  }
+  .docs :global(.callout__body a) {
+    color: var(--chip-bright);
+  }
+  .docs :global(.callout__body code) {
+    color: var(--chip-bright);
+    background: #1c1916;
   }
   /* scrollspy state (#257) — same affordance family as the sidebar's current
      page (--coral-deep is theme-retuned, so no per-theme override needed) */

--- a/site/src/layouts/Docs.astro
+++ b/site/src/layouts/Docs.astro
@@ -5,6 +5,13 @@ import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
 import Statusline from '../components/Statusline.astro';
 import { REPO, asset, DOCS, FLOORS, type DocId } from '../consts';
+import tabs from '../install.json';
+
+// The ONE install-command source (README-synced via gen-readme) — never a
+// second copy of the literal.
+const brew = tabs.find((t) => t.id === 'brew');
+if (!brew) throw new Error('Docs.astro: install.json has no "brew" entry');
+const installCmd = brew.cmds[0];
 
 interface Props {
   title: string;
@@ -121,6 +128,12 @@ const toc = raw.map((h) => ({ ...h, text: h.text.replace(/\s*\([^)]*\)\s*$/, '')
           {sourcePath}
         </a> — {sourceNote}
       </p>
+
+      <div class="docs__install hw-panel">
+        <code class="docs__install-cmd">$ {installCmd}</code>
+        <button class="docs__install-copy" data-docs-copy={installCmd}>copy</button>
+        <span class="sr-only" role="status" data-docs-copy-status></span>
+      </div>
     </div>
 
     {
@@ -183,6 +196,56 @@ const toc = raw.map((h) => ({ ...h, text: h.text.replace(/\s*\([^)]*\)\s*$/, '')
     });
     const fromHash = location.hash.slice(1);
     if (fromHash && bySlug[fromHash]) setActive(fromHash);
+  })();
+</script>
+
+<script is:inline>
+  // The per-doc closing install strip (§6). Fires pix:install-copy
+  // {source:'docs'} AFTER a successful clipboard write (the contract: any
+  // install-copy control dispatches post-write) — wb-1's listeners (hire
+  // receipt, statusline flash) consume it.
+  (function () {
+    const btn = document.querySelector('[data-docs-copy]');
+    if (!btn) return;
+    const status = document.querySelector('[data-docs-copy-status]');
+    let restore = 0;
+    const LABEL = (btn.textContent || 'copy').trim();
+    function flash(label, announce) {
+      btn.textContent = label;
+      if (status) status.textContent = announce;
+      clearTimeout(restore);
+      restore = setTimeout(function () {
+        btn.textContent = LABEL;
+        if (status) status.textContent = '';
+      }, 1600);
+    }
+    btn.addEventListener('click', function () {
+      if (!navigator.clipboard || !navigator.clipboard.writeText) {
+        // no/blocked Clipboard API: select the command for a manual copy — and
+        // do NOT fire pix:install-copy (nothing was written)
+        const code = document.querySelector('.docs__install-cmd');
+        const sel = window.getSelection && window.getSelection();
+        if (code && sel) {
+          const range = document.createRange();
+          range.selectNodeContents(code);
+          sel.removeAllRanges();
+          sel.addRange(range);
+        }
+        flash('select & copy', 'Press Ctrl+C to copy the selected command');
+        return;
+      }
+      navigator.clipboard
+        .writeText(btn.dataset.docsCopy)
+        .then(function () {
+          flash('copied ✓', 'Copied to clipboard');
+          document.dispatchEvent(
+            new CustomEvent('pix:install-copy', { detail: { source: 'docs' } })
+          );
+        })
+        .catch(function () {
+          flash('copy failed', 'Copy failed — copy the command manually');
+        });
+    });
   })();
 </script>
 
@@ -369,6 +432,55 @@ const toc = raw.map((h) => ({ ...h, text: h.text.replace(/\s*\([^)]*\)\s*$/, '')
     font-family: var(--font-mono);
     font-size: 0.84rem;
     color: var(--fg-muted);
+  }
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+  .docs__install {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-top: 1.4rem;
+    padding: 0.8rem 1rem;
+    background: var(--screen);
+    font-family: var(--font-mono);
+  }
+  .docs__install-cmd {
+    color: var(--chip-bright);
+    background: none;
+    padding: 0;
+    overflow-x: auto;
+    white-space: nowrap;
+  }
+  .docs__install-copy {
+    flex: none;
+    font: inherit;
+    font-size: 0.8rem;
+    font-weight: 700;
+    padding: 0.35rem 0.8rem;
+    border: 1px solid var(--chip-line);
+    background: none;
+    color: var(--chip-ink);
+    cursor: pointer;
+  }
+  .docs__install-copy:hover,
+  .docs__install-copy:focus-visible {
+    color: var(--led);
+    border-color: var(--led);
+  }
+  @media (pointer: coarse) {
+    .docs__install-copy {
+      min-height: 44px;
+    }
   }
   /* single column: content first, rails hidden (Nav's Docs dropdown covers them) */
   @media (max-width: 1000px) {

--- a/site/src/pages/404.astro
+++ b/site/src/pages/404.astro
@@ -2,6 +2,7 @@
 import Base from '../layouts/Base.astro';
 import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
+import Statusline from '../components/Statusline.astro';
 import { asset } from '../consts';
 ---
 
@@ -46,6 +47,7 @@ import { asset } from '../consts';
     </div>
   </main>
   <Footer />
+  <Statusline doc="404" />
 </Base>
 
 <style>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -6,6 +6,7 @@ import Hero from '../components/Hero.astro';
 import Showcase from '../components/Showcase.astro';
 import HowItWorks from '../components/HowItWorks.astro';
 import ProofSplit from '../components/ProofSplit.astro';
+import PantryFaq from '../components/PantryFaq.astro';
 import SupportedTools from '../components/SupportedTools.astro';
 import Install from '../components/Install.astro';
 import Footer from '../components/Footer.astro';
@@ -67,6 +68,7 @@ const softwareJsonLd = {
           <p class="eyebrow">{amenities.fl} · {amenities.label}</p>
         </div>
         <ProofSplit />
+        <PantryFaq />
       </div>
     </section>
     <HowItWorks />

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -33,6 +33,13 @@
      .terminal__screen / lift-digit literals; the statusline + every opaque
      interactive chip sits on --screen regardless of theme). */
   --screen: #0e0d0c;
+  /* the ONE hardware hover/active ground (statusline floor buttons, tenant
+     board rows, docs elevator rows + callout code) — was 6 copies of the
+     same literal across 3 files before wb-5's review round tokenized it */
+  --hw-hover: #1c1916;
+  /* the "adjacent chunk in one section" rhythm (.section-head's gap; the
+     pantry band reuses it) — one scale, not per-component copies */
+  --rhythm-adjacent: clamp(1.1rem, 3vw, 1.8rem);
   --led: #8de069;
   --led-glow: rgba(141, 224, 105, 0.55);
   --led-off: #6f675a; /* an unlit LED (also the statusline idle dot) */
@@ -360,7 +367,7 @@ section {
 }
 .section-head {
   max-width: 48ch;
-  margin-bottom: clamp(1.1rem, 3vw, 1.8rem);
+  margin-bottom: var(--rhythm-adjacent);
 }
 .section-head .lead {
   margin-top: 0.9rem;
@@ -560,9 +567,6 @@ section {
 .led-dot.is-on {
   background: var(--led);
   box-shadow: 0 0 6px var(--led-glow);
-}
-.led-dot.is-warn {
-  background: var(--amber); /* wb-5: 'experimental' OS support */
 }
 .led-selected {
   color: var(--led);

--- a/site/tests/e2e/docs-lobby.spec.ts
+++ b/site/tests/e2e/docs-lobby.spec.ts
@@ -64,3 +64,24 @@ test('markdown callouts render as terminal windows (note + warning)', async ({ p
   await expect(note).toBeVisible();
   await expect(note.locator('.callout__title')).toHaveText('~ note');
 });
+
+test('tenant board: hw-panel screen, LED dots with shape distinction, sr-only values survive', async ({
+  page,
+}) => {
+  await page.addInitScript(() => sessionStorage.setItem('pix-booted', '1'));
+  await page.goto('./');
+  await page.evaluate(() =>
+    document.getElementById('tools')!.scrollIntoView({ block: 'center', behavior: 'instant' })
+  );
+  const board = page.locator('#tools .tools__board');
+  await expect(board).toHaveClass(/hw-panel/);
+  // ten supported CLIs × macOS = at least ten lit LEDs; windows column = rings
+  expect(await board.locator('.tools__led--on').count()).toBeGreaterThanOrEqual(10);
+  expect(await board.locator('.tools__led--exp').count()).toBeGreaterThan(0);
+  // the LED is aria-hidden; the value still rides the sr-only sibling (WCAG)
+  await expect(board.locator('td.tools__cell .sr-only').first()).toHaveText(
+    /supported|experimental/
+  );
+  // the section anchor speaks the shared floor vocabulary (wb-1 already stamped it)
+  await expect(page.locator('#tools')).toHaveAttribute('data-floor', '2F');
+});

--- a/site/tests/e2e/docs-lobby.spec.ts
+++ b/site/tests/e2e/docs-lobby.spec.ts
@@ -34,3 +34,33 @@ test('404 mounts the statusline too', async ({ page }) => {
   await page.goto('./no-such-desk');
   await expect(page.locator('#statusline')).toContainText('~ pixtuoid docs · /404');
 });
+
+test('the docs sidebar is an elevator panel: current-doc LED + a building bank from FLOORS', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1280, height: 900 }); // rails hide below 1000px
+  await page.goto('./config');
+  const panel = page.locator('.docs__sidebar');
+  await expect(panel).toHaveClass(/hw-panel/);
+  // the current doc's LED is the lit one
+  await expect(panel.locator('a[aria-current="page"] .led-dot')).toHaveClass(/led-selected/);
+  expect(await panel.locator('.led-dot.led-selected').count()).toBe(1);
+  // the building bank reads the shared FLOORS manifest — 6 floors, landing anchors
+  const building = panel.locator('.docs__list--building a');
+  await expect(building).toHaveCount(6);
+  await expect(building.first()).toHaveAttribute('href', /\/pixtuoid\/#/);
+});
+
+test('markdown callouts render as terminal windows (note + warning)', async ({ page }) => {
+  // CONTRIBUTING.md:34 carries the "**Don't chain …**" blockquote → warning;
+  // ARCHITECTURE.md:5 carries a plain editorial blockquote → note.
+  await page.goto('./contributing');
+  const warn = page.locator('.callout--warn').first();
+  await expect(warn).toBeVisible();
+  await expect(warn.locator('.callout__title')).toHaveText('~ warning');
+  await expect(warn.locator('.terminal__dot--r')).toBeAttached();
+  await page.goto('./architecture');
+  const note = page.locator('.callout--note').first();
+  await expect(note).toBeVisible();
+  await expect(note.locator('.callout__title')).toHaveText('~ note');
+});

--- a/site/tests/e2e/docs-lobby.spec.ts
+++ b/site/tests/e2e/docs-lobby.spec.ts
@@ -99,3 +99,34 @@ test('the star plaque hangs beside the tenant board with the sourced engraving',
     'fleets of 100+ agents have run this repo through this very office'
   );
 });
+
+test('pantry FAQ: bubbles pop in sequence, join pix:paused, reduced-motion is static', async ({
+  page,
+  browser,
+}) => {
+  await page.addInitScript(() => sessionStorage.setItem('pix-booted', '1'));
+  await page.goto('./');
+  await page.evaluate(() =>
+    document.querySelector('.pantry')!.scrollIntoView({ block: 'center', behavior: 'instant' })
+  );
+  const first = page.locator('.pantry__bubble').first();
+  // the reveal ('in') arms the pop; fill-mode carries the bubble to opacity 1
+  await expect
+    .poll(() => first.evaluate((el) => getComputedStyle(el).opacity), { timeout: 10_000 })
+    .toBe('1');
+  // bubbles are pix:paused CONSUMERS (spec §7: bubbles join the set)
+  await page.evaluate(() =>
+    document.dispatchEvent(new CustomEvent('pix:paused', { detail: { paused: true } }))
+  );
+  await expect
+    .poll(() => first.evaluate((el) => (el as HTMLElement).style.animationPlayState))
+    .toBe('paused');
+  // reduced-motion: static, no animation, fully visible
+  const ctx = await browser.newContext({ reducedMotion: 'reduce' });
+  const m = await ctx.newPage();
+  await m.goto('./');
+  const mb = m.locator('.pantry__bubble').first();
+  expect(await mb.evaluate((el) => getComputedStyle(el).animationName)).toBe('none');
+  expect(await mb.evaluate((el) => getComputedStyle(el).opacity)).toBe('1');
+  await ctx.close();
+});

--- a/site/tests/e2e/docs-lobby.spec.ts
+++ b/site/tests/e2e/docs-lobby.spec.ts
@@ -64,3 +64,31 @@ test('markdown callouts render as terminal windows (note + warning)', async ({ p
   await expect(note).toBeVisible();
   await expect(note.locator('.callout__title')).toHaveText('~ note');
 });
+
+test('the docs install strip copies and fires pix:install-copy {source:"docs"}', async ({
+  page,
+  context,
+}) => {
+  // clipboard-read is needed for the readText() assertion below — the
+  // smoke suite's `install:` test (smoke.spec.ts:400) shows the working set.
+  await context.grantPermissions(['clipboard-write', 'clipboard-read']);
+  await page.addInitScript(() => {
+    const w = window as unknown as { __copies: unknown[] };
+    w.__copies = [];
+    document.addEventListener('pix:install-copy', (e) =>
+      w.__copies.push((e as CustomEvent).detail?.source)
+    );
+  });
+  await page.goto('./config');
+  const btn = page.locator('[data-docs-copy]');
+  await btn.scrollIntoViewIfNeeded();
+  await btn.click();
+  await expect(btn).toHaveText(/copied ✓/);
+  await expect
+    .poll(() => page.evaluate(() => (window as unknown as { __copies: unknown[] }).__copies))
+    .toContain('docs');
+  // the copied text is the ONE install.json brew command
+  expect(await page.evaluate(() => navigator.clipboard.readText())).toContain(
+    'brew install IvanWng97/pixtuoid/pixtuoid'
+  );
+});

--- a/site/tests/e2e/docs-lobby.spec.ts
+++ b/site/tests/e2e/docs-lobby.spec.ts
@@ -64,31 +64,3 @@ test('markdown callouts render as terminal windows (note + warning)', async ({ p
   await expect(note).toBeVisible();
   await expect(note.locator('.callout__title')).toHaveText('~ note');
 });
-
-test('the docs install strip copies and fires pix:install-copy {source:"docs"}', async ({
-  page,
-  context,
-}) => {
-  // clipboard-read is needed for the readText() assertion below — the
-  // smoke suite's `install:` test (smoke.spec.ts:400) shows the working set.
-  await context.grantPermissions(['clipboard-write', 'clipboard-read']);
-  await page.addInitScript(() => {
-    const w = window as unknown as { __copies: unknown[] };
-    w.__copies = [];
-    document.addEventListener('pix:install-copy', (e) =>
-      w.__copies.push((e as CustomEvent).detail?.source)
-    );
-  });
-  await page.goto('./config');
-  const btn = page.locator('[data-docs-copy]');
-  await btn.scrollIntoViewIfNeeded();
-  await btn.click();
-  await expect(btn).toHaveText(/copied ✓/);
-  await expect
-    .poll(() => page.evaluate(() => (window as unknown as { __copies: unknown[] }).__copies))
-    .toContain('docs');
-  // the copied text is the ONE install.json brew command
-  expect(await page.evaluate(() => navigator.clipboard.readText())).toContain(
-    'brew install IvanWng97/pixtuoid/pixtuoid'
-  );
-});

--- a/site/tests/e2e/docs-lobby.spec.ts
+++ b/site/tests/e2e/docs-lobby.spec.ts
@@ -85,3 +85,17 @@ test('tenant board: hw-panel screen, LED dots with shape distinction, sr-only va
   // the section anchor speaks the shared floor vocabulary (wb-1 already stamped it)
   await expect(page.locator('#tools')).toHaveAttribute('data-floor', '2F');
 });
+
+test('the star plaque hangs beside the tenant board with the sourced engraving', async ({
+  page,
+}) => {
+  await page.addInitScript(() => sessionStorage.setItem('pix-booted', '1'));
+  await page.goto('./');
+  const plaque = page.locator('#tools .tools__plaque');
+  await expect(plaque).toHaveClass(/hw-panel/);
+  await expect(plaque).toContainText('★');
+  // the engraving is the claim ALREADY shipped in showcase.json:9 — verbatim
+  await expect(plaque).toContainText(
+    'fleets of 100+ agents have run this repo through this very office'
+  );
+});

--- a/site/tests/e2e/docs-lobby.spec.ts
+++ b/site/tests/e2e/docs-lobby.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test, type Page } from '@playwright/test';
+
+// wb-5 runtime contracts: the docs shell joins the building (statusline mount,
+// callout chrome, closing install strip) and the lobby floor (tenant board,
+// star plaque, pantry FAQ). Runs against the PRODUCTION build (see
+// playwright.config.ts) — same posture as smoke.spec.ts.
+
+function watchErrors(page: Page): () => string[] {
+  const errors: string[] = [];
+  page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`));
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') errors.push(`console.error: ${msg.text()}`);
+  });
+  return () => errors;
+}
+
+test('docs mount the statusline: route path left, install chip right, no landing organs', async ({
+  page,
+}) => {
+  const errors = watchErrors(page);
+  await page.goto('./config');
+  const bar = page.locator('#statusline');
+  await expect(bar).toBeVisible();
+  await expect(bar).toContainText('~ pixtuoid docs · /config');
+  // wb-1's right-end chip block mounts on every variant
+  await expect(bar.locator('#sl-install')).toBeAttached();
+  // the landing organs (floor lift, feed, env readouts) are index-only
+  await expect(bar.locator('[data-floor-toggle]')).toHaveCount(0);
+  await expect(bar.locator('.sl__feed')).toHaveCount(0);
+  expect(errors()).toEqual([]);
+});
+
+test('404 mounts the statusline too', async ({ page }) => {
+  await page.goto('./no-such-desk');
+  await expect(page.locator('#statusline')).toContainText('~ pixtuoid docs · /404');
+});

--- a/site/tests/e2e/floors.spec.ts
+++ b/site/tests/e2e/floors.spec.ts
@@ -304,7 +304,7 @@ test('elevator shaft: the ding pulse joins the pix:paused set', async ({ page })
   ).toBe(false);
 });
 
-test('scroll budget: the page fits ~8.4 viewport-heights at 1440×900', async ({ browser }) => {
+test('scroll budget: the page fits ~8.6 viewport-heights at 1440×900', async ({ browser }) => {
   // The spec's original compression target (§4) was 6.5vh — a plan-authoring
   // proxy that turned out to bake in assumptions three LOCKED design
   // decisions invalidate: hold #1 stays full-viewport, the hero stays
@@ -327,12 +327,28 @@ test('scroll budget: the page fits ~8.4 viewport-heights at 1440×900', async ({
   // before, now plus ProofSplit's own clamp()-bounded stage) plus ~0.27vh of
   // headroom: tight enough to still catch a future section ballooning,
   // honest about where the page actually sits today.
+  //
+  // Task 7 moved the pin again: PantryFaq mounts a second block inside
+  // section#amenities, after ProofSplit — a still image + a 2-turn chitchat
+  // FAQ, genuinely new content, not padding. Before implementing, this same
+  // build measured 8.113vh (unchanged from Task 6). The FIRST draft used a
+  // symmetric padding-block on .pantry (measured 8.601vh) — redundant with
+  // ProofSplit's OWN bottom padding closing the same gap, so it was cut to a
+  // single margin-top reusing .section-head's existing "adjacent chunk in
+  // one section" scale (8.494vh), confirmed via getBoundingClientRect that
+  // the remaining added height is genuinely the still image (294.5px, the
+  // taller of its two flex columns) + that margin (28.8px) — no further
+  // padding to cut without shrinking the image itself. Final measured:
+  // 8.472vh. 8.6 = that measured value plus ~0.13vh of headroom — tighter
+  // in absolute terms than Task 4's 0.27vh margin, but this floor's content
+  // is now real (an image + real copy, not a placeholder), so a future
+  // regression here is a real ballooning, not slack being eaten.
   const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 } });
   const page = await ctx.newPage();
   await page.addInitScript(() => sessionStorage.setItem('pix-booted', '1'));
   await page.goto('./');
   await page.waitForLoadState('networkidle');
   const vh = await page.evaluate(() => document.documentElement.scrollHeight / window.innerHeight);
-  expect(vh).toBeLessThanOrEqual(8.4);
+  expect(vh).toBeLessThanOrEqual(8.6);
   await ctx.close();
 });

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -1546,6 +1546,44 @@ test('tenant board text (badges, legend, planned rows, soon marks, star plaque) 
   }
 });
 
+test('pantry chitchat bubble text clears WCAG AA against its own dark ground (day + night)', async ({
+  page,
+}) => {
+  // Same pattern as the tenant-board sweep above: .pantry__bubble paints its
+  // OWN opaque --screen background (not a shared board), so read fg/bg off
+  // the bubble element directly rather than a separate panel ancestor. Both
+  // tokens are THEME-INDEPENDENT (global.css never redefines --screen/
+  // --chip-bright per theme, same reasoning as the board/plaque), so this
+  // sweep is defense-in-depth, not an expected-to-move ratio.
+  for (const theme of ['day', 'night'] as const) {
+    await page.addInitScript((t) => {
+      sessionStorage.setItem('pix-booted', '1');
+      localStorage.setItem('pix-theme', t);
+    }, theme);
+    await page.goto('./');
+    await expect(page.locator('html')).toHaveAttribute('data-theme', theme);
+    await page.evaluate(() =>
+      document.querySelector('.pantry')!.scrollIntoView({ block: 'center', behavior: 'instant' })
+    );
+    const bubbles = await page.evaluate(() =>
+      [...document.querySelectorAll('.pantry__bubble')].map((b) => {
+        const cs = getComputedStyle(b);
+        return { color: cs.color, bg: cs.backgroundColor, label: b.textContent?.trim() };
+      })
+    );
+    expect(bubbles.length, `${theme}: no .pantry__bubble rendered`).toBeGreaterThan(0);
+    for (const { color, bg, label } of bubbles) {
+      const fg = parseRgb(color).slice(0, 3) as [number, number, number];
+      const bgRgb = parseRgb(bg).slice(0, 3) as [number, number, number];
+      const ratio = contrastRatio(fg, bgRgb);
+      expect(
+        ratio,
+        `${theme} "${label}": WCAG AA floor is 4.5:1; ${color} on ${bg} measured ${ratio.toFixed(2)}:1`
+      ).toBeGreaterThanOrEqual(4.5);
+    }
+  }
+});
+
 test('the statusline feed ellipsizes on the wrapping text span, not the flex row', async ({
   page,
 }) => {

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -1527,6 +1527,10 @@ test('tenant board text (badges, legend, planned rows, soon marks, star plaque) 
     // markup SupportedTools.astro's template emits for a planned row
     // (MARK('planned')), injected into the real table so it picks up the
     // live cascade — pins the rule even with an empty planned set.
+    // PAIRED-COPY PIN: MARK() is inline in SupportedTools.astro (unexported —
+    // Playwright can't call Astro frontmatter), so this literal MUST track
+    // MARK's 'planned'/'soon' markup by hand; edit both or the probe asserts
+    // stale markup. (The matching note sits on MARK() itself.)
     const planned = await page.evaluate(() => {
       const table = document.querySelector('.tools__board table')!;
       const tbody = document.createElement('tbody');

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -1447,6 +1447,49 @@ test('hero badge hues clear WCAG AA against their theme-aware chip surface (day 
   }
 });
 
+test('tenant board badge hues clear WCAG AA against the dark board ground (day + night)', async ({
+  page,
+}) => {
+  // The tenant board (#tools) is a .hw-panel — its --screen ground is a
+  // THEME-INDEPENDENT literal (global.css never redefines --screen per
+  // theme), unlike the hero's day/night chip split. This sweep runs both
+  // page themes anyway as a defense-in-depth pin, not because the ratio is
+  // expected to move.
+  for (const theme of ['day', 'night'] as const) {
+    await page.addInitScript((t) => {
+      sessionStorage.setItem('pix-booted', '1');
+      localStorage.setItem('pix-theme', t);
+    }, theme);
+    await page.goto('./');
+    await expect(page.locator('html')).toHaveAttribute('data-theme', theme);
+    await page.evaluate(() =>
+      document.getElementById('tools')!.scrollIntoView({ block: 'center', behavior: 'instant' })
+    );
+
+    const boardBg = await page.evaluate(
+      () => getComputedStyle(document.querySelector('.tools__board')!).backgroundColor
+    );
+    const badges = await page.evaluate(() =>
+      [...document.querySelectorAll('.tools__board .tools__badge')].map((b) => ({
+        codeColor: getComputedStyle(b).color,
+        label: b.textContent?.trim(),
+      }))
+    );
+    expect(badges.length, `${theme}: no .tools__badge chips rendered`).toBe(
+      supportedSources.length
+    );
+    const bg = parseRgb(boardBg).slice(0, 3) as [number, number, number];
+    for (const { codeColor, label } of badges) {
+      const fg = parseRgb(codeColor).slice(0, 3) as [number, number, number];
+      const ratio = contrastRatio(fg, bg);
+      expect(
+        ratio,
+        `${theme} "${label}": WCAG AA floor is 4.5:1; code ${codeColor} on board ${boardBg} measured ${ratio.toFixed(2)}:1`
+      ).toBeGreaterThanOrEqual(4.5);
+    }
+  }
+});
+
 test('the statusline feed ellipsizes on the wrapping text span, not the flex row', async ({
   page,
 }) => {

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -1447,7 +1447,7 @@ test('hero badge hues clear WCAG AA against their theme-aware chip surface (day 
   }
 });
 
-test('tenant board text (badges, legend, planned rows, soon marks) clears WCAG AA against the dark board ground (day + night)', async ({
+test('tenant board text (badges, legend, planned rows, soon marks, star plaque) clears WCAG AA against the dark board ground (day + night)', async ({
   page,
 }) => {
   // The tenant board (#tools) is a .hw-panel — its --screen ground is a
@@ -1497,6 +1497,29 @@ test('tenant board text (badges, legend, planned rows, soon marks) clears WCAG A
       () => getComputedStyle(document.querySelector('.tools__legend')!).color
     );
     assertAA(legendColor, 'legend');
+
+    // the star plaque is its OWN .hw-panel beside the board (same --screen
+    // ground); assert its own bg rather than reuse boardBg, so a future
+    // divergence between the two panels' grounds can't go unnoticed.
+    const plaqueBg = await page.evaluate(
+      () => getComputedStyle(document.querySelector('.tools__plaque')!).backgroundColor
+    );
+    const assertPlaqueAA = (codeColor: string, label: string) => {
+      const fg = parseRgb(codeColor).slice(0, 3) as [number, number, number];
+      const ratio = contrastRatio(fg, parseRgb(plaqueBg).slice(0, 3) as [number, number, number]);
+      expect(
+        ratio,
+        `${theme} "${label}": WCAG AA floor is 4.5:1; color ${codeColor} on plaque ${plaqueBg} measured ${ratio.toFixed(2)}:1`
+      ).toBeGreaterThanOrEqual(4.5);
+    };
+    const plaqueColors = await page.evaluate(() => ({
+      stars: getComputedStyle(document.querySelector('.tools__plaque-stars')!).color,
+      engraving: getComputedStyle(document.querySelector('.tools__plaque-engraving')!).color,
+      link: getComputedStyle(document.querySelector('.tools__plaque-link')!).color,
+    }));
+    assertPlaqueAA(plaqueColors.stars, 'plaque stars');
+    assertPlaqueAA(plaqueColors.engraving, 'plaque engraving');
+    assertPlaqueAA(plaqueColors.link, 'plaque link');
 
     // sources.json currently has zero "planned" rows, so the planned tbody
     // and its "soon" mark never render on the live page. Probe the SAME

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -1,4 +1,11 @@
 import { expect, test, type Page } from '@playwright/test';
+import sourcesData from '../../src/sources.json' with { type: 'json' };
+
+// read the manifest directly (same idiom as floors.spec.ts's features.json
+// import) so the hero-badge bridge test below can't drift from a hand-copied
+// expected count.
+type SourceRow = { badge: string; badge_color: string; name: string; status: string };
+const supportedSources = (sourcesData as SourceRow[]).filter((s) => s.status === 'supported');
 
 // The smoke suite: one assertion per cross-component CONTRACT of the OPEN
 // FLOOR page — the seams that only exist at runtime (window globals, custom
@@ -37,10 +44,21 @@ function compositeOver(
   return [r * a + ur * (1 - a), g * a + ug * (1 - a), b * a + ub * (1 - a)];
 }
 function parseRgb(css: string): [number, number, number, number] {
-  const m = css.match(/rgba?\(([^)]+)\)/);
-  if (!m) throw new Error(`unparseable color: ${css}`);
-  const [r, g, b, a] = m[1].split(',').map((s) => parseFloat(s));
-  return [r, g, b, a ?? 1];
+  const rgb = css.match(/rgba?\(([^)]+)\)/);
+  if (rgb) {
+    const [r, g, b, a] = rgb[1].split(',').map((s) => parseFloat(s));
+    return [r, g, b, a ?? 1];
+  }
+  // Chromium resolves a color-mix() result to the `color(srgb r g b [/ a])`
+  // functional form (0–1 components), not rgb() — the hero badge-code hue
+  // (color-mix toward white/black) hits this path; every other caller still
+  // sees plain rgb()/rgba() and takes the branch above.
+  const srgb = css.match(/color\(srgb\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)(?:\s*\/\s*([\d.]+))?\)/);
+  if (srgb) {
+    const [r, g, b, a] = srgb.slice(1, 5).map((s) => (s === undefined ? undefined : parseFloat(s)));
+    return [r! * 255, g! * 255, b! * 255, a ?? 1];
+  }
+  throw new Error(`unparseable color: ${css}`);
 }
 /**
  * Fail the calling test if the page logs an uncaught error or console.error.
@@ -1369,6 +1387,61 @@ test('bare hero text clears WCAG AA at the real office composite (day + night)',
       expect(
         ratio,
         `${theme} ${selector}: WCAG AA floor is 4.5:1; measured ${ratio.toFixed(2)}:1`
+      ).toBeGreaterThanOrEqual(4.5);
+    }
+  }
+});
+
+test('hero badge row: one chip per registered source, matching the tools-table row count', async ({
+  page,
+}) => {
+  // One manifest (sources.json), two consumers (Hero's chip row, the tools
+  // table on #tools) — a bridge, not two independently-maintained counts, so
+  // adding/removing a source can't silently desync them.
+  await page.addInitScript(() => sessionStorage.setItem('pix-booted', '1'));
+  await page.goto('./');
+  const chips = page.locator('.hero__badges .hero__badge');
+  await expect(chips).toHaveCount(supportedSources.length);
+  await expect(chips.first()).toHaveText(
+    `${supportedSources[0].badge.replace('·', '')} ${supportedSources[0].name}`
+  );
+
+  const tableRows = page.locator('.tools tbody:not(.tools__planned) tr');
+  await expect(tableRows).toHaveCount(supportedSources.length);
+});
+
+test('hero badge hues clear WCAG AA against their theme-aware chip surface (day + night)', async ({
+  page,
+}) => {
+  // The badge-code hue is a cross-boundary copy of the app's per-source color
+  // (pinned to theme::NORMAL.source by the Rust bridge test), painted on a
+  // chip surface that FLIPS per theme — day's light --surface chip darkens
+  // the hue toward black, night's dark --screen chip lightens it toward
+  // white (global.css's .hero__badge-code doc comment) — so this sweeps
+  // every rendered hue in both themes rather than trusting one spot check.
+  for (const theme of ['day', 'night'] as const) {
+    await page.addInitScript((t) => {
+      sessionStorage.setItem('pix-booted', '1');
+      localStorage.setItem('pix-theme', t);
+    }, theme);
+    await page.goto('./');
+    await expect(page.locator('html')).toHaveAttribute('data-theme', theme);
+
+    const chips = await page.evaluate(() =>
+      [...document.querySelectorAll('.hero__badge')].map((li) => ({
+        codeColor: getComputedStyle(li.querySelector('.hero__badge-code')!).color,
+        chipBg: getComputedStyle(li).backgroundColor,
+        label: li.textContent?.trim(),
+      }))
+    );
+    expect(chips.length, `${theme}: no .hero__badge chips rendered`).toBe(supportedSources.length);
+    for (const { codeColor, chipBg, label } of chips) {
+      const fg = parseRgb(codeColor).slice(0, 3) as [number, number, number];
+      const bg = parseRgb(chipBg).slice(0, 3) as [number, number, number];
+      const ratio = contrastRatio(fg, bg);
+      expect(
+        ratio,
+        `${theme} "${label}": WCAG AA floor is 4.5:1; code ${codeColor} on chip ${chipBg} measured ${ratio.toFixed(2)}:1`
       ).toBeGreaterThanOrEqual(4.5);
     }
   }

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -1382,6 +1382,7 @@ test('bare hero text clears WCAG AA at the real office composite (day + night)',
       '#tools .section-head .lead',
       '#install .section-head .lead',
       '#amenities .eyebrow',
+      '.pantry__cite',
     ]) {
       const { ratio } = await worstCaseRatio(selector);
       expect(

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -431,7 +431,7 @@ test('reduced motion: an install copy writes the clipboard but hires nobody', as
 
 test('docs pages keep the sticky nav with section links', async ({ page }) => {
   // The floating-nav treatment is index-ONLY; the docs pages have no office
-  // backdrop or statusline, so they keep the sticky bar (the #426-review
+  // backdrop (they DO mount the statusline since wb-5), so they keep the sticky bar (the #426-review
   // regression: `nav--floating` leaked here — absolute, transparent, links
   // hidden — and every scroll offset went stale).
   const errors = watchErrors(page);

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -1447,7 +1447,7 @@ test('hero badge hues clear WCAG AA against their theme-aware chip surface (day 
   }
 });
 
-test('tenant board badge hues clear WCAG AA against the dark board ground (day + night)', async ({
+test('tenant board text (badges, legend, planned rows, soon marks) clears WCAG AA against the dark board ground (day + night)', async ({
   page,
 }) => {
   // The tenant board (#tools) is a .hw-panel — its --screen ground is a
@@ -1469,6 +1469,16 @@ test('tenant board badge hues clear WCAG AA against the dark board ground (day +
     const boardBg = await page.evaluate(
       () => getComputedStyle(document.querySelector('.tools__board')!).backgroundColor
     );
+    const bg = parseRgb(boardBg).slice(0, 3) as [number, number, number];
+    const assertAA = (codeColor: string, label: string) => {
+      const fg = parseRgb(codeColor).slice(0, 3) as [number, number, number];
+      const ratio = contrastRatio(fg, bg);
+      expect(
+        ratio,
+        `${theme} "${label}": WCAG AA floor is 4.5:1; color ${codeColor} on board ${boardBg} measured ${ratio.toFixed(2)}:1`
+      ).toBeGreaterThanOrEqual(4.5);
+    };
+
     const badges = await page.evaluate(() =>
       [...document.querySelectorAll('.tools__board .tools__badge')].map((b) => ({
         codeColor: getComputedStyle(b).color,
@@ -1478,15 +1488,38 @@ test('tenant board badge hues clear WCAG AA against the dark board ground (day +
     expect(badges.length, `${theme}: no .tools__badge chips rendered`).toBe(
       supportedSources.length
     );
-    const bg = parseRgb(boardBg).slice(0, 3) as [number, number, number];
-    for (const { codeColor, label } of badges) {
-      const fg = parseRgb(codeColor).slice(0, 3) as [number, number, number];
-      const ratio = contrastRatio(fg, bg);
-      expect(
-        ratio,
-        `${theme} "${label}": WCAG AA floor is 4.5:1; code ${codeColor} on board ${boardBg} measured ${ratio.toFixed(2)}:1`
-      ).toBeGreaterThanOrEqual(4.5);
-    }
+    for (const { codeColor, label } of badges) assertAA(codeColor, `badge ${label}`);
+
+    // the legend is the sole decode key for the LED marks — always renders,
+    // since the current manifest always has both 'yes' and 'experimental'
+    // states on screen.
+    const legendColor = await page.evaluate(
+      () => getComputedStyle(document.querySelector('.tools__legend')!).color
+    );
+    assertAA(legendColor, 'legend');
+
+    // sources.json currently has zero "planned" rows, so the planned tbody
+    // and its "soon" mark never render on the live page. Probe the SAME
+    // markup SupportedTools.astro's template emits for a planned row
+    // (MARK('planned')), injected into the real table so it picks up the
+    // live cascade — pins the rule even with an empty planned set.
+    const planned = await page.evaluate(() => {
+      const table = document.querySelector('.tools__board table')!;
+      const tbody = document.createElement('tbody');
+      tbody.className = 'tools__planned';
+      tbody.innerHTML =
+        '<tr><th scope="row">Probe Tool</th><td class="tools__cell" data-state="planned">' +
+        '<span class="tools__mark tools__soon" aria-hidden="true">soon</span></td></tr>';
+      table.appendChild(tbody);
+      const result = {
+        rowColor: getComputedStyle(tbody.querySelector('th')!).color,
+        soonColor: getComputedStyle(tbody.querySelector('.tools__soon')!).color,
+      };
+      tbody.remove();
+      return result;
+    });
+    assertAA(planned.rowColor, 'planned row');
+    assertAA(planned.soonColor, 'soon mark');
   }
 });
 


### PR DESCRIPTION
## What

wb-5, the final Working Building workstream — the lobby gets its hardware, the docs join the building — plus the hero badge row folded in per owner direction.

- **Hero badges** (cherry-picked): the subcopy's 3-name enumeration becomes one chip per registered source (sources.json-derived, chips==sources==table-rows bridge-tested; theme-aware `color-mix` contrast, measured min 5.09:1).
- **Docs join the building** (5 routes + 404): Statusline **doc variant** (`~ pixtuoid docs · /<route>`; index organs omitted from the HTML, PR-feed fetch skipped at build), the sidebar becomes an **elevator panel** (DOCS wing with a lit current-doc LED + a building bank, both off the one `FLOORS` manifest), and every top-level blockquote promotes to **terminal-window callout chrome** via `config/rehype-callouts.mjs` (pure hast transform + unit tests; handles remark-smartypants' U+2019 rewrite).
- **The lobby**: SupportedTools → dark **tenant-directory board** (per-CLI neon badges beside full names — never bare codes; LED marks keep the WCAG 1.4.1 shape rule: filled disc = supported, hollow ring = experimental; sources.json byte-untouched so the Rust bridge tests hold), a **star plaque** (build-time `__GH_STARS__`, `starText` null-arm unit-tested, engraving verbatim from showcase.json), and the **pantry FAQ** (sequenced chitchat bubbles styled after the product's real `paint_chitchat_bubbles`, every answer citing a repo contract, `pix:paused` members, reduced-motion/no-JS static).
- A per-doc closing install strip was implemented then **reverted mid-arc by owner descope** (the 6dff06d0/227de845 pair).
- One Rust change: a WHY comment in the proof example pinning PR #512's "captured"-framing adjudication.

## Review (three lenses, whole branch, + per-task reviews with fix rounds)

Correctness APPROVE-WITH-NITS · design APPROVE-WITH-NITS · rendered-runtime **APPROVE, zero findings** (full contrast table min 5.09:1 both themes; 390px pan clean incl. docs; sequence timing verified; 0 console errors). All accepted findings landed in one round (4e0b4a8c): the index statusline's two rightmost items had been silently swapped (restored + doc-gated in place), `--hw-hover`/`--rhythm-adjacent` tokenize 8 literal copies, dead `.led-dot.is-warn` + its false forward-reference deleted, MARK↔probe paired-copy pins, docs wording. Notable earlier catches: a smartypants misclassification of real CONTRIBUTING copy (regression-tested), a padded-span text regression Playwright's whitespace normalization masked, the tall-poster blank-box class, the pantry cite spoiling the sequenced reveal + failing day-theme AA at 4.26:1 (now `--office-ink`, pinned in the bare-over-dim sweep).

## Gates

preflight 2164/2164 · site-check 0 (32/32 unit) · `just site-e2e` 69/69 · scroll-budget pin moved 8.4→8.6vh per its own contract (trim-first, measured, documented) — the only loosened threshold in the diff; every other new assertion tightens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015A8aAnRVr89oJEd4bAaAFn