### PR TITLE
test(reducer): shared apply-DSL for the reducer suite (−360 LOC, coverage-neutral)

### DIFF
--- a/crates/pixtuoid-core/tests/CLAUDE.md
+++ b/crates/pixtuoid-core/tests/CLAUDE.md
@@ -20,7 +20,7 @@ tests/
 │   │   └── fixtures/hook-payloads.jsonl   codewhale's OWN data (single-owner; NOT scanned)
 │   ├── snapshots/            insta snaps  (sources__conformance__<source>__<scenario>)
 │   └── fixtures/<source>/    ══ conformance scenarios ONLY — dir name MUST be a registered source ══
-├── reducer/main.rs           state-machine behavior (1 binary; shared builders `start`/`delegating_pair` live in main.rs)
+├── reducer/main.rs           state-machine behavior (1 binary; shared scaffolding lives in main.rs — builders `start`/`delegating_pair` + the apply-DSL `act_start`/`act_end`/`waiting`/`proof_of_life`/`sess_end`)
 │   ├── lifecycle.rs          SessionStart/End arms: registration/capacity, resurrect-in-place, hook synthesis of unknown ids, duplicate-start backfill, `Identity`
 │   ├── activity.rs           per-slot FSM: Active/Idle debounce, Waiting set/resolve gates, active_ms + tool_call_count
 │   ├── tasks.rs              active_tasks suppression, hook-wins dedup, drains, b1 cascade grace + waiting-clobber pins

--- a/crates/pixtuoid-core/tests/reducer/activity.rs
+++ b/crates/pixtuoid-core/tests/reducer/activity.rs
@@ -547,7 +547,6 @@ fn codex_permission_then_jsonl_output_resumes_to_active() {
     // Regression: a cx· agent stuck Waiting on a permission prompt must return
     // to Active once the transcript's function_call_output (an ActivityStart)
     // arrives. Hook and JSONL coalesce on the session UUID.
-    use pixtuoid_core::source::ToolDetail;
     let mut reducer = Reducer::new();
     let mut scene = SceneState::uniform(4);
     let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1000);
@@ -580,13 +579,12 @@ fn codex_permission_then_jsonl_output_resumes_to_active() {
         "should be Waiting on permission"
     );
 
-    reducer.apply(
+    act_start(
+        &mut reducer,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: None,
-            detail: Some(ToolDetail::from("exec_command")),
-        },
+        id,
+        None,
+        Some("exec_command"),
         now,
         Transport::Jsonl,
     );

--- a/crates/pixtuoid-core/tests/reducer/activity.rs
+++ b/crates/pixtuoid-core/tests/reducer/activity.rs
@@ -6,7 +6,7 @@ use pixtuoid_core::state::reducer::Reducer;
 use pixtuoid_core::state::{ActivityState, SceneState};
 use pixtuoid_core::AgentId;
 
-use crate::start;
+use crate::{act_end, act_start, start, waiting};
 
 #[test]
 fn activity_start_sets_state_active() {
@@ -15,13 +15,12 @@ fn activity_start_sets_state_active() {
     let id = AgentId::from_transcript_path("/p/a.jsonl");
     start(&mut r, &mut scene, id);
 
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t1".into()),
-            detail: Some("Edit: foo.rs".into()),
-        },
+        id,
+        Some("t1"),
+        Some("Edit: foo.rs"),
         SystemTime::now(),
         Transport::Hook,
     );
@@ -43,22 +42,20 @@ fn activity_end_arms_debounce_then_tick_flips_to_idle() {
     let id = AgentId::from_transcript_path("/p/a.jsonl");
     start(&mut r, &mut scene, id);
     let t0 = SystemTime::now();
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t1".into()),
-            detail: None,
-        },
+        id,
+        Some("t1"),
+        None,
         t0,
         Transport::Hook,
     );
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: id,
-            tool_use_id: Some("t1".into()),
-        },
+        id,
+        Some("t1"),
         t0 + Duration::from_millis(100),
         Transport::Hook,
     );
@@ -92,34 +89,31 @@ fn activity_start_inside_grace_window_cancels_debounce() {
     let id = AgentId::from_transcript_path("/p/a.jsonl");
     start(&mut r, &mut scene, id);
     let t0 = SystemTime::now();
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t1".into()),
-            detail: None,
-        },
+        id,
+        Some("t1"),
+        None,
         t0,
         Transport::Hook,
     );
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: id,
-            tool_use_id: Some("t1".into()),
-        },
+        id,
+        Some("t1"),
         t0 + Duration::from_millis(100),
         Transport::Hook,
     );
     assert!(scene.agents.get(&id).unwrap().pending_idle_at.is_some());
     // Second tool starts 200ms later — well inside the grace window.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t2".into()),
-            detail: None,
-        },
+        id,
+        Some("t2"),
+        None,
         t0 + Duration::from_millis(300),
         Transport::Hook,
     );
@@ -144,12 +138,11 @@ fn waiting_sets_state_with_reason() {
     let id = AgentId::from_transcript_path("/p/a.jsonl");
     start(&mut r, &mut scene, id);
 
-    r.apply(
+    waiting(
+        &mut r,
         &mut scene,
-        AgentEvent::Waiting {
-            agent_id: id,
-            reason: "Bash: rm -rf?".into(),
-        },
+        id,
+        "Bash: rm -rf?",
         SystemTime::now(),
         Transport::Hook,
     );
@@ -170,34 +163,31 @@ fn tool_call_count_increments_on_activity_start() {
 
     assert_eq!(scene.agents.get(&id).unwrap().tool_call_count, 0);
 
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t1".into()),
-            detail: None,
-        },
+        id,
+        Some("t1"),
+        None,
         t0,
         Transport::Hook,
     );
     assert_eq!(scene.agents.get(&id).unwrap().tool_call_count, 1);
 
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: id,
-            tool_use_id: Some("t1".into()),
-        },
+        id,
+        Some("t1"),
         t0 + Duration::from_millis(500),
         Transport::Hook,
     );
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t2".into()),
-            detail: None,
-        },
+        id,
+        Some("t2"),
+        None,
         t0 + Duration::from_millis(600),
         Transport::Hook,
     );
@@ -212,13 +202,12 @@ fn active_ms_accumulates_on_state_transitions() {
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
     start(&mut r, &mut scene, id);
 
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t1".into()),
-            detail: None,
-        },
+        id,
+        Some("t1"),
+        None,
         t0,
         Transport::Hook,
     );
@@ -226,15 +215,7 @@ fn active_ms_accumulates_on_state_transitions() {
 
     // End after 1 second, then tick past grace window to flush to Idle
     let t1 = t0 + Duration::from_secs(1);
-    r.apply(
-        &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: id,
-            tool_use_id: Some("t1".into()),
-        },
-        t1,
-        Transport::Hook,
-    );
+    act_end(&mut r, &mut scene, id, Some("t1"), t1, Transport::Hook);
     // active_ms not yet accumulated (happens on next ActivityStart or expire)
     r.tick(&mut scene, t1 + Duration::from_secs(3));
     let slot = scene.agents.get(&id).unwrap();
@@ -253,35 +234,25 @@ fn active_ms_does_not_double_count_on_duplicate_activity_end() {
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
     start(&mut r, &mut scene, id);
 
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t1".into()),
-            detail: None,
-        },
+        id,
+        Some("t1"),
+        None,
         t0,
         Transport::Hook,
     );
 
     let t1 = t0 + Duration::from_secs(2);
     // First ActivityEnd (hook)
-    r.apply(
-        &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: id,
-            tool_use_id: Some("t1".into()),
-        },
-        t1,
-        Transport::Hook,
-    );
+    act_end(&mut r, &mut scene, id, Some("t1"), t1, Transport::Hook);
     // Second ActivityEnd (late JSONL, past dedup window)
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: id,
-            tool_use_id: Some("t1".into()),
-        },
+        id,
+        Some("t1"),
         t1 + Duration::from_millis(600),
         Transport::Jsonl,
     );
@@ -308,13 +279,12 @@ fn active_ms_preserved_when_task_arrives_during_active_tool() {
     start(&mut r, &mut scene, id);
 
     // Tool starts
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t1".into()),
-            detail: None,
-        },
+        id,
+        Some("t1"),
+        None,
         t0,
         Transport::Hook,
     );
@@ -348,27 +318,18 @@ fn active_ms_preserved_when_waiting_interrupts_active() {
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
     start(&mut r, &mut scene, id);
 
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t1".into()),
-            detail: None,
-        },
+        id,
+        Some("t1"),
+        None,
         t0,
         Transport::Hook,
     );
 
     let t1 = t0 + Duration::from_secs(3);
-    r.apply(
-        &mut scene,
-        AgentEvent::Waiting {
-            agent_id: id,
-            reason: "permission".into(),
-        },
-        t1,
-        Transport::Hook,
-    );
+    waiting(&mut r, &mut scene, id, "permission", t1, Transport::Hook);
 
     let slot = scene.agents.get(&id).unwrap();
     assert!(
@@ -395,22 +356,20 @@ fn gated_tool_end_while_waiting_resolves_to_idle_after_grace() {
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
 
     start(&mut r, &mut scene, id);
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t1".into()),
-            detail: None,
-        },
+        id,
+        Some("t1"),
+        None,
         t0,
         Transport::Hook,
     );
-    r.apply(
+    waiting(
+        &mut r,
         &mut scene,
-        AgentEvent::Waiting {
-            agent_id: id,
-            reason: "permission".into(),
-        },
+        id,
+        "permission",
         t0 + Duration::from_millis(500),
         Transport::Hook,
     );
@@ -418,15 +377,7 @@ fn gated_tool_end_while_waiting_resolves_to_idle_after_grace() {
     // The gated tool's own PostToolUse arrives — arms the idle debounce, still
     // visually Waiting for the grace window (no instant flip).
     let end = t0 + Duration::from_millis(1000);
-    r.apply(
-        &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: id,
-            tool_use_id: Some("t1".into()),
-        },
-        end,
-        Transport::Hook,
-    );
+    act_end(&mut r, &mut scene, id, Some("t1"), end, Transport::Hook);
     let slot = scene.agents.get(&id).unwrap();
     assert!(
         matches!(slot.state, ActivityState::Waiting { .. }),
@@ -462,33 +413,30 @@ fn parallel_tool_end_while_waiting_keeps_waiting() {
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
 
     start(&mut r, &mut scene, id);
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t1".into()),
-            detail: None,
-        },
+        id,
+        Some("t1"),
+        None,
         t0,
         Transport::Hook,
     );
-    r.apply(
+    waiting(
+        &mut r,
         &mut scene,
-        AgentEvent::Waiting {
-            agent_id: id,
-            reason: "permission".into(),
-        },
+        id,
+        "permission",
         t0 + Duration::from_millis(500),
         Transport::Hook,
     );
 
     // A different tool ends — must be ignored (its permission isn't this one).
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: id,
-            tool_use_id: Some("t2".into()),
-        },
+        id,
+        Some("t2"),
         t0 + Duration::from_millis(1000),
         Transport::Jsonl,
     );
