### PR TITLE
fix: decouple the _pid peek from the exit-watch backend

### DIFF
--- a/crates/pixtuoid-core/CLAUDE.md
+++ b/crates/pixtuoid-core/CLAUDE.md
@@ -113,9 +113,11 @@ src/
 
 **Focus-jump plumbing (#focus-jump):** the shim fills `_pid` (getppid) into the
 hook envelope WHEN ABSENT — opencode's plugin and CodeWhale's env-mode supply
-their own, which win; the daemon's `handle_conn` already peeked `_pid` for the
-`HookPidWatch` exit-watch, and now ALSO stamps it onto the batch's `Identity`
-events (`patch_identity_pids` — the per-source decoders never see the key).
+their own, which win; the daemon's `handle_conn` peeks `_pid` UNCONDITIONALLY
+(an exit-watch backend failing to init — pre-5.3 Linux — must not take the
+focus pid cache down with it; only the `HookPidWatch` BIND needs the watch)
+and stamps it onto the batch's `Identity` events (`patch_identity_pids` — the
+per-source decoders never see the key).
 The reducer caches it on `AgentSlot.pid` (fill at registration, refresh per
 Identity, `Some` never downgraded), serde-skipped so the scene golden doesn't
 churn. Transcript-family sources stay `pid: None` — STRUCTURALLY:
@@ -124,9 +126,13 @@ the hook-command parent, never recycle-guarded, and a stamped stale pid would
 shadow the probe in `resolve_pid`). Their channel is the
 recycle-guarded probes, exposed as the two pub point-query seams
 `source::cc_pid_for_session` (projects root → sibling sessions registry) and
