### PR TITLE
fix(site): #503 — break long prose links; mobile pan guard covers every doc route

### DIFF
--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -886,6 +886,13 @@ code,
 .prose a {
   color: var(--coral-deep);
   font-weight: 600;
+  /* #503: long unbreakable link text (repo paths, URLs) was the widest box on
+     /parallel-delivery at phone widths — it expanded the whole mobile layout
+     viewport (375→526). break-word, NOT anywhere: `anywhere` feeds soft-wrap
+     into MIN-CONTENT sizing and re-crushes table columns (the #501 class,
+     documented on the docs-table guard); break-word wraps at overflow time
+     only, leaving intrinsic sizing alone. */
+  overflow-wrap: break-word;
 }
 :root[data-theme='night'] .prose a,
 :root[data-theme='dracula'] .prose a {

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -1180,14 +1180,17 @@ test('no horizontal overflow at phone widths (mobile pan guard)', async ({ brows
   // documentElement scrollWidth<=clientWidth guard catches it. This whole class
   // slipped the #453 whole-site audit (desktop-eyeballed, no such assertion);
   // pin index + a docs page at real phone widths so it can't silently regress.
-  // #503: the guard's old scrollW<=clientW assertion is BLIND to the second
-  // overflow mode — on mobile emulation, content wider than the meta-viewport
-  // EXPANDS the whole layout viewport (scrollW==clientW==526 at a 375 device),
-  // so both sides of the old inequality grow together and it passes. Assert
-  // clientW<=device width too, and cover every doc route (the /parallel-
-  // delivery Shiki/anchor overflow lived on the one route not in this list)
-  // plus the tablet width.
+  // #503: the missed coverage was the ROUTE MATRIX — /parallel-delivery (the
+  // one page with a wide ASCII pre + long unbreakable links) was never in the
+  // list, and the old scrollW<=clientW assertion catches its overflow fine
+  // once it is (measured pre-fix: scrollW 526 vs clientW 320 → red 206px).
+  // The innerWidth assertion below is a second, DIFFERENT tripwire: under
+  // mobile emulation window.innerWidth expands with over-wide content (526 at
+  // a 375 device — review-measured) while documentElement.clientWidth stays
+  // pinned to the device width, so it trips even if a future layout mode
+  // absorbs the overflow out of scrollWidth's view.
   for (const [path, width] of [
+    ['./', 320], // iPhone SE — the narrowest supported
     ['./', 360], // Android
     ['./', 390], // iPhone 12–14
     ['./', 430], // iPhone Pro Max
@@ -1212,17 +1215,18 @@ test('no horizontal overflow at phone widths (mobile pan guard)', async ({ brows
     // The reported symptom is a left-right drag at the BOTTOM — measure there,
     // after any late layout settles.
     await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight));
-    const { scrollW, clientW } = await page.evaluate(() => ({
+    const { scrollW, clientW, innerW } = await page.evaluate(() => ({
       scrollW: document.documentElement.scrollWidth,
       clientW: document.documentElement.clientWidth,
+      innerW: window.innerWidth,
     }));
     expect(
       scrollW,
       `${path} at ${width}px is ${scrollW - clientW}px wider than the viewport (horizontal pan)`
     ).toBeLessThanOrEqual(clientW);
     expect(
-      clientW,
-      `${path} at ${width}px: the layout viewport expanded to ${clientW}px (${clientW - width}px past the device width — mode-2 overflow, the #503 class)`
+      innerW,
+      `${path} at ${width}px: window.innerWidth expanded to ${innerW}px (${innerW - width}px past the device width — over-wide content grew the emulated viewport)`
     ).toBeLessThanOrEqual(width);
     await context.close();
   }

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -1180,11 +1180,26 @@ test('no horizontal overflow at phone widths (mobile pan guard)', async ({ brows
   // documentElement scrollWidth<=clientWidth guard catches it. This whole class
   // slipped the #453 whole-site audit (desktop-eyeballed, no such assertion);
   // pin index + a docs page at real phone widths so it can't silently regress.
+  // #503: the guard's old scrollW<=clientW assertion is BLIND to the second
+  // overflow mode — on mobile emulation, content wider than the meta-viewport
+  // EXPANDS the whole layout viewport (scrollW==clientW==526 at a 375 device),
+  // so both sides of the old inequality grow together and it passes. Assert
+  // clientW<=device width too, and cover every doc route (the /parallel-
+  // delivery Shiki/anchor overflow lived on the one route not in this list)
+  // plus the tablet width.
   for (const [path, width] of [
     ['./', 360], // Android
     ['./', 390], // iPhone 12–14
     ['./', 430], // iPhone Pro Max
+    ['./', 768], // tablet
     ['./config', 390], // docs shell: code blocks / mermaid can overflow too
+    ['./config', 768],
+    ['./architecture', 375], // build-time mermaid SVG
+    ['./contributing', 375],
+    ['./knowledge-base', 375],
+    ['./parallel-delivery', 320], // the #503 repro: wide ASCII pre + long links
+    ['./parallel-delivery', 375],
+    ['./parallel-delivery', 768],
   ] as const) {
     const context = await browser.newContext({
       viewport: { width, height: 820 },
@@ -1205,6 +1220,10 @@ test('no horizontal overflow at phone widths (mobile pan guard)', async ({ brows
       scrollW,
       `${path} at ${width}px is ${scrollW - clientW}px wider than the viewport (horizontal pan)`
     ).toBeLessThanOrEqual(clientW);
+    expect(
+      clientW,
+      `${path} at ${width}px: the layout viewport expanded to ${clientW}px (${clientW - width}px past the device width — mode-2 overflow, the #503 class)`
+    ).toBeLessThanOrEqual(width);
     await context.close();
   }
 });


### PR DESCRIPTION
## What

The #503 mobile overflow, fixed with a corrected diagnosis. The issue blamed the /parallel-delivery Shiki block; on today's main the `pre` is contained (overflow-x:auto works) — the actual driver is **long unbreakable link text** in the prose: the widest anchor's 526px box expanded the emulated mobile viewport at 375/320 (the issue's exact 151px/206px). And the `nav__toggle` 5px @768 half is already gone (measured clean on three routes — fixed incidentally during wb-3..5).

- `.prose a { overflow-wrap: break-word }` — deliberately NOT `anywhere`, which feeds soft-wrap into min-content intrinsic sizing and re-crushes the #501 table columns (the docs-table guard stays green as proof).
- The pan guard's route×width matrix now covers **all five doc routes** plus 320/768 (the repro route was the one page never in the list — red-proven 206px@320 before the fix), and gains a second tripwire on `window.innerWidth` (which really does expand under emulation, 375→526 pre-fix, while `documentElement.clientWidth` stays pinned — review-measured).

## Review (two lenses)

Correctness APPROVE-WITH-NITS · design APPROVE-WITH-NITS. The correctness lens independently reproduced the exact 206px@320 red and caught my first-draft assertion reading the wrong property (`clientWidth`, which never expands) — fixed in the second commit: assertion reads `innerWidth`, comment tells the true story (the missed coverage was the route matrix). Design lens verified `.prose` has exactly one consumer (the docs shell), break-word only engages at overflow time, and added the index@320 gap row. Its bundled-deps flag was misattributed (upstream dependabot commits between the stale briefing base and the true merge-base — this PR's diff is 2 files).

## Gates

site-check 0 (32/32 unit) · `just site-e2e` 69/69 · site-only (no Rust/media/wasm — semver/gen-check untouched by construction).

Closes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015A8aAnRVr89oJEd4bAaAFn