@@ -531,12 +479,11 @@ fn turn_end_stop_hook_resolves_stale_waiting() {
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
 
     start(&mut r, &mut scene, id);
-    r.apply(
+    waiting(
+        &mut r,
         &mut scene,
-        AgentEvent::Waiting {
-            agent_id: id,
-            reason: "approval needed: bash rm -rf ./build".into(),
-        },
+        id,
+        "approval needed: bash rm -rf ./build",
         t0,
         Transport::Hook,
     );
@@ -547,15 +494,7 @@ fn turn_end_stop_hook_resolves_stale_waiting() {
 
     // Turn ends (denied prompt): Stop → ActivityEnd with no id, Hook transport.
     let end = t0 + Duration::from_millis(800);
-    r.apply(
-        &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: id,
-            tool_use_id: None,
-        },
-        end,
-        Transport::Hook,
-    );
+    act_end(&mut r, &mut scene, id, None, end, Transport::Hook);
     r.tick(
         &mut scene,
         end + ACTIVE_GRACE_WINDOW + Duration::from_millis(100),
@@ -580,22 +519,13 @@ fn jsonl_none_id_end_while_waiting_keeps_waiting() {
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
 
     start(&mut r, &mut scene, id);
-    r.apply(
-        &mut scene,
-        AgentEvent::Waiting {
-            agent_id: id,
-            reason: "permission".into(),
-        },
-        t0,
-        Transport::Hook,
-    );
+    waiting(&mut r, &mut scene, id, "permission", t0, Transport::Hook);
     // A late rollout line for the PREVIOUS tool races in after the prompt.
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: id,
-            tool_use_id: None,
-        },
+        id,
+        None,
         t0 + Duration::from_millis(200),
         Transport::Jsonl,
     );
@@ -637,12 +567,11 @@ fn codex_permission_then_jsonl_output_resumes_to_active() {
         Transport::Hook,
     );
 
-    reducer.apply(
+    waiting(
+        &mut reducer,
         &mut scene,
-        AgentEvent::Waiting {
-            agent_id: id,
-            reason: "permission".into(),
-        },
+        id,
+        "permission",
         now,
         Transport::Hook,
     );

--- a/crates/pixtuoid-core/tests/reducer/child_ledger.rs
+++ b/crates/pixtuoid-core/tests/reducer/child_ledger.rs
@@ -8,7 +8,7 @@ use pixtuoid_core::state::reducer::{
 use pixtuoid_core::state::SceneState;
 use pixtuoid_core::AgentId;
 
-use crate::start;
+use crate::{act_end, act_start, sess_end, start};
 
 #[test]
 fn hook_session_end_tombstone_blocks_reordered_trailing_event_synthesis() {
@@ -24,22 +24,13 @@ fn hook_session_end_tombstone_blocks_reordered_trailing_event_synthesis() {
     let other = AgentId::from_parts("claude-code", "still-alive");
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
 
-    r.apply(
-        &mut scene,
-        AgentEvent::SessionEnd {
-            agent_id: id,
-            as_child: false,
-        },
-        t0,
-        Transport::Hook,
-    );
+    sess_end(&mut r, &mut scene, id, false, t0, Transport::Hook);
     // The straggler lands shortly after — within the tombstone TTL.
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: id,
-            tool_use_id: None,
-        },
+        id,
+        None,
         t0 + Duration::from_millis(50),
         Transport::Hook,
     );
@@ -50,12 +41,11 @@ fn hook_session_end_tombstone_blocks_reordered_trailing_event_synthesis() {
 
     // Control: a DIFFERENT id is untouched by the tombstone — hook proof of
     // life still synthesizes for it.
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: other,
-            tool_use_id: None,
-        },
+        other,
+        None,
         t0 + Duration::from_millis(50),
         Transport::Hook,
     );
@@ -75,22 +65,13 @@ fn hook_event_after_tombstone_ttl_synthesizes_again() {
     let id = AgentId::from_parts("claude-code", "revived-later");
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
 
-    r.apply(
+    sess_end(&mut r, &mut scene, id, false, t0, Transport::Hook);
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::SessionEnd {
-            agent_id: id,
-            as_child: false,
-        },
-        t0,
-        Transport::Hook,
-    );
-    r.apply(
-        &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t1".into()),
-            detail: None,
-        },
+        id,
+        Some("t1"),
+        None,
         t0 + HOOK_SESSION_END_TOMBSTONE_TTL + Duration::from_secs(1),
         Transport::Hook,
     );
@@ -117,15 +98,7 @@ fn jsonl_child_session_start_within_tombstone_is_gated_too() {
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
 
     start(&mut r, &mut scene, parent);
-    r.apply(
-        &mut scene,
-        AgentEvent::SessionEnd {
-            agent_id: child,
-            as_child: true,
-        },
-        t0,
-        Transport::Hook,
-    );
+    sess_end(&mut r, &mut scene, child, true, t0, Transport::Hook);
     // The watcher's first-sight emission for the child's transcript lands
     // within the TTL.
     r.apply(
@@ -161,15 +134,7 @@ fn non_child_session_end_tombstone_alone_gates_a_parented_start() {
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
 
     start(&mut r, &mut scene, parent);
-    r.apply(
-        &mut scene,
-        AgentEvent::SessionEnd {
-            agent_id: child,
-            as_child: false,
-        },
-        t0,
-        Transport::Hook,
-    );
+    sess_end(&mut r, &mut scene, child, false, t0, Transport::Hook);
     r.apply(
         &mut scene,
         AgentEvent::SessionStart {
@@ -205,15 +170,7 @@ fn child_session_start_past_tombstone_ttl_registers() {
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
 
     start(&mut r, &mut scene, parent);
-    r.apply(
-        &mut scene,
-        AgentEvent::SessionEnd {
-            agent_id: child,
-            as_child: true,
-        },
-        t0,
-        Transport::Hook,
-    );
+    sess_end(&mut r, &mut scene, child, true, t0, Transport::Hook);
     r.apply(
         &mut scene,
         AgentEvent::SessionStart {
@@ -245,15 +202,7 @@ fn tombstoned_parentless_session_start_still_registers() {
     let id = AgentId::from_parts("reasonix", "/Users/dev/proj");
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
 
-    r.apply(
-        &mut scene,
-        AgentEvent::SessionEnd {
-            agent_id: id,
-            as_child: false,
-        },
-        t0,
-        Transport::Hook,
-    );
+    sess_end(&mut r, &mut scene, id, false, t0, Transport::Hook);
     r.apply(
         &mut scene,
         AgentEvent::SessionStart {
@@ -537,12 +486,11 @@ fn parentless_session_start_enriching_a_parentless_child_slot_adopts_ledger_pare
         t0 + Duration::from_secs(1),
         Transport::Hook,
     );
-    r.apply(
+    sess_end(
+        &mut r,
         &mut scene,
-        AgentEvent::SessionEnd {
-            agent_id: child,
-            as_child: true,
-        },
+        child,
+        true,
         t0 + Duration::from_secs(2),
         Transport::Hook,
     );
@@ -553,13 +501,12 @@ fn parentless_session_start_enriching_a_parentless_child_slot_adopts_ledger_pare
     // The hook straggler at +10s (inside the 90s ledger window, no #242
     // tombstone — the end had a slot) re-registers the child PARENTLESS via
     // hook synthesis.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: child,
-            tool_use_id: Some("t-straggler".into()),
-            detail: None,
-        },
+        child,
+        Some("t-straggler"),
+        None,
         gone + Duration::from_secs(10),
         Transport::Hook,
     );
@@ -704,12 +651,11 @@ fn adopted_ledger_parent_still_runs_the_cycle_filter() {
         t0 + Duration::from_secs(1),
         Transport::Hook,
     );
-    r.apply(
+    sess_end(
+        &mut r,
         &mut scene,
-        AgentEvent::SessionEnd {
-            agent_id: x,
-            as_child: true,
-        },
+        x,
+        true,
         t0 + Duration::from_secs(2),
         Transport::Hook,
     );
@@ -775,23 +721,21 @@ fn reasonix_resurrect_is_unaffected_by_a_ledger_entry_for_another_id() {
         t0,
         Transport::Hook,
     );
-    r.apply(
+    sess_end(
+        &mut r,
         &mut scene,
-        AgentEvent::SessionEnd {
-            agent_id: codex_child,
-            as_child: true,
-        },
+        codex_child,
+        true,
         t0 + Duration::from_secs(1),
         Transport::Hook,
     );
 
     // The Reasonix `/new` rotation, inside every ledger/tombstone window.
-    r.apply(
+    sess_end(
+        &mut r,
         &mut scene,
-        AgentEvent::SessionEnd {
-            agent_id: rx,
-            as_child: false,
-        },
+        rx,
+        false,
         t0 + Duration::from_secs(2),
         Transport::Hook,
     );

--- a/crates/pixtuoid-core/tests/reducer/display.rs
+++ b/crates/pixtuoid-core/tests/reducer/display.rs
@@ -6,7 +6,7 @@ use pixtuoid_core::state::reducer::Reducer;
 use pixtuoid_core::state::SceneState;
 use pixtuoid_core::AgentId;
 
-use crate::start;
+use crate::{act_start, sess_end, start};
 
 #[test]
 fn session_start_with_cwd_derives_label_from_basename() {
@@ -81,13 +81,12 @@ fn session_start_label_caps_a_pathologically_long_cwd_basename() {
     // The sibling mint site: a blank hook-synthesized slot whose fallback
     // label the duplicate-SessionStart backfill upgrades (explicitly capped).
     let upgraded = AgentId::from_transcript_path("/p/upgraded.jsonl");
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: upgraded,
-            tool_use_id: Some("t-1".into()),
-            detail: Some("Bash: ls".into()),
-        },
+        upgraded,
+        Some("t-1"),
+        Some("Bash: ls"),
         t0,
         Transport::Hook,
     );
@@ -202,15 +201,7 @@ fn capacity_dropped_unknown_cwd_session_consumes_no_ghost_ordinal() {
 
     // Free the desk, then a NEW unknown-cwd session is the FIRST ghost: cc#1,
     // not cc#2 — the dropped one consumed no ordinal.
-    r.apply(
-        &mut scene,
-        AgentEvent::SessionEnd {
-            agent_id: occupant,
-            as_child: false,
-        },
-        t0,
-        Transport::Hook,
-    );
+    sess_end(&mut r, &mut scene, occupant, false, t0, Transport::Hook);
     r.tick(&mut scene, t0 + EXIT_GRACE_WINDOW + Duration::from_secs(1));
     assert!(!scene.agents.contains_key(&occupant), "occupant reaped");
 

--- a/crates/pixtuoid-core/tests/reducer/lifecycle.rs
+++ b/crates/pixtuoid-core/tests/reducer/lifecycle.rs
@@ -6,7 +6,7 @@ use pixtuoid_core::state::reducer::{Reducer, B1_CASCADE_GRACE};
 use pixtuoid_core::state::{ActivityState, GlobalDeskIndex, SceneState};
 use pixtuoid_core::AgentId;
 
-use crate::{delegating_pair, start};
+use crate::{act_end, act_start, delegating_pair, sess_end, start, waiting};
 
 #[test]
 fn session_start_creates_idle_slot_at_first_free_desk() {
@@ -47,15 +47,7 @@ fn session_end_marks_slot_exiting_then_tick_removes_it_after_grace() {
     start(&mut r, &mut scene, b);
 
     let t0 = SystemTime::now();
-    r.apply(
-        &mut scene,
-        AgentEvent::SessionEnd {
-            agent_id: a,
-            as_child: false,
-        },
-        t0,
-        Transport::Hook,
-    );
+    sess_end(&mut r, &mut scene, a, false, t0, Transport::Hook);
 
     let slot = scene
         .agents
@@ -172,15 +164,7 @@ fn session_start_on_exiting_slot_resurrects_in_place() {
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
 
     start(&mut r, &mut scene, id);
-    r.apply(
-        &mut scene,
-        AgentEvent::SessionEnd {
-            agent_id: id,
-            as_child: false,
-        },
-        t0,
-        Transport::Hook,
-    );
+    sess_end(&mut r, &mut scene, id, false, t0, Transport::Hook);
     assert!(scene.agents.get(&id).unwrap().exiting_at.is_some());
 
     // The rotation's SessionStart lands ms later (same cwd → same id).
@@ -202,13 +186,12 @@ fn session_start_on_exiting_slot_resurrects_in_place() {
     );
 
     // The new session's first turn works — and survives past the old grace.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: None,
-            detail: None,
-        },
+        id,
+        None,
+        None,
         t0 + Duration::from_millis(500),
         Transport::Hook,
     );
@@ -233,25 +216,8 @@ fn resurrect_in_place_folds_the_active_span_into_active_ms() {
     start(&mut r, &mut scene, id);
     // Go Active and hold the span open across the exit (mark_exiting leaves the
     // slot Active; no tick settles it).
-    r.apply(
-        &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: None,
-            detail: None,
-        },
-        t0,
-        Transport::Hook,
-    );
-    r.apply(
-        &mut scene,
-        AgentEvent::SessionEnd {
-            agent_id: id,
-            as_child: false,
-        },
-        t0,
-        Transport::Hook,
-    );
+    act_start(&mut r, &mut scene, id, None, None, t0, Transport::Hook);
+    sess_end(&mut r, &mut scene, id, false, t0, Transport::Hook);
     assert_eq!(
         scene.agents.get(&id).unwrap().active_ms,
         0,
@@ -319,12 +285,11 @@ fn session_start_on_exiting_subagent_does_not_resurrect() {
     );
 
     // Parent ends → cascade marks the child exiting.
-    r.apply(
+    sess_end(
+        &mut r,
         &mut scene,
-        AgentEvent::SessionEnd {
-            agent_id: parent,
-            as_child: false,
-        },
+        parent,
+        false,
         t0 + Duration::from_secs(1),
         Transport::Hook,
     );
@@ -391,13 +356,12 @@ fn duplicate_root_session_start_does_not_resurrect_a_live_session() {
         Transport::Hook,
     );
     // Drive it Active — a live, in-flight session that is NEVER exiting.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: root,
-            tool_use_id: Some("t1".into()),
-            detail: Some("Edit: foo.rs".into()),
-        },
+        root,
+        Some("t1"),
+        Some("Edit: foo.rs"),
         t0 + Duration::from_secs(1),
         Transport::Hook,
     );
@@ -456,22 +420,20 @@ fn resurrect_in_place_clears_stale_active_tasks_so_fresh_session_hooks_apply() {
         Transport::Hook,
     );
     // The old life dispatches a Task… and dies before it drains.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("task-stale".into()),
-            detail: Some("Agent".into()),
-        },
+        id,
+        Some("task-stale"),
+        Some("Agent"),
         t0 + Duration::from_secs(1),
         Transport::Hook,
     );
-    r.apply(
+    sess_end(
+        &mut r,
         &mut scene,
-        AgentEvent::SessionEnd {
-            agent_id: id,
-            as_child: false,
-        },
+        id,
+        false,
         t0 + Duration::from_secs(2),
         Transport::Hook,
     );
@@ -495,13 +457,12 @@ fn resurrect_in_place_clears_stale_active_tasks_so_fresh_session_hooks_apply() {
 
     // The fresh life's first hook tool: with the stale tuid still tracked it
     // would be suppressed as a subagent leak and the slot would stay Idle.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t-new".into()),
-            detail: Some("Read: /x".into()),
-        },
+        id,
+        Some("t-new"),
+        Some("Read: /x"),
         t0 + Duration::from_secs(3),
         Transport::Hook,
     );
@@ -543,33 +504,30 @@ fn resurrect_in_place_cancels_stale_pending_b1_cascade() {
         Transport::Hook,
     );
     // Old life: a Task dispatch drains → the deferred b1 cascade is armed.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("task-old".into()),
-            detail: Some("Agent".into()),
-        },
+        parent,
+        Some("task-old"),
+        Some("Agent"),
         t0 + Duration::from_secs(1),
         Transport::Hook,
     );
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: parent,
-            tool_use_id: Some("task-old".into()),
-        },
+        parent,
+        Some("task-old"),
         t0 + Duration::from_secs(2),
         Transport::Hook,
     );
     // The old life ends and the next session resurrects in place, all inside
     // the armed cascade's grace.
-    r.apply(
+    sess_end(
+        &mut r,
         &mut scene,
-        AgentEvent::SessionEnd {
-            agent_id: parent,
-            as_child: false,
-        },
+        parent,
+        false,
         t0 + Duration::from_millis(2_200),
         Transport::Hook,
     );
@@ -735,15 +693,7 @@ fn codex_subagent_cascades_with_parent_on_session_end() {
     codex_session_start(&mut r, &mut scene, parent, None, Transport::Hook);
     codex_session_start(&mut r, &mut scene, child, Some(parent), Transport::Hook);
 
-    r.apply(
-        &mut scene,
-        AgentEvent::SessionEnd {
-            agent_id: parent,
-            as_child: false,
-        },
-        now,
-        Transport::Hook,
-    );
+    sess_end(&mut r, &mut scene, parent, false, now, Transport::Hook);
     assert!(
         scene.agents.get(&parent).unwrap().exiting_at.is_some(),
         "parent should be exiting"
@@ -770,13 +720,12 @@ fn hook_activity_start_for_unknown_id_synthesizes_slot_and_goes_active() {
     let id = AgentId::from_parts("claude-code", "gated-sess");
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
 
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t1".into()),
-            detail: Some("Edit: foo.rs".into()),
-        },
+        id,
+        Some("t1"),
+        Some("Edit: foo.rs"),
         t0,
         Transport::Hook,
     );
@@ -806,15 +755,7 @@ fn hook_waiting_for_unknown_id_synthesizes_slot_in_waiting_state() {
     let id = AgentId::from_parts("claude-code", "parked-sess");
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
 
-    r.apply(
-        &mut scene,
-        AgentEvent::Waiting {
-            agent_id: id,
-            reason: "permission".into(),
-        },
-        t0,
-        Transport::Hook,
-    );
+    waiting(&mut r, &mut scene, id, "permission", t0, Transport::Hook);
 
     let slot = scene
         .agents
@@ -836,25 +777,16 @@ fn jsonl_event_for_unknown_id_stays_a_no_op() {
     let id = AgentId::from_parts("claude-code", "replayed-sess");
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
 
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t1".into()),
-            detail: None,
-        },
+        id,
+        Some("t1"),
+        None,
         t0,
         Transport::Jsonl,
     );
-    r.apply(
-        &mut scene,
-        AgentEvent::Waiting {
-            agent_id: id,
-            reason: "perm".into(),
-        },
-        t0,
-        Transport::Jsonl,
-    );
+    waiting(&mut r, &mut scene, id, "perm", t0, Transport::Jsonl);
 
     assert!(
         scene.agents.is_empty(),
@@ -871,15 +803,7 @@ fn hook_session_end_for_unknown_id_does_not_create_slot() {
     let id = AgentId::from_parts("claude-code", "already-gone");
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
 
-    r.apply(
-        &mut scene,
-        AgentEvent::SessionEnd {
-            agent_id: id,
-            as_child: false,
-        },
-        t0,
-        Transport::Hook,
-    );
+    sess_end(&mut r, &mut scene, id, false, t0, Transport::Hook);
 
     assert!(scene.agents.is_empty(), "SessionEnd must not synthesize");
 }
@@ -894,13 +818,12 @@ fn jsonl_session_start_after_hook_synthesis_coalesces_into_same_slot() {
     let id = AgentId::from_parts("claude-code", "revived-sess");
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
 
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t1".into()),
-            detail: None,
-        },
+        id,
+        Some("t1"),
+        None,
         t0,
         Transport::Hook,
     );
@@ -941,15 +864,7 @@ fn hook_synthesized_slot_is_exempt_from_unknown_cwd_reap() {
     let id = AgentId::from_parts("claude-code", "parked-sess");
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
 
-    r.apply(
-        &mut scene,
-        AgentEvent::Waiting {
-            agent_id: id,
-            reason: "permission".into(),
-        },
-        t0,
-        Transport::Hook,
-    );
+    waiting(&mut r, &mut scene, id, "permission", t0, Transport::Hook);
     assert!(
         !scene.agents.get(&id).expect("synthesized").unknown_cwd,
         "process-proven slot must not carry the startup-ghost flag"
@@ -997,27 +912,18 @@ fn refused_hook_registration_does_not_poison_dedup_for_the_later_jsonl_copy() {
         t0,
         Transport::Hook,
     );
-    r.apply(
-        &mut scene,
-        AgentEvent::SessionEnd {
-            agent_id: occupant,
-            as_child: false,
-        },
-        t0,
-        Transport::Hook,
-    );
+    sess_end(&mut r, &mut scene, occupant, false, t0, Transport::Hook);
 
     // Hook ActivityStart for an unknown session while the desk is still held:
     // synthesis is refused. Sanity: no slot was created.
     let id = AgentId::from_parts("claude-code", "gated-sess");
     let th = t0 + EXIT_GRACE_WINDOW - Duration::from_millis(100);
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t9".into()),
-            detail: None,
-        },
+        id,
+        Some("t9"),
+        None,
         th,
         Transport::Hook,
     );
@@ -1041,13 +947,12 @@ fn refused_hook_registration_does_not_poison_dedup_for_the_later_jsonl_copy() {
         tj,
         Transport::Jsonl,
     );
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t9".into()),
-            detail: None,
-        },
+        id,
+        Some("t9"),
+        None,
         tj,
         Transport::Jsonl,
     );
@@ -1076,13 +981,12 @@ fn duplicate_session_start_backfills_hook_synthesized_slot() {
     let id = AgentId::from_parts("claude-code", "gated-sess");
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
 
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t1".into()),
-            detail: None,
-        },
+        id,
+        Some("t1"),
+        None,
         t0,
         Transport::Hook,
     );
@@ -1198,13 +1102,12 @@ fn backfill_does_not_clobber_a_renamed_label() {
     let id = AgentId::from_parts("claude-code", "gated-sess");
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
 
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t1".into()),
-            detail: None,
-        },
+        id,
+        Some("t1"),
+        None,
         t0,
         Transport::Hook,
     );
@@ -1251,15 +1154,7 @@ fn two_step_backfill_source_first_then_cwd_still_upgrades_the_label() {
     let id = AgentId::from_parts("claude-code", "gated-sess");
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
 
-    r.apply(
-        &mut scene,
-        AgentEvent::Waiting {
-            agent_id: id,
-            reason: "permission".into(),
-        },
-        t0,
-        Transport::Hook,
-    );
+    waiting(&mut r, &mut scene, id, "permission", t0, Transport::Hook);
     r.apply(
         &mut scene,
         AgentEvent::SessionStart {
@@ -1435,12 +1330,11 @@ fn hook_identity_on_existing_unknown_cwd_slot_clears_ghost_reap() {
         t0 + Duration::from_secs(1),
         Transport::Hook,
     );
-    r.apply(
+    waiting(
+        &mut r,
         &mut scene,
-        AgentEvent::Waiting {
-            agent_id: id,
-            reason: "permission".into(),
-        },
+        id,
+        "permission",
         t0 + Duration::from_secs(1),
         Transport::Hook,
     );
@@ -1473,15 +1367,7 @@ fn hook_identity_backfills_blank_synthesized_slot() {
     let id = AgentId::from_parts("reasonix", "/Users/dev/proj");
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
 
-    r.apply(
-        &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: id,
-            tool_use_id: None,
-        },
-        t0,
-        Transport::Hook,
-    );
+    act_end(&mut r, &mut scene, id, None, t0, Transport::Hook);
     assert_eq!(&*scene.agents.get(&id).unwrap().label, "#1", "blank slot");
 
     r.apply(
@@ -1557,15 +1443,7 @@ fn hook_identity_respects_session_end_tombstone() {
     let id = AgentId::from_parts("claude-code", "exited-invisible");
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
 
-    r.apply(
-        &mut scene,
-        AgentEvent::SessionEnd {
-            agent_id: id,
-            as_child: false,
-        },
-        t0,
-        Transport::Hook,
-    );
+    sess_end(&mut r, &mut scene, id, false, t0, Transport::Hook);
     r.apply(
         &mut scene,
         AgentEvent::Identity {
@@ -1717,13 +1595,12 @@ fn reconcile_connected_evicts_a_blank_source_gate_slipper() {
     let blank = AgentId::from_transcript_path("/p/blank.jsonl");
 
     // An identity-less Hook ActivityStart for an unknown id → blank-source slot.
-    reducer.apply(
+    act_start(
+        &mut reducer,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: blank,
-            tool_use_id: None,
-            detail: None,
-        },
+        blank,
+        None,
+        None,
         now,
         Transport::Hook,
     );

--- a/crates/pixtuoid-core/tests/reducer/liveness.rs
+++ b/crates/pixtuoid-core/tests/reducer/liveness.rs
@@ -6,7 +6,7 @@ use pixtuoid_core::state::reducer::Reducer;
 use pixtuoid_core::state::SceneState;
 use pixtuoid_core::AgentId;
 
-use crate::delegating_pair;
+use crate::{act_end, act_start, delegating_pair, proof_of_life, sess_end, waiting};
 
 // --- stale-agent sweep ---------------------------------------------------
 
@@ -104,15 +104,7 @@ fn exit_gc_spares_a_slot_at_exactly_the_grace_window() {
         t0,
         Transport::Hook,
     );
-    reducer.apply(
-        &mut scene,
-        AgentEvent::SessionEnd {
-            agent_id: id,
-            as_child: false,
-        },
-        t0,
-        Transport::Hook,
-    );
+    sess_end(&mut reducer, &mut scene, id, false, t0, Transport::Hook);
     assert!(scene.agents.get(&id).unwrap().exiting_at.is_some());
     reducer.tick(&mut scene, t0 + EXIT_GRACE_WINDOW);
     assert!(
@@ -150,13 +142,12 @@ fn stale_active_agent_uses_shorter_timeout_than_idle() {
         t0,
         Transport::Hook,
     );
-    reducer.apply(
+    act_start(
+        &mut reducer,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t".into()),
-            detail: None,
-        },
+        id,
+        Some("t"),
+        None,
         t0,
         Transport::Hook,
     );
@@ -251,26 +242,12 @@ fn proof_of_life_exempts_active_slot_from_stale_sweep() {
         t0,
         Transport::Hook,
     );
-    r.apply(
-        &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t".into()),
-            detail: None,
-        },
-        t0,
-        Transport::Hook,
-    );
+    act_start(&mut r, &mut scene, id, Some("t"), None, t0, Transport::Hook);
 
     // The watcher re-vouches every ~60s, so by the time the slot crosses the
     // Active threshold a fresh ProofOfLife has landed well inside the TTL.
     let vouch_at = t0 + STALE_ACTIVE_TIMEOUT;
-    r.apply(
-        &mut scene,
-        AgentEvent::ProofOfLife { agent_id: id },
-        vouch_at,
-        Transport::Jsonl,
-    );
+    proof_of_life(&mut r, &mut scene, id, vouch_at, Transport::Jsonl);
 
     // Past the Active threshold (measured from last_event_at = t0) but inside
     // the vouch TTL: without the exemption this sweep reaps the slot (pinned
@@ -304,25 +281,11 @@ fn proof_of_life_lapse_restores_normal_sweep() {
         t0,
         Transport::Hook,
     );
-    r.apply(
-        &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t".into()),
-            detail: None,
-        },
-        t0,
-        Transport::Hook,
-    );
+    act_start(&mut r, &mut scene, id, Some("t"), None, t0, Transport::Hook);
 
     // Last vouch lands mid-window (the process then exits: emissions stop).
     let vouch_at = t0 + STALE_ACTIVE_TIMEOUT - Duration::from_secs(100);
-    r.apply(
-        &mut scene,
-        AgentEvent::ProofOfLife { agent_id: id },
-        vouch_at,
-        Transport::Jsonl,
-    );
+    proof_of_life(&mut r, &mut scene, id, vouch_at, Transport::Jsonl);
 
     // Inside the TTL the slot is exempt — also pins that ProofOfLife did NOT
     // refresh last_event_at (the slot is past the Active threshold here).
@@ -349,12 +312,7 @@ fn proof_of_life_for_unknown_id_is_a_no_op() {
     let mut r = Reducer::new();
     let id = AgentId::from_transcript_path("/p/pol-unknown.jsonl");
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
-    r.apply(
-        &mut scene,
-        AgentEvent::ProofOfLife { agent_id: id },
-        t0,
-        Transport::Jsonl,
-    );
+    proof_of_life(&mut r, &mut scene, id, t0, Transport::Jsonl);
     assert!(
         scene.agents.is_empty(),
         "ProofOfLife must never create a slot — only hook tool/permission events synthesize"
@@ -379,31 +337,23 @@ fn proof_of_life_does_not_touch_activity_state() {
         t0,
         Transport::Hook,
     );
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t1".into()),
-            detail: Some("Edit: foo.rs".into()),
-        },
+        id,
+        Some("t1"),
+        Some("Edit: foo.rs"),
         t0,
         Transport::Hook,
     );
     // Arm the idle debounce — ProofOfLife must not cancel or re-arm it.
-    r.apply(
-        &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: id,
-            tool_use_id: Some("t1".into()),
-        },
-        t0,
-        Transport::Hook,
-    );
+    act_end(&mut r, &mut scene, id, Some("t1"), t0, Transport::Hook);
     let before = scene.agents.get(&id).unwrap().clone();
 
-    r.apply(
+    proof_of_life(
+        &mut r,
         &mut scene,
-        AgentEvent::ProofOfLife { agent_id: id },
+        id,
         t0 + Duration::from_millis(100),
         Transport::Jsonl,
     );
@@ -441,20 +391,14 @@ fn proof_of_life_does_not_block_session_end() {
         t0,
         Transport::Hook,
     );
-    r.apply(
-        &mut scene,
-        AgentEvent::ProofOfLife { agent_id: id },
-        t0,
-        Transport::Jsonl,
-    );
+    proof_of_life(&mut r, &mut scene, id, t0, Transport::Jsonl);
     // A real exit still removes promptly: SessionEnd marks exiting despite the
     // fresh vouch, and the grace GC reclaims the slot on schedule.
-    r.apply(
+    sess_end(
+        &mut r,
         &mut scene,
-        AgentEvent::SessionEnd {
-            agent_id: id,
-            as_child: false,
-        },
+        id,
+        false,
         t0 + Duration::from_secs(1),
         Transport::Hook,
     );
@@ -499,12 +443,7 @@ fn codex_vouched_idle_slot_outlives_short_idle_reap() {
         );
     }
     let vouch_at = t0 + STALE_SHORT_IDLE_TIMEOUT - Duration::from_secs(100);
-    r.apply(
-        &mut scene,
-        AgentEvent::ProofOfLife { agent_id: vouched },
-        vouch_at,
-        Transport::Jsonl,
-    );
+    proof_of_life(&mut r, &mut scene, vouched, vouch_at, Transport::Jsonl);
 
     let sweep_at = t0 + STALE_SHORT_IDLE_TIMEOUT + Duration::from_secs(1);
     assert!(sweep_at.duration_since(vouch_at).unwrap() < PROOF_OF_LIFE_TTL);
@@ -551,35 +490,32 @@ fn proof_of_life_on_delegating_parent_shields_its_active_subtree() {
         Transport::Jsonl,
     );
     // Parent dispatches a Task → active_tasks[parent] non-empty (delegating).
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("task-T".into()),
-            detail: Some("Agent".into()),
-        },
+        parent,
+        Some("task-T"),
+        Some("Agent"),
         t0 + Duration::from_secs(1),
         Transport::Hook,
     );
     // Child + grandchild go Active via their own JSONL, then fall silent
     // (blocked behind the parent's permission prompt).
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: child,
-            tool_use_id: Some("c1".into()),
-            detail: Some("Read: /x".into()),
-        },
+        child,
+        Some("c1"),
+        Some("Read: /x"),
         t0 + Duration::from_secs(2),
         Transport::Jsonl,
     );
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: grandchild,
-            tool_use_id: Some("g1".into()),
-            detail: Some("Read: /y".into()),
-        },
+        grandchild,
+        Some("g1"),
+        Some("Read: /y"),
         t0 + Duration::from_secs(3),
         Transport::Jsonl,
     );
@@ -587,12 +523,7 @@ fn proof_of_life_on_delegating_parent_shields_its_active_subtree() {
     // The probe re-vouches the PARENT only, well past the subtree's Active
     // threshold (the watcher re-emits every ~60s, so the vouch is fresh).
     let vouch_at = t0 + STALE_ACTIVE_TIMEOUT + Duration::from_secs(60);
-    r.apply(
-        &mut scene,
-        AgentEvent::ProofOfLife { agent_id: parent },
-        vouch_at,
-        Transport::Jsonl,
-    );
+    proof_of_life(&mut r, &mut scene, parent, vouch_at, Transport::Jsonl);
 
     let sweep_at = vouch_at + Duration::from_secs(1);
     assert!(sweep_at.duration_since(vouch_at).unwrap() < PROOF_OF_LIFE_TTL);
@@ -621,35 +552,28 @@ fn vouch_lapse_restores_subtree_sweep() {
     let mut r = Reducer::new();
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
     let (parent, child) = delegating_pair(&mut r, &mut scene, "pol-lapse-tree", t0);
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("task-T".into()),
-            detail: Some("Agent".into()),
-        },
+        parent,
+        Some("task-T"),
+        Some("Agent"),
         t0 + Duration::from_secs(1),
         Transport::Hook,
     );
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: child,
-            tool_use_id: Some("c1".into()),
-            detail: Some("Read: /x".into()),
-        },
+        child,
+        Some("c1"),
+        Some("Read: /x"),
         t0 + Duration::from_secs(2),
         Transport::Jsonl,
     );
 
     // Last vouch lands mid-window; the process then exits — emissions stop.
     let vouch_at = t0 + STALE_ACTIVE_TIMEOUT - Duration::from_secs(100);
-    r.apply(
-        &mut scene,
-        AgentEvent::ProofOfLife { agent_id: parent },
-        vouch_at,
-        Transport::Jsonl,
-    );
+    proof_of_life(&mut r, &mut scene, parent, vouch_at, Transport::Jsonl);
 
     let lapsed_at = vouch_at + PROOF_OF_LIFE_TTL + Duration::from_secs(1);
     r.tick(&mut scene, lapsed_at);
@@ -677,12 +601,7 @@ fn vouched_idle_parent_without_tasks_does_not_shield_idle_child() {
     // NO Task dispatch: active_tasks[parent] stays empty; both slots sit Idle.
 
     let vouch_at = t0 + STALE_IDLE_TIMEOUT + Duration::from_secs(60);
-    r.apply(
-        &mut scene,
-        AgentEvent::ProofOfLife { agent_id: parent },
-        vouch_at,
-        Transport::Jsonl,
-    );
+    proof_of_life(&mut r, &mut scene, parent, vouch_at, Transport::Jsonl);
 
     let sweep_at = vouch_at + Duration::from_secs(1);
     assert!(sweep_at.duration_since(vouch_at).unwrap() < PROOF_OF_LIFE_TTL);
@@ -719,12 +638,11 @@ fn fresh_event_resets_stale_timer() {
 
     // At 29 min (just before 30 min idle threshold), send a new event.
     let almost = t0 + STALE_IDLE_TIMEOUT - Duration::from_secs(60);
-    reducer.apply(
+    waiting(
+        &mut reducer,
         &mut scene,
-        AgentEvent::Waiting {
-            agent_id: id,
-            reason: "perm".into(),
-        },
+        id,
+        "perm",
         almost,
         Transport::Hook,
     );
@@ -868,12 +786,11 @@ fn session_end_cascades_to_children() {
     );
     assert!(scene.agents.get(&child).unwrap().exiting_at.is_none());
 
-    r.apply(
+    sess_end(
+        &mut r,
         &mut scene,
-        AgentEvent::SessionEnd {
-            agent_id: parent,
-            as_child: false,
-        },
+        parent,
+        false,
         t0 + Duration::from_secs(10),
         Transport::Hook,
     );
@@ -933,12 +850,11 @@ fn session_end_cascades_to_grandchildren() {
         Transport::Jsonl,
     );
 
-    r.apply(
+    sess_end(
+        &mut r,
         &mut scene,
-        AgentEvent::SessionEnd {
-            agent_id: grandparent,
-            as_child: false,
-        },
+        grandparent,
+        false,
         t0 + Duration::from_secs(10),
         Transport::Hook,
     );
@@ -999,12 +915,11 @@ fn session_end_cascade_marks_all_descendants_exiting() {
     assert!(scene.agents.get(&child_a).unwrap().exiting_at.is_none());
     assert!(scene.agents.get(&child_b).unwrap().exiting_at.is_none());
 
-    r.apply(
+    sess_end(
+        &mut r,
         &mut scene,
-        AgentEvent::SessionEnd {
-            agent_id: parent,
-            as_child: false,
-        },
+        parent,
+        false,
         t0 + Duration::from_secs(5),
         Transport::Hook,
     );
@@ -1356,13 +1271,12 @@ fn long_delegation_keeps_parent_and_live_subagent_alive() {
 
     // Parent delegates one long Task → Active{Delegating}. The Task-start arm
     // does NOT bump last_event_at, so the parent's liveness is frozen at t0.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("task-T".into()),
-            detail: Some("Agent".into()),
-        },
+        parent,
+        Some("task-T"),
+        Some("Agent"),
         t0 + Duration::from_secs(1),
         Transport::Hook,
     );
@@ -1370,13 +1284,12 @@ fn long_delegation_keeps_parent_and_live_subagent_alive() {
     // The subagent works for ~9 min; each tool call is a hook event CC
     // misattributes to the parent's AgentId, so the reducer suppresses it.
     for (mins, tuid) in [(5u64, "sub-R1"), (9u64, "sub-R2")] {
-        r.apply(
+        act_start(
+            &mut r,
             &mut scene,
-            AgentEvent::ActivityStart {
-                agent_id: parent,
-                tool_use_id: Some(tuid.into()),
-                detail: Some("Read: /x".into()),
-            },
+            parent,
+            Some(tuid),
+            Some("Read: /x"),
             t0 + Duration::from_secs(mins * 60),
             Transport::Hook,
         );
@@ -1440,23 +1353,21 @@ fn stale_sweep_spares_subagent_blocked_under_a_waiting_parent() {
         Transport::Jsonl,
     );
     // Subagent runs a tool → Active (10-min stale timeout).
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: child,
-            tool_use_id: Some("c-tool".into()),
-            detail: Some("WebFetch: /x".into()),
-        },
+        child,
+        Some("c-tool"),
+        Some("WebFetch: /x"),
         t0 + Duration::from_secs(1),
         Transport::Jsonl,
     );
     // That tool needs permission → CC's Notification hook lands on the PARENT.
-    r.apply(
+    waiting(
+        &mut r,
         &mut scene,
-        AgentEvent::Waiting {
-            agent_id: parent,
-            reason: "permission?".into(),
-        },
+        parent,
+        "permission?",
         t0 + Duration::from_secs(2),
         Transport::Hook,
     );
@@ -1527,23 +1438,21 @@ fn stale_sweep_spares_grandchild_under_a_waiting_ancestor() {
     );
     // Middle + leaf are Active (10-min); grandparent holds the permission gate.
     for id in [parent, child] {
-        r.apply(
+        act_start(
+            &mut r,
             &mut scene,
-            AgentEvent::ActivityStart {
-                agent_id: id,
-                tool_use_id: Some("t".into()),
-                detail: Some("WebFetch: /x".into()),
-            },
+            id,
+            Some("t"),
+            Some("WebFetch: /x"),
             t0 + Duration::from_secs(1),
             Transport::Jsonl,
         );
     }
-    r.apply(
+    waiting(
+        &mut r,
         &mut scene,
-        AgentEvent::Waiting {
-            agent_id: gp,
-            reason: "permission?".into(),
-        },
+        gp,
+        "permission?",
         t0 + Duration::from_secs(2),
         Transport::Hook,
     );
@@ -1601,26 +1510,24 @@ fn active_subagent_keeps_parent_alive_via_jsonl_events() {
     );
     // Parent delegates → Active{Delegating} (10-min threshold); its OWN last
     // event is now frozen at t0+1s.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("task-T".into()),
-            detail: Some("Agent".into()),
-        },
+        parent,
+        Some("task-T"),
+        Some("Agent"),
         t0 + Duration::from_secs(1),
         Transport::Hook,
     );
     // Subagent works for >10 min, emitting ONLY JSONL events (no hooks reach the
     // parent). Each keeps the parent's lineage alive.
     for mins in [4u64, 8, 12] {
-        r.apply(
+        act_start(
+            &mut r,
             &mut scene,
-            AgentEvent::ActivityStart {
-                agent_id: child,
-                tool_use_id: Some("c".into()),
-                detail: Some("Read: /x".into()),
-            },
+            child,
+            Some("c"),
+            Some("Read: /x"),
             t0 + Duration::from_secs(mins * 60),
             Transport::Jsonl,
         );
@@ -1743,15 +1650,7 @@ fn waiting_parent_cycle_is_still_reaped_by_the_stale_sweep() {
     );
     // One member parks on a permission prompt → Waiting (its resolution
     // never arrives — the slots are malformed input, not a real session).
-    r.apply(
-        &mut scene,
-        AgentEvent::Waiting {
-            agent_id: b,
-            reason: "permission".into(),
-        },
-        t0,
-        Transport::Hook,
-    );
+    waiting(&mut r, &mut scene, b, "permission", t0, Transport::Hook);
 
     // Even the most generous threshold elapsing must reap the whole cycle:
     // the Waiting member is collected on STALE_WAITING_TIMEOUT (it is NOT
@@ -1830,15 +1729,7 @@ fn mutual_waiting_parent_cycle_is_refused_at_the_link_seam_and_reaped() {
     );
     // Both members park Waiting — pre-fix this pair was immortal.
     for id in [a, b] {
-        r.apply(
-            &mut scene,
-            AgentEvent::Waiting {
-                agent_id: id,
-                reason: "permission".into(),
-            },
-            t0,
-            Transport::Hook,
-        );
+        waiting(&mut r, &mut scene, id, "permission", t0, Transport::Hook);
     }
 
     r.tick(

--- a/crates/pixtuoid-core/tests/reducer/main.rs
+++ b/crates/pixtuoid-core/tests/reducer/main.rs
@@ -66,3 +66,100 @@ fn delegating_pair(
     );
     (parent, child)
 }
+
+// ── The reducer-suite DSL ─────────────────────────────────────────────────
+// One terse applier per AgentEvent shape the suite hand-rolls the most. Each is
+// behavior-identical to the `r.apply(scene, AgentEvent::…, at, tp)` block it
+// replaces — pure test scaffolding, no reducer logic. `Some(&str)` args convert
+// through `.into()` exactly as the inline constructors did (`String` for ids/
+// reasons, `ToolDetail` for the tool detail). Calls the DSL can't express
+// verbatim (a `ToolDetail::` enum detail, a `SessionStart` with custom fields)
+// stay inline / use `start` + `delegating_pair`.
+
+fn act_start(
+    r: &mut Reducer,
+    scene: &mut SceneState,
+    id: AgentId,
+    tool_use_id: Option<&str>,
+    detail: Option<&str>,
+    at: SystemTime,
+    tp: Transport,
+) {
+    r.apply(
+        scene,
+        AgentEvent::ActivityStart {
+            agent_id: id,
+            tool_use_id: tool_use_id.map(Into::into),
+            detail: detail.map(Into::into),
+        },
+        at,
+        tp,
+    );
+}
+
+fn act_end(
+    r: &mut Reducer,
+    scene: &mut SceneState,
+    id: AgentId,
+    tool_use_id: Option<&str>,
+    at: SystemTime,
+    tp: Transport,
+) {
+    r.apply(
+        scene,
+        AgentEvent::ActivityEnd {
+            agent_id: id,
+            tool_use_id: tool_use_id.map(Into::into),
+        },
+        at,
+        tp,
+    );
+}
+
+fn waiting(
+    r: &mut Reducer,
+    scene: &mut SceneState,
+    id: AgentId,
+    reason: &str,
+    at: SystemTime,
+    tp: Transport,
+) {
+    r.apply(
+        scene,
+        AgentEvent::Waiting {
+            agent_id: id,
+            reason: reason.into(),
+        },
+        at,
+        tp,
+    );
+}
+
+fn proof_of_life(
+    r: &mut Reducer,
+    scene: &mut SceneState,
+    id: AgentId,
+    at: SystemTime,
+    tp: Transport,
+) {
+    r.apply(scene, AgentEvent::ProofOfLife { agent_id: id }, at, tp);
+}
+
+fn sess_end(
+    r: &mut Reducer,
+    scene: &mut SceneState,
+    id: AgentId,
+    as_child: bool,
+    at: SystemTime,
+    tp: Transport,
+) {
+    r.apply(
+        scene,
+        AgentEvent::SessionEnd {
+            agent_id: id,
+            as_child,
+        },
+        at,
+        tp,
+    );
+}

--- a/crates/pixtuoid-core/tests/reducer/tasks.rs
+++ b/crates/pixtuoid-core/tests/reducer/tasks.rs
@@ -10,7 +10,7 @@ use pixtuoid_core::state::{ActivityState, SceneState};
 use pixtuoid_core::AgentId;
 use serde_json::json;
 
-use crate::{delegating_pair, start};
+use crate::{act_end, act_start, delegating_pair, start, waiting};
 
 /// Assert the slot renders Active("Delegating") — `ToolDetail::Task`'s
 /// display, set by `fsm::enter_delegating`.
@@ -32,24 +32,22 @@ fn jsonl_duplicate_of_recent_hook_is_dropped() {
     start(&mut r, &mut scene, id);
 
     let t0 = SystemTime::now();
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t-1".into()),
-            detail: None,
-        },
+        id,
+        Some("t-1"),
+        None,
         t0,
         Transport::Hook,
     );
 
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t-1".into()),
-            detail: Some("FROM_JSONL".into()),
-        },
+        id,
+        Some("t-1"),
+        Some("FROM_JSONL"),
         t0 + Duration::from_millis(100),
         Transport::Jsonl,
     );
@@ -83,26 +81,24 @@ fn hook_activity_during_active_task_is_suppressed() {
     let t0 = SystemTime::now();
 
     // Parent enters Task tool — hook fires first, carrying the tool_use_id.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("task-T".into()),
-            detail: Some("Agent".into()),
-        },
+        parent,
+        Some("task-T"),
+        Some("Agent"),
         t0,
         Transport::Hook,
     );
 
     // Subagent fires a Read hook. CC reports it on parent's transcript_path,
     // so it lands on parent's AgentId — we must drop it.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("subagent-R".into()),
-            detail: Some("Read: /foo".into()),
-        },
+        parent,
+        Some("subagent-R"),
+        Some("Read: /foo"),
         t0 + Duration::from_millis(50),
         Transport::Hook,
     );
@@ -118,12 +114,11 @@ fn hook_activity_during_active_task_is_suppressed() {
     }
 
     // Subagent's PostToolUse hook for Read also lands on parent — drop it.
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: parent,
-            tool_use_id: Some("subagent-R".into()),
-        },
+        parent,
+        Some("subagent-R"),
         t0 + Duration::from_millis(60),
         Transport::Hook,
     );
@@ -148,12 +143,11 @@ fn hook_activity_during_active_task_is_suppressed() {
     // hook IS allowed through. With the Active-grace debounce, the
     // transition to Idle is deferred — `pending_idle_at` arms now,
     // `reducer.tick` past ACTIVE_GRACE_WINDOW (1500ms) realizes it.
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: parent,
-            tool_use_id: Some("task-T".into()),
-        },
+        parent,
+        Some("task-T"),
         t0 + Duration::from_millis(200),
         Transport::Hook,
     );
@@ -181,24 +175,22 @@ fn subagent_jsonl_activity_is_unaffected_by_parent_task_suppression() {
 
     let t0 = SystemTime::now();
     // Parent enters a Task.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("task-T".into()),
-            detail: Some("Agent".into()),
-        },
+        parent,
+        Some("task-T"),
+        Some("Agent"),
         t0,
         Transport::Hook,
     );
     // Subagent's JSONL activity targets ITS OWN AgentId — must apply normally.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: subagent,
-            tool_use_id: Some("sub-R".into()),
-            detail: Some("Read: /bar".into()),
-        },
+        subagent,
+        Some("sub-R"),
+        Some("Read: /bar"),
         t0 + Duration::from_millis(120),
         Transport::Jsonl,
     );
@@ -218,13 +210,12 @@ fn hook_activity_without_active_task_applies_normally() {
     let id = AgentId::from_transcript_path("/p/a.jsonl");
     start(&mut r, &mut scene, id);
 
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t".into()),
-            detail: Some("Bash: ls".into()),
-        },
+        id,
+        Some("t"),
+        Some("Bash: ls"),
         SystemTime::now(),
         Transport::Hook,
     );
@@ -252,15 +243,7 @@ fn active_tasks_drained_by_jsonl_end_even_if_hook_end_arrived_first() {
     let t0 = SystemTime::now();
 
     // Hook PostToolUse arrives first (active_tasks empty — Pre was missed).
-    r.apply(
-        &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: id,
-            tool_use_id: Some("task-X".into()),
-        },
-        t0,
-        Transport::Hook,
-    );
+    act_end(&mut r, &mut scene, id, Some("task-X"), t0, Transport::Hook);
 
     // JSONL ActivityStart for the same Task arrives after the hook dedup
     // window has expired — passes through and populates active_tasks.
@@ -276,24 +259,22 @@ fn active_tasks_drained_by_jsonl_end_even_if_hook_end_arrived_first() {
     );
 
     // JSONL ActivityEnd from the same transcript drains active_tasks.
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: id,
-            tool_use_id: Some("task-X".into()),
-        },
+        id,
+        Some("task-X"),
         t0 + Duration::from_millis(800),
         Transport::Jsonl,
     );
 
     // Subsequent hook activity must apply normally — proves active_tasks drained.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("other".into()),
-            detail: Some("Bash: ls".into()),
-        },
+        id,
+        Some("other"),
+        Some("Bash: ls"),
         t0 + Duration::from_millis(900),
         Transport::Hook,
     );
@@ -318,13 +299,12 @@ fn jsonl_event_after_dedup_window_is_applied() {
     start(&mut r, &mut scene, id);
 
     let t0 = SystemTime::now();
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t-1".into()),
-            detail: Some("hook-side".into()),
-        },
+        id,
+        Some("t-1"),
+        Some("hook-side"),
         t0,
         Transport::Hook,
     );
@@ -334,13 +314,12 @@ fn jsonl_event_after_dedup_window_is_applied() {
     // is the discriminator: a vacuous `Active { .. }` check passes even if the
     // event were wrongly suppressed (the hook already made it Active), so
     // assert the slot reflects the JSONL event's detail specifically.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t-1".into()),
-            detail: Some("jsonl-side".into()),
-        },
+        id,
+        Some("t-1"),
+        Some("jsonl-side"),
         t0 + Duration::from_millis(600),
         Transport::Jsonl,
     );