-`source::codex_pid_for_session` (rollout UUID). Windows hook-family pids are
-effectively absent by design: the hook runs under `cmd /C`, so getppid names a
-transient cmd.exe (the documented `parent_pid` trap) — focus silently no-ops.
+`source::codex_pid_for_session` (rollout UUID). On Windows the SHIM sends no
+pid (the hook runs under `cmd /C`, so getppid would name a transient cmd.exe —
+the documented `parent_pid` trap), so shim-dependent sources focus-no-op there;
+a plugin-stamped pid (opencode's `process.pid`) still flows — the peek doesn't
+need the exit-watch, whose backend is also absent on Windows/pre-5.3 Linux. On
+those no-watch platforms an abrupt exit can't set `exiting_at`, so the
+click-time pid-staleness window is wider (the documented v1 sharp edge).
 
 ## Known sharp edges (don't be surprised by these)
 

--- a/crates/pixtuoid-core/src/source/hook/mod.rs
+++ b/crates/pixtuoid-core/src/source/hook/mod.rs
@@ -265,12 +265,15 @@ pub(crate) async fn handle_conn(
                 // shim fills it from getppid when the plugin didn't stamp one);
                 // the transcript family is filtered downstream in
                 // `patch_identity_pids` — the probes are their channel.
-                // `as_u64` already rejects negatives; the `> 0` filter drops a
-                // crafted `_pid: 0` too (kill(0) targets the process GROUP —
-                // same guard as cc_probe/fd_probe/openclaw).
-                let pid = pid_watch
-                    .as_ref()
-                    .and_then(|_| v.get("_pid"))
+                // Deliberately NOT gated on `pid_watch`: the exit-watch backend
+                // failing to init (pre-5.3 Linux kernel, Windows) must not
+                // take the focus-jump pid cache down with it — only the BIND
+                // below needs the watch. `as_u64` already rejects negatives;
+                // the `> 0` filter drops a crafted `_pid: 0` too (kill(0)
+                // targets the process GROUP — same guard as
+                // cc_probe/fd_probe/openclaw).
+                let pid = v
+                    .get("_pid")
                     .and_then(serde_json::Value::as_u64)
                     .and_then(|p| i32::try_from(p).ok())
                     .filter(|p| *p > 0);
@@ -732,18 +735,14 @@ mod tests {
 
     // The composed focus-jump path (peek `_pid` → decode → patch_identity_pids):
     // a transcript-family (CC) payload's Identity must arrive with pid: None
-    // even when the shim stamped `_pid` and a live pid_watch enables the peek —
-    // the unit test on patch_identity_pids can't catch a wiring regression in
-    // handle_conn itself. Platform-gated like the bind test above.
+    // even when the shim stamped `_pid` — the unit test on patch_identity_pids
+    // can't catch a wiring regression in handle_conn itself. The peek needs no
+    // watch (deliberately un-gated), so this runs on every platform.
     #[tokio::test]
     async fn handle_conn_never_stamps_a_transcript_family_identity_pid() {
         let (tx, mut rx) = tokio::sync::mpsc::channel::<(Transport, AgentEvent)>(8);
-        let Some(watch) = HookPidWatch::spawn(tx.clone()) else {
-            return; // no exit-watch backend on this platform — the peek is off
-        };
         let (mut client, server) = tokio::io::duplex(4096);
-        let task = tokio::spawn(handle_conn(server, tx, Some(watch), None));
-        // Our own (live) pid so the bound exit-watch never fires mid-test.
+        let task = tokio::spawn(handle_conn(server, tx, None, None));
         let me = std::process::id();
         let line = format!(
             "{{\"hook_event_name\":\"PreToolUse\",\"session_id\":\"ses-cc\",\
@@ -764,6 +763,33 @@ mod tests {
         );
         let (_, ev) = rx.recv().await.expect("the paired ActivityStart");
         assert!(matches!(ev, AgentEvent::ActivityStart { .. }), "got {ev:?}");
+    }
+
+    // The focus-jump stamp must survive a missing exit-watch backend: the
+    // `_pid` peek is deliberately NOT gated on `pid_watch` (pre-5.3 Linux /
+    // Windows spawn `None`), so a hook-family Identity still carries the pid
+    // with NO watch attached — only the exit-watch BIND needs the watch.
+    // This is the regression pin: re-gating the peek fails this test.
+    #[tokio::test]
+    async fn handle_conn_stamps_identity_pid_even_without_a_pid_watch() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<(Transport, AgentEvent)>(8);
+        let (mut client, server) = tokio::io::duplex(4096);
+        let task = tokio::spawn(handle_conn(server, tx, None, None));
+        // CodeWhale tool_call_before decodes to [Identity, ActivityStart].
+        let line = "{\"_pixtuoid_source\":\"codewhale\",\"event\":\"tool_call_before\",\
+                    \"cwd\":\"/repo\",\"tool\":\"exec_shell\",\"_pid\":4242}\n";
+        client.write_all(line.as_bytes()).await.unwrap();
+        drop(client);
+        task.await.unwrap();
+
+        let (_, ev) = rx
+            .recv()
+            .await
+            .expect("the Identity ahead of the tool event");
+        assert!(
+            matches!(&ev, AgentEvent::Identity { source, pid: Some(4242), .. } if source == "codewhale"),
+            "hook-family Identity must carry the peeked pid without a watch, got {ev:?}"
+        );
     }
 
     // The decode-error arm (line 280): a syntactically-valid JSON object whose

--- a/crates/pixtuoid/CLAUDE.md
+++ b/crates/pixtuoid/CLAUDE.md
@@ -141,8 +141,9 @@ src/
 │                       so the walk surfaces the terminal, not the agent) else EWMH _NET_ACTIVE_WINDOW via
 │                       x11rb — i3 rides EWMH, NOT swaymsg (GNOME Wayland fails closed). ONE failure rule: every
 │                       miss = tracing::debug + silent no-op — no fallback tiers, no info UI (user-directed).
-│                       App-level only in v1 (no tab/pane precision — backlog). Windows hook-family pids are
-│                       effectively absent (the shim's parent is a transient cmd.exe — see pixtuoid-hook).
+│                       App-level only in v1 (no tab/pane precision — backlog). On Windows the SHIM sends no
+│                       pid (transient cmd.exe parent — see pixtuoid-hook), but a plugin-stamped pid
+│                       (opencode's process.pid) still flows: the `_pid` peek doesn't need the exit-watch.
 ├── config.rs           AppConfig persistence (~/.config/pixtuoid/config.toml), XDG-aware
 ├── runtime/            mod.rs (RunConfig, boot-capacity math, headless summarize — all unit-tested;
 │                       ConnectedSources = the live `Arc<Mutex<HashSet<String>>>` connected-set,


### PR DESCRIPTION
## What

`handle_conn`'s `_pid` peek was gated on `pid_watch.is_some()` — an unrelated kernel subsystem (kqueue/pidfd exit-watch init) failing silently disabled focus-jump's pid caching too. Flagged independently by two reviewers on #532 (the local design lens and the online Claude Review, MEDIUM). The peek only reads the already-parsed payload, so it's now unconditional; the exit-watch **bind** stays watch-gated (byte-identical behavior there).

## Behavior delta

Only path that gains a value: `patch_identity_pids` when `pid_watch` is `None`. Concretely:
- **pre-5.3 Linux** (no pidfd): hook-family focus-jump now works.
- **Windows** (no named-pipe exit-watch): a plugin-stamped pid (opencode's `process.pid`, cross-platform) now flows; the shim itself still deliberately sends none (`cmd /C` transient parent). The blanket "Windows hook-family pids absent" CLAUDE.md claim is rescoped to the shim path, and the wider no-watch pid-staleness window (no exit-watch → no `exiting_at` on abrupt exit) is called out as the documented v1 sharp edge.

Transcript-family stays structurally un-stamped (`line_decoder` gate, unchanged — the #532 pinned invariant).

## Tests

- New composed test `handle_conn_stamps_identity_pid_even_without_a_pid_watch` (CodeWhale `tool_call_before` + `_pid`, `pid_watch=None`) — fails if the gate is reinstated.
- `handle_conn_never_stamps_a_transcript_family_identity_pid` drops its watch requirement → now runs on every platform (was macOS/Linux-only via the spawn early-return).

## Review

Local two-lens done (correctness + design, both approve): all findings — the two stale CLAUDE.md coupling claims and two stale test comments — applied in-diff. Preflight 2198/2198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BT3bfjgBPqZE5sqtccZm3v