### PR TITLE
feat(focus): start-marker recycle guard + doctor focus section

### DIFF
--- a/crates/pixtuoid-core/CLAUDE.md
+++ b/crates/pixtuoid-core/CLAUDE.md
@@ -125,10 +125,17 @@ so the binary's click re-reads the marker and REFUSES a recycled/dead pid
 (#527; markerless stamps skip the check, additive).
 The reducer caches it on `AgentSlot.pid` (fill at registration, refresh per
 Identity, `Some` never downgraded), serde-skipped so the scene golden doesn't
-churn. Transcript-family sources stay `pid: None` — STRUCTURALLY:
-`patch_identity_pids` skips any source with a `line_decoder` (their getppid is
-the hook-command parent, never recycle-guarded, and a stamped stale pid would
-shadow the probe in `resolve_pid`). Their channel is the
+churn. WHICH channel a source rides is the registry's **`FocusChannel`
+capability** (`ShimStamp`/`PluginStamp`/`TranscriptProbe`/`Unsupported`, a
+field of `SourceKind::Agent` so daemons structurally can't carry one) — the
+ONE data-driven truth shared by the stamp gate (`patch_identity_pids` stamps
+iff `accepts_stamp()`), the click-time probe dispatch (`focus::resolve_pid`),
+and the doctor report. It is DATA-only on purpose: the const table compiles
+to wasm, so the native-only probe FNS stay in the binary, pinned to the enum
+by the `transcript_probe_sources_all_have_a_resolve_arm` lockstep test.
+`TranscriptProbe` (CC/Codex) is never stamped — their getppid is the
+hook-command parent, never recycle-guarded, and a stamped stale pid would
+shadow the probe in `resolve_pid`. Their channel is the
 recycle-guarded probes, exposed as the two pub point-query seams
 `source::cc_pid_for_session` (projects root → sibling sessions registry) and
 `source::codex_pid_for_session` (rollout UUID). On Windows the SHIM sends no
@@ -136,9 +143,11 @@ pid (the hook runs under `cmd /C`, so getppid would name a transient cmd.exe —
 the documented `parent_pid` trap), so shim-dependent sources focus-no-op there;
 a plugin-stamped pid (opencode's `process.pid`) still flows — the peek doesn't
 need the exit-watch, whose backend is also absent on Windows/pre-5.3 Linux. On
-those no-watch platforms an abrupt exit can't set `exiting_at`, but the #527
-start-marker check still refuses the recycled pid at click time wherever a
-marker was readable at stamp time (everywhere except non-mac/linux daemons).
+those no-watch platforms an abrupt exit can't set `exiting_at`; the #527
+start-marker check still refuses the recycled pid at click time on pre-5.3
+LINUX (marker readable at stamp time), but `pid_start_marker` is None on every
+non-mac/linux OS — Windows hook-family stamps are markerless, so the guard is
+inert there and the wide staleness window REMAINS a Windows sharp edge (#528).
 
 ## Known sharp edges (don't be surprised by these)
 

--- a/crates/pixtuoid-core/CLAUDE.md
+++ b/crates/pixtuoid-core/CLAUDE.md
@@ -117,7 +117,12 @@ their own, which win; the daemon's `handle_conn` peeks `_pid` UNCONDITIONALLY
 (an exit-watch backend failing to init — pre-5.3 Linux — must not take the
 focus pid cache down with it; only the `HookPidWatch` BIND needs the watch)
 and stamps it onto the batch's `Identity` events (`patch_identity_pids` — the
-per-source decoders never see the key).
+per-source decoders never see the key). The stamp is a `PidIdentity` — pid +
+the kernel start MARKER read at peek time (`source::pid_start_marker`: macOS
+`pbi_start_tvsec`, Linux `/proc` stat field-22 raw ticks — EQUALITY-only, no
+epoch conversion, which is why #220's macOS-only limitation doesn't apply) —
+so the binary's click re-reads the marker and REFUSES a recycled/dead pid
+(#527; markerless stamps skip the check, additive).
 The reducer caches it on `AgentSlot.pid` (fill at registration, refresh per
 Identity, `Some` never downgraded), serde-skipped so the scene golden doesn't
 churn. Transcript-family sources stay `pid: None` — STRUCTURALLY:
@@ -131,8 +136,9 @@ pid (the hook runs under `cmd /C`, so getppid would name a transient cmd.exe —
 the documented `parent_pid` trap), so shim-dependent sources focus-no-op there;
 a plugin-stamped pid (opencode's `process.pid`) still flows — the peek doesn't
 need the exit-watch, whose backend is also absent on Windows/pre-5.3 Linux. On
-those no-watch platforms an abrupt exit can't set `exiting_at`, so the
-click-time pid-staleness window is wider (the documented v1 sharp edge).
+those no-watch platforms an abrupt exit can't set `exiting_at`, but the #527
+start-marker check still refuses the recycled pid at click time wherever a
+marker was readable at stamp time (everywhere except non-mac/linux daemons).
 
 ## Known sharp edges (don't be surprised by these)
 

--- a/crates/pixtuoid-core/src/source/cc_probe.rs
+++ b/crates/pixtuoid-core/src/source/cc_probe.rs
@@ -272,31 +272,15 @@ const PID_START_TOLERANCE_SECS: u64 = 10;
 /// failure (pid gone mid-probe, EPERM) — never an error: the check is additive.
 #[cfg(target_os = "macos")]
 fn pid_start_time_secs(pid: i32) -> Option<u64> {
-    // SAFETY: all-zero bytes are a valid value for this repr(C) plain-old-data
-    // struct (integers + byte arrays only).
-    let mut info: libc::proc_bsdinfo = unsafe { std::mem::zeroed() };
-    let size = std::mem::size_of::<libc::proc_bsdinfo>() as libc::c_int;
-    // SAFETY: the buffer is exactly `size` bytes of a repr(C) struct matching
-    // the macOS SDK's proc_bsdinfo layout (proc_info.h, ABI-stable since
-    // 10.5), so the kernel fills only memory we own. PROC_PIDTBSDINFO returns
-    // the full struct or <= 0 on failure.
-    let n = unsafe {
-        libc::proc_pidinfo(
-            pid,
-            libc::PROC_PIDTBSDINFO,
-            0,
-            &mut info as *mut _ as *mut std::ffi::c_void,
-            size,
-        )
-    };
-    if n != size {
-        return None;
-    }
-    Some(info.pbi_start_tvsec)
+    // On macOS the shared start MARKER (`proc_start`) is exactly epoch
+    // seconds (pbi_start_tvsec), so this wall-clock check can ride it.
+    super::proc_start::pid_start_marker(pid)
 }
 
 #[cfg(all(unix, not(target_os = "macos")))]
 fn pid_start_time_secs(_pid: i32) -> Option<u64> {
+    // The Linux MARKER is ticks-since-boot — NOT epoch — so this wall-clock
+    // comparison must not ride it; epoch conversion stays deferred (#220).
     None
 }
 

--- a/crates/pixtuoid-core/src/source/hook/mod.rs
+++ b/crates/pixtuoid-core/src/source/hook/mod.rs
@@ -193,22 +193,30 @@ fn pid_bind_target(ev: &AgentEvent) -> Option<AgentId> {
 /// point IS the whole wiring. `None` leaves events untouched (the reducer
 /// never downgrades a cached pid either — belt and braces).
 ///
-/// The TRANSCRIPT family (any source with a `line_decoder`) is skipped: the
-/// shim's `getppid` is their hook-command parent (possibly a transient shell,
-/// never recycle-guarded), while their real focus channel is the liveness
-/// probes (`cc_pid_for_session`/`codex_pid_for_session`). A stamped stale pid
-/// would shadow the probe's recycle guard in `resolve_pid`.
+/// The gate is the registry's [`FocusChannel`] capability — ONE data-driven
+/// source of truth shared with `focus::resolve_pid` and the doctor report.
+/// `TranscriptProbe` sources (CC/Codex) are skipped: the shim's `getppid` is
+/// their hook-command parent (possibly a transient shell, never
+/// recycle-guarded), and a stamped stale pid would shadow the probe's recycle
+/// guard in `resolve_pid`.
 ///
-/// The stamp is a [`PidIdentity`] — pid PLUS the kernel start marker read at
-/// peek time — so the click-time guard can refuse a recycled pid (#527).
-fn patch_identity_pids(evs: &mut [AgentEvent], pid: Option<crate::source::PidIdentity>) {
+/// The stamp is a [`PidIdentity`] — pid PLUS the kernel start marker — so the
+/// click-time guard can refuse a recycled pid (#527). The marker is read
+/// LAZILY on the first accepting Identity: the highest-volume sources
+/// (CC/Codex) never accept, so their per-event syscall is skipped entirely.
+fn patch_identity_pids(evs: &mut [AgentEvent], pid: Option<i32>) {
+    use crate::source::registry::FocusChannel;
     let Some(pid) = pid else { return };
+    let mut stamp: Option<crate::source::PidIdentity> = None;
     for ev in evs {
         if let AgentEvent::Identity { source, pid: p, .. } = ev {
-            let transcript_bearing = crate::source::registry::descriptor_for(source)
-                .is_some_and(|d| d.line_decoder().is_some());
-            if !transcript_bearing {
-                *p = Some(pid);
+            let channel = crate::source::registry::descriptor_for(source)
+                .map_or(FocusChannel::Unsupported, |d| d.focus_channel());
+            if channel.accepts_stamp() {
+                *p = Some(*stamp.get_or_insert_with(|| crate::source::PidIdentity {
+                    pid,
+                    started: crate::source::pid_start_marker(pid),
+                }));
             }
         }
     }
@@ -305,20 +313,11 @@ pub(crate) async fn handle_conn(
                             }
                         }
                         // Second consumer of the SAME peeked `_pid`: the
-                        // focus-jump cache (see `patch_identity_pids`). The
-                        // start marker is read HERE — the closest moment to
-                        // the hook event itself — so a later click can refuse
-                        // a recycled pid (#527). Marker unreadable (pid died
-                        // between hook and peek, non-unix) → `None` → the
-                        // click-time identity check is skipped, not failed.
+                        // focus-jump cache (see `patch_identity_pids`, which
+                        // also reads the #527 recycle marker — lazily, so the
+                        // transcript family costs no syscall).
                         let mut evs = evs;
-                        patch_identity_pids(
-                            &mut evs,
-                            pid.map(|p| crate::source::PidIdentity {
-                                pid: p,
-                                started: crate::source::pid_start_marker(p),
-                            }),
-                        );
+                        patch_identity_pids(&mut evs, pid);
                         let mut undelivered = UndeliveredEvents::new(&evs);
                         for ev in evs {
                             debug!("hook event: {ev:?}");
@@ -348,13 +347,6 @@ mod tests {
     use crate::AgentId;
     use tokio::io::AsyncWriteExt;
 
-    fn pid77() -> crate::source::PidIdentity {
-        crate::source::PidIdentity {
-            pid: 77,
-            started: Some(1_000),
-        }
-    }
-
     #[test]
     fn patch_identity_pids_stamps_only_identity_events() {
         let id = AgentId::from_parts("opencode", "ses_x");
@@ -372,14 +364,16 @@ mod tests {
                 detail: None,
             },
         ];
-        patch_identity_pids(&mut evs, Some(pid77()));
+        patch_identity_pids(&mut evs, Some(i32::MAX));
         assert!(
-            matches!(evs[0], AgentEvent::Identity { pid: Some(p), .. } if p == pid77()),
+            matches!(evs[0], AgentEvent::Identity { pid: Some(p), .. } if p.pid == i32::MAX && p.started.is_none()),
             "Identity stamped"
         );
         // None leaves the batch untouched.
         patch_identity_pids(&mut evs, None);
-        assert!(matches!(evs[0], AgentEvent::Identity { pid: Some(p), .. } if p == pid77()));
+        assert!(
+            matches!(evs[0], AgentEvent::Identity { pid: Some(p), .. } if p.pid == i32::MAX && p.started.is_none())
+        );
     }
 
     #[test]
@@ -395,7 +389,7 @@ mod tests {
                 cwd: None,
                 pid: None,
             }];
-            patch_identity_pids(&mut evs, Some(pid77()));
+            patch_identity_pids(&mut evs, Some(i32::MAX));
             assert!(
                 matches!(evs[0], AgentEvent::Identity { pid: None, .. }),
                 "{source} Identity must stay pid: None"
@@ -410,9 +404,9 @@ mod tests {
                 cwd: None,
                 pid: None,
             }];
-            patch_identity_pids(&mut evs, Some(pid77()));
+            patch_identity_pids(&mut evs, Some(i32::MAX));
             assert!(
-                matches!(evs[0], AgentEvent::Identity { pid: Some(p), .. } if p == pid77()),
+                matches!(evs[0], AgentEvent::Identity { pid: Some(p), .. } if p.pid == i32::MAX && p.started.is_none()),
                 "{source} Identity must be stamped"
             );
         }
@@ -797,8 +791,14 @@ mod tests {
         let (mut client, server) = tokio::io::duplex(4096);
         let task = tokio::spawn(handle_conn(server, tx, None, None));
         // CodeWhale tool_call_before decodes to [Identity, ActivityStart].
-        let line = "{\"_pixtuoid_source\":\"codewhale\",\"event\":\"tool_call_before\",\
-                    \"cwd\":\"/repo\",\"tool\":\"exec_shell\",\"_pid\":4242}\n";
+        // i32::MAX as the pid: the stamp path does a REAL kernel marker read,
+        // and an allocatable pid (4242…) can be a live process on a busy CI
+        // host — an unallocatable one guarantees `started: None`.
+        let line = format!(
+            "{{\"_pixtuoid_source\":\"codewhale\",\"event\":\"tool_call_before\",\
+             \"cwd\":\"/repo\",\"tool\":\"exec_shell\",\"_pid\":{}}}\n",
+            i32::MAX
+        );
         client.write_all(line.as_bytes()).await.unwrap();
         drop(client);
         task.await.unwrap();
@@ -809,7 +809,7 @@ mod tests {
             .expect("the Identity ahead of the tool event");
         assert!(
             matches!(&ev, AgentEvent::Identity { source, pid: Some(p), .. }
-                if source == "codewhale" && p.pid == 4242 && p.started.is_none()),
+                if source == "codewhale" && p.pid == i32::MAX && p.started.is_none()),
             "hook-family Identity must carry the peeked pid without a watch \
              (and no start marker for a pid that does not exist), got {ev:?}"
         );

--- a/crates/pixtuoid-core/src/source/hook/mod.rs
+++ b/crates/pixtuoid-core/src/source/hook/mod.rs
@@ -198,7 +198,10 @@ fn pid_bind_target(ev: &AgentEvent) -> Option<AgentId> {
 /// never recycle-guarded), while their real focus channel is the liveness
 /// probes (`cc_pid_for_session`/`codex_pid_for_session`). A stamped stale pid
 /// would shadow the probe's recycle guard in `resolve_pid`.
-fn patch_identity_pids(evs: &mut [AgentEvent], pid: Option<i32>) {
+///
+/// The stamp is a [`PidIdentity`] — pid PLUS the kernel start marker read at
+/// peek time — so the click-time guard can refuse a recycled pid (#527).
+fn patch_identity_pids(evs: &mut [AgentEvent], pid: Option<crate::source::PidIdentity>) {
     let Some(pid) = pid else { return };
     for ev in evs {
         if let AgentEvent::Identity { source, pid: p, .. } = ev {
@@ -302,9 +305,20 @@ pub(crate) async fn handle_conn(
                             }
                         }
                         // Second consumer of the SAME peeked `_pid`: the
-                        // focus-jump cache (see `patch_identity_pids`).
+                        // focus-jump cache (see `patch_identity_pids`). The
+                        // start marker is read HERE — the closest moment to
+                        // the hook event itself — so a later click can refuse
+                        // a recycled pid (#527). Marker unreadable (pid died
+                        // between hook and peek, non-unix) → `None` → the
+                        // click-time identity check is skipped, not failed.
                         let mut evs = evs;
-                        patch_identity_pids(&mut evs, pid);
+                        patch_identity_pids(
+                            &mut evs,
+                            pid.map(|p| crate::source::PidIdentity {
+                                pid: p,
+                                started: crate::source::pid_start_marker(p),
+                            }),
+                        );
                         let mut undelivered = UndeliveredEvents::new(&evs);
                         for ev in evs {
                             debug!("hook event: {ev:?}");
@@ -334,6 +348,13 @@ mod tests {
     use crate::AgentId;
     use tokio::io::AsyncWriteExt;
 
+    fn pid77() -> crate::source::PidIdentity {
+        crate::source::PidIdentity {
+            pid: 77,
+            started: Some(1_000),
+        }
+    }
+
     #[test]
     fn patch_identity_pids_stamps_only_identity_events() {
         let id = AgentId::from_parts("opencode", "ses_x");
@@ -351,14 +372,14 @@ mod tests {
                 detail: None,
             },
         ];
-        patch_identity_pids(&mut evs, Some(77));
+        patch_identity_pids(&mut evs, Some(pid77()));
         assert!(
-            matches!(evs[0], AgentEvent::Identity { pid: Some(77), .. }),
+            matches!(evs[0], AgentEvent::Identity { pid: Some(p), .. } if p == pid77()),
             "Identity stamped"
         );
         // None leaves the batch untouched.
         patch_identity_pids(&mut evs, None);
-        assert!(matches!(evs[0], AgentEvent::Identity { pid: Some(77), .. }));
+        assert!(matches!(evs[0], AgentEvent::Identity { pid: Some(p), .. } if p == pid77()));
     }
 
     #[test]
@@ -374,7 +395,7 @@ mod tests {
                 cwd: None,
                 pid: None,
             }];
-            patch_identity_pids(&mut evs, Some(77));
+            patch_identity_pids(&mut evs, Some(pid77()));
             assert!(
                 matches!(evs[0], AgentEvent::Identity { pid: None, .. }),
                 "{source} Identity must stay pid: None"
@@ -389,9 +410,9 @@ mod tests {
                 cwd: None,
                 pid: None,
             }];
-            patch_identity_pids(&mut evs, Some(77));
+            patch_identity_pids(&mut evs, Some(pid77()));
             assert!(
-                matches!(evs[0], AgentEvent::Identity { pid: Some(77), .. }),
+                matches!(evs[0], AgentEvent::Identity { pid: Some(p), .. } if p == pid77()),
                 "{source} Identity must be stamped"
             );
         }
@@ -787,8 +808,10 @@ mod tests {
             .await
             .expect("the Identity ahead of the tool event");
         assert!(
-            matches!(&ev, AgentEvent::Identity { source, pid: Some(4242), .. } if source == "codewhale"),
-            "hook-family Identity must carry the peeked pid without a watch, got {ev:?}"
+            matches!(&ev, AgentEvent::Identity { source, pid: Some(p), .. }
+                if source == "codewhale" && p.pid == 4242 && p.started.is_none()),
+            "hook-family Identity must carry the peeked pid without a watch \
+             (and no start marker for a pid that does not exist), got {ev:?}"
         );
     }
 

--- a/crates/pixtuoid-core/src/source/mod.rs
+++ b/crates/pixtuoid-core/src/source/mod.rs
@@ -247,15 +247,26 @@ pub enum AgentEvent {
 /// mismatch (or a dead pid) means this is not the process the hook came from.
 /// `started: None` = no marker was readable at stamp time (non-unix daemon,
 /// EPERM); the click-time guard then skips the identity check (additive, the
-/// #220 posture). Field name `pid` everywhere keeps the `pid: None`
-/// construction sites stable across the `Option<i32>` → `Option<PidIdentity>`
-/// migration.
+/// #220 posture) — so on no-exit-watch platforms a markerless cache retains
+/// the pre-#527 recycled-pid residual until the stale sweep (compound-rare;
+/// documented, not guarded). Field name `pid` everywhere keeps the
+/// `pid: None` construction sites stable across the `Option<i32>` →
+/// `Option<PidIdentity>` migration. `non_exhaustive` so a future identity
+/// component (a boot id, a Windows session id) is a non-breaking add —
+/// cross-crate construction goes through [`PidIdentity::new`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
 pub struct PidIdentity {
     /// The agent CLI's OS pid (`pid_t`; matches `DaemonPresence.current_pid`).
     pub pid: i32,
     /// Opaque per-OS start marker — equality-only, see [`pid_start_marker`].
     pub started: Option<u64>,
+}
+
+impl PidIdentity {
+    pub fn new(pid: i32, started: Option<u64>) -> Self {
+        Self { pid, started }
+    }
 }
 
 impl AgentEvent {

--- a/crates/pixtuoid-core/src/source/mod.rs
+++ b/crates/pixtuoid-core/src/source/mod.rs
@@ -228,17 +228,34 @@ pub enum AgentEvent {
         /// Codex PermissionRequest) — the registration is then label-ordinal
         /// but still reap-exempt, exactly like the blank synthesis path.
         cwd: Option<PathBuf>,
-        /// The agent process's pid, from the shim/plugin `_pid` stamp — the
-        /// focus-jump channel for hook-only sources. Transcript-family
-        /// sources resolve pid via their liveness probes instead and always
-        /// carry `None` here (structural: `patch_identity_pids` skips any
-        /// source with a `line_decoder`). Hook-transport Identity recurs
-        /// ahead of every activity, so the slot's cached pid stays fresh.
-        /// serde-skipped so the conformance/scene goldens don't churn on
-        /// `None`.
+        /// The agent process's pid (+ recycle marker), from the shim/plugin
+        /// `_pid` stamp — the focus-jump channel for hook-only sources.
+        /// Transcript-family sources resolve pid via their liveness probes
+        /// instead and always carry `None` here (structural:
+        /// `patch_identity_pids` skips any source with a `line_decoder`).
+        /// Hook-transport Identity recurs ahead of every activity, so the
+        /// slot's cached pid stays fresh. serde-skipped so the
+        /// conformance/scene goldens don't churn on `None`.
         #[serde(skip_serializing_if = "Option::is_none", default)]
-        pid: Option<i32>,
+        pid: Option<PidIdentity>,
     },
+}
+
+/// A cached agent pid PLUS the kernel start marker read when it was stamped
+/// ([`pid_start_marker`]) — together they name ONE process incarnation, so a
+/// focus click can refuse a RECYCLED pid (#527): re-read the marker, and a
+/// mismatch (or a dead pid) means this is not the process the hook came from.
+/// `started: None` = no marker was readable at stamp time (non-unix daemon,
+/// EPERM); the click-time guard then skips the identity check (additive, the
+/// #220 posture). Field name `pid` everywhere keeps the `pid: None`
+/// construction sites stable across the `Option<i32>` → `Option<PidIdentity>`
+/// migration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct PidIdentity {
+    /// The agent CLI's OS pid (`pid_t`; matches `DaemonPresence.current_pid`).
+    pub pid: i32,
+    /// Opaque per-OS start marker — equality-only, see [`pid_start_marker`].
+    pub started: Option<u64>,
 }
 
 impl AgentEvent {
@@ -269,6 +286,15 @@ pub fn cc_pid_for_session(projects_root: &std::path::Path, session_id: &str) -> 
         .pid_of
         .get(session_id)
         .copied()
+}
+
+/// The CC sessions-registry dir the pid queries consult — the SAME
+/// standard-layout gate the probe applies (a `--projects-root /tmp/fixture`
+/// replay yields `None`). Exposed so `doctor` can report the focus channel's
+/// on-disk state without re-deriving the sibling layout (#526).
+#[cfg(feature = "native")]
+pub fn cc_registry_dir(projects_root: &std::path::Path) -> Option<std::path::PathBuf> {
+    cc_probe::cc_sessions_dir(projects_root)
 }
 
 /// Codex twin of [`cc_pid_for_session`], keyed by the rollout UUID (the
@@ -322,6 +348,13 @@ mod native;
 pub use native::{DynSource, Source, TaggedReceiver, TaggedSender};
 pub mod openclaw;
 pub mod opencode;
+// The kernel start-marker read shared by the hook stamp and the binary's
+// click-time recycle guard (#527); the fn is the pub seam, the platform
+// impls stay private.
+#[cfg(feature = "native")]
+mod proc_start;
+#[cfg(feature = "native")]
+pub use proc_start::pid_start_marker;
 pub mod reasonix;
 // `doc(hidden)`: the registry is an internal fact table, `pub` ONLY so the
 // integration-test crates (sources::conformance) can read it. Hiding it keeps it

--- a/crates/pixtuoid-core/src/source/proc_start.rs
+++ b/crates/pixtuoid-core/src/source/proc_start.rs
@@ -1,0 +1,92 @@
+//! Kernel process-start MARKERS — the identity half of pid-recycle guards.
+//!
+//! [`pid_start_marker`] returns an opaque per-OS value that is stable for a
+//! process's whole life and different for a recycled pid: macOS epoch seconds
+//! (`proc_pidinfo(PROC_PIDTBSDINFO)` → `pbi_start_tvsec`), Linux clock ticks
+//! since boot (`/proc/<pid>/stat` field 22, read RAW — equality needs no
+//! boot-time/ticks-per-sec conversion, the blocker that kept #220's epoch
+//! check macOS-only). The units DIFFER per OS: compare two markers from the
+//! SAME machine for equality, never across hosts and never as wall-clock.
+//! `None` on any failure (pid gone, EPERM, unsupported OS) — callers treat a
+//! missing marker as "no identity check available", never an error.
+//!
+//! Two consumers: the hook plane stamps `(pid, marker)` at `_pid` peek time
+//! (`PidIdentity`), and the binary's focus click re-reads the marker to
+//! refuse a recycled pid (#527).
+
+/// Opaque start marker for `pid`, or `None` when unreadable/unsupported.
+pub fn pid_start_marker(pid: i32) -> Option<u64> {
+    imp(pid)
+}
+
+#[cfg(target_os = "macos")]
+fn imp(pid: i32) -> Option<u64> {
+    // SAFETY: all-zero bytes are a valid value for this repr(C) plain-old-data
+    // struct (integers + byte arrays only).
+    let mut info: libc::proc_bsdinfo = unsafe { std::mem::zeroed() };
+    let size = std::mem::size_of::<libc::proc_bsdinfo>() as libc::c_int;
+    // SAFETY: the buffer is exactly `size` bytes of a repr(C) struct matching
+    // the macOS SDK's proc_bsdinfo layout (proc_info.h, ABI-stable since
+    // 10.5), so the kernel fills only memory we own. PROC_PIDTBSDINFO returns
+    // the full struct or <= 0 on failure.
+    let n = unsafe {
+        libc::proc_pidinfo(
+            pid,
+            libc::PROC_PIDTBSDINFO,
+            0,
+            &mut info as *mut _ as *mut std::ffi::c_void,
+            size,
+        )
+    };
+    if n != size {
+        return None;
+    }
+    Some(info.pbi_start_tvsec)
+}
+
+#[cfg(target_os = "linux")]
+fn imp(pid: i32) -> Option<u64> {
+    // /proc/<pid>/stat field 22 is starttime; the comm field (2) can contain
+    // spaces/parens, so count fields AFTER the last ')' (comm is field 2,
+    // so starttime is the 20th token past it).
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let after = stat.rsplit_once(')')?.1;
+    after.split_whitespace().nth(19)?.parse().ok()
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn imp(_pid: i32) -> Option<u64> {
+    None
+}
+
+#[cfg(all(test, any(target_os = "macos", target_os = "linux")))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn marker_is_stable_for_a_live_process_and_none_after_it_dies() {
+        let mut child = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn a child to mark");
+        let pid = child.id() as i32;
+        let first = pid_start_marker(pid).expect("a live child has a marker");
+        let second = pid_start_marker(pid).expect("still alive");
+        assert_eq!(first, second, "the marker never changes for one process");
+        child.kill().expect("kill the child");
+        child.wait().expect("reap so the pid leaves the table");
+        // A reaped pid has no /proc entry / bsdinfo — the read fails to None.
+        assert_eq!(pid_start_marker(pid), None);
+    }
+
+    #[test]
+    fn own_process_has_a_marker() {
+        assert!(pid_start_marker(std::process::id() as i32).is_some());
+    }
+
+    #[test]
+    fn garbage_pid_is_none() {
+        assert_eq!(pid_start_marker(-1), None);
+        assert_eq!(pid_start_marker(i32::MAX), None);
+    }
+}

--- a/crates/pixtuoid-core/src/source/registry.rs
+++ b/crates/pixtuoid-core/src/source/registry.rs
@@ -172,6 +172,38 @@ pub struct Transcript {
     pub cwd_extractor: CwdExtractor,
 }
 
+/// How focus-jump resolves this source's OS pid — a DATA-only capability
+/// (this const table compiles to wasm via `default-features = false`, so a
+/// native-only probe FN POINTER can never live here; the transcript probes
+/// stay in the BINARY's `focus::resolve_pid`, pinned to this enum by its
+/// lockstep test). ONE source of truth for the three consumers that used to
+/// hand-agree: the hook stamp gate (`patch_identity_pids`), the click-time
+/// probe dispatch (`focus::resolve_pid`), and the doctor report bucketing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FocusChannel {
+    /// The shim stamps its `getppid` into `_pid` — trustworthy because
+    /// `sh -c` EXECs the hook so the parent IS the CLI; absent on Windows
+    /// (`cmd /C` transient parent, the documented `parent_pid` trap).
+    ShimStamp,
+    /// The source's own runtime stamps `_pid` (opencode's `process.pid`) —
+    /// cross-platform, survives even where the shim sends nothing.
+    PluginStamp,
+    /// Pid resolves through a recycle-guarded liveness probe at CLICK time;
+    /// hook stamps are never trusted (the shim's getppid is the hook-command
+    /// parent, not the CLI). The probe fn itself lives in the binary.
+    TranscriptProbe,
+    /// No pid channel — a focus click silently no-ops (the ONE failure rule).
+    Unsupported,
+}
+
+impl FocusChannel {
+    /// Whether a hook-envelope `_pid` stamp is a trustworthy pid for this
+    /// source — the `patch_identity_pids` gate.
+    pub fn accepts_stamp(self) -> bool {
+        matches!(self, FocusChannel::ShimStamp | FocusChannel::PluginStamp)
+    }
+}
+
 /// The two source classes, type-isolated. Adding a daemon (a 2nd one is "one
 /// `Daemon` row + one binary mascot arm + one badge arm") needs no `handle_conn`
 /// edit and no new reducer arm — the registry-driven demux + the
@@ -185,6 +217,9 @@ pub enum SourceKind {
         transcript: Option<Transcript>,
         hook: HookDecoding,
         caps: SourceCaps,
+        /// The focus-jump pid channel. Lives INSIDE `Agent` so a daemon can't
+        /// carry one (structurally unrepresentable — a mascot isn't clickable).
+        focus: FocusChannel,
     },
     /// Produces `DaemonPresenceUpdate`s → `SceneState::daemons` → a wandering
     /// mascot (the OpenClaw gateway is instance #1). Its `presence_decoder` maps
@@ -219,6 +254,15 @@ impl SourceDescriptor {
     /// daemon — neither has a transcript for the walker to head-scan).
     pub fn cwd_extractor(&self) -> Option<CwdExtractor> {
         self.transcript().map(|t| t.cwd_extractor)
+    }
+
+    /// The focus-jump pid channel (`Unsupported` for a daemon — a mascot has
+    /// no terminal to jump to).
+    pub fn focus_channel(&self) -> FocusChannel {
+        match &self.kind {
+            SourceKind::Agent { focus, .. } => *focus,
+            SourceKind::Daemon { .. } => FocusChannel::Unsupported,
+        }
     }
 
     /// The hook-decoding spec (`None` for a daemon — its payloads never reach
@@ -334,6 +378,7 @@ const CLAUDE_CODE: SourceDescriptor = SourceDescriptor {
             resurrects_on_prompt: false,
             delegations_are_hook_silent: false,
         },
+        focus: FocusChannel::TranscriptProbe,
     },
 };
 
@@ -359,6 +404,7 @@ const CODEX: SourceDescriptor = SourceDescriptor {
             resurrects_on_prompt: true,
             delegations_are_hook_silent: false,
         },
+        focus: FocusChannel::TranscriptProbe,
     },
 };
 
@@ -384,6 +430,7 @@ const ANTIGRAVITY: SourceDescriptor = SourceDescriptor {
             resurrects_on_prompt: false,
             delegations_are_hook_silent: false,
         },
+        focus: FocusChannel::Unsupported,
     },
 };
 
@@ -416,6 +463,7 @@ const REASONIX: SourceDescriptor = SourceDescriptor {
             // stale window (see `stale_threshold_with_caps`).
             delegations_are_hook_silent: true,
         },
+        focus: FocusChannel::ShimStamp,
     },
 };
 
@@ -455,6 +503,7 @@ const CODEWHALE: SourceDescriptor = SourceDescriptor {
             // `codewhale::decode_cw_subagent`.)
             delegations_are_hook_silent: true,
         },
+        focus: FocusChannel::ShimStamp,
     },
 };
 