@@ -368,26 +347,24 @@ fn hook_wins_dedup_drops_jsonl_duplicate_within_window() {
     let t0 = SystemTime::now();
 
     // Hook event first — establishes the tool_use_id in the dedup map.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("dedup-1".into()),
-            detail: Some("Edit: hook.rs".into()),
-        },
+        id,
+        Some("dedup-1"),
+        Some("Edit: hook.rs"),
         t0,
         Transport::Hook,
     );
     assert_eq!(scene.agents.get(&id).unwrap().tool_call_count, 1);
 
     // JSONL event with same tool_use_id within 500ms — must be dropped.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("dedup-1".into()),
-            detail: Some("Edit: jsonl.rs".into()),
-        },
+        id,
+        Some("dedup-1"),
+        Some("Edit: jsonl.rs"),
         t0 + Duration::from_millis(200),
         Transport::Jsonl,
     );
@@ -447,34 +424,31 @@ fn subagent_is_removed_promptly_when_its_parent_task_completes() {
         Transport::Jsonl,
     );
     // Parent delegates a Task → Active{Delegating}, active_tasks[parent]={task-T}.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("task-T".into()),
-            detail: Some("Agent".into()),
-        },
+        parent,
+        Some("task-T"),
+        Some("Agent"),
         t0 + Duration::from_secs(1),
         Transport::Hook,
     );
     // Subagent does some work.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: child,
