### PR TITLE
refactor: slim dead/duplicated fallback safety-nets across the workspace

### DIFF
--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -94,7 +94,7 @@ given change/tree, say so, don't skip it.
   `Furniture::Desk` footprint `unwrap_or(Size{DESK_W,DESK_H})` both dead (the
   const table is always `Some`) AND WRONG (`decor.rs` is `DESK_W+4`, so a
   hypothetical None mis-placed the sprite), plus the `(7,4)` table footprint
-  re-hardcoded inline in three painters — read the authority (`if let Some(..) =
+  re-hardcoded inline in two more painters — read the authority (`if let Some(..) =
   furniture_def(x).footprint`), never re-copy its fallback. The test is "can the
   trigger fire, and does the arm duplicate/contradict an authority", NOT "does it
   look defensive": load-bearing defense STAYS (documented sharp edges, liveness

--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -84,7 +84,22 @@ given change/tree, say so, don't skip it.
   dedicated fix-round review; `just arch` had zero CI reach until #273).
 - **(B) Design-debt** — duplication/DRY (N implementations of one concept —
   weight by DIVERGENCE risk, not line count); god-object / oversized module with
-  a clean split; dead code / legacy remnant; leaky or missing abstraction;
+  a clean split; dead code / legacy remnant; **unnecessary fallback / dead
+  default** — a defensive arm (`unwrap_or`/`map_or`/catch-all `_ =>`/`.or_else`/
+  retry) whose trigger CANNOT occur, or that DUPLICATES — worse, CONTRADICTS — a
+  source of truth, is debt not safety: fallback only when a REAL failure mode
+  needs it. The INVERSE of negative-space rule 2 (which forbids demanding
+  defense-in-depth where a primary defense exists) — here, don't ADD or LEAVE a
+  guard for a state that can't arise. The 0.13 slimming audit found a
+  `Furniture::Desk` footprint `unwrap_or(Size{DESK_W,DESK_H})` both dead (the
+  const table is always `Some`) AND WRONG (`decor.rs` is `DESK_W+4`, so a
+  hypothetical None mis-placed the sprite), plus the `(7,4)` table footprint
+  re-hardcoded inline in three painters — read the authority (`if let Some(..) =
+  furniture_def(x).footprint`), never re-copy its fallback. The test is "can the
+  trigger fire, and does the arm duplicate/contradict an authority", NOT "does it
+  look defensive": load-bearing defense STAYS (documented sharp edges, liveness
+  ladders, the shim exit-0 contract, clock-regression `duration_since` folds,
+  config-never-wipe); leaky or missing abstraction;
   correlated-state bundling — N fields that ALWAYS change together (a phase + its
   clock + its profile; a liveness axis + its run-set; a decoder + the extractor it
   pairs with) belong in ONE struct/newtype so an illegal combination is

--- a/crates/pixtuoid-core/src/platform.rs
+++ b/crates/pixtuoid-core/src/platform.rs
@@ -52,13 +52,21 @@ pub(crate) fn codex_home() -> PathBuf {
     resolve_codex_home(std::env::var("CODEX_HOME").ok(), user_home())
 }
 
+/// An env var value counts as UNSET when it's empty or whitespace-only — a
+/// whitespace-only path is never a valid home/config dir. The ONE spelling of
+/// that "empty env == unset" rule, shared by every resolver below (the module's
+/// "one trim semantics"), so the four call sites can't drift.
+fn nonempty(v: Option<String>) -> Option<String> {
+    v.filter(|s| !s.trim().is_empty())
+}
+
 /// Pure precedence core, separated so it's unit-testable without env mutation.
 /// (`is_dir` still touches the filesystem.) On a set-but-absent `CODEX_HOME`,
 /// upstream codex returns a FATAL error; we deliberately fall back to `~/.codex`
 /// instead — benign for a visualizer, since codex itself won't run (and writes
 /// no rollouts under that path) when its own home dir is missing.
 fn resolve_codex_home(codex_home_env: Option<String>, home: String) -> PathBuf {
-    if let Some(p) = codex_home_env.filter(|s| !s.trim().is_empty()) {
+    if let Some(p) = nonempty(codex_home_env) {
         let pb = PathBuf::from(p);
         if pb.is_dir() {
             return pb;
@@ -108,7 +116,6 @@ fn resolve_home_first(
     home: Option<String>,
     userprofile: Option<String>,
 ) -> Option<String> {
-    let nonempty = |v: Option<String>| v.filter(|s| !s.trim().is_empty());
     nonempty(home).or_else(|| if windows { nonempty(userprofile) } else { None })
 }
 
@@ -128,7 +135,6 @@ pub fn resolve_user_config_dir(
     xdg: Option<String>,
     home: &Path,
 ) -> PathBuf {
-    let nonempty = |v: Option<String>| v.filter(|s| !s.trim().is_empty());
     match os {
         "macos" => home.join("Library/Application Support"),
         "windows" => nonempty(appdata)
@@ -169,7 +175,6 @@ pub fn resolve_user_home_opt(
     userprofile: Option<String>,
     home: Option<String>,
 ) -> Option<String> {
-    let nonempty = |v: Option<String>| v.filter(|s| !s.trim().is_empty());
     if windows {
         // USERPROFILE is effectively always set on Windows; a lone HOME here
         // was set deliberately (MSYS users exporting a real Windows path).

--- a/crates/pixtuoid-core/src/source/codewhale.rs
+++ b/crates/pixtuoid-core/src/source/codewhale.rs
@@ -249,21 +249,18 @@ pub(crate) fn decode_cw_hook_custom(v: &Value) -> Result<Option<Vec<AgentEvent>>
 /// carry no `subagent_type`, so the shared semantic detection can't see it),
 /// everything else gets a `"name: target"` display. `tool_args` arrives as the
 /// raw `DEEPSEEK_TOOL_ARGS` JSON STRING (e.g. `{"command":"ls -la","cwd":"…"}`,
-/// captured live), so it is parsed here before the target key lookup; an object
-/// is also accepted defensively. Target keys, in priority order, match the
-/// args CodeWhale's builtin tools emit: `exec_shell`→`command`, the file tools→
+/// captured live), so it is parsed here before the target key lookup. Target
+/// keys, in priority order, match the args CodeWhale's builtin tools emit:
+/// `exec_shell`→`command`, the file tools→
 /// `file_path`/`path`, search→`pattern`, fetch→`url`.
 fn cw_tool_detail(tool: &str, raw_args: Option<&Value>) -> ToolDetail {
     if SUBAGENT_TOOLS.contains(&tool) {
         return ToolDetail::Task;
     }
-    // `tool_args` is a JSON string in the shim envelope; parse it. Accept a
-    // bare object too (defensive — a future caller might embed it directly).
-    let parsed: Option<Value> = match raw_args {
-        Some(Value::String(s)) => serde_json::from_str(s).ok(),
-        Some(v @ Value::Object(_)) => Some(v.clone()),
-        _ => None,
-    };
+    // `tool_args` is a JSON string in the shim envelope; parse it.
+    let parsed: Option<Value> = raw_args
+        .and_then(Value::as_str)
+        .and_then(|s| serde_json::from_str(s).ok());
     // Per-source target vocabulary; the shared scan lives in the decoder, the
     // last-mile assembly (name + `: target` with the matching caps) in
     // `generic_tool_display`.
@@ -346,22 +343,6 @@ mod tests {
             }
             other => panic!("expected ActivityStart, got {other:?}"),
         }
-    }
-
-    #[test]
-    fn tool_args_object_form_is_also_accepted() {
-        // Defensive: a future caller embedding tool_args as an object (not a
-        // JSON string) must still resolve the target.
-        let ev = decode(json!({
-            "event": "tool_call_before",
-            "cwd": "/repo",
-            "tool": "read_file",
-            "tool_args": {"path": "src/main.rs"}
-        }));
-        assert!(
-            matches!(ev, AgentEvent::ActivityStart { detail: Some(d), .. }
-            if d.display() == "read_file: src/main.rs")
-        );
     }
 
     #[test]

--- a/crates/pixtuoid-core/src/source/copilot.rs
+++ b/crates/pixtuoid-core/src/source/copilot.rs
@@ -62,11 +62,11 @@ pub fn copilot_home() -> PathBuf {
 /// The session id = the **parent directory name** of `events.jsonl`
 /// (`…/session-state/<sessionId>/events.jsonl`). The filename stem is the
 /// constant `events`, so — unlike CC/Codex — the id is the containing dir.
-/// Falls back to the stem if there is no parent (defensive).
+/// A parentless path (never produced by the directory-walking watcher) yields
+/// an empty key, not the colliding constant stem `events`.
 pub fn copilot_id_from_path(path: &Path) -> String {
     path.parent()
         .and_then(|p| p.file_name())
-        .or_else(|| path.file_stem())
         .and_then(|s| s.to_str())
         .unwrap_or("")
         .to_string()
@@ -78,6 +78,15 @@ pub fn derive_copilot_label(_path: &Path, source: &str, cwd: &Path) -> String {
 
 fn str_at<'a>(v: &'a Value, key: &str) -> Option<&'a str> {
     v.get(key).and_then(|x| x.as_str())
+}
+
+/// The subagent child key for a `subagent.*` envelope: the top-level `agentId`
+/// (== the spawning `task` tool's `data.toolCallId`), falling back to
+/// `data.toolCallId`. One spelling shared by the started/completed/failed arms.
+fn copilot_child_key<'a>(v: &'a Value, data: Option<&'a Value>) -> Option<&'a str> {
+    str_at(v, "agentId")
+        .filter(|s| !s.is_empty())
+        .or_else(|| data.and_then(|d| str_at(d, "toolCallId")))
 }
 
 /// First-sight cwd extractor (the walker's head scan, dispatched via the
@@ -202,10 +211,7 @@ pub fn decode_copilot_line(
         "subagent.started" => {
             // The child id is the envelope `agentId` (== data.toolCallId). Register
             // it as a child of the root session, then name it from the display name.
-            let Some(child_key) = str_at(&v, "agentId")
-                .filter(|s| !s.is_empty())
-                .or_else(|| data.and_then(|d| str_at(d, "toolCallId")))
-            else {
+            let Some(child_key) = copilot_child_key(&v, data) else {
                 return Ok(vec![]);
             };
             let child = AgentId::from_parts(source, child_key);
@@ -233,10 +239,7 @@ pub fn decode_copilot_line(
             evs
         }
         "subagent.completed" | "subagent.failed" => {
-            let Some(child_key) = str_at(&v, "agentId")
-                .filter(|s| !s.is_empty())
-                .or_else(|| data.and_then(|d| str_at(d, "toolCallId")))
-            else {
+            let Some(child_key) = copilot_child_key(&v, data) else {
                 return Ok(vec![]);
             };
             vec![AgentEvent::SessionEnd {

--- a/crates/pixtuoid-core/src/state/correlation.rs
+++ b/crates/pixtuoid-core/src/state/correlation.rs
@@ -206,6 +206,16 @@ pub(super) struct Correlation {
     pub(super) gated_before_waiting: HashMap<AgentId, Arc<str>>,
 }
 
+/// Freshness under a TTL, clock-regression-safe: `SystemTime::duration_since`
+/// returns `Err` when `ts` is in the future (the wall clock went backwards),
+/// which folds to NOT-fresh — a future timestamp is stale either way. The ONE
+/// spelling of the `elapsed < ttl` policy every correlation map and predicate
+/// routes through, so the strict-`<` boundary can't drift across the sites
+/// (pinned by the exact-TTL tests below).
+fn is_fresh(now: SystemTime, ts: SystemTime, ttl: Duration) -> bool {
+    now.duration_since(ts).is_ok_and(|d| d < ttl)
+}
+
 impl Correlation {
     /// Whether a hook `SessionEnd` for `id` (which had no slot) is still inside
     /// its [`HOOK_SESSION_END_TOMBSTONE_TTL`]: a trailing hook event delivered
@@ -213,10 +223,9 @@ impl Correlation {
     /// [`Reducer::synthesize_hook_registration`], the `Identity` arm, and the
     /// `SessionStart` arm's child-registration gate (#242).
     pub(super) fn hook_session_end_tombstoned(&self, id: AgentId, now: SystemTime) -> bool {
-        self.recent_hook_session_ends.get(&id).is_some_and(|ts| {
-            now.duration_since(*ts)
-                .is_ok_and(|d| d < HOOK_SESSION_END_TOMBSTONE_TTL)
-        })
+        self.recent_hook_session_ends
+            .get(&id)
+            .is_some_and(|ts| is_fresh(now, *ts, HOOK_SESSION_END_TOMBSTONE_TTL))
     }
 
     /// Whether the child ledger records `id` as ENDED within
@@ -225,36 +234,26 @@ impl Correlation {
     /// safe like the `gc` retains (a future timestamp is not fresh).
     pub(super) fn child_recently_ended(&self, id: AgentId, now: SystemTime) -> bool {
         self.child_ledger.get(&id).is_some_and(|e| {
-            e.ended_at.is_some_and(|ts| {
-                now.duration_since(ts)
-                    .is_ok_and(|d| d < CHILD_END_LEDGER_TTL)
-            })
+            e.ended_at
+                .is_some_and(|ts| is_fresh(now, ts, CHILD_END_LEDGER_TTL))
         })
     }
 
     pub(super) fn gc(&mut self, now: SystemTime) {
-        // SystemTime::duration_since returns Err when `ts` is in the future
-        // (clock went backwards). Drop those — stale entries either way.
         self.recent_hook_tool_uses
-            .retain(|_, (ts, _)| now.duration_since(*ts).is_ok_and(|d| d < HOOK_WINS_WINDOW));
-        self.recent_hook_session_ends.retain(|_, ts| {
-            now.duration_since(*ts)
-                .is_ok_and(|d| d < HOOK_SESSION_END_TOMBSTONE_TTL)
-        });
+            .retain(|_, (ts, _)| is_fresh(now, *ts, HOOK_WINS_WINDOW));
+        self.recent_hook_session_ends
+            .retain(|_, ts| is_fresh(now, *ts, HOOK_SESSION_END_TOMBSTONE_TTL));
         self.recent_proof_of_life
-            .retain(|_, ts| now.duration_since(*ts).is_ok_and(|d| d < PROOF_OF_LIFE_TTL));
-        self.recent_task_drains.retain(|_, ts| {
-            now.duration_since(*ts)
-                .is_ok_and(|d| d < DRAINED_TASK_TOMBSTONE_TTL)
-        });
+            .retain(|_, ts| is_fresh(now, *ts, PROOF_OF_LIFE_TTL));
+        self.recent_task_drains
+            .retain(|_, ts| is_fresh(now, *ts, DRAINED_TASK_TOMBSTONE_TTL));
         // Not-yet-ended entries ride until their end/sweep stamps ended_at
         // (every slot removal goes through sweep_exited, which stamps it), so
         // the map is bounded by live children + the TTL's trailing window.
         self.child_ledger.retain(|_, e| match e.ended_at {
             None => true,
-            Some(ts) => now
-                .duration_since(ts)
-                .is_ok_and(|d| d < CHILD_END_LEDGER_TTL),
+            Some(ts) => is_fresh(now, ts, CHILD_END_LEDGER_TTL),
         });
     }
 
@@ -266,7 +265,7 @@ impl Correlation {
     pub(super) fn vouch_fresh(&self, id: &AgentId, now: SystemTime) -> bool {
         self.recent_proof_of_life
             .get(id)
-            .is_some_and(|t| now.duration_since(*t).is_ok_and(|d| d < PROOF_OF_LIFE_TTL))
+            .is_some_and(|t| is_fresh(now, *t, PROOF_OF_LIFE_TTL))
     }
 }
 

--- a/crates/pixtuoid-scene/src/anim.rs
+++ b/crates/pixtuoid-scene/src/anim.rs
@@ -63,10 +63,7 @@ pub fn eased_progress(
     easing: Easing,
     now: SystemTime,
 ) -> f32 {
-    let elapsed = now
-        .duration_since(started_at)
-        .unwrap_or(Duration::ZERO)
-        .as_millis() as f32;
+    let elapsed = elapsed_ms(now, started_at) as f32;
     let raw = if duration_ms == 0 {
         1.0
     } else {

--- a/crates/pixtuoid-scene/src/floor.rs
+++ b/crates/pixtuoid-scene/src/floor.rs
@@ -715,7 +715,6 @@ pub fn num_floors(scene: &SceneState) -> usize {
         .map(|a| a.floor_idx + 1)
         .max()
         .unwrap_or(1)
-        .max(1)
 }
 
 /// One agent projected onto a floor by [`build_floor_scene`]: the slot — its

--- a/crates/pixtuoid-scene/src/pixel_painter/background/lighting.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/background/lighting.rs
@@ -261,18 +261,20 @@ pub(in crate::pixel_painter) fn paint_clock(
 /// Quantize a fractional turn (0.0..1.0, 0.0 = north) to one of 8 octant
 /// (dx, dy) unit offsets.
 fn octant_offset(turn: f32) -> (i32, i32) {
+    // rem_euclid(8) maps every i32 (incl. a NaN turn's 0 cast) into 0..=7, so
+    // the table is total — a match would need a dead wildcard arm.
+    const OCTANTS: [(i32, i32); 8] = [
+        (0, -1),
+        (1, -1),
+        (1, 0),
+        (1, 1),
+        (0, 1),
+        (-1, 1),
+        (-1, 0),
+        (-1, -1),
+    ];
     let oct = ((turn * 8.0).round() as i32).rem_euclid(8);
-    match oct {
-        0 => (0, -1),
-        1 => (1, -1),
-        2 => (1, 0),
-        3 => (1, 1),
-        4 => (0, 1),
-        5 => (-1, 1),
-        6 => (-1, 0),
-        7 => (-1, -1),
-        _ => (0, 0),
-    }
+    OCTANTS[oct as usize]
 }
 
 /// Office corridor runner — a darker wood strip with subtle lighter stripes,

--- a/crates/pixtuoid-scene/src/pixel_painter/drawable.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/drawable.rs
@@ -28,6 +28,7 @@ use super::effects::{
     paint_walking_dust,
 };
 use super::epoch_ms;
+use super::frame_at;
 use super::furniture::{
     paint_area_rug, paint_meeting_table, paint_pantry_chair, paint_pantry_table, paint_side_table,
 };
@@ -808,10 +809,7 @@ pub(super) fn paint_drawable(
             }
         }
         DrawableKind::Door { pos, frame_idx } => {
-            if let Some(f) = pack
-                .animation("door")
-                .and_then(|a| a.frames.get(*frame_idx).or_else(|| a.frames.first()))
-            {
+            if let Some(f) = pack.animation("door").and_then(|a| frame_at(a, *frame_idx)) {
                 blit_frame(f, pos.x, pos.y, buf);
             }
         }
@@ -902,7 +900,7 @@ pub(super) fn paint_drawable(
             let Some(anim) = pack.animation(anim_name) else {
                 return;
             };
-            let Some(frame) = anim.frames.get(*frame_idx).or(anim.frames.first()) else {
+            let Some(frame) = frame_at(anim, *frame_idx) else {
                 return;
             };
             let final_frame = if *flip {
@@ -929,7 +927,7 @@ pub(super) fn paint_drawable(
             let Some(anim) = pack.animation(anim_name) else {
                 return;
             };
-            let Some(frame) = anim.frames.get(*frame_idx).or(anim.frames.first()) else {
+            let Some(frame) = frame_at(anim, *frame_idx) else {
                 return;
             };
             let px = pos.x.saturating_sub(frame.width() / 2);

--- a/crates/pixtuoid-scene/src/pixel_painter/furniture.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/furniture.rs
@@ -82,9 +82,12 @@ pub(super) fn paint_side_table(buf: &mut RgbBuffer, cx: u16, cy: u16, theme: &cr
     let mag_trim = theme.furniture.magazine_trim;
     // Sprite dimensions from the one furniture table (== the mask footprint for
     // the side table) so the painted block can't drift from the blocked ground.
-    let (w, h) = crate::layout::furniture_def(crate::layout::Furniture::LoungeSideTable)
-        .footprint
-        .map_or((7, 4), |s| (s.w as i32, s.h as i32));
+    let Some(fp) =
+        crate::layout::furniture_def(crate::layout::Furniture::LoungeSideTable).footprint
+    else {
+        return;
+    };
+    let (w, h) = (fp.w as i32, fp.h as i32);
     for dy in 0..h {
         for dx in 0..w {
             let px = cx as i32 - w / 2 + dx;
@@ -124,9 +127,11 @@ pub(super) fn paint_pantry_table(
 ) {
     let top = theme.furniture.wood_top;
     let trim = theme.furniture.wood_trim;
-    let (w, h) = crate::layout::furniture_def(crate::layout::Furniture::PantryTable)
-        .footprint
-        .map_or((7, 4), |s| (s.w as i32, s.h as i32));
+    let Some(fp) = crate::layout::furniture_def(crate::layout::Furniture::PantryTable).footprint
+    else {
+        return;
+    };
+    let (w, h) = (fp.w as i32, fp.h as i32);
     for dy in 0..h {
         for dx in 0..w {
             let on_corner = (dx == 0 || dx == w - 1) && (dy == 0 || dy == h - 1);

--- a/crates/pixtuoid-scene/src/pixel_painter/mod.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/mod.rs
@@ -19,7 +19,7 @@ use std::time::SystemTime;
 
 use pixtuoid_core::sprite::blit::blit_frame;
 use pixtuoid_core::sprite::format::Pack;
-use pixtuoid_core::sprite::{Rgb, RgbBuffer};
+use pixtuoid_core::sprite::{Frame, Rgb, RgbBuffer, Sprite};
 use pixtuoid_core::state::{ActivityState, FloorLocalDeskIndex};
 use pixtuoid_core::{AgentSlot, SceneState};
 
@@ -28,7 +28,7 @@ use crate::floor::LightingState;
 use crate::frame_cache::FrameCache;
 use crate::layout::{
     z_sort_row, Anchor, Layout, PlantItem, PodDecorItem, Point, Size, WallDecorItem, WallSegment,
-    DESK_H, DESK_W, ELEVATOR_H, ELEVATOR_W,
+    DESK_W, ELEVATOR_H, ELEVATOR_W,
 };
 use crate::motion::MotionState;
 use crate::pet::PetFrame;
@@ -760,6 +760,15 @@ fn enqueue_room_walls_h<'a>(layout: &'a Layout, drawables: &mut Vec<Drawable<'a>
     }
 }
 
+/// The frame to paint for `idx`, clamped into range: a custom `--pack-dir`
+/// animation whose sprite has fewer frames than the shared cycle's `frame_idx`
+/// would otherwise yield `None` and vanish the sprite, so fall back to the
+/// first frame. `None` only for a genuinely empty animation (the caller skips).
+/// The ONE spelling of this out-of-range guard — was open-coded at four sites.
+pub(super) fn frame_at(anim: &Sprite, idx: usize) -> Option<&Frame> {
+    anim.frames.get(idx).or_else(|| anim.frames.first())
+}
+
 /// Desk cubicles — each carries its divider + cabinet + bin + screen glow.
 /// The desk sprite (16×8) sorts at `desk.y + footprint_h + DESK_FRONT_OVERHANG`
 /// (front-lip overhang past the blocked footprint), just past the seated
@@ -775,15 +784,13 @@ fn enqueue_desk_cubicles<'a>(
 ) {
     for (i, &desk) in ctx.layout.home_desks.iter().enumerate() {
         let local = FloorLocalDeskIndex(i);
-        let Size {
+        let Some(Size {
             w: desk_fp_w,
             h: desk_fp_h,
-        } = crate::layout::desk_furniture_def()
-            .footprint
-            .unwrap_or(Size {
-                w: DESK_W,
-                h: DESK_H,
-            });
+        }) = crate::layout::desk_furniture_def().footprint
+        else {
+            continue;
+        };
         let is_last_col = desk.x + desk_fp_w + DESK_W
             >= ctx.layout.cubicle_band.x + ctx.layout.cubicle_band.width;
         let occupant = agents

--- a/crates/pixtuoid-scene/src/pixel_painter/seat.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/seat.rs
@@ -25,7 +25,7 @@ pub(super) fn paint_character_at(
     let Some(anim) = pack.animation(anim_name) else {
         return;
     };
-    let Some(frame) = anim.frames.get(frame_idx).or_else(|| anim.frames.first()) else {
+    let Some(frame) = frame_at(anim, frame_idx) else {
         return;
     };
     // A cwd backfill re-keys the outfit (Team Palette) mid-lifetime — flag the

--- a/crates/pixtuoid-scene/src/pose/pure.rs
+++ b/crates/pixtuoid-scene/src/pose/pure.rs
@@ -359,13 +359,16 @@ pub fn pick_aimless_dest(layout: &SceneLayout, seed: u64, home_desk: Point) -> P
         width: layout.cubicle_band.width,
         height: 10,
     };
+    // The corridor zone (its cubicle-aisle fallback) is used twice — the wander
+    // zone table and the fallback midline scan below — so bind it once.
+    let corridor_zone = layout.corridor.unwrap_or(layout.cubicle_aisle);
     let zones: [(Bounds, u16); 5] = [
         // Stretch + look-at-the-view at the top of the cubicle band.
         (window_strip, 30),
         // Pantry interior — snack break, coffee, chat.
         (layout.pantry_room.unwrap_or(window_strip), 25),
         // Main corridor — incidental traffic.
-        (layout.corridor.unwrap_or(layout.cubicle_aisle), 20),
+        (corridor_zone, 20),
         // Cubicle band (pod aisles) — within own area, stretching.
         (layout.cubicle_band, 15),
         // Meeting room — occasional drift-in.
@@ -404,7 +407,7 @@ pub fn pick_aimless_dest(layout: &SceneLayout, seed: u64, home_desk: Point) -> P
     // nearest walkable midline cell — everywhere else this function's
     // contract is "returns a walkable pixel". Bounded by the corridor width
     // and purely (layout, seed)-deterministic, like the probes above.
-    let c = layout.corridor.unwrap_or(layout.cubicle_aisle);
+    let c = corridor_zone;
     let x_jitter = (seed as u16) % c.width.max(1);
     let base_x = c.x + x_jitter;
     let mid_y = c.y + c.height / 2;

--- a/crates/pixtuoid-web/src/lib.rs
+++ b/crates/pixtuoid-web/src/lib.rs
@@ -217,7 +217,9 @@ impl Office {
     /// page-relative clock pins the scene at 1970 — permanently 00:00,
     /// defeating the browser-timezone support entirely).
     pub fn step(&mut self, now_ms: f64, w: u32, h: u32) {
-        let now = SystemTime::UNIX_EPOCH + Duration::from_millis(now_ms.max(0.0) as u64);
+        // `f64 as u64` saturates (negatives/NaN → 0) since Rust 1.45, so the
+        // contract's "epoch ms" pre-clamp is already the cast's behavior.
+        let now = SystemTime::UNIX_EPOCH + Duration::from_millis(now_ms as u64);
         self.last_now = Some(now);
         let buf_w = w.clamp(1, u16::MAX as u32) as u16;
         let buf_h = h.clamp(1, u16::MAX as u32) as u16;


### PR DESCRIPTION
## What

A whole-codebase fallback/兜底 (safety-net) audit (146 sites across the 5 Rust crates) found the defensive logic **~90% load-bearing** (liveness ladders, never-panic decoder/shim contracts, clock-regression guards, config-never-wipe, platform path precedence, render-edge clamps). This PR lands the genuinely-slimmable subset — **all behavior-preserving except two dead-in-prod removals** — and leaves every documented/test-pinned guard intact.

## Changes

**Dead defaults (the desk one also fixes a latent bug):**
- `pixel_painter`: desk footprint `unwrap_or(Size{DESK_W,DESK_H})` was dead **and wrong** (`decor.rs` is `DESK_W+4`, so a hypothetical `None` mis-placed the sprite); Lounge/Pantry table `(7,4)` `map_or` dups — now read `furniture_def(x).footprint` via `let-else` (the `mask.rs` idiom), no re-hardcoded literal.

**DRY-centralizations (guards preserved, one source of truth):**
- `correlation.rs`: 8× `duration_since(ts).is_ok_and(|d| d<TTL)` → `is_fresh()` (exact-boundary tombstone tests still pin strict `<`)
- `platform.rs`: 4× trim-nonempty closure → `fn nonempty`
- `pixel_painter`: 4× out-of-range frame guard (two spellings) → `frame_at` (guard stays — custom `--pack-dir` packs)
- `copilot.rs`: subagent child-key ladder ×2 → `copilot_child_key`
- `pose/pure.rs`: `corridor.unwrap_or(cubicle_aisle)` ×2 → one binding

**Micro / dead-code:**
- `anim.rs`: reuse the file's own `elapsed_ms` helper
- `floor.rs`: drop provable no-op `.max(1)`
- `codewhale.rs`: drop dead self-labeled-YAGNI Object arm + its pinning test
- `lighting.rs`: octant `match` → total const array (drops the dead `_ =>` arm; byte-identical render)
- `web/lib.rs`: drop redundant `.max(0.0)` (saturating cast covers it since Rust 1.45)
- `copilot.rs`: drop dead `.or_else(file_stem)` (returned a colliding constant `events` if ever hit; never reached by the directory-walking watcher)

**Kept (fallback IS necessary):** `install/verify.rs` `shell_shim_ref`'s last-token fallback is **test-pinned intentional behavior** (`shell_shim_ref_lone_trailing_quote_is_not_a_quoted_span` documents the WHY) — it recovers a path for `doctor`'s exists/executable stat on hand-edited configs.

**Process:** adds an **"unnecessary fallback / dead default"** factor to `.github/prompts/pr-review.prompt.md` (Family B) — the inverse of negative-space rule 2, with an explicit load-bearing-defense carve-out. That taxonomy is the shared source, so it upgrades both the diff gate and the whole-codebase audit.

## Verification

Local gates, all exit 0: `just clippy` · `just test` (2180 passed) · `just gen-check` (0 pixel drift) · `just hack` · `just lint` · `just wasm-build`. No public API changed (all new fns private/`pub(super)`) → semver-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xxFWw2cafxi4x65NxVzES