@@ -488,6 +537,7 @@ const OPENCODE: SourceDescriptor = SourceDescriptor {
             // needed.
             delegations_are_hook_silent: false,
         },
+        focus: FocusChannel::PluginStamp,
     },
 };
 
@@ -541,6 +591,7 @@ const COPILOT: SourceDescriptor = SourceDescriptor {
             // `subagent.started`/`completed` events, so a delegation is not hook-silent.
             delegations_are_hook_silent: false,
         },
+        focus: FocusChannel::Unsupported,
     },
 };
 
@@ -584,6 +635,7 @@ const CURSOR: SourceDescriptor = SourceDescriptor {
             // `sessionEnd` reaps it cleanly in the normal case).
             delegations_are_hook_silent: true,
         },
+        focus: FocusChannel::ShimStamp,
     },
 };
 
@@ -618,6 +670,7 @@ const HERMES: SourceDescriptor = SourceDescriptor {
             // no hook-silent delegation window to hold.
             delegations_are_hook_silent: false,
         },
+        focus: FocusChannel::ShimStamp,
     },
 };
 

--- a/crates/pixtuoid-core/src/state/mod.rs
+++ b/crates/pixtuoid-core/src/state/mod.rs
@@ -356,14 +356,16 @@ pub struct AgentSlot {
     pub active_ms: u64,
     pub unknown_cwd: bool,
     pub parent_id: Option<AgentId>,
-    /// The agent process's pid — the focus-jump channel for hook-only sources
-    /// (filled from the shim/plugin `_pid` riding each hook-transport
-    /// `Identity`; refreshed per event, never downgraded to `None`).
-    /// Transcript-family sources stay `None` here — their pid channel is the
-    /// liveness probe, queried at click time. serde-skipped so the scene
-    /// serialization golden doesn't churn on `None`.
+    /// The agent process's pid + recycle marker — the focus-jump channel for
+    /// hook-only sources (filled from the shim/plugin `_pid` riding each
+    /// hook-transport `Identity`; refreshed per event, never downgraded to
+    /// `None`). The click-time guard re-reads the marker and refuses a
+    /// recycled pid (#527). Transcript-family sources stay `None` here —
+    /// their pid channel is the liveness probe, queried at click time.
+    /// serde-skipped so the scene serialization golden doesn't churn on
+    /// `None`.
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub pid: Option<i32>,
+    pub pid: Option<crate::source::PidIdentity>,
 }
 
 /// Liveness of a daemon-style source (the OpenClaw gateway). Drives the