-            tool_use_id: Some("c1".into()),
-            detail: Some("Read: /x".into()),
-        },
+        child,
+        Some("c1"),
+        Some("Read: /x"),
         t0 + Duration::from_secs(2),
         Transport::Jsonl,
     );
     // The Task returns to the parent → drains active_tasks → subagent completed.
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: parent,
-            tool_use_id: Some("task-T".into()),
-        },
+        parent,
+        Some("task-T"),
         t0 + Duration::from_secs(10),
         Transport::Hook,
     );
@@ -540,13 +514,12 @@ fn oversized_attach_synthesized_task_start_restores_suppression_and_b1() {
     );
 
     // The synthesized Task start (Jsonl, no prior hook record at attach).
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("tu_task".into()),
-            detail: Some("Agent".into()),
-        },
+        parent,
+        Some("tu_task"),
+        Some("Agent"),
         t0 + Duration::from_secs(1),
         Transport::Jsonl,
     );
@@ -559,13 +532,12 @@ fn oversized_attach_synthesized_task_start_restores_suppression_and_b1() {
     // The subagent's next tool fires a hook misattributed to the PARENT
     // (CC hook transcript_path is always the parent's). With active_tasks
     // seeded, it must be suppressed — parent stays Delegating.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("sub-R".into()),
-            detail: Some("Read: /foo".into()),
-        },
+        parent,
+        Some("sub-R"),
+        Some("Read: /foo"),
         t0 + Duration::from_secs(2),
         Transport::Hook,
     );
