### PR TITLE
fix(site): mobile hero copy slid under the floating nav

### DIFF
--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -58,7 +58,13 @@ const badges = sources.filter((s) => s.status === 'supported');
     display: flex;
     align-items: flex-end;
     overflow: hidden;
-    padding-block: 0 clamp(3.5rem, 8vh, 6rem);
+    /* Top: reserve the floating nav's row (--nav-h + a breath) — the copy is
+       bottom-anchored, so whenever it outgrows the viewport (narrow phones,
+       iOS text inflation) its TOP is what gives way, and with no reservation
+       the eyebrow slid under the absolute nav's logo (mobile overlap bug).
+       Desktop is unaffected: the copy is short, so flex-end keeps it at the
+       bottom and the padding is dead space it never reaches. */
+    padding-block: calc(var(--nav-h) + 0.75rem) clamp(3.5rem, 8vh, 6rem);
   }
   .dust {
     position: absolute;

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -5,7 +5,7 @@ const home = asset('');
 // `floating` = the OPEN FLOOR index treatment (corner chrome over the live
 // office, scrolls away — the statusline is that page's persistent chrome).
 // The default is the sticky bar: Docs/404 have no backdrop and no statusline,
-// so they keep persistent nav, the 60px layout reservation, and section links.
+// so they keep persistent nav, the --nav-h layout reservation, and section links.
 const { floating = false } = Astro.props;
 ---
 

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -204,7 +204,7 @@ const { floating = false } = Astro.props;
     display: flex;
     align-items: center;
     gap: 1rem;
-    height: 60px;
+    height: var(--nav-h); /* single-sourced in global.css — Hero reserves the same */
   }
   .nav__logo {
     display: flex;

--- a/site/src/layouts/Docs.astro
+++ b/site/src/layouts/Docs.astro
@@ -198,16 +198,16 @@ const toc = raw.map((h) => ({ ...h, text: h.text.replace(/\s*\([^)]*\)\s*$/, '')
     justify-content: center;
     align-items: start;
   }
-  /* rails: sticky below the 60px sticky nav */
-  /* anchored headings clear the 60px sticky nav (same offset the rails use) —
+  /* rails: sticky below the --nav-h sticky nav (+ 1.5rem breath) */
+  /* anchored headings clear the sticky nav (same offset the rails use) —
      also parks clicked headings nearer the scrollspy band */
   .docs :global(.prose h2),
   .docs :global(.prose h3) {
-    scroll-margin-top: 84px;
+    scroll-margin-top: calc(var(--nav-h) + 1.5rem);
   }
   .docs__rail {
     position: sticky;
-    top: 84px;
+    top: calc(var(--nav-h) + 1.5rem);
     font-family: var(--font-mono);
     font-size: 0.84rem;
   }

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -84,12 +84,14 @@
   --maxw: 1120px;
   --radius: 16px;
   --radius-sm: 10px;
-  /* The nav bar's row height — single-sourced because TWO components must agree:
-     Nav.astro sizes .nav__inner with it, and Hero.astro reserves exactly this
-     much top padding so the bottom-anchored hero copy can never rise underneath
-     the index's floating (absolute) nav when the copy outgrows the viewport
-     (the mobile eyebrow-under-logo overlap; headless cleared it by only ~10px,
-     real iOS text metrics crossed the line). */
+  /* The nav bar's row height — single-sourced because THREE consumers must
+     agree: Nav.astro sizes .nav__inner with it; Hero.astro reserves exactly
+     this much top padding so the bottom-anchored hero copy can never rise
+     underneath the index's floating (absolute) nav when the copy outgrows the
+     viewport (the mobile eyebrow-under-logo overlap; headless cleared it by
+     only ~10px, real iOS text metrics crossed the line); and Docs.astro
+     derives its rail top + heading scroll-margin from it (clearing the sticky
+     nav variant). */
   --nav-h: 60px;
 
   /* Screen chrome — text that sits on/over the office render, THEME-INDEPENDENT

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -84,6 +84,13 @@
   --maxw: 1120px;
   --radius: 16px;
   --radius-sm: 10px;
+  /* The nav bar's row height — single-sourced because TWO components must agree:
+     Nav.astro sizes .nav__inner with it, and Hero.astro reserves exactly this
+     much top padding so the bottom-anchored hero copy can never rise underneath
+     the index's floating (absolute) nav when the copy outgrows the viewport
+     (the mobile eyebrow-under-logo overlap; headless cleared it by only ~10px,
+     real iOS text metrics crossed the line). */
+  --nav-h: 60px;
 
   /* Screen chrome — text that sits on/over the office render, THEME-INDEPENDENT
      (the office pixels don't change with the site theme, so neither do these):

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -1272,6 +1272,42 @@ test('no horizontal overflow at phone widths (mobile pan guard)', async ({ brows
   }
 });
 
+test('the hero copy clears the floating nav at phone viewports (vertical overlap guard)', async ({
+  browser,
+}) => {
+  // The hero is min-height:100svh with the copy BOTTOM-anchored (flex-end), so
+  // when the copy outgrows the viewport (narrow phones; iOS text metrics), its
+  // TOP is what gives way — with no top reservation the eyebrow slid to page
+  // y=0, straight under the index's floating (absolute) nav logo (measured
+  // pre-fix: eyebrow.top 0 vs nav bottom 60 at 402×700; a 1206×2622 iPhone
+  // field report). The fix reserves --nav-h + a breath as .hero padding-top.
+  // The pan guard above is width-only — this is the VERTICAL twin. 402×700 ≈
+  // iOS Safari's visible viewport on a 874pt phone; 360×640 = small Android.
+  for (const [width, height] of [
+    [402, 700],
+    [360, 640],
+    [402, 874],
+  ] as const) {
+    const context = await browser.newContext({
+      viewport: { width, height },
+      isMobile: true,
+      hasTouch: true,
+    });
+    const page = await context.newPage();
+    await page.addInitScript(() => sessionStorage.setItem('pix-booted', '1'));
+    await page.goto('./');
+    const { navBottom, eyebrowTop } = await page.evaluate(() => ({
+      navBottom: document.querySelector('.nav .nav__inner')!.getBoundingClientRect().bottom,
+      eyebrowTop: document.querySelector('.hero__copy .eyebrow')!.getBoundingClientRect().top,
+    }));
+    expect(
+      eyebrowTop,
+      `at ${width}x${height} the hero eyebrow (top ${eyebrowTop}px) sits under the floating nav (bottom ${navBottom}px)`
+    ).toBeGreaterThanOrEqual(navBottom);
+    await context.close();
+  }
+});
+
 test('docs-table code cells render single-line (column-collapse guard)', async ({ browser }) => {
   // `.prose :not(pre) > code`'s overflow-wrap:anywhere feeds its soft-wrap
   // opportunities into MIN-CONTENT intrinsic sizing (unlike break-word), so

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -1283,6 +1283,9 @@ test('the hero copy clears the floating nav at phone viewports (vertical overlap
   // field report). The fix reserves --nav-h + a breath as .hero padding-top.
   // The pan guard above is width-only — this is the VERTICAL twin. 402×700 ≈
   // iOS Safari's visible viewport on a 874pt phone; 360×640 = small Android.
+  // reducedMotion pins the copy's `rise` entry animation (translateY 22px →
+  // none) to its SETTLED position — the steady-state clearance is only ~12px,
+  // so a mid-animation read could mask a partial regression (false green).
   for (const [width, height] of [
     [402, 700],
     [360, 640],
@@ -1292,6 +1295,7 @@ test('the hero copy clears the floating nav at phone viewports (vertical overlap
       viewport: { width, height },
       isMobile: true,
       hasTouch: true,
+      reducedMotion: 'reduce',
     });
     const page = await context.newPage();
     await page.addInitScript(() => sessionStorage.setItem('pix-booted', '1'));


### PR DESCRIPTION
## What

Field report (iPhone): the hero eyebrow `› 6F · PENTHOUSE — TERMINAL-NATIVE…` rendered on top of the floating nav's `pixtuoid v0.13.0` logo, garbling both.

## Why

The hero is `min-height: 100svh` with the copy **bottom-anchored** (`align-items: flex-end`) and **no top clearance** — when the copy outgrows the viewport (narrow phones, iOS text metrics), its top gives way and slides under the `position: absolute` nav. Measured pre-fix: eyebrow at page **y=0** vs nav bottom **60** at 402×700 / 360×640 (iOS Safari's real visible viewport shapes); headless 402×874 cleared by only ~10px.

## Fix

- `--nav-h: 60px` single-sourced in `global.css` — `Nav.astro` sizes `.nav__inner` with it, `Hero.astro` reserves `calc(var(--nav-h) + 0.75rem)` as top padding, so the copy top can never reach the nav.
- Desktop unaffected: the copy is shorter than the fold, so flex-end keeps it bottom-anchored and the reservation is dead space (verified: eyebrow at 233.7px @1440×900, unchanged).

## Test

New e2e — the **vertical twin of the mobile pan guard**: eyebrow must clear the nav bottom at 402×700, 360×640, 402×874. Fails pre-fix (0 vs 60), passes post-fix (72 vs 60).

Gates: `site-check` green, `site-e2e` **72 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BT3bfjgBPqZE5sqtccZm3v