### PR TITLE
test(theme): pin by_prefix badge arms directly to the registry

### DIFF
--- a/crates/pixtuoid-scene/src/theme/mod.rs
+++ b/crates/pixtuoid-scene/src/theme/mod.rs
@@ -442,4 +442,25 @@ mod tests {
              new source's field to SourceColors + all() (and a hue in every theme file)"
         );
     }
+
+    // `by_prefix`'s match arms are a hand-kept copy of the registry's
+    // authoritative `SourceDescriptor::label_prefix` strings. The count guard
+    // above and the distinctness guard pin the HUES, not the prefix STRINGS —
+    // those were only pinned transitively, via the site-manifest chain and only
+    // for `status == "supported"` rows. A registry prefix RENAME that misses the
+    // matching `by_prefix` arm silently drops that source's badge to the idle
+    // fallback (`by_prefix(tag).unwrap_or(ui.label_idle)` in the painters). Pin
+    // the string mapping directly to the registry so the rename fails loudly HERE.
+    #[test]
+    fn by_prefix_accepts_every_registered_label_prefix() {
+        for d in pixtuoid_core::source::registry::REGISTRY {
+            assert!(
+                NORMAL.source.by_prefix(d.label_prefix).is_some(),
+                "theme::by_prefix has no arm for source {:?} label_prefix {:?} — its badge \
+                 would fall back to idle; add the arm (or align it with the registry rename)",
+                d.name,
+                d.label_prefix
+            );
+        }
+    }
 }


### PR DESCRIPTION
## What

Tier-C robustness item from the whole-codebase refactor audit. `SourceColors::by_prefix`'s match arms are a hand-kept copy of the registry's authoritative `SourceDescriptor::label_prefix` strings, but only the badge **hue count** (`source_colors_cover_every_registered_source`) and **distinctness** (`source_badges_legible_for_every_theme`) were guarded — the prefix **strings** were pinned only *transitively* (the site-manifest chain `supported_sources_manifest.rs` → `site_badge_colors.rs`, and only for `status=="supported"` rows).

A registry prefix **rename** that missed the matching `by_prefix` arm would silently drop that source's badge to the idle fallback (`by_prefix(tag).unwrap_or(ui.label_idle)` in the dashboard/sources painters) with no direct test.

## Change

One bridge test iterating `REGISTRY` and asserting `by_prefix(d.label_prefix).is_some()` for every registered source. Teeth verified: temporarily renaming an arm made it fail naming the source (`hermes`/`hm`). This also makes the `by_prefix` doc comment's "kept in lockstep by the badge-coverage guards" **true** (it was over-claiming — the guards covered hues, not the prefix strings).

Test-only, `pixtuoid-scene`. No prod behavior change.

## Audit note (for the reviewer)

The refactor audit's two *bigger* Tier-C items were **refuted** against the architecture and are NOT in this PR:
- **Hook-lifecycle extract** across the 4 hook decoders — refuted: it would move event→AgentEvent **dispatch** into a shared builder, but the multi-source sharp edge mandates "per-source decoders own only DISPATCH knowledge"; the 4 CLIs are independently-drifting wire formats and the shared mechanical parts are already centralized in `decoder.rs`. Coupling them fights invariant #3.
- **AA-blend PixelSink trait** — refuted: the blend curve is already single-source (`aa_text::blend_channel`, "the ONE blend curve"); the 3 sites are irreducible per-pixel-format adapters, so a trait would add abstraction to replace one-liners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xxFWw2cafxi4x65NxVzES