@@ -574,12 +546,11 @@ fn oversized_attach_synthesized_task_start_restores_suppression_and_b1() {
         parent,
         "the misattributed subagent hook must be suppressed, not animated on the parent",
     );
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: parent,
-            tool_use_id: Some("sub-R".into()),
-        },
+        parent,
+        Some("sub-R"),
         t0 + Duration::from_secs(3),
         Transport::Hook,
     );
@@ -592,12 +563,11 @@ fn oversized_attach_synthesized_task_start_restores_suppression_and_b1() {
     // transcript) drains the seeded task and arms the grace-deferred b1
     // cascade — the completed subagent leaves promptly instead of lingering
     // to the 30-min idle sweep.
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: parent,
-            tool_use_id: Some("tu_task".into()),
-        },
+        parent,
+        Some("tu_task"),
         t0 + Duration::from_secs(10),
         Transport::Jsonl,
     );
@@ -636,35 +606,32 @@ fn late_jsonl_dispatch_copy_inside_grace_cancels_premature_cascade() {
     let t1 = t0 + Duration::from_secs(1);
 
     // First Task dispatch — applies normally, active_tasks = {task-1}.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("task-1".into()),
-            detail: Some("Agent".into()),
-        },
+        parent,
+        Some("task-1"),
+        Some("Agent"),
         t1,
         Transport::Hook,
     );
     // Parallel SECOND dispatch via hook — suppressed (leg 1: not recorded).
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("task-2".into()),
-            detail: Some("Agent".into()),
-        },
+        parent,
+        Some("task-2"),
+        Some("Agent"),
         t1 + Duration::from_millis(50),
         Transport::Hook,
     );
     // First Task's END drains the set BEFORE the second dispatch's JSONL
     // copy has been delivered (watcher latency) — the #151A race.
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: parent,
-            tool_use_id: Some("task-1".into()),
-        },
+        parent,
+        Some("task-1"),
         t1 + Duration::from_millis(200),
         Transport::Hook,
     );