--- a/crates/pixtuoid-core/tests/reducer/lifecycle.rs
+++ b/crates/pixtuoid-core/tests/reducer/lifecycle.rs
@@ -1314,10 +1314,7 @@ fn hook_identity_pid_fills_refreshes_and_never_downgrades_slot_pid() {
     let mut r = Reducer::new();
     let id = AgentId::from_parts("opencode", "ses_pid");
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
-    let pid_id = |pid: i32| pixtuoid_core::source::PidIdentity {
-        pid,
-        started: Some(1_000),
-    };
+    let pid_id = |pid: i32| pixtuoid_core::source::PidIdentity::new(pid, Some(1_000));
     let identity = |pid: Option<pixtuoid_core::source::PidIdentity>| AgentEvent::Identity {
         agent_id: id,
         source: "opencode".into(),

--- a/crates/pixtuoid-core/tests/reducer/lifecycle.rs
+++ b/crates/pixtuoid-core/tests/reducer/lifecycle.rs
@@ -1314,7 +1314,11 @@ fn hook_identity_pid_fills_refreshes_and_never_downgrades_slot_pid() {
     let mut r = Reducer::new();
     let id = AgentId::from_parts("opencode", "ses_pid");
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
-    let identity = |pid: Option<i32>| AgentEvent::Identity {
+    let pid_id = |pid: i32| pixtuoid_core::source::PidIdentity {
+        pid,
+        started: Some(1_000),
+    };
+    let identity = |pid: Option<pixtuoid_core::source::PidIdentity>| AgentEvent::Identity {
         agent_id: id,
         source: "opencode".into(),
         session_id: "ses_pid".into(),
@@ -1323,16 +1327,28 @@ fn hook_identity_pid_fills_refreshes_and_never_downgrades_slot_pid() {
     };
 
     // Registration fills the cache.
-    r.apply(&mut scene, identity(Some(41)), t0, Transport::Hook);
-    assert_eq!(scene.agents[&id].pid, Some(41), "registration fills pid");
+    r.apply(&mut scene, identity(Some(pid_id(41))), t0, Transport::Hook);
+    assert_eq!(
+        scene.agents[&id].pid,
+        Some(pid_id(41)),
+        "registration fills pid"
+    );
 
     // A later Identity refreshes it (restart under a new pid).
-    r.apply(&mut scene, identity(Some(42)), t0, Transport::Hook);
-    assert_eq!(scene.agents[&id].pid, Some(42), "backfill refreshes pid");
+    r.apply(&mut scene, identity(Some(pid_id(42))), t0, Transport::Hook);
+    assert_eq!(
+        scene.agents[&id].pid,
+        Some(pid_id(42)),
+        "backfill refreshes pid"
+    );
 
     // A pid-less Identity keeps the cached value.
     r.apply(&mut scene, identity(None), t0, Transport::Hook);
-    assert_eq!(scene.agents[&id].pid, Some(42), "None never downgrades");
+    assert_eq!(
+        scene.agents[&id].pid,
+        Some(pid_id(42)),
+        "None never downgrades"
+    );
 }
 
 #[test]

--- a/crates/pixtuoid-hook/src/main.rs
+++ b/crates/pixtuoid-hook/src/main.rs
@@ -141,6 +141,10 @@ fn env_payload(event: &str) -> serde_json::Map<String, Value> {
 /// (the WRONG pid, and it exits right after spawning the shim → a false
 /// exit / a recycled-pid focus), so we send no pid there: CodeWhale falls
 /// back to `session_end` + the stale-sweep, focus to a silent no-op.
+/// Container caveat: with a bind-mounted socket this pid is a CONTAINER-
+/// namespace pid the host-side daemon can't translate — the walk then hits
+/// an unrelated host process (usually surface-less → no-op). Gated behind
+/// deliberate socket sharing; default containers never reach the socket.
 #[cfg(unix)]
 fn parent_pid() -> Option<u32> {
     // getppid() is always safe (no args, infallible) and gives the hook's

--- a/crates/pixtuoid/CLAUDE.md
+++ b/crates/pixtuoid/CLAUDE.md
@@ -124,12 +124,18 @@ src/
 │                       (main.rs), AND `run` (the CLI report) all read — surfaces can't drift apart. Version
 │                       skew stays report-ONLY (the <cli> --version probe is too costly for the interactive
 │                       panel-open; advisory). doctor=health PROVIDER, ConnState=connection lifecycle it
-│                       ANNOTATES (sub-state, not overlap)
+│                       ANNOTATES (sub-state, not overlap). + the #526 focus-jump block (`focus_section`,
+│                       pure + registry-bucketed: activation backend per OS — linux via the pure
+│                       `linux_activation_backend` over the SAME env markers focus/linux.rs keys on —
+│                       + CC/Codex probe-root presence via `source::cc_registry_dir` / codex
+│                       default_paths; report-only, NO TUI notice — user-cut)
 ├── focus/              FOCUS-JUMP (click a sprite / dashboard `f` → the agent's terminal APP comes to the
 │                       foreground; spec docs/superpowers/specs/2026-07-10). mod.rs: resolve_pid (slot.pid for
-│                       the hook family — filled from the `_pid` riding each hook Identity — else the CC/Codex
-│                       point queries `source::{cc,codex}_pid_for_session`, both recycle-guarded; an EXITING
-│                       slot is REFUSED — the cheap click-time pid-recycle guard) + ancestor_walk (PURE over an
+│                       the hook family — a `PidIdentity` (pid + kernel start marker) riding each hook
+│                       Identity — else the CC/Codex point queries `source::{cc,codex}_pid_for_session`, both
+│                       recycle-guarded; TWO click-time guards on the cached path: an EXITING slot is REFUSED,
+│                       and the start marker is re-read via ProcessTable::start_time — mismatch/gone = recycled
+│                       pid, refused, #527) + ancestor_walk (PURE over an
 │                       injected ProcessTable, cycle-guarded, stops at pid≤1 — mock-table unit tests) +
 │                       focus_agent (the ONE orchestration entry; activation injected so dispatch tests never
 │                       touch the OS). Per-OS glue (codecov-ignored, winit-class): macos.rs `/bin/ps -o ppid=`

--- a/crates/pixtuoid/CLAUDE.md
+++ b/crates/pixtuoid/CLAUDE.md
@@ -130,13 +130,17 @@ src/
 │                       + CC/Codex probe-root presence via `source::cc_registry_dir` / codex
 │                       default_paths; report-only, NO TUI notice — user-cut)
 ├── focus/              FOCUS-JUMP (click a sprite / dashboard `f` → the agent's terminal APP comes to the
-│                       foreground; spec docs/superpowers/specs/2026-07-10). mod.rs: resolve_pid (slot.pid for
-│                       the hook family — a `PidIdentity` (pid + kernel start marker) riding each hook
-│                       Identity — else the CC/Codex point queries `source::{cc,codex}_pid_for_session`, both
-│                       recycle-guarded; TWO click-time guards on the cached path: an EXITING slot is REFUSED,
+│                       foreground; spec docs/superpowers/specs/2026-07-10). mod.rs: focus_slot (the ONE
+│                       painter-agnostic dispatch entry — tui click/`f` today, the floating trigger later) →
+│                       resolve_pid (slot.pid for stamp-channel sources — a `PidIdentity` (pid + kernel start
+│                       marker) riding each hook Identity — else the registry `FocusChannel::TranscriptProbe`
+│                       gate + the CC/Codex point queries `source::{cc,codex}_pid_for_session`, recycle-guarded;
+│                       probe fns stay HERE, lockstep-tested against the registry enum — wasm const-table
+│                       boundary; TWO click-time guards on the cached path: an EXITING slot is REFUSED,
 │                       and the start marker is re-read via ProcessTable::start_time — mismatch/gone = recycled
 │                       pid, refused, #527) + ancestor_walk (PURE over an
-│                       injected ProcessTable, cycle-guarded, stops at pid≤1 — mock-table unit tests) +
+│                       injected ProcessTable, cycle-guarded, stops at pid≤1 — mock-table unit tests; KNOWN
+│                       common miss #538: tmux/screen/zellij servers are daemonized → walk dead-ends at pid 1) +
 │                       focus_agent (the ONE orchestration entry; activation injected so dispatch tests never
 │                       touch the OS). Per-OS glue (codecov-ignored, winit-class): macos.rs `/bin/ps -o ppid=`
 │                       per hop (NOT proc_pidinfo — it EPERMs at the setuid-root `login` in terminal chains;

--- a/crates/pixtuoid/src/doctor.rs
+++ b/crates/pixtuoid/src/doctor.rs
@@ -545,6 +545,128 @@ fn probe_version(argv: &'static [&'static str]) -> Option<String> {
     first_sanitized_line(&output.stdout).or_else(|| first_sanitized_line(&output.stderr))
 }
 
+/// The desktop activation backend focus-jump would use on THIS host — the
+/// per-OS half of the #526 focus diagnostic. Linux detection is the pure
+/// [`linux_activation_backend`] over the env markers `focus/linux.rs` keys on.
+fn activation_backend() -> String {
+    #[cfg(target_os = "macos")]
+    {
+        "NSRunningApplication (macOS) ✓".to_string()
+    }
+    #[cfg(target_os = "linux")]
+    {
+        linux_activation_backend(
+            std::env::var_os("SWAYSOCK").is_some(),
+            std::env::var_os("HYPRLAND_INSTANCE_SIGNATURE").is_some(),
+            std::env::var_os("DISPLAY").is_some(),
+        )
+        .to_string()
+    }
+    #[cfg(windows)]
+    {
+        "SetForegroundWindow (Windows) ✓ — the foreground lock may still deny".to_string()
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
+    {
+        "none — focus-jump is unsupported on this OS".to_string()
+    }
+}
+
+/// Pure so every arm is unit-tested on any host: mirrors `focus/linux.rs`'s
+/// ONE-channel-per-env order (sway IPC → hyprland IPC → X11 EWMH → nothing).
+/// Only the linux `activation_backend` arm calls it in prod — on other hosts
+/// the tests are the (deliberate) only caller.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn linux_activation_backend(sway: bool, hyprland: bool, x11: bool) -> &'static str {
+    if sway {
+        "sway IPC (swaymsg) ✓"
+    } else if hyprland {
+        "hyprland IPC (hyprctl) ✓"
+    } else if x11 {
+        "X11 EWMH ($DISPLAY) ✓"
+    } else {
+        "✗ none detected — focus will silently no-op (GNOME Wayland forbids focus-steal)"
+    }
+}
+
+/// The focus-jump block of the report (#526): the activation backend + which
+/// pid channel each source family rides, with the transcript-family probe
+/// roots checked on disk. Pure over the probed facts; the family buckets come
+/// straight from the registry (a new source lands in the right bucket with no
+/// edit here).
+pub fn focus_section(
+    backend: &str,
+    cc_registry: Option<(&std::path::Path, bool)>,
+    codex_sessions: (&std::path::Path, bool),
+) -> String {
+    let prefix_of = |src: &str| {
+        registry::descriptor_for(src)
+            .map(|d| d.label_prefix)
+            .unwrap_or("??")
+    };
+    let mut hook_family = Vec::new();
+    let mut no_channel = Vec::new();
+    for &src in REGISTERED_SOURCES {
+        let Some(d) = registry::descriptor_for(src) else {
+            continue;
+        };
+        // Daemons (the lobster) aren't click-focusable agents; CC/Codex get
+        // their own probe rows below.
+        if d.is_daemon()
+            || src == pixtuoid_core::source::claude_code::SOURCE_NAME
+            || src == pixtuoid_core::source::codex::SOURCE_NAME
+        {
+            continue;
+        }
+        let tag = format!("{}\u{b7}{}", d.label_prefix, src);
+        if d.line_decoder().is_some() {
+            no_channel.push(tag);
+        } else {
+            hook_family.push(tag);
+        }
+    }
+    let mut out = String::from("focus-jump (click a sprite → its terminal comes forward):\n");
+    out.push_str(&format!("  backend: {backend}\n"));
+    let cc_prefix = prefix_of(pixtuoid_core::source::claude_code::SOURCE_NAME);
+    match cc_registry {
+        Some((dir, true)) => out.push_str(&format!(
+            "  {cc_prefix}\u{b7}claude-code — registry probe: {} ✓\n",
+            dir.display()
+        )),
+        Some((dir, false)) => out.push_str(&format!(
+            "  {cc_prefix}\u{b7}claude-code — registry probe: {} ✗ missing (focus no-ops until CC writes it)\n",
+            dir.display()
+        )),
+        None => out.push_str(&format!(
+            "  {cc_prefix}\u{b7}claude-code — registry probe disabled (non-standard projects root) — focus no-ops\n"
+        )),
+    }
+    let cx_prefix = prefix_of(pixtuoid_core::source::codex::SOURCE_NAME);
+    let (codex_dir, codex_present) = codex_sessions;
+    out.push_str(&format!(
+        "  {cx_prefix}\u{b7}codex — rollout fd probe: {} {}\n",
+        codex_dir.display(),
+        if codex_present {
+            "✓"
+        } else {
+            "✗ missing (focus no-ops until codex writes it)"
+        }
+    ));
+    if !hook_family.is_empty() {
+        out.push_str(&format!(
+            "  {} — shim/plugin `_pid` rides each hook event\n",
+            hook_family.join(", ")
+        ));
+    }
+    if !no_channel.is_empty() {
+        out.push_str(&format!(
+            "  {} — no focus channel (click no-ops)\n",
+            no_channel.join(", ")
+        ));
+    }
+    out
+}
+
 /// Run the diagnosis: read config + install-state + the log, probe installed CLI
 /// versions, print a per-source health table. Read-only. `log_path` is injected
 /// by `main` (it owns the log-path resolution, which lives in the bin, not lib).
@@ -660,6 +782,20 @@ pub fn run(log_path: &std::path::Path) -> anyhow::Result<String> {
     } else {
         out.push_str(" · ✓ no decode drift\n");
     }
+    // The #526 focus diagnostic — probe roots come from the SAME default
+    // resolution the runtime seeds its watchers with (a --projects-root /
+    // --codex-sessions-root override changes the RUNNING app, and doctor
+    // diagnoses the default setup — noted so the mismatch can't surprise).
+    let cc_projects =
+        pixtuoid_core::source::claude_code::ClaudeCodeSource::default_paths().projects_root;
+    let cc_registry = pixtuoid_core::source::cc_registry_dir(&cc_projects);
+    let codex_sessions = pixtuoid_core::source::codex::CodexSource::default_paths().sessions_root;
+    out.push('\n');
+    out.push_str(&focus_section(
+        &activation_backend(),
+        cc_registry.as_deref().map(|d| (d, d.is_dir())),
+        (&codex_sessions, codex_sessions.is_dir()),
+    ));
     // Windows safety net: a HOME≠USERPROFILE shell is the one host condition under
     // which a CLI's home-resolution could land hooks where pixtuoid didn't write.
     if let Some(adv) = home_split_advisory(
@@ -678,6 +814,52 @@ mod tests {
     use std::io::Write;
     use std::sync::{Arc, Mutex};
     use tracing_subscriber::fmt::MakeWriter;
+
+    #[test]
+    fn linux_activation_backend_covers_every_channel_in_priority_order() {
+        assert!(linux_activation_backend(true, true, true).contains("sway"));
+        assert!(linux_activation_backend(false, true, true).contains("hyprland"));
+        assert!(linux_activation_backend(false, false, true).contains("EWMH"));
+        assert!(linux_activation_backend(false, false, false).contains("✗ none"));
+    }
+
+    #[test]
+    fn focus_section_buckets_sources_from_the_registry() {
+        let cc = std::path::Path::new("/home/u/.claude/sessions");
+        let cx = std::path::Path::new("/home/u/.codex/sessions");
+        let s = focus_section("test-backend ✓", Some((cc, true)), (cx, true));
+        assert!(s.contains("backend: test-backend ✓"));
+        assert!(s.contains("claude-code — registry probe") && s.contains("✓"));
+        assert!(s.contains("codex — rollout fd probe"));
+        // Hook-only sources ride the _pid stamp; transcript-only non-probe
+        // sources have no channel — both buckets are REGISTRY-derived, so a
+        // new source lands correctly with no doctor edit.
+        assert!(
+            s.contains("opencode") && s.contains("_pid"),
+            "hook family listed: {s}"
+        );
+        let no_channel_line = s
+            .lines()
+            .find(|l| l.contains("no focus channel"))
+            .expect("a no-channel line");
+        assert!(
+            no_channel_line.contains("antigravity") && no_channel_line.contains("copilot"),
+            "transcript-only sources listed: {no_channel_line}"
+        );
+        // The daemon (lobster) is not a click-focusable agent.
+        assert!(!s.contains("openclaw"), "daemons are excluded: {s}");
+    }
+
+    #[test]
+    fn focus_section_reports_missing_and_disabled_probe_roots() {
+        let cc = std::path::Path::new("/home/u/.claude/sessions");
+        let cx = std::path::Path::new("/home/u/.codex/sessions");
+        let missing = focus_section("b", Some((cc, false)), (cx, false));
+        assert!(missing.contains("✗ missing (focus no-ops until CC writes it)"));
+        assert!(missing.contains("✗ missing (focus no-ops until codex writes it)"));
+        let disabled = focus_section("b", None, (cx, true));
+        assert!(disabled.contains("registry probe disabled (non-standard projects root)"));
+    }
 
     #[test]
     fn run_renders_the_structural_report_headers() {

--- a/crates/pixtuoid/src/doctor.rs
+++ b/crates/pixtuoid/src/doctor.rs
@@ -558,6 +558,7 @@ fn activation_backend() -> String {
         linux_activation_backend(
             std::env::var_os("SWAYSOCK").is_some(),
             std::env::var_os("HYPRLAND_INSTANCE_SIGNATURE").is_some(),
+            std::env::var_os("WAYLAND_DISPLAY").is_some(),
             std::env::var_os("DISPLAY").is_some(),
         )
         .to_string()
@@ -573,19 +574,27 @@ fn activation_backend() -> String {
 }
 
 /// Pure so every arm is unit-tested on any host: mirrors `focus/linux.rs`'s
-/// ONE-channel-per-env order (sway IPC → hyprland IPC → X11 EWMH → nothing).
-/// Only the linux `activation_backend` arm calls it in prod — on other hosts
-/// the tests are the (deliberate) only caller.
+/// ONE-channel-per-env order (sway IPC → hyprland IPC → X11 EWMH → nothing) —
+/// EXCEPT that a Wayland session without a pid-addressable IPC must NOT be
+/// reported as "X11 EWMH ✓": XWayland sets $DISPLAY, but a native-Wayland
+/// terminal never appears in XWayland's client list and mutter/kwin block
+/// focus-steal anyway, so the ✓ would mislead exactly the users focus fails
+/// for. Only the linux `activation_backend` arm calls this in prod — on
+/// other hosts the tests are the (deliberate) only caller.
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
-fn linux_activation_backend(sway: bool, hyprland: bool, x11: bool) -> &'static str {
+fn linux_activation_backend(sway: bool, hyprland: bool, wayland: bool, x11: bool) -> &'static str {
     if sway {
         "sway IPC (swaymsg) ✓"
     } else if hyprland {
         "hyprland IPC (hyprctl) ✓"
+    } else if wayland {
+        "✗ Wayland compositor without a pid-addressable focus channel (GNOME/KDE \
+         forbid focus-steal; xdg-activation unimplemented) — focus will silently \
+         no-op for native-Wayland terminals"
     } else if x11 {
         "X11 EWMH ($DISPLAY) ✓"
     } else {
-        "✗ none detected — focus will silently no-op (GNOME Wayland forbids focus-steal)"
+        "✗ none detected — focus will silently no-op"
     }
 }
 
@@ -594,7 +603,7 @@ fn linux_activation_backend(sway: bool, hyprland: bool, x11: bool) -> &'static s
 /// roots checked on disk. Pure over the probed facts; the family buckets come
 /// straight from the registry (a new source lands in the right bucket with no
 /// edit here).
-pub fn focus_section(
+pub(crate) fn focus_section(
     backend: &str,
     cc_registry: Option<(&std::path::Path, bool)>,
     codex_sessions: (&std::path::Path, bool),
@@ -604,25 +613,25 @@ pub fn focus_section(
             .map(|d| d.label_prefix)
             .unwrap_or("??")
     };
-    let mut hook_family = Vec::new();
+    use registry::FocusChannel;
+    let mut shim_stamp = Vec::new();
+    let mut plugin_stamp = Vec::new();
     let mut no_channel = Vec::new();
     for &src in REGISTERED_SOURCES {
         let Some(d) = registry::descriptor_for(src) else {
             continue;
         };
-        // Daemons (the lobster) aren't click-focusable agents; CC/Codex get
-        // their own probe rows below.
-        if d.is_daemon()
-            || src == pixtuoid_core::source::claude_code::SOURCE_NAME
-            || src == pixtuoid_core::source::codex::SOURCE_NAME
-        {
+        // Daemons (the lobster) aren't click-focusable agents; the
+        // TranscriptProbe sources (CC/Codex) get their own rows below.
+        if d.is_daemon() || d.focus_channel() == FocusChannel::TranscriptProbe {
             continue;
         }
         let tag = format!("{}\u{b7}{}", d.label_prefix, src);
-        if d.line_decoder().is_some() {
-            no_channel.push(tag);
-        } else {
-            hook_family.push(tag);
+        match d.focus_channel() {
+            FocusChannel::ShimStamp => shim_stamp.push(tag),
+            FocusChannel::PluginStamp => plugin_stamp.push(tag),
+            FocusChannel::Unsupported => no_channel.push(tag),
+            FocusChannel::TranscriptProbe => unreachable!("skipped above"),
         }
     }
     let mut out = String::from("focus-jump (click a sprite → its terminal comes forward):\n");
@@ -652,10 +661,16 @@ pub fn focus_section(
             "✗ missing (focus no-ops until codex writes it)"
         }
     ));
-    if !hook_family.is_empty() {
+    if !shim_stamp.is_empty() {
         out.push_str(&format!(
-            "  {} — shim/plugin `_pid` rides each hook event\n",
-            hook_family.join(", ")
+            "  {} — shim `_pid` (getppid) rides each hook event (unix; absent on Windows)\n",
+            shim_stamp.join(", ")
+        ));
+    }
+    if !plugin_stamp.is_empty() {
+        out.push_str(&format!(
+            "  {} — plugin-stamped `_pid` rides each hook event (all platforms)\n",
+            plugin_stamp.join(", ")
         ));
     }
     if !no_channel.is_empty() {
@@ -817,10 +832,13 @@ mod tests {
 
     #[test]
     fn linux_activation_backend_covers_every_channel_in_priority_order() {
-        assert!(linux_activation_backend(true, true, true).contains("sway"));
-        assert!(linux_activation_backend(false, true, true).contains("hyprland"));
-        assert!(linux_activation_backend(false, false, true).contains("EWMH"));
-        assert!(linux_activation_backend(false, false, false).contains("✗ none"));
+        assert!(linux_activation_backend(true, true, true, true).contains("sway"));
+        assert!(linux_activation_backend(false, true, true, true).contains("hyprland"));
+        // A Wayland session without sway/hyprland must be an HONEST ✗ even
+        // when XWayland set $DISPLAY — never "X11 EWMH ✓" (the F2 fix).
+        assert!(linux_activation_backend(false, false, true, true).contains("✗ Wayland"));
+        assert!(linux_activation_backend(false, false, false, true).contains("EWMH"));
+        assert!(linux_activation_backend(false, false, false, false).contains("✗ none"));
     }
 
     #[test]
@@ -835,8 +853,12 @@ mod tests {
         // sources have no channel — both buckets are REGISTRY-derived, so a
         // new source lands correctly with no doctor edit.
         assert!(
-            s.contains("opencode") && s.contains("_pid"),
-            "hook family listed: {s}"
+            s.contains("opencode") && s.contains("plugin-stamped"),
+            "plugin stampers listed separately: {s}"
+        );
+        assert!(
+            s.contains("cursor") && s.contains("shim `_pid`"),
+            "shim stampers listed separately: {s}"
         );
         let no_channel_line = s
             .lines()

--- a/crates/pixtuoid/src/focus/mod.rs
+++ b/crates/pixtuoid/src/focus/mod.rs
@@ -10,6 +10,12 @@
 //! is a SILENT no-op with a `tracing::debug!` breadcrumb. Success = the
 //! window comes forward; failure = nothing happens.
 //!
+//! KNOWN common miss (#538): an agent inside a terminal MULTIPLEXER
+//! (tmux/screen/zellij). The multiplexer SERVER is daemonized (parent =
+//! launchd/init) and owns no GUI surface, so the walk dead-ends at pid 1 —
+//! live-verified. The fix (walk the CLIENT's chain via e.g.
+//! `tmux display -p '#{client_pid}'`) is backlog #538.
+//!
 //! Lives in the BINARY (invariant #1: core/scene stay window-free). The
 //! walker is PURE over an injected [`ProcessTable`], so the logic is unit
 //! tested on mock tables; the per-OS glue (`macos`/`windows`/`linux`) is
@@ -29,7 +35,11 @@ mod windows;
 
 /// The process-tree view `ancestor_walk` needs — injected so the walk is a
 /// pure function (mock tables in tests; the real per-OS impls query the
-/// kernel).
+/// kernel). Deliberately BUNDLES kernel reads (`ppid`/`start_time`) with the
+/// window-ownership probe (`focusable`): one trait = one mock across 3 OSes.
+/// Split it (ProcessTree vs WindowBackend, with `activate` moving onto the
+/// window half) only when tab-precision lands and forces a terminal
+/// classifier — not before (YAGNI).
 pub(crate) trait ProcessTable {
     /// Parent pid, `None` when the process is gone / unreadable.
     fn ppid(&self, pid: i32) -> Option<i32>;
@@ -102,8 +112,19 @@ pub(crate) fn resolve_pid(
         }
         return Some(cached.pid);
     }
-    // The registry consts, not literals — a source rename must not silently
-    // drop these arms to `_ => None`.
+    // The registry's FocusChannel capability decides WHETHER a probe applies;
+    // the probe FNS themselves stay here in the binary (deliberate: the
+    // registry const table compiles to wasm, a native-only fn pointer can't
+    // live in it). The name match uses the registry consts, not literals — a
+    // source rename must not silently drop an arm to `_ => None` — and the
+    // `transcript_probe_sources_all_have_a_resolve_arm` lockstep test pins
+    // that every `TranscriptProbe` row has an arm below.
+    use pixtuoid_core::source::registry::FocusChannel;
+    let channel = pixtuoid_core::source::registry::descriptor_for(&slot.source)
+        .map_or(FocusChannel::Unsupported, |d| d.focus_channel());
+    if channel != FocusChannel::TranscriptProbe {
+        return None;
+    }
     match slot.source.as_ref() {
         s if s == pixtuoid_core::source::claude_code::SOURCE_NAME => paths
             .cc_projects_root
@@ -113,6 +134,23 @@ pub(crate) fn resolve_pid(
             .and_then(|d| pixtuoid_core::source::codex_pid_for_session(d, &slot.session_id)),
         _ => None,
     }
+}
+
+/// The painter-agnostic focus dispatch — ANY painter's trigger (the TUI's
+/// sprite click and dashboard `f` today; the floating window's future
+/// trigger) resolves + walks + activates through this ONE entry with the
+/// real OS table. `roots` = (CC projects root, Codex sessions root), the
+/// clone `runtime/driver.rs` takes BEFORE `build_source_set` consumes the
+/// originals.
+pub(crate) fn focus_slot(
+    slot: &AgentSlot,
+    roots: &(Option<std::path::PathBuf>, Option<std::path::PathBuf>),
+) {
+    let paths = FocusPaths {
+        cc_projects_root: roots.0.as_deref(),
+        codex_sessions_root: roots.1.as_deref(),
+    };
+    focus_agent(slot, &paths, &OsProcessTable, activate_os);
 }
 
 /// The orchestration entry — the ONE caller of the per-OS glue. `activate`
@@ -236,7 +274,7 @@ mod tests {
     }
 
     fn pid_id(pid: i32, started: Option<u64>) -> pixtuoid_core::source::PidIdentity {
-        pixtuoid_core::source::PidIdentity { pid, started }
+        pixtuoid_core::source::PidIdentity::new(pid, started)
     }
 
     fn slot(
@@ -334,6 +372,33 @@ mod tests {
         // Unknown/remote source likewise.
         let r = slot("some-remote", "ses_c", None);
         assert_eq!(resolve_pid(&r, &NO_PATHS, &empty_table()), None);
+        // FocusChannel::Unsupported (transcript-only, no probe) likewise.
+        let a = slot("antigravity", "ses_d", None);
+        assert_eq!(resolve_pid(&a, &NO_PATHS, &empty_table()), None);
+    }
+
+    #[test]
+    fn transcript_probe_sources_all_have_a_resolve_arm() {
+        // The registry's FocusChannel is DATA; the probe fns live here in the
+        // binary. This is the lockstep pin: marking a new source
+        // `TranscriptProbe` in the registry REQUIRES wiring a probe arm in
+        // `resolve_pid` — extend BOTH, then add its name here.
+        use pixtuoid_core::source::registry::FocusChannel;
+        let wired = [
+            pixtuoid_core::source::claude_code::SOURCE_NAME,
+            pixtuoid_core::source::codex::SOURCE_NAME,
+        ];
+        for &src in pixtuoid_core::source::REGISTERED_SOURCES {
+            let Some(d) = pixtuoid_core::source::registry::descriptor_for(src) else {
+                continue;
+            };
+            if d.focus_channel() == FocusChannel::TranscriptProbe {
+                assert!(
+                    wired.contains(&src),
+                    "{src} is TranscriptProbe but resolve_pid has no probe arm for it"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/pixtuoid/src/focus/mod.rs
+++ b/crates/pixtuoid/src/focus/mod.rs
@@ -36,6 +36,13 @@ pub(crate) trait ProcessTable {
     /// Whether this pid owns a focusable surface (a regular GUI app on macOS,
     /// a top-level window on Windows/X11).
     fn focusable(&self, pid: i32) -> bool;
+    /// Kernel start marker for `pid` — the identity half of the recycle guard
+    /// (#527). The default rides the shared core read (the SAME source the
+    /// hook stamp used, so equality means "same incarnation"); mock tables
+    /// override it.
+    fn start_time(&self, pid: i32) -> Option<u64> {
+        pixtuoid_core::source::pid_start_marker(pid)
+    }
 }
 
 /// Walk `ppid` upward from `start` until the first focusable ancestor.
@@ -66,17 +73,34 @@ pub(crate) struct FocusPaths<'a> {
 /// Resolve the agent's OS pid. Precedence: the slot's cached pid (hook-family
 /// sources — filled from the shim/plugin `_pid` riding each Identity) → the
 /// transcript-family point queries (CC registry / Codex fd probe, both
-/// recycle-guarded) → None. An EXITING slot refuses resolution outright: its
-/// process is going or gone, and a recycled pid would focus a random app (the
-/// cheap v1 answer to click-time pid staleness; the residual window is a
-/// documented sharp edge).
-pub(crate) fn resolve_pid(slot: &AgentSlot, paths: &FocusPaths<'_>) -> Option<i32> {
+/// recycle-guarded) → None. Two click-time recycle guards on the cached path:
+/// an EXITING slot refuses outright (its process is going or gone), and a
+/// cached start marker must match the kernel's CURRENT marker for that pid
+/// (#527) — a mismatch means the pid was recycled by an unrelated process
+/// after an abrupt death, and a missing current read means the process is
+/// gone. A cache stamped WITHOUT a marker (non-unix daemon) skips the
+/// identity check — additive, the #220 posture.
+pub(crate) fn resolve_pid(
+    slot: &AgentSlot,
+    paths: &FocusPaths<'_>,
+    table: &impl ProcessTable,
+) -> Option<i32> {
     if slot.exiting_at.is_some() {
         tracing::debug!(agent = %slot.label, "focus: refused — agent is exiting");
         return None;
     }
-    if let Some(pid) = slot.pid {
-        return Some(pid);
+    if let Some(cached) = slot.pid {
+        if let Some(stamped) = cached.started {
+            if table.start_time(cached.pid) != Some(stamped) {
+                tracing::debug!(
+                    agent = %slot.label,
+                    pid = cached.pid,
+                    "focus: refused — cached pid gone or recycled (start marker mismatch)"
+                );
+                return None;
+            }
+        }
+        return Some(cached.pid);
     }
     // The registry consts, not literals — a source rename must not silently
     // drop these arms to `_ => None`.
@@ -100,7 +124,7 @@ pub(crate) fn focus_agent(
     table: &impl ProcessTable,
     activate: impl FnOnce(i32) -> bool,
 ) {
-    let Some(pid) = resolve_pid(slot, paths) else {
+    let Some(pid) = resolve_pid(slot, paths, table) else {
         tracing::debug!(agent = %slot.label, "focus: no pid resolved");
         return;
     };
@@ -129,6 +153,10 @@ mod tests {
     struct MockTable {
         parents: HashMap<i32, i32>,
         focusable: Vec<i32>,
+        /// pid → current kernel start marker; empty = "every pid reads None"
+        /// (gone), which the default-marker tests below never hit because a
+        /// markerless cache skips the check.
+        started: HashMap<i32, u64>,
     }
     impl ProcessTable for MockTable {
         fn ppid(&self, pid: i32) -> Option<i32> {
@@ -136,6 +164,9 @@ mod tests {
         }
         fn focusable(&self, pid: i32) -> bool {
             self.focusable.contains(&pid)
+        }
+        fn start_time(&self, pid: i32) -> Option<u64> {
+            self.started.get(&pid).copied()
         }
     }
 
@@ -145,6 +176,7 @@ mod tests {
         let t = MockTable {
             parents: HashMap::from([(300, 200), (200, 100), (100, 1)]),
             focusable: vec![100],
+            started: HashMap::new(),
         };
         assert_eq!(ancestor_walk(&t, 300), Some(100));
     }
@@ -155,6 +187,7 @@ mod tests {
         let t = MockTable {
             parents: HashMap::from([(300, 200), (200, 1)]),
             focusable: vec![],
+            started: HashMap::new(),
         };
         assert_eq!(ancestor_walk(&t, 300), None);
     }
@@ -165,12 +198,14 @@ mod tests {
         let t = MockTable {
             parents: HashMap::from([(300, 200), (200, 300)]),
             focusable: vec![],
+            started: HashMap::new(),
         };
         assert_eq!(ancestor_walk(&t, 300), None);
         // And the degenerate self-parent.
         let t2 = MockTable {
             parents: HashMap::from([(300, 300)]),
             focusable: vec![],
+            started: HashMap::new(),
         };
         assert_eq!(ancestor_walk(&t2, 300), None);
     }
@@ -183,6 +218,7 @@ mod tests {
         let t = MockTable {
             parents: HashMap::new(),
             focusable: vec![],
+            started: HashMap::new(),
         };
         assert_eq!(ancestor_walk(&t, 4242), None);
     }
@@ -194,11 +230,20 @@ mod tests {
         let t = MockTable {
             parents: HashMap::new(),
             focusable: vec![300],
+            started: HashMap::new(),
         };
         assert_eq!(ancestor_walk(&t, 300), Some(300));
     }
 
-    fn slot(source: &str, session_id: &str, pid: Option<i32>) -> AgentSlot {
+    fn pid_id(pid: i32, started: Option<u64>) -> pixtuoid_core::source::PidIdentity {
+        pixtuoid_core::source::PidIdentity { pid, started }
+    }
+
+    fn slot(
+        source: &str,
+        session_id: &str,
+        pid: Option<pixtuoid_core::source::PidIdentity>,
+    ) -> AgentSlot {
         use pixtuoid_core::state::ActivityState;
         use std::sync::Arc;
         use std::time::SystemTime;
@@ -230,19 +275,54 @@ mod tests {
         codex_sessions_root: None,
     };
 
+    fn empty_table() -> MockTable {
+        MockTable {
+            parents: HashMap::new(),
+            focusable: vec![],
+            started: HashMap::new(),
+        }
+    }
+
     #[test]
     fn resolve_pid_prefers_the_slot_cache() {
-        let s = slot("opencode", "ses_a", Some(4242));
-        assert_eq!(resolve_pid(&s, &NO_PATHS), Some(4242));
+        // Markerless cache (stamped where no marker was readable): the
+        // identity check is skipped — additive, the #220 posture.
+        let s = slot("opencode", "ses_a", Some(pid_id(4242, None)));
+        assert_eq!(resolve_pid(&s, &NO_PATHS, &empty_table()), Some(4242));
+    }
+
+    #[test]
+    fn resolve_pid_verifies_the_start_marker_when_stamped() {
+        let s = slot("opencode", "ses_a", Some(pid_id(4242, Some(1_000))));
+        // Same incarnation: current marker matches the stamp.
+        let mut t = empty_table();
+        t.started.insert(4242, 1_000);
+        assert_eq!(resolve_pid(&s, &NO_PATHS, &t), Some(4242));
+    }
+
+    #[test]
+    fn resolve_pid_refuses_a_recycled_or_dead_pid() {
+        // #527: an abruptly-dead agent's pid got recycled — the kernel's
+        // CURRENT start marker differs from the stamped one → refuse.
+        let s = slot("opencode", "ses_a", Some(pid_id(4242, Some(1_000))));
+        let mut t = empty_table();
+        t.started.insert(4242, 2_000);
+        assert_eq!(resolve_pid(&s, &NO_PATHS, &t), None, "recycled → refuse");
+        // Process gone entirely (marker unreadable) → refuse too.
+        assert_eq!(
+            resolve_pid(&s, &NO_PATHS, &empty_table()),
+            None,
+            "dead → refuse"
+        );
     }
 
     #[test]
     fn resolve_pid_refuses_an_exiting_slot() {
-        // The cheap click-time pid-recycle guard: an exiting agent's process
-        // is going or gone — a recycled pid would focus a random app.
-        let mut s = slot("opencode", "ses_a", Some(4242));
+        // The first click-time guard: an exiting agent's process is going or
+        // gone — a recycled pid would focus a random app.
+        let mut s = slot("opencode", "ses_a", Some(pid_id(4242, None)));
         s.exiting_at = Some(std::time::SystemTime::UNIX_EPOCH);
-        assert_eq!(resolve_pid(&s, &NO_PATHS), None);
+        assert_eq!(resolve_pid(&s, &NO_PATHS, &empty_table()), None);
     }
 
     #[test]
@@ -250,10 +330,10 @@ mod tests {
         // Hook-family slot without a cached pid and no probe roots → None
         // (the ONE failure rule: silent).
         let s = slot("cursor", "ses_b", None);
-        assert_eq!(resolve_pid(&s, &NO_PATHS), None);
+        assert_eq!(resolve_pid(&s, &NO_PATHS, &empty_table()), None);
         // Unknown/remote source likewise.
         let r = slot("some-remote", "ses_c", None);
-        assert_eq!(resolve_pid(&r, &NO_PATHS), None);
+        assert_eq!(resolve_pid(&r, &NO_PATHS, &empty_table()), None);
     }
 
     #[test]
@@ -261,12 +341,18 @@ mod tests {
         let t = MockTable {
             parents: HashMap::from([(4242, 100)]),
             focusable: vec![100],
+            started: HashMap::new(),
         };
         let mut activated = None;
-        focus_agent(&slot("opencode", "s", Some(4242)), &NO_PATHS, &t, |p| {
-            activated = Some(p);
-            true
-        });
+        focus_agent(
+            &slot("opencode", "s", Some(pid_id(4242, None))),
+            &NO_PATHS,
+            &t,
+            |p| {
+                activated = Some(p);
+                true
+            },
+        );
         assert_eq!(activated, Some(100), "the terminal app pid is activated");
 
         // No pid → the activate seam is never reached.

--- a/crates/pixtuoid/src/tui/mod.rs
+++ b/crates/pixtuoid/src/tui/mod.rs
@@ -155,27 +155,8 @@ fn focus_clicked_agent<B: ratatui::backend::Backend<Error: Send + Sync + 'static
         .cached_layout()
         .and_then(|layout| renderer::hit_test_from_tui(&floor_scene, layout, col, row));
     if let Some(slot) = hit.and_then(|id| snap.agents.get(&id)) {
-        focus_slot(slot, focus_roots);
+        crate::focus::focus_slot(slot, focus_roots);
     }
-}
-
-/// The shared focus dispatch (sprite click + dashboard `f`): resolve the
-/// slot's pid, walk to its terminal app, activate — all through the
-/// `crate::focus` orchestration entry with the real OS table.
-fn focus_slot(
-    slot: &pixtuoid_core::AgentSlot,
-    focus_roots: &(Option<std::path::PathBuf>, Option<std::path::PathBuf>),
-) {
-    let paths = crate::focus::FocusPaths {
-        cc_projects_root: focus_roots.0.as_deref(),
-        codex_sessions_root: focus_roots.1.as_deref(),
-    };
-    crate::focus::focus_agent(
-        slot,
-        &paths,
-        &crate::focus::OsProcessTable,
-        crate::focus::activate_os,
-    );
 }
 
 /// Connect a source from the panel: delegate the persist + install + rollback to
@@ -732,7 +713,7 @@ pub(crate) async fn run_tui(session: TuiSession) -> Result<()> {
                                 if let Some(slot) =
                                     ui.dashboard_focus().and_then(|id| snapshot.agents.get(&id))
                                 {
-                                    focus_slot(slot, &focus_roots);
+                                    crate::focus::focus_slot(slot, &focus_roots);
                                 }
                             }
                             KeyAction::ToggleConnection => {


### PR DESCRIPTION
## What

Closes the two remaining focus-jump backlog items that are closable from this machine:

**#527 — the pid-recycle deep guard.** The residual window: an abruptly-dead hook-family agent leaves a cached `slot.pid` the OS can recycle; a click then focused a random app. The identity check is the **kernel start marker**, not a per-CLI process-name mapping (inherently unstable — opencode runs under bun):
- new core seam `source::pid_start_marker` — macOS `pbi_start_tvsec` (moved from cc_probe, which now delegates), Linux `/proc/<pid>/stat` field-22 **raw ticks** (equality needs no boot-time conversion — the blocker that kept #220's check macOS-only doesn't apply), elsewhere `None`
- the stamp is now `PidIdentity { pid, started }`, read at `_pid` peek time and carried on `Identity`/`AgentSlot` under the same field name (the ~60 `pid: None` construction sites compile unchanged; serde shape for `None` unchanged — goldens quiet)
- `ProcessTable::start_time` (default = the shared core read; mocks override); `resolve_pid` re-reads the marker on the cached path and **refuses** mismatch (recycled) or gone; markerless stamps skip the check (additive, the #220 posture)

**#526 — the doctor focus block** (doctor-row half only; the in-TUI failure notice stays cut per the ONE-failure rule): activation backend per OS (linux via a pure detector over the same env markers `focus/linux.rs` keys on) + each family's pid channel with the CC/Codex probe roots checked on disk. Buckets are registry-derived — a new source lands correctly with no doctor edit.

Timing: pre-0.14.0-tag, so the `AgentSlot`/`Identity` type change costs no extra semver bump (0.14.0 already covers the breaking surface vs published 0.13.0).

## Verification

- preflight 2206/2206 (8 new tests: proc_start ×3, resolve guard ×3, doctor ×3, minus renames)
- doctor dogfooded on this machine — both probe roots ✓, buckets correct, daemon excluded
- local two-lens review running; findings will be applied before merge

Closes #527, closes #526.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BT3bfjgBPqZE5sqtccZm3v