### PR TITLE
feat(site): move to the custom domain pixtuoid.dev (base '/')

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@
 </p>
 
 <p align="center">
-  <a href="https://ivanwng97.github.io/pixtuoid/"><strong>🖥&#xFE0E; Live demo ↗</strong></a>
-  &nbsp;·&nbsp; <a href="https://ivanwng97.github.io/pixtuoid/architecture">Architecture</a>
-  &nbsp;·&nbsp; <a href="https://ivanwng97.github.io/pixtuoid/config">Configuration</a>
-  &nbsp;·&nbsp; <a href="https://ivanwng97.github.io/pixtuoid/contributing">Contributing</a>
+  <a href="https://pixtuoid.dev/"><strong>🖥&#xFE0E; Live demo ↗</strong></a>
+  &nbsp;·&nbsp; <a href="https://pixtuoid.dev/architecture">Architecture</a>
+  &nbsp;·&nbsp; <a href="https://pixtuoid.dev/config">Configuration</a>
+  &nbsp;·&nbsp; <a href="https://pixtuoid.dev/contributing">Contributing</a>
 </p>
 
 ---
@@ -69,7 +69,7 @@ Press `s` to open the **Sources** panel and connect your agent CLI (Claude Code,
 
 **Keyboard shortcuts:** `q` quit · `p` pause · `s` sources (connect / health) · `t` themes · `Tab` agent dashboard · `?` help · `↑↓/jk/PgUp/PgDn` floors · click to pin tooltip
 
-**More ways to install** — Cargo, prebuilt binaries, and Debian `.deb`s — are on the **[install guide ↗](https://ivanwng97.github.io/pixtuoid/#install)**.
+**More ways to install** — Cargo, prebuilt binaries, and Debian `.deb`s — are on the **[install guide ↗](https://pixtuoid.dev/#install)**.
 
 ## Features
 
@@ -92,7 +92,7 @@ Press `s` to open the **Sources** panel and connect your agent CLI (Claude Code,
 <!-- features:end -->
 
 <p align="center">
-  <a href="https://ivanwng97.github.io/pixtuoid/#showcase"><strong>▶ See every feature live — floors, themes, weather, pets, the office tour →</strong></a>
+  <a href="https://pixtuoid.dev/#showcase"><strong>▶ See every feature live — floors, themes, weather, pets, the office tour →</strong></a>
 </p>
 
 ## Supported Tools
@@ -105,7 +105,7 @@ Press `s` to open the **Sources** panel and connect your agent CLI (Claude Code,
 
 _Also supported: [Antigravity CLI](https://github.com/antiGravity-AI/antigravity-cli), [DeepSeek-Reasonix](https://github.com/esengine/DeepSeek-Reasonix), [CodeWhale](https://github.com/Hmbown/CodeWhale), [Copilot CLI](https://github.com/github/copilot-cli), [opencode](https://github.com/anomalyco/opencode), [Cursor CLI](https://cursor.com/cli), [Hermes Agent](https://hermes-agent.nousresearch.com), [OpenClaw](https://github.com/openclaw/openclaw)._
 
-**→ [Full tool × OS support matrix on the site](https://ivanwng97.github.io/pixtuoid/#tools)**
+**→ [Full tool × OS support matrix on the site](https://pixtuoid.dev/#tools)**
 
 _\* experimental — limited testing, unsigned binaries._
 <!-- tools:end -->
@@ -128,13 +128,13 @@ live-preview picker across six built-in palettes; your pick persists across sess
 See **[docs/CONFIGURATION.md](docs/CONFIGURATION.md)** for the full key reference
 (defaults, system-managed keys), the custom sprite-pack workflow, and **logging /
 troubleshooting** (diagnostics go to `~/.cache/pixtuoid/log`) — or browse it live
-at **[/config](https://ivanwng97.github.io/pixtuoid/config)**.
+at **[/config](https://pixtuoid.dev/config)**.
 
 ## How It Works
 
 Agent CLIs emit events two ways — a hook shim (a 200ms fire-and-forget write to a Unix socket, or a named pipe on Windows, that can never block your agent) and JSONL transcript watching. Both feed one channel; a reducer folds events into office state; the renderer draws it as half-block pixel art. Five Rust crates, zero terminal deps in the core.
 
-**[Full architecture with diagrams →](https://ivanwng97.github.io/pixtuoid/architecture)** · single source: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
+**[Full architecture with diagrams →](https://pixtuoid.dev/architecture)** · single source: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
 
 ## Privacy & Security
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,7 +3,7 @@
 How a running coding-agent session becomes a moving sprite in the office.
 
 > This file is the **single source** for pixtuoid's architecture overview. It
-> renders on the website at [`/architecture`](https://ivanwng97.github.io/pixtuoid/architecture)
+> renders on the website at [`/architecture`](https://pixtuoid.dev/architecture)
 > and on GitHub (the diagram below is native Mermaid). `CLAUDE.md` (the agent
 > guide) links here; per-crate "sharp edges" live in the nested `CLAUDE.md` files.
 
@@ -199,7 +199,7 @@ These are load-bearing — see `CLAUDE.md` and the nested guides before changing
 ## Where to go next
 
 - **Configure it:** [`docs/CONFIGURATION.md`](CONFIGURATION.md) ·
-  [live `/config`](https://ivanwng97.github.io/pixtuoid/config)
+  [live `/config`](https://pixtuoid.dev/config)
 - **Contribute:** [`CONTRIBUTING.md`](CONTRIBUTING.md)
 - **Agent/contributor detail:** the workspace `CLAUDE.md` + the nested per-crate
   `CLAUDE.md` files.

--- a/justfile
+++ b/justfile
@@ -303,7 +303,7 @@ site-setup:
     npx --prefix site playwright install chromium
 
 [group('site')]
-[doc('Site dev server with HMR → http://localhost:4321/pixtuoid/ (foreground; agents: site-dev-bg)')]
+[doc('Site dev server with HMR → http://localhost:4321/ (foreground; agents: site-dev-bg)')]
 site-dev:
     npm --prefix site run dev
 
@@ -324,7 +324,7 @@ site-dev-bg:
     # 60 × 0.5s = 30s readiness budget
     for _ in $(seq 1 60); do
         if curl -fsS -m 2 http://localhost:4321/_astro/status >/dev/null 2>&1; then
-            echo "ready → http://localhost:4321/pixtuoid/  (logs: cd site && npx astro dev logs --follow)"
+            echo "ready → http://localhost:4321/  (logs: cd site && npx astro dev logs --follow)"
             exit 0
         fi
         sleep 0.5

--- a/scripts/gen-readme.mjs
+++ b/scripts/gen-readme.mjs
@@ -26,7 +26,7 @@ const features = JSON.parse(readFileSync(join(root, 'site', 'src', 'features.jso
 const sources = JSON.parse(readFileSync(join(root, 'site', 'src', 'sources.json'), 'utf8'));
 const install = JSON.parse(readFileSync(join(root, 'site', 'src', 'install.json'), 'utf8'));
 
-const SITE = 'https://ivanwng97.github.io/pixtuoid';
+const SITE = 'https://pixtuoid.dev';
 const check = process.argv.includes('--check');
 let readme = readFileSync(readmePath, 'utf8');
 const errors = [];

--- a/scripts/gen-readme.mjs
+++ b/scripts/gen-readme.mjs
@@ -26,6 +26,10 @@ const features = JSON.parse(readFileSync(join(root, 'site', 'src', 'features.jso
 const sources = JSON.parse(readFileSync(join(root, 'site', 'src', 'sources.json'), 'utf8'));
 const install = JSON.parse(readFileSync(join(root, 'site', 'src', 'install.json'), 'utf8'));
 
+// MUST match `site` in site/astro.config.mjs. A repo-root Node script can't
+// cheaply import the astro config (it pulls @astrojs/*), so this is a
+// boundary-separated copy — gen-readme-check catches README drift, not a
+// mismatch against the config, so keep the two in lockstep by hand.
 const SITE = 'https://pixtuoid.dev';
 const check = process.argv.includes('--check');
 let readme = readFileSync(readmePath, 'utf8');

--- a/site/README.md
+++ b/site/README.md
@@ -2,7 +2,8 @@
 
 The marketing landing page for [pixtuoid](https://github.com/IvanWng97/pixtuoid),
 built with [Astro](https://astro.build). Deploys to GitHub Pages at
-**https://ivanwng97.github.io/pixtuoid/**.
+**https://pixtuoid.dev/** (the old project page
+https://ivanwng97.github.io/pixtuoid/ redirects there).
 
 Self-contained: this is a Node project that lives in `site/` and is independent
 of the Rust workspace. Its CI (`.github/workflows/site.yml`) runs the same checks
@@ -12,7 +13,7 @@ as `npm run verify`; deploys run via `.github/workflows/pages.yml`.
 
 ```sh
 npm install        # or: just site-setup   (from the repo root)
-npm run dev        # http://localhost:4321/pixtuoid/   ·  just site-dev
+npm run dev        # http://localhost:4321/   ·  just site-dev
 ```
 
 **Agent-driven (non-TTY) dev server** — foreground `astro dev` exits on stdin
@@ -250,12 +251,14 @@ render script all pick it up automatically — no component edits.
 
 ## Custom domain
 
-Project page today (`base: '/pixtuoid'`). To move to e.g. `pixtuoid.dev`: add
-`public/CNAME` with the domain, set `base: '/'` and `site: 'https://pixtuoid.dev'`
-in `astro.config.mjs`, then point DNS at GitHub Pages. `robots.txt` and its
-sitemap URL (`src/pages/robots.txt.ts`) derive from that config automatically —
-note that on the project page crawlers never fetch it (they only read the
-ORIGIN root's robots.txt), so it only becomes authoritative on a custom domain.
+The site lives on **pixtuoid.dev** (`base: '/'`, `site: 'https://pixtuoid.dev'`
+in `astro.config.mjs`). The domain itself is configured in the repo's
+**Settings → Pages** — Actions deploys need no `public/CNAME` file (that's a
+branch-deploy mechanism) — with DNS A/AAAA records on the apex pointing at
+GitHub Pages and `www` CNAME'd to `ivanwng97.github.io`. `robots.txt` and its
+sitemap URL (`src/pages/robots.txt.ts`) derive from the config automatically,
+and now serve at the origin root where crawlers actually read them. GitHub
+redirects the old `ivanwng97.github.io/pixtuoid/` project-page URLs here.
 
 ## First deploy (one-time)
 

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -205,11 +205,12 @@ function cspInlineHashes() {
   };
 }
 
-// Project page → https://ivanwng97.github.io/pixtuoid/
-// If a custom domain is later added, set base back to '/' (and update CNAME).
+// Custom domain → https://pixtuoid.dev/ (the domain lives in the repo's
+// Settings → Pages, not in the artifact — Actions deploys need no CNAME file).
+// GitHub redirects the old project page ivanwng97.github.io/pixtuoid/ here.
 export default defineConfig({
-  site: 'https://ivanwng97.github.io',
-  base: '/pixtuoid',
+  site: 'https://pixtuoid.dev',
+  base: '/',
   trailingSlash: 'ignore',
   // Astro 7 flipped the default to 'jsx' (JSX-rule whitespace stripping), which
   // drops the space between adjacent inline elements on separate source lines —
@@ -241,11 +242,9 @@ export default defineConfig({
       ],
     }),
   },
-  // Sitemap respects `site` + `base`, so emitted URLs carry the /pixtuoid
-  // prefix → submit /pixtuoid/sitemap-index.xml to Search Console. A
-  // robots.txt pointing at it is prerendered by src/pages/robots.txt.ts —
-  // note it serves under /pixtuoid/ while crawlers only read robots.txt from
-  // the origin root, so it becomes authoritative only on a custom domain.
+  // Sitemap respects `site` + `base` → https://pixtuoid.dev/sitemap-index.xml.
+  // robots.txt (prerendered by src/pages/robots.txt.ts) serves at the origin
+  // root on the custom domain, so crawlers pick the sitemap up from it directly.
   integrations: [sitemap(), cspInlineHashes()],
   // Prefetch same-site links on hover — the docs pages are tiny static HTML,
   // so hover-to-tap latency covers the fetch. The injected prefetch client is

--- a/site/lighthouserc.json
+++ b/site/lighthouserc.json
@@ -6,11 +6,11 @@
       "startServerReadyTimeout": 20000,
       "numberOfRuns": 1,
       "url": [
-        "http://localhost:4321/pixtuoid/",
-        "http://localhost:4321/pixtuoid/architecture/",
-        "http://localhost:4321/pixtuoid/config/",
-        "http://localhost:4321/pixtuoid/contributing/",
-        "http://localhost:4321/pixtuoid/knowledge-base/"
+        "http://localhost:4321/",
+        "http://localhost:4321/architecture/",
+        "http://localhost:4321/config/",
+        "http://localhost:4321/contributing/",
+        "http://localhost:4321/knowledge-base/"
       ]
     },
     "assert": {

--- a/site/playwright.config.ts
+++ b/site/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   reporter: process.env.CI ? 'github' : 'list',
   timeout: 45_000,
   use: {
-    baseURL: 'http://localhost:4321/pixtuoid/',
+    baseURL: 'http://localhost:4321/',
     trace: 'on-first-retry',
   },
   projects: [
@@ -34,7 +34,7 @@ export default defineConfig({
     // (and preview has no --background/stop either; those are `astro dev`
     // subcommands, adopted in `just site-dev-bg`/`site-dev-stop`).
     command: 'node node_modules/astro/bin/astro.mjs preview --port 4321',
-    url: 'http://localhost:4321/pixtuoid/',
+    url: 'http://localhost:4321/',
     reuseExistingServer: false,
     timeout: 30_000,
   },

--- a/site/src/consts.ts
+++ b/site/src/consts.ts
@@ -10,6 +10,11 @@ import featuresData from './features.json';
 export const REPO = 'https://github.com/IvanWng97/pixtuoid';
 export const CRATES = 'https://crates.io/crates/pixtuoid';
 export const SPONSOR = 'https://buymeacoffee.com/IvanWng97';
+// Deploy origin. The BUILD authority is `site` in astro.config.mjs — `Astro.site`
+// reflects it, and this const is only the type-narrowing fallback for the
+// (build-time unreachable) `Astro.site` undefined arm, shared so the two head
+// consumers (Base.astro canonical/og, index.astro JSON-LD) can't drift apart.
+export const SITE_ORIGIN = 'https://pixtuoid.dev';
 
 const BASE = import.meta.env.BASE_URL;
 export const asset = (p: string): string => `${BASE.replace(/\/$/, '')}/${p.replace(/^\//, '')}`;

--- a/site/src/consts.ts
+++ b/site/src/consts.ts
@@ -4,8 +4,9 @@ import showcaseData from './showcase.json';
 import featuresData from './features.json';
 
 // Shared site constants + a base-path-safe asset/link helper.
-// (GitHub Pages serves the site under /pixtuoid/, so every internal URL must
-//  be prefixed with import.meta.env.BASE_URL — asset() does that robustly.)
+// (The site serves at the origin root of pixtuoid.dev — base '/' — but every
+//  internal URL still goes through asset()/BASE_URL so a base change, like the
+//  old /pixtuoid/ project page, can never silently break links.)
 export const REPO = 'https://github.com/IvanWng97/pixtuoid';
 export const CRATES = 'https://crates.io/crates/pixtuoid';
 export const SPONSOR = 'https://buymeacoffee.com/IvanWng97';

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -18,7 +18,7 @@ import '@fontsource/lora/400.css';
 // nothing else). Loading the real 600 gives those a genuine weight step.
 import '@fontsource/lora/600.css';
 import '../styles/global.css';
-import { asset, THEMES, THEME_BG, THEME_STORAGE_KEY, VALID_THEMES } from '../consts';
+import { asset, THEMES, THEME_BG, THEME_STORAGE_KEY, VALID_THEMES, SITE_ORIGIN } from '../consts';
 import sources from '../sources.json';
 
 // Splash single sources: the CLI count comes from the sources manifest's
@@ -42,7 +42,7 @@ const {
 } = Astro.props;
 
 // Absolute URLs for crawlers (Astro.site is the deploy origin).
-const SITE = Astro.site ?? new URL('https://pixtuoid.dev');
+const SITE = Astro.site ?? new URL(SITE_ORIGIN);
 const ogImage = new URL(asset('demos/hero-poster.png'), SITE).href;
 // Per-page canonical/og:url — Astro.url.pathname includes the configured base in
 // the static build, so /config no longer self-declares the homepage as canonical.

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -42,9 +42,9 @@ const {
 } = Astro.props;
 
 // Absolute URLs for crawlers (Astro.site is the deploy origin).
-const SITE = Astro.site ?? new URL('https://ivanwng97.github.io');
+const SITE = Astro.site ?? new URL('https://pixtuoid.dev');
 const ogImage = new URL(asset('demos/hero-poster.png'), SITE).href;
-// Per-page canonical/og:url — Astro.url.pathname includes the /pixtuoid base in
+// Per-page canonical/og:url — Astro.url.pathname includes the configured base in
 // the static build, so /config no longer self-declares the homepage as canonical.
 const canonical = new URL(Astro.url.pathname, SITE).href;
 const version = __PIXTUOID_VERSION__; // from the workspace Cargo.toml at build

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -12,14 +12,14 @@ import Install from '../components/Install.astro';
 import Footer from '../components/Footer.astro';
 import Statusline from '../components/Statusline.astro';
 import ElevatorShaft from '../components/ElevatorShaft.astro';
-import { asset, REPO, CRATES, floorById } from '../consts';
+import { asset, REPO, CRATES, floorById, SITE_ORIGIN } from '../consts';
 
 const amenities = floorById('amenities');
 
 // Homepage structured data: a free cross-platform developer tool. Search
 // engines use this for a rich result; the version is single-sourced from the
 // workspace Cargo.toml at build (same define as everywhere else).
-const SITE = Astro.site ?? new URL('https://pixtuoid.dev');
+const SITE = Astro.site ?? new URL(SITE_ORIGIN);
 const softwareJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'SoftwareApplication',

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -19,7 +19,7 @@ const amenities = floorById('amenities');
 // Homepage structured data: a free cross-platform developer tool. Search
 // engines use this for a rich result; the version is single-sourced from the
 // workspace Cargo.toml at build (same define as everywhere else).
-const SITE = Astro.site ?? new URL('https://ivanwng97.github.io');
+const SITE = Astro.site ?? new URL('https://pixtuoid.dev');
 const softwareJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'SoftwareApplication',

--- a/site/src/pages/robots.txt.ts
+++ b/site/src/pages/robots.txt.ts
@@ -3,11 +3,10 @@ import type { APIRoute } from 'astro';
 // robots.txt, prerendered to dist/robots.txt. The sitemap URL is DERIVED from
 // the one canonical origin (`site` in astro.config.mjs) + BASE_URL, so a
 // custom-domain move (README "Custom domain") can't leave a stale hardcoded
-// origin behind. Note the project-page caveat: GitHub Pages serves this at
-// /pixtuoid/robots.txt, while crawlers only fetch robots.txt from the ORIGIN
-// root — it becomes fully authoritative the day the site moves to its own
-// domain (base '/'); until then the sitemap is submitted directly to Search
-// Console (see the sitemap() note in astro.config.mjs).
+// origin behind. On pixtuoid.dev (base '/') this serves at the ORIGIN root —
+// the only place crawlers fetch robots.txt from — so it is authoritative and
+// crawlers discover the sitemap through it. (On the old /pixtuoid/ project
+// page it was unreachable and the sitemap went to Search Console directly.)
 export const GET: APIRoute = ({ site }) => {
   const base = import.meta.env.BASE_URL.replace(/\/$/, '');
   const sitemap = new URL(`${base}/sitemap-index.xml`, site);

--- a/site/tests/e2e/docs-lobby.spec.ts
+++ b/site/tests/e2e/docs-lobby.spec.ts
@@ -48,7 +48,7 @@ test('the docs sidebar is an elevator panel: current-doc LED + a building bank f
   // the building bank reads the shared FLOORS manifest — 6 floors, landing anchors
   const building = panel.locator('.docs__list--building a');
   await expect(building).toHaveCount(6);
-  await expect(building.first()).toHaveAttribute('href', /\/pixtuoid\/#/);
+  await expect(building.first()).toHaveAttribute('href', /^\/#/);
 });
 
 test('markdown callouts render as terminal windows (note + warning)', async ({ page }) => {

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -1125,7 +1125,7 @@ test('nav menus + docs: dropdown, TOC scrollspy, 404, mobile burger', async ({ p
         .evaluate((img) => (img as HTMLImageElement).naturalWidth)
     )
     .toBeGreaterThan(0);
-  await expect(page.locator('.lost__cta .btn-primary')).toHaveAttribute('href', '/pixtuoid/');
+  await expect(page.locator('.lost__cta .btn-primary')).toHaveAttribute('href', '/');
   expect(errors().filter((e) => !e.includes('Failed to load resource'))).toEqual([]);
   // Mobile burger: below 760px the link panel is display:none until .is-open —
   // a dead burger means no navigation at all on phones. Same Esc-focus-return


### PR DESCRIPTION
## What

Repo half of the pixtuoid.dev custom-domain move: flips the deploy origin from the GitHub Pages project page (`ivanwng97.github.io/pixtuoid/`, base `/pixtuoid`) to the apex domain (`https://pixtuoid.dev`, base `/`), and sweeps every committed reference to the old origin.

The other half is NOT in this PR by design — DNS records (apex A/AAAA → GitHub Pages, `www` CNAME → `ivanwng97.github.io`) and the custom domain in **Settings → Pages**. Actions deploys (`pages.yml` → `actions/deploy-pages`) take the domain from repo settings, so no `CNAME` file is committed.

## Changes

- **`site/astro.config.mjs`** — `site: 'https://pixtuoid.dev'`, `base: '/'` (the config's own comment anticipated exactly this). Sitemap/robots comments updated: `robots.txt` now serves at the origin root — the only place crawlers read it — so it becomes authoritative and carries the sitemap.
- **`site/playwright.config.ts`**, **`site/lighthouserc.json`** — localhost URLs drop `/pixtuoid/`.
- **`site/tests/e2e/smoke.spec.ts`** — 404 CTA href expectation `/pixtuoid/` → `/`.
- **`site/tests/e2e/docs-lobby.spec.ts`** — building-bank anchor regex `/\/pixtuoid\/#/` → `/^\/#/`. (The escaped `\/pixtuoid\/` form dodged the literal stale-path sweep; the e2e run caught it — the one red out of 69.)
- **`site/src/layouts/Base.astro`**, **`site/src/pages/index.astro`** — fallback `SITE` consts (`Astro.site` still wins; canonical/og:url/JSON-LD now emit pixtuoid.dev).
- **`scripts/gen-readme.mjs`** — `SITE` const, README sections regenerated; hand-authored links in `README.md` / `docs/ARCHITECTURE.md` / `site/README.md` swept.
- **`site/src/consts.ts`**, **`site/src/pages/robots.txt.ts`** — comments only. Everything else rides `import.meta.env.BASE_URL` and adapts with no edit.
- **`site/README.md`** "Custom domain" section rewritten from "how to move" instructions to the now-true state (incl. the automatic github.io → custom-domain redirect that keeps old links alive).

## Verification

- `just site-check` green (format, lint, `astro check`, knip, unit, build — routes emit at the root).
- `just site-e2e` **69/69** against the production build.
- `just gen-readme-check` in sync.
- Stale-origin sweep clean (`ivanwng97.github.io` / `/pixtuoid/` — remaining hits are crate paths, XDG config paths, and the intentional DNS instruction).
- `just links` is `lychee --offline`, so the not-yet-resolving domain cannot redden CI.

## Merge choreography (matters — brief broken window)

Merge this **immediately after** setting the custom domain in Settings → Pages: between the settings flip and this PR's redeploy, pixtuoid.dev serves the old `/pixtuoid`-based build at the root and assets 404. The merge push triggers `pages.yml` and closes the gap. `.dev` is HSTS-preloaded (HTTPS mandatory) — enable **Enforce HTTPS** once GitHub's cert is issued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)