@@ -675,13 +642,12 @@ fn late_jsonl_dispatch_copy_inside_grace_cancels_premature_cascade() {
 
     // The JSONL copy lands inside the grace → tracks task-2 + cancels the
     // pending cascade.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("task-2".into()),
-            detail: Some("Agent".into()),
-        },
+        parent,
+        Some("task-2"),
+        Some("Agent"),
         t1 + Duration::from_secs(1),
         Transport::Jsonl,
     );
@@ -697,12 +663,11 @@ fn late_jsonl_dispatch_copy_inside_grace_cancels_premature_cascade() {
 
     // Teeth: the second Task's drain re-arms, and with nothing arriving the
     // cascade fires after the grace.
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: parent,
-            tool_use_id: Some("task-2".into()),
-        },
+        parent,
+        Some("task-2"),
         t1 + Duration::from_secs(5),
         Transport::Jsonl,
     );
@@ -732,43 +697,39 @@ fn second_drain_inside_grace_restarts_the_cascade_clock() {
     let (parent, child) = delegating_pair(&mut r, &mut scene, "orch-rearm", t0);
     let t1 = t0 + Duration::from_secs(1);
 
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("task-1".into()),
-            detail: Some("Agent".into()),
-        },
+        parent,
+        Some("task-1"),
+        Some("Agent"),
         t1,
         Transport::Hook,
     );
     // First drain arms the pending cascade.
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: parent,
-            tool_use_id: Some("task-1".into()),
-        },
+        parent,
+        Some("task-1"),
         t1 + Duration::from_millis(200),
         Transport::Hook,
     );
     // A second Task lands and drains again, all inside the first grace.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("task-2".into()),
-            detail: Some("Agent".into()),
-        },
+        parent,
+        Some("task-2"),
+        Some("Agent"),
         t1 + Duration::from_secs(1),
         Transport::Jsonl,
     );
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: parent,
-            tool_use_id: Some("task-2".into()),
-        },
+        parent,
+        Some("task-2"),
         t1 + Duration::from_secs(2),
         Transport::Jsonl,
     );
@@ -810,45 +771,41 @@ fn late_jsonl_replay_of_drained_task_end_does_not_false_resolve_waiting() {
     let (parent, _child) = delegating_pair(&mut r, &mut scene, "orch-152", t0);
     let t1 = t0 + Duration::from_secs(1);
 
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("task-T".into()),
-            detail: Some("Agent".into()),
-        },
+        parent,
+        Some("task-T"),
+        Some("Agent"),
         t1,
         Transport::Hook,
     );
     // The parent's own permission prompt fires while Delegating → the gate
     // records the Task's tuid.
-    r.apply(
+    waiting(
+        &mut r,
         &mut scene,
-        AgentEvent::Waiting {
-            agent_id: parent,
-            reason: "permission".into(),
-        },
+        parent,
+        "permission",
         t1 + Duration::from_millis(100),
         Transport::Hook,
     );
     // Task self-END drains via tracking; the parent must stay Waiting
     // (pinned elsewhere) and the gate's tuid is now history.
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: parent,
-            tool_use_id: Some("task-T".into()),
-        },
+        parent,
+        Some("task-T"),
         t1 + Duration::from_secs(1),
         Transport::Hook,
     );
     // Late JSONL replay of the same END, outside the dedup window.
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: parent,
-            tool_use_id: Some("task-T".into()),
-        },
+        parent,
+        Some("task-T"),
         t1 + Duration::from_secs(1) + HOOK_WINS_WINDOW + Duration::from_millis(100),
         Transport::Jsonl,
     );
@@ -885,54 +842,49 @@ fn task_drain_keeps_parallel_ordinary_tool_gate() {
     let (parent, _child) = delegating_pair(&mut r, &mut scene, "orch-keep", t0);
     let t1 = t0 + Duration::from_secs(1);
 
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("task-T".into()),
-            detail: Some("Agent".into()),
-        },
+        parent,
+        Some("task-T"),
+        Some("Agent"),
         t1,
         Transport::Hook,
     );
     // Parent's own ordinary tool via JSONL while delegating.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("bash-1".into()),
-            detail: Some("Bash: ls".into()),
-        },
+        parent,
+        Some("bash-1"),
+        Some("Bash: ls"),
         t1 + Duration::from_millis(100),
         Transport::Jsonl,
     );
     // Permission prompt fires mid-bash → gate records bash-1.
-    r.apply(
+    waiting(
+        &mut r,
         &mut scene,
-        AgentEvent::Waiting {
-            agent_id: parent,
-            reason: "permission".into(),
-        },
+        parent,
+        "permission",
         t1 + Duration::from_millis(200),
         Transport::Hook,
     );
     // The Task drains — must not touch bash-1's gate.
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: parent,
-            tool_use_id: Some("task-T".into()),
-        },
+        parent,
+        Some("task-T"),
         t1 + Duration::from_secs(1),
         Transport::Hook,
     );
     // bash-1's END resolves the Waiting through the kept gate.
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: parent,
-            tool_use_id: Some("bash-1".into()),
-        },
+        parent,
+        Some("bash-1"),
         t1 + Duration::from_secs(2),
         Transport::Jsonl,
     );
@@ -965,47 +917,43 @@ fn suppressed_child_event_keeps_parents_own_parallel_tool_gate() {
     let (parent, _child) = delegating_pair(&mut r, &mut scene, "orch-own-gate", t0);
     let t1 = t0 + Duration::from_secs(1);
 
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("task-T".into()),
-            detail: Some("Agent".into()),
-        },
+        parent,
+        Some("task-T"),
+        Some("Agent"),
         t1,
         Transport::Hook,
     );
     // Parent's own ordinary tool via JSONL while delegating.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("bash-1".into()),
-            detail: Some("Bash: ls".into()),
-        },
+        parent,
+        Some("bash-1"),
+        Some("Bash: ls"),
         t1 + Duration::from_millis(100),
         Transport::Jsonl,
     );
     // Permission prompt fires mid-bash → gate records bash-1 (∉ active_tasks).
-    r.apply(
+    waiting(
+        &mut r,
         &mut scene,
-        AgentEvent::Waiting {
-            agent_id: parent,
-            reason: "permission".into(),
-        },
+        parent,
+        "permission",
         t1 + Duration::from_millis(200),
         Transport::Hook,
     );
     // The subagent keeps working on its independent loop — its next
     // misattributed hook event is suppressed (parent in-Task). It must not
     // clobber the parent's OWN still-pending prompt.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("sub-R".into()),
-            detail: Some("Read: /foo".into()),
-        },
+        parent,
+        Some("sub-R"),
+        Some("Read: /foo"),
         t1 + Duration::from_millis(300),
         Transport::Hook,
     );
@@ -1017,12 +965,11 @@ fn suppressed_child_event_keeps_parents_own_parallel_tool_gate() {
         "a suppressed child event must not hide the parent's own still-pending permission Waiting"
     );
     // …and the kept gate still resolves: bash-1's END clears the Waiting.
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: parent,
-            tool_use_id: Some("bash-1".into()),
-        },
+        parent,
+        Some("bash-1"),
         t1 + Duration::from_secs(1),
         Transport::Jsonl,
     );
@@ -1053,34 +1000,31 @@ fn own_parallel_tool_end_mid_delegation_returns_parent_to_delegating() {
     let (parent, child) = delegating_pair(&mut r, &mut scene, "orch-own-end", t0);
     let t1 = t0 + Duration::from_secs(1);
 
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("task-T".into()),
-            detail: Some("Agent".into()),
-        },
+        parent,
+        Some("task-T"),
+        Some("Agent"),
         t1,
         Transport::Hook,
     );
     // The parent's own quick tool overwrites Delegating with Active(Bash)…
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("bash-1".into()),
-            detail: Some("Bash: ls".into()),
-        },
+        parent,
+        Some("bash-1"),
+        Some("Bash: ls"),
         t1 + Duration::from_millis(100),
         Transport::Jsonl,
     );
     // …and its END arrives while task-T is still in flight.
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: parent,
-            tool_use_id: Some("bash-1".into()),
-        },
+        parent,
+        Some("bash-1"),
         t1 + Duration::from_millis(500),
         Transport::Jsonl,
     );
@@ -1117,22 +1061,20 @@ fn late_batched_jsonl_pair_after_delivered_hook_end_is_fully_dropped() {
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
 
     // Fast tool: both hooks deliver.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t-fast".into()),
-            detail: Some("Read: /x".into()),
-        },
+        id,
+        Some("t-fast"),
+        Some("Read: /x"),
         t0,
         Transport::Hook,
     );
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: id,
-            tool_use_id: Some("t-fast".into()),
-        },
+        id,
+        Some("t-fast"),
         t0 + HOOK_WINS_WINDOW / 10,
         Transport::Hook,
     );
@@ -1147,22 +1089,20 @@ fn late_batched_jsonl_pair_after_delivered_hook_end_is_fully_dropped() {
     // now, so only the END record's both-kinds dominance can drop the stale
     // START. Mutation-validated against BOTH rejected shapes (symmetric
     // value matching AND a (id, tuid, kind) key).
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t-fast".into()),
-            detail: Some("Read: /x".into()),
-        },
+        id,
+        Some("t-fast"),
+        Some("Read: /x"),
         t0 + HOOK_WINS_WINDOW + HOOK_WINS_WINDOW / 20,
         Transport::Jsonl,
     );
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: id,
-            tool_use_id: Some("t-fast".into()),
-        },
+        id,
+        Some("t-fast"),
         t0 + HOOK_WINS_WINDOW + HOOK_WINS_WINDOW / 20,
         Transport::Jsonl,
     );
@@ -1194,35 +1134,32 @@ fn jsonl_task_start_duplicate_does_not_clobber_waiting_parent() {
     let (parent, _child) = delegating_pair(&mut r, &mut scene, "orch-wait", t0);
 
     // Hook Task dispatch — records the Start in the dedup map + active_tasks.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("task-T".into()),
-            detail: Some("Agent".into()),
-        },
+        parent,
+        Some("task-T"),
+        Some("Agent"),
         t0 + Duration::from_secs(1),
         Transport::Hook,
     );
     // The parent's own permission Notification fires mid-dispatch.
-    r.apply(
+    waiting(
+        &mut r,
         &mut scene,
-        AgentEvent::Waiting {
-            agent_id: parent,
-            reason: "permission".into(),
-        },
+        parent,
+        "permission",
         t0 + Duration::from_secs(1) + HOOK_WINS_WINDOW / 50,
         Transport::Hook,
     );
     // The dispatch's JSONL copy, inside the window — must be dedup-dropped
     // before it can re-enter Delegating over the live Waiting.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("task-T".into()),
-            detail: Some("Agent".into()),
-        },
+        parent,
+        Some("task-T"),
+        Some("Agent"),
         t0 + Duration::from_secs(1) + HOOK_WINS_WINDOW / 5,
         Transport::Jsonl,
     );
@@ -1251,36 +1188,33 @@ fn jsonl_task_start_replay_outside_dedup_window_does_not_clobber_waiting_parent(
     let (parent, _child) = delegating_pair(&mut r, &mut scene, "orch-wait-late", t0);
 
     // Hook Task dispatch — records the Start in the dedup map + active_tasks.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("task-T".into()),
-            detail: Some("Agent".into()),
-        },
+        parent,
+        Some("task-T"),
+        Some("Agent"),
         t0 + Duration::from_secs(1),
         Transport::Hook,
     );
     // The parent's own permission Notification fires mid-dispatch.
-    r.apply(
+    waiting(
+        &mut r,
         &mut scene,
-        AgentEvent::Waiting {
-            agent_id: parent,
-            reason: "permission".into(),
-        },
+        parent,
+        "permission",
         t0 + Duration::from_secs(1) + HOOK_WINS_WINDOW / 50,
         Transport::Hook,
     );
     // The dispatch's JSONL copy lands at 2× the dedup window — the record is
     // GC'd, so it reaches the tracker. Its insert is a duplicate (the tuid is
     // still in flight), which must NOT re-enter Delegating.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("task-T".into()),
-            detail: Some("Agent".into()),
-        },
+        parent,
+        Some("task-T"),
+        Some("Agent"),
         t0 + Duration::from_secs(1) + HOOK_WINS_WINDOW * 2,
         Transport::Jsonl,
     );
@@ -1311,33 +1245,30 @@ fn lagged_jsonl_task_pair_after_drain_does_not_clobber_waiting_parent() {
     let (parent, _child) = delegating_pair(&mut r, &mut scene, "orch-drained", t0);
 
     // Fast Task: both hooks deliver — the Start tracks, the End DRAINS.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("task-T".into()),
-            detail: Some("Agent".into()),
-        },
+        parent,
+        Some("task-T"),
+        Some("Agent"),
         t0 + Duration::from_secs(1),
         Transport::Hook,
     );
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: parent,
-            tool_use_id: Some("task-T".into()),
-        },
+        parent,
+        Some("task-T"),
         t0 + Duration::from_secs(2),
         Transport::Hook,
     );
 
     // The parent's own permission prompt fires in the gap → Waiting.
-    r.apply(
+    waiting(
+        &mut r,
         &mut scene,
-        AgentEvent::Waiting {
-            agent_id: parent,
-            reason: "permission".into(),
-        },
+        parent,
+        "permission",
         t0 + Duration::from_secs(3),
         Transport::Hook,
     );
@@ -1345,13 +1276,12 @@ fn lagged_jsonl_task_pair_after_drain_does_not_clobber_waiting_parent() {
     // The batched JSONL pair lands at real skew — far outside
     // HOOK_WINS_WINDOW, so no dedup record is left and the set is empty.
     let replay_at = t0 + Duration::from_secs(2) + B1_CASCADE_GRACE + Duration::from_millis(100);
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("task-T".into()),
-            detail: Some("Agent".into()),
-        },
+        parent,
+        Some("task-T"),
+        Some("Agent"),
         replay_at,
         Transport::Jsonl,
     );
@@ -1364,12 +1294,11 @@ fn lagged_jsonl_task_pair_after_drain_does_not_clobber_waiting_parent() {
     );
 
     // ...and the replayed End must not arm an idle-resolve on the prompt.
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: parent,
-            tool_use_id: Some("task-T".into()),
-        },
+        parent,
+        Some("task-T"),
         replay_at,
         Transport::Jsonl,
     );
@@ -1400,24 +1329,22 @@ fn jsonl_ordinary_tool_end_drains_when_hook_end_drops() {
     start(&mut r, &mut scene, id);
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
 
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: id,
-            tool_use_id: Some("t-1".into()),
-            detail: Some("Read: /x".into()),
-        },
+        id,
+        Some("t-1"),
+        Some("Read: /x"),
         t0,
         Transport::Hook,
     );
     // PostToolUse hook DROPS. The JSONL END inside HOOK_WINS_WINDOW of the
     // hook START's record must apply and arm the idle debounce.
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: id,
-            tool_use_id: Some("t-1".into()),
-        },
+        id,
+        Some("t-1"),
         t0 + HOOK_WINS_WINDOW / 5,
         Transport::Jsonl,
     );
@@ -1445,25 +1372,23 @@ fn suppressed_parallel_task_dispatch_jsonl_copy_survives_dedup_and_tracks() {
     let (parent, child) = delegating_pair(&mut r, &mut scene, "orch-par", t0);
 
     // First Task dispatch — applies normally, active_tasks = {task-1}.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("task-1".into()),
-            detail: Some("Agent".into()),
-        },
+        parent,
+        Some("task-1"),
+        Some("Agent"),
         t0 + Duration::from_secs(1),
         Transport::Hook,
     );
     // Parallel SECOND Task dispatch via hook while task-1 is in flight —
     // suppressed as a leak (and must NOT record "task-2" in the dedup map).
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("task-2".into()),
-            detail: Some("Agent".into()),
-        },
+        parent,
+        Some("task-2"),
+        Some("Agent"),
         t0 + Duration::from_secs(1) + HOOK_WINS_WINDOW / 10,
         Transport::Hook,
     );
@@ -1471,24 +1396,22 @@ fn suppressed_parallel_task_dispatch_jsonl_copy_survives_dedup_and_tracks() {
     // suppressed hook copy (so a wrongly-recorded "task-2" would dedup-drop
     // it). It must survive dedup — it is the only transport left to track
     // task-2.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("task-2".into()),
-            detail: Some("Agent".into()),
-        },
+        parent,
+        Some("task-2"),
+        Some("Agent"),
         t0 + Duration::from_secs(1) + HOOK_WINS_WINDOW / 10 + HOOK_WINS_WINDOW / 5,
         Transport::Jsonl,
     );
     // First Task's own PostToolUse drains task-1. task-2 must still be in
     // flight, so the subtree must NOT cascade-exit yet.
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: parent,
-            tool_use_id: Some("task-1".into()),
-        },
+        parent,
+        Some("task-1"),
         t0 + Duration::from_secs(1) + HOOK_WINS_WINDOW * 2 / 5,
         Transport::Hook,
     );
@@ -1518,12 +1441,11 @@ fn suppressed_parallel_task_dispatch_jsonl_copy_survives_dedup_and_tracks() {
     // Teeth: draining the SECOND Task must fire the cascade after the grace
     // — proves the child is wired to the parent and the earlier no-cascade
     // assertion wasn't vacuous.
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: parent,
-            tool_use_id: Some("task-2".into()),
-        },
+        parent,
+        Some("task-2"),
         t0 + Duration::from_secs(5),
         Transport::Jsonl,
     );
@@ -1553,25 +1475,23 @@ fn jsonl_task_self_end_drains_when_hook_end_drops() {
     let (parent, child) = delegating_pair(&mut r, &mut scene, "orch-drop", t0);
 
     // Hook Task dispatch — records "task-T" in the dedup map + active_tasks.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("task-T".into()),
-            detail: Some("Agent".into()),
-        },
+        parent,
+        Some("task-T"),
+        Some("Agent"),
         t0 + Duration::from_secs(1),
         Transport::Hook,
     );
     // The Task fails fast; its PostToolUse hook DROPS (never applied). The
     // JSONL END arrives inside HOOK_WINS_WINDOW of the hook START's record —
     // it is the only completion signal the reducer will ever get.
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: parent,
-            tool_use_id: Some("task-T".into()),
-        },
+        parent,
+        Some("task-T"),
         t0 + Duration::from_secs(1) + HOOK_WINS_WINDOW / 5,
         Transport::Jsonl,
     );
@@ -1589,13 +1509,12 @@ fn jsonl_task_self_end_drains_when_hook_end_drops() {
     );
     // The parent must not be stuck Delegating: a later ordinary hook event
     // applies normally instead of being suppressed as a subagent leak.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("b-1".into()),
-            detail: Some("Bash: ls".into()),
-        },
+        parent,
+        Some("b-1"),
+        Some("Bash: ls"),
         t0 + Duration::from_secs(5),
         Transport::Hook,
     );
@@ -1649,23 +1568,21 @@ fn parent_waiting_on_subagent_permission_resolves_when_the_subagent_resumes() {
         Transport::Jsonl,
     );
     // Parent delegates → Active{Delegating}, active_tasks[parent]={task-T}.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("task-T".into()),
-            detail: Some("Agent".into()),
-        },
+        parent,
+        Some("task-T"),
+        Some("Agent"),
         t0 + Duration::from_secs(1),
         Transport::Hook,
     );
     // Subagent's permission prompt → Notification misattributed to the parent.
-    r.apply(
+    waiting(
+        &mut r,
         &mut scene,
-        AgentEvent::Waiting {
-            agent_id: parent,
-            reason: "permission?".into(),
-        },
+        parent,
+        "permission?",
         t0 + Duration::from_secs(2),
         Transport::Hook,
     );
@@ -1679,13 +1596,12 @@ fn parent_waiting_on_subagent_permission_resolves_when_the_subagent_resumes() {
 
     // User grants; the subagent resumes a tool → a misattributed child hook,
     // suppressed because the parent is in-Task.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("sub-bash".into()),
-            detail: Some("Bash: ls".into()),
-        },
+        parent,
+        Some("sub-bash"),
+        Some("Bash: ls"),
         t0 + Duration::from_secs(3),
         Transport::Hook,
     );
@@ -1737,23 +1653,21 @@ fn parent_waiting_on_subagent_permission_resolves_when_the_subagent_ends_a_tool(
         Transport::Jsonl,
     );
     // Parent delegates → Active(Delegating), active_tasks[parent] = {task-T}.
-    r.apply(
+    act_start(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityStart {
-            agent_id: parent,
-            tool_use_id: Some("task-T".into()),
-            detail: Some("Agent".into()),
-        },
+        parent,
+        Some("task-T"),
+        Some("Agent"),
         t0 + Duration::from_secs(1),
         Transport::Hook,
     );
     // Subagent's permission prompt → Notification misattributed to the parent.
-    r.apply(
+    waiting(
+        &mut r,
         &mut scene,
-        AgentEvent::Waiting {
-            agent_id: parent,
-            reason: "permission?".into(),
-        },
+        parent,
+        "permission?",
         t0 + Duration::from_secs(2),
         Transport::Hook,
     );
@@ -1767,12 +1681,11 @@ fn parent_waiting_on_subagent_permission_resolves_when_the_subagent_ends_a_tool(
     // Subagent resumes by ENDING a tool → a misattributed child hook END (a
     // different tuid, so not the Task's self-end): suppressed, and the
     // suppression restores Active(Delegating).
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: parent,
-            tool_use_id: Some("sub-bash".into()),
-        },
+        parent,
+        Some("sub-bash"),
         t0 + Duration::from_secs(3),
         Transport::Hook,
     );
@@ -1812,12 +1725,11 @@ fn task_drain_while_parent_waiting_keeps_waiting() {
         Transport::Hook,
     );
     // A permission prompt fires while delegating → Waiting.
-    r.apply(
+    waiting(
+        &mut r,
         &mut scene,
-        AgentEvent::Waiting {
-            agent_id: id,
-            reason: "permission".into(),
-        },
+        id,
+        "permission",
         t0 + Duration::from_millis(500),
         Transport::Hook,
     );
@@ -1828,12 +1740,11 @@ fn task_drain_while_parent_waiting_keeps_waiting() {
 
     // The Task's own PostToolUse drains active_tasks — must NOT arm an idle
     // resolve on the Waiting parent (permission still pending).
-    r.apply(
+    act_end(
+        &mut r,
         &mut scene,
-        AgentEvent::ActivityEnd {
-            agent_id: id,
-            tool_use_id: Some("task-T".into()),
-        },
+        id,
+        Some("task-T"),
         t0 + Duration::from_millis(1000),
         Transport::Hook,
     );


### PR DESCRIPTION
## What

The reducer integration suite hand-rolled every event as an 8–10 line `r.apply(scene, AgentEvent::X { .. }, at, tp)` block. This adds five terse appliers to `tests/reducer/main.rs` — `act_start` / `act_end` / `waiting` / `proof_of_life` / `sess_end` — and routes ~155 of those blocks through them. A new reducer test is now **one line, not a block**.

**Pure test scaffolding** — no reducer/prod logic touched.

## Scope kept deliberately safe

Only the *uniform* shapes convert. Left inline (the DSL takes `Option<&str>`, so anything it can't express byte-for-byte stays as-is): every `SessionStart` (custom source/session_id/cwd/parent_id), `Identity`, `Rename`, `ToolDetail::`-enum details, and decoder feed-loops. Converting fewer calls correctly beats converting one wrongly.

## Verified teeth-preserving (not trusted)

- `#[test]` count **unchanged** in all 6 files (26/32/37/15/12/8)
- reducer suite **green: 131 passed, 0 failed**
- diff RED-FLAG scan: **zero** `assert` / `.tick(` / `matches!` / comment lines added or removed — the only changed lines are apply-blocks → DSL calls + the `use crate::{…}` imports
- args **spot-checked byte-exact**, incl. the transport-sensitive hook-wins dedup test (`Hook` vs `Jsonl`, `t0 + Nms` timestamps preserved)
- `clippy -D warnings` clean; all five helpers used (no dead test code)

Identical inputs (byte-exact DSL args) + identical assertions ⟹ identical mutant-kill set, so this is coverage-neutral by construction.

## LOC

Net **−360** (test files −451, DSL +91). Modest after rustfmt wraps the 7-arg calls — the plan's −1,423 assumed a richer DSL (incl. SessionStart) and no line-wrapping. The ergonomic win (a block → a call) is the real payoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xxFWw2cafxi4x65NxVzES