### PR TITLE
feat(drift): burn-tier wire-field watch (#541) + CC ultra-exit instant flame-off

### DIFF
--- a/crates/pixtuoid-core/CLAUDE.md
+++ b/crates/pixtuoid-core/CLAUDE.md
@@ -114,8 +114,14 @@ src/
 **Burn-tier plumbing (model flame):** `AgentEvent::ModelInfo { model, effort }`
 carries RAW wire strings (interpret-at-paint — the tier tables live in
 `pixtuoid-scene::burn`): CC assistant lines' `message.model` (per turn, filters
-`<synthetic>`) + the periodic `ultra_effort_enter`/`ultrathink_effort`
-attachment markers (no wire value → decoder-synthesized "ultra"/"ultrathink");
+`<synthetic>`) + TWO CC effort channels — the HOOK payloads' documented
+`effort.level` (low..max verbatim, on every tool-context hook; ultracode
+reports as `xhigh` — the PRIMARY channel, decoded in the shared arms) and the
+transcript's periodic `ultra_effort_enter`/`ultrathink_effort` attachment
+markers (no wire value → decoder-synthesized "ultra"/"ultrathink"; the
+`ultra_effort_exit` twin synthesizes the NON-max "ultra_exit", so
+last-seen-wins kills the flame instantly, the TTL only backstops a missed
+exit) — plus the SessionStart hook's optional `model` field;
 Codex `turn_context` model+effort verbatim; copilot per-tool `data.model`
 (attributed to the ACTING agent); opencode `session.created` `info.model.id`.
 The reducer caches `slot.model` (last-seen-wins — a mid-session `/model`

--- a/crates/pixtuoid-core/src/source/claude_code.rs
+++ b/crates/pixtuoid-core/src/source/claude_code.rs
@@ -182,11 +182,11 @@ pub fn decode_cc_line(transcript_path: &str, source: &str, v: Value) -> Result<V
 
     // Burn-tier effort observation: CC stamps a PERIODIC reminder attachment
     // while ultra-class effort is active (verified live 2026-07-10: re-fires
-    // every ~dozen prompts for the whole ultra span) — the wire carries no
-    // effort VALUE, so the arm synthesizes the marker's own label. The `/effort`
-    // picker's chosen level is deliberately NOT derivable (its command line has
-    // empty args); freshness-TTL on the reducer side turns this periodic ping
-    // into a steady signal.
+    // every ~dozen prompts for the whole ultra span) plus an EXIT marker on
+    // leaving it — the wire carries no effort VALUE, so the arm synthesizes
+    // each marker's own label. The `/effort` picker's chosen level is
+    // deliberately NOT derivable (its command line has empty args);
+    // freshness-TTL on the reducer side backstops a missed exit.
     if ty == "attachment" {
         if let Some(kind) = obj
             .get("attachment")
@@ -196,6 +196,12 @@ pub fn decode_cc_line(transcript_path: &str, source: &str, v: Value) -> Result<V
             let effort = match kind {
                 "ultra_effort_enter" => Some("ultra"),
                 "ultrathink_effort" => Some("ultrathink"),
+                // The EXIT marker (rare but real — 7 in a 280-enter corpus,
+                // shape `{"type":"ultra_effort_exit"}`): synthesize a label
+                // that is NOT in the scene's MAX_EFFORTS set, so
+                // last-seen-wins drops the boost IMMEDIATELY instead of
+                // waiting out the freshness TTL.
+                "ultra_effort_exit" => Some("ultra_exit"),
                 _ => None,
             };
             if let Some(effort) = effort {
@@ -393,6 +399,9 @@ mod tests {
         for (kind, label) in [
             ("ultra_effort_enter", "ultra"),
             ("ultrathink_effort", "ultrathink"),
+            // The exit marker synthesizes a NON-max label so last-seen-wins
+            // kills the flame immediately (no TTL wait).
+            ("ultra_effort_exit", "ultra_exit"),
         ] {
             let v = json!({
                 "type": "attachment",

--- a/crates/pixtuoid-core/src/source/decoder.rs
+++ b/crates/pixtuoid-core/src/source/decoder.rs
@@ -228,17 +228,50 @@ pub fn decode_hook_payload(v: Value) -> Result<Vec<AgentEvent>> {
         pid: None,
     };
 
+    // Burn-tier effort observation (CC): tool-context hook payloads carry an
+    // `effort: {level}` object (documented in hooks.md — low/medium/high/
+    // xhigh/max; ULTRACODE mode "is not a distinct level and reports as
+    // xhigh", also exported as $CLAUDE_EFFORT — live-verified 2026-07-10).
+    // Codex hook payloads carry no such field — absent = emit nothing. This
+    // is the primary CC effort channel (per tool event, verbatim vocabulary);
+    // the transcript's periodic ultra attachment markers are the JSONL twin.
+    let effort_info = || {
+        obj.get("effort")
+            .and_then(|e| e.get("level"))
+            .and_then(|l| l.as_str())
+            .filter(|l| !l.is_empty())
+            .map(|level| AgentEvent::ModelInfo {
+                agent_id,
+                model: None,
+                effort: Some(ellipsize(level, MAX_DECODED_FIELD_CHARS)),
+            })
+    };
+
     match event {
         "SessionStart" => {
             let cwd = obj.get("cwd").and_then(|s| s.as_str()).unwrap_or("").into();
             let source = source.to_string();
-            Ok(vec![AgentEvent::SessionStart {
+            let mut evs = vec![AgentEvent::SessionStart {
                 agent_id,
-                source,
+                source: source.clone(),
                 session_id,
                 cwd,
                 parent_id: None,
-            }])
+            }];
+            // "Only SessionStart hooks can receive a `model` field, and it is
+            // not guaranteed to be present" (hooks.md) — take it when offered.
+            if let Some(model) = obj
+                .get("model")
+                .and_then(|m| m.as_str())
+                .filter(|m| !m.is_empty())
+            {
+                evs.push(AgentEvent::ModelInfo {
+                    agent_id,
+                    model: Some(ellipsize(model, MAX_DECODED_FIELD_CHARS)),
+                    effort: None,
+                });
+            }
+            Ok(evs)
         }
         "PreToolUse" => {
             let tool_name = obj
@@ -252,27 +285,31 @@ pub fn decode_hook_payload(v: Value) -> Result<Vec<AgentEvent>> {
                 .get("tool_use_id")
                 .and_then(|s| s.as_str())
                 .map(String::from);
-            Ok(vec![
+            let mut evs = vec![
                 identity(),
                 AgentEvent::ActivityStart {
                     agent_id,
                     tool_use_id,
                     detail: Some(make_tool_detail(source, tool_name, obj.get("tool_input"))),
                 },
-            ])
+            ];
+            evs.extend(effort_info());
+            Ok(evs)
         }
         "PostToolUse" => {
             let tool_use_id = obj
                 .get("tool_use_id")
                 .and_then(|s| s.as_str())
                 .map(String::from);
-            Ok(vec![
+            let mut evs = vec![
                 identity(),
                 AgentEvent::ActivityEnd {
                     agent_id,
                     tool_use_id,
                 },
-            ])
+            ];
+            evs.extend(effort_info());
+            Ok(evs)
         }
         "Notification" => {
             let msg = obj
@@ -453,6 +490,73 @@ pub(crate) fn ellipsize(s: &str, max_chars: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---- burn-tier observations riding the shared hook arms ----
+
+    #[test]
+    fn tool_hooks_surface_the_effort_level() {
+        // hooks.md: tool-context payloads carry `effort:{level}`; ultracode
+        // reports as "xhigh" (live-verified via $CLAUDE_EFFORT 2026-07-10).
+        for event in ["PreToolUse", "PostToolUse"] {
+            let v = serde_json::json!({
+                "hook_event_name": event,
+                "session_id": "ses-e",
+                "transcript_path": "/p/ses-e.jsonl",
+                "cwd": "/repo",
+                "tool_name": "Bash",
+                "tool_use_id": "t1",
+                "effort": {"level": "xhigh"}
+            });
+            let evs = decode_hook_payload(v).unwrap();
+            assert!(
+                evs.iter().any(|e| matches!(e, AgentEvent::ModelInfo { model: None, effort: Some(f), .. } if f == "xhigh")),
+                "{event} must surface effort, got {evs:?}"
+            );
+        }
+        // Effort-less payloads (codex hooks, older CC) emit no ModelInfo.
+        let v = serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "session_id": "ses-e",
+            "transcript_path": "/p/ses-e.jsonl",
+            "tool_name": "Bash"
+        });
+        let evs = decode_hook_payload(v).unwrap();
+        assert!(
+            !evs.iter()
+                .any(|e| matches!(e, AgentEvent::ModelInfo { .. })),
+            "got {evs:?}"
+        );
+    }
+
+    #[test]
+    fn session_start_hook_surfaces_the_model_when_offered() {
+        // "Only SessionStart hooks can receive a model field, and it is not
+        // guaranteed" (hooks.md) — present → observation, absent → nothing.
+        let v = serde_json::json!({
+            "hook_event_name": "SessionStart",
+            "session_id": "ses-m",
+            "transcript_path": "/p/ses-m.jsonl",
+            "cwd": "/repo",
+            "model": "claude-fable-5"
+        });
+        let evs = decode_hook_payload(v).unwrap();
+        assert!(
+            evs.iter().any(|e| matches!(e, AgentEvent::ModelInfo { model: Some(m), effort: None, .. } if m == "claude-fable-5")),
+            "got {evs:?}"
+        );
+        let v = serde_json::json!({
+            "hook_event_name": "SessionStart",
+            "session_id": "ses-m",
+            "transcript_path": "/p/ses-m.jsonl",
+            "cwd": "/repo"
+        });
+        let evs = decode_hook_payload(v).unwrap();
+        assert!(
+            !evs.iter()
+                .any(|e| matches!(e, AgentEvent::ModelInfo { .. })),
+            "got {evs:?}"
+        );
+    }
     use serde_json::json;
 
     // Real CC sessions are full of task-management tools whose names START WITH

--- a/crates/pixtuoid-core/src/source/hook/mod.rs
+++ b/crates/pixtuoid-core/src/source/hook/mod.rs
@@ -236,6 +236,8 @@ pub(crate) async fn handle_conn(
                 if line.trim().is_empty() {
                     continue;
                 }
+                // TEMP wire probe (not for commit): dump the raw payload.
+                tracing::warn!("RAW_HOOK_PROBE: {line}");
                 let v: serde_json::Value = match serde_json::from_str(&line) {
                     Ok(v) => v,
                     Err(e) => {

--- a/crates/pixtuoid-scene/CLAUDE.md
+++ b/crates/pixtuoid-scene/CLAUDE.md
@@ -74,6 +74,10 @@ src/                (the pixtuoid-scene crate root; default pack at ../sprites/d
 │                   lives HERE; the RAW strings live on AgentSlot (core). Consumed by
 │                   pixel_painter's paint_character_at (ember 'H' recolor + Top flame crown) and
 │                   the binary's tooltip. Unknown model → Normal (fail-quiet, never flames).
+│                   BACK-VIEW ember slab is DELIBERATE (user-ratified): walking_back/back_couch
+│                   sprites are ~6 rows of 'H', so Premium+ reads as a solid red back — accepted
+│                   (transient pose; spotting an expensive agent from behind is the point). Don't
+│                   "fix" with per-row recolor.
 ├── board.rs        backend-agnostic NEON WALL-BOARD model + shared scene-stats — the sibling of overlay.rs for
 │                   the wall panel (brand+★ / mood pulse / uptime·floor·gateway). Owns StateCounts + scene_stats/
 │                   bucket_slot/per_floor_counts/gateway_rollup/compact_hms (relocated from the binary's tui

--- a/crates/pixtuoid-scene/src/burn.rs
+++ b/crates/pixtuoid-scene/src/burn.rs
@@ -124,9 +124,15 @@ mod tests {
             );
         }
         // Ordinary efforts split to Premium, and effort NEVER promotes a
-        // non-top model (the "only these burn" pin).
+        // non-top model (the "only these burn" pin). CC's synthesized
+        // "ultra_exit" label (the exit marker) is deliberately NON-max, so
+        // last-seen-wins kills the flame the moment it arrives.
         assert_eq!(
             burn_tier(Some("claude-fable-5"), Some("medium")),
+            BurnTier::Premium
+        );
+        assert_eq!(
+            burn_tier(Some("claude-fable-5"), Some("ultra_exit")),
             BurnTier::Premium
         );
         assert_eq!(burn_tier(Some("gpt-5.5"), Some("xhigh")), BurnTier::Normal);

--- a/crates/pixtuoid/examples/snapshot/scenes.rs
+++ b/crates/pixtuoid/examples/snapshot/scenes.rs
@@ -22,6 +22,7 @@ pub(crate) async fn capture_live_scene(
     );
     let scene: Arc<RwLock<SceneState>> = Arc::new(RwLock::new(SceneState::uniform(12)));
     let (tx, mut rx) = mpsc::channel::<(Transport, AgentEvent)>(1024);
+    let tx_hook = tx.clone();
     let root = PathBuf::from(projects_root);
     let watcher = JsonlWatcher::new(
         root,
@@ -29,8 +30,32 @@ pub(crate) async fn capture_live_scene(
         pixtuoid_core::source::claude_code::decode_cc_line,
         pixtuoid_core::source::claude_code::cc_derive_label,
         pixtuoid_core::source::claude_code::cc_session_ended,
-    );
+    )
+    // The SAME UUID keying the real CC source wires (claude_code/native.rs):
+    // without it the watcher registers under the path-hash id while every
+    // line-decoded event (activity, ModelInfo) keys on the UUID — nothing
+    // coalesces and --live agents sit Idle/model-less forever (latent since
+    // #203, exposed by the burn-tier replay).
+    .with_id_deriver(pixtuoid_core::source::claude_code::cc_id_from_path);
     let watcher_handle = tokio::spawn(async move { watcher.run(tx).await });
+    // ALSO listen on the real hook socket: a live CC session's hooks carry
+    // activity + the burn-tier effort level (hooks.md `effort:{level}`;
+    // ultracode reports as xhigh) that the transcript alone can't provide in
+    // real time. Same latent-gap class as the id-deriver above — "--live"
+    // without hooks was silently activity-poor. SocketBusy (a running
+    // pixtuoid owns the socket) degrades to transcript-only, like the app.
+    let hook_handle = {
+        use pixtuoid_core::source::hook::HookRouter;
+        use pixtuoid_core::source::DynSource;
+        let socket = pixtuoid_core::source::claude_code::ClaudeCodeSource::default_socket_path();
+        let router: Box<dyn DynSource> = Box::new(HookRouter::new(socket));
+        let tx = tx_hook;
+        tokio::spawn(async move {
+            if let Err(e) = router.run(tx).await {
+                eprintln!("hook listener unavailable ({e}); transcript-only capture");
+            }
+        })
+    };
 
     let mut reducer = Reducer::new();
     let deadline = tokio::time::Instant::now() + Duration::from_secs(listen_secs);
@@ -55,11 +80,17 @@ pub(crate) async fn capture_live_scene(
     );
     for (id, slot) in &snapshot.agents {
         println!(
-            "  {} ({}) at desk {}: {:?}",
-            slot.label, id, slot.desk_index.0, slot.state
+            "  {} ({}) at desk {}: {:?} model={:?} effort={:?}",
+            slot.label,
+            id,
+            slot.desk_index.0,
+            slot.state,
+            slot.model,
+            slot.effort.as_ref().map(|e| e.value.clone())
         );
     }
     watcher_handle.abort();
+    hook_handle.abort();
     Ok(snapshot)
 }
 

--- a/scripts/check_upstream_drift.py
+++ b/scripts/check_upstream_drift.py
@@ -31,7 +31,11 @@ and compares against the live upstream:
   * CodeWhale hooks    -> `CODEWHALE_EVENTS` in crates/pixtuoid/src/install/codewhale.rs
                           vs the snake_case `HookEvent` enum in
                           Hmbown/CodeWhale crates/tui/src/hooks.rs
-  * opencode events    -> the EventV2 `type`s the decoder maps (the `match event`
+  * burn-tier fields   -> codex turn_context.{model,effort} (TurnContextItem,
+                        protocol.rs) + copilot data.model (schema) + opencode
+                        info.model (session.ts) + CC ultra attachment markers
+                        (docs appearance watch) — see #541
+* opencode events    -> the EventV2 `type`s the decoder maps (the `match event`
                           block in crates/pixtuoid-core/src/source/opencode.rs)
                           vs the `EventV2.define` type literals in
                           anomalyco/opencode packages/schema/src/v1/session.ts +
@@ -145,6 +149,13 @@ CC_LIFECYCLE_SURFACE_MARKERS = {
     "session_end": 'a structural transcript end record (subtype:"session_end")',
     ".claude/sessions/": "the ~/.claude/sessions/<pid>.json session registry",
     "procStart": "the sessions-registry procStart field",
+    # burn tier (#541): the periodic ultra-effort attachment markers the CC
+    # decoder synthesizes effort labels from (undocumented wire, verified live
+    # 2026-07-10). CC is a closed binary, so like the registry above this is an
+    # APPEARANCE watch: the docs mentioning them = upstream started documenting
+    # the surface — a review ping to re-verify our synthesized labels/shape.
+    "ultra_effort_enter": "the ultra-effort transcript attachment marker",
+    "ultrathink_effort": "the ultrathink transcript attachment marker",
 }
 
 # Codex hook events we DELIBERATELY do not register — they are not agent
@@ -267,6 +278,10 @@ OPENCODE_TOLERATED = {"permission.asked"}
 OPENCODE_PAYLOAD_FIELDS = {
     "info", "id", "parentID", "directory",
     "part", "sessionID", "callID", "tool", "state", "status", "input",
+    # burn tier (#541): session.created carries `info.model.{id, providerID}`
+    # (SessionInfo.model → SessionModel in session.ts); the decoder reads
+    # `model.id` — `id` is watched above, this watches the wrapper.
+    "model",
 }
 
 # Copilot CLI publishes a session-events JSON schema; unpkg serves the file
@@ -306,6 +321,9 @@ COPILOT_PAYLOAD_FIELDS = {
     "agentId", "sessionId", "context", "cwd",
     "toolCallId", "toolName", "arguments", "agentDisplayName",
     "permissionRequest", "result", "kind",
+    # burn tier (#541): the per-tool model (ToolExecutionCompleteData.model,
+    # schema-verified 2026-07-10) — a rename silently darkens the cp· badge.
+    "model",
 }
 
 # Cursor CLI (`cursor-agent`) is HOOK-ONLY; the events we register/decode are
@@ -516,6 +534,18 @@ def codex_function_call_fields(text: str) -> set[str] | None:
     if not m:
         return None
     return set(re.findall(r"\b([a-z_][a-z0-9_]*)\s*:", m.group(1)))
+
+
+def codex_turn_context_fields(text: str) -> set[str] | None:
+    """The field idents of the `TurnContextItem` struct (protocol.rs) — the
+    burn-tier feature reads `model` + `effort` off every `turn_context`
+    rollout line (source/codex.rs). Same graceful-skip contract as
+    `codex_function_call_fields`: None = the struct moved/changed shape, the
+    caller alarms on that separately."""
+    m = re.search(r"pub struct TurnContextItem\s*\{([^}]*)\}", text)
+    if not m:
+        return None
+    return set(re.findall(r"\bpub ([a-z_][a-z0-9_]*)\s*:", m.group(1)))
 
 
 def upstream_cc_hook_events(text: str) -> set[str] | None:
@@ -749,6 +779,27 @@ def run_checks(
                             f"source/codex.rs) is GONE from upstream `EventMsg` — "
                             f"renamed; the transcript decoder drops it SILENTLY "
                             f"(`_ => vec![]`, no drift breadcrumb)."
+                        )
+        # `turn_context` FIELD survival (burn tier, #541): the transcript
+        # decoder reads `model` + `effort` off every turn_context line
+        # (source/codex.rs) — a rename silently kills the model badge/flame
+        # (fail-quiet by design, so this watch is the only alarm).
+        if text is not None:
+            tc_fields = codex_turn_context_fields(text)
+            if tc_fields is None:
+                breaking.append(
+                    "Codex `TurnContextItem` struct not found in protocol.rs — "
+                    "upstream moved it; update the parser (burn-tier model/effort "
+                    "watch is blind)."
+                )
+            else:
+                for f in ("model", "effort"):
+                    if f not in tc_fields:
+                        breaking.append(
+                            f"Codex turn_context field `{f}` is GONE from "
+                            f"TurnContextItem in protocol.rs — renamed; the "
+                            f"burn-tier decoder reads None (model badge/flame "
+                            f"silently dark for codex agents)."
                         )
         # Rollout `response_item` types → the ResponseItem enum in models.rs.
         if codex_rollout is not None:

--- a/scripts/check_upstream_drift.py
+++ b/scripts/check_upstream_drift.py
@@ -167,6 +167,7 @@ CC_LIFECYCLE_SURFACE_MARKERS = {
     # the surface — a review ping to re-verify our synthesized labels/shape.
     "ultra_effort_enter": "the ultra-effort transcript attachment marker",
     "ultrathink_effort": "the ultrathink transcript attachment marker",
+    "ultra_effort_exit": "the ultra-effort EXIT attachment marker (instant flame-off)",
 }
 
 # Codex hook events we DELIBERATELY do not register — they are not agent

--- a/scripts/check_upstream_drift.py
+++ b/scripts/check_upstream_drift.py
@@ -145,6 +145,17 @@ CC_HOOKS_URL = "https://code.claude.com/docs/en/hooks.md"
 # review-class drift (something new to adopt), never breaking. `session_end`
 # is snake_case on purpose: the SessionEnd HOOK name appears throughout
 # hooks.md and must not match.
+# CC hook-payload surfaces we DEPEND on that are DOCUMENTED (hooks.md) — the
+# inverse direction of the appearance markers below: these strings VANISHING
+# from hooks.md is review-class drift (the docs moved/renamed a surface the
+# burn-tier decoder reads). `CLAUDE_EFFORT` pins the effort row (the decoder
+# reads `effort.level` off tool-context payloads; ultracode reports as xhigh);
+# the model sentence pins SessionStart's optional `model` field.
+CC_DEPENDED_DOC_MARKERS = {
+    "CLAUDE_EFFORT": "the hook-payload effort surface (effort.level, burn tier)",
+    "receive a `model` field": "SessionStart's optional model field (burn tier)",
+}
+
 CC_LIFECYCLE_SURFACE_MARKERS = {
     "session_end": 'a structural transcript end record (subtype:"session_end")',
     ".claude/sessions/": "the ~/.claude/sessions/<pid>.json session registry",
@@ -1092,6 +1103,12 @@ def run_checks(
                         f"install/claude.rs EVENTS, or add it to "
                         f"CC_KNOWN_OMITTED)."
                     )
+        for marker, what in sorted(CC_DEPENDED_DOC_MARKERS.items()):
+            if marker not in hooks_doc:
+                review.append(
+                    f"CC hooks.md no longer mentions `{marker}` — {what} may have "
+                    f"moved/renamed; re-verify the burn-tier hook decode."
+                )
         for marker, what in sorted(CC_LIFECYCLE_SURFACE_MARKERS.items()):
             if marker in hooks_doc:
                 review.append(

--- a/scripts/check_upstream_drift_selftest.py
+++ b/scripts/check_upstream_drift_selftest.py
@@ -190,6 +190,25 @@ def test_upstream_parsers_extract_from_a_snippet() -> None:
         d.codex_function_call_fields("FunctionCall(FunctionCallItem),") is None,
         "codex FunctionCall tuple variant -> None (graceful skip, not an alarm)",
     )
+    # TurnContextItem (burn tier, #541): field idents extracted incl. the two
+    # the decoder depends on; a moved/renamed struct → None (caller alarms).
+    tc_struct = (
+        "pub struct TurnContextItem {\n"
+        "    #[serde(default, skip_serializing_if = \"Option::is_none\")]\n"
+        "    pub turn_id: Option<String>,\n"
+        "    pub cwd: AbsolutePathBuf,\n"
+        "    pub model: String,\n"
+        "    #[serde(skip_serializing_if = \"Option::is_none\")]\n"
+        "    pub effort: Option<ReasoningEffortConfig>,\n"
+        "}\n"
+    )
+    up = d.codex_turn_context_fields(tc_struct)
+    check(up is not None and {"model", "effort"} <= up, f"codex TurnContextItem fields: {up}")
+    check(
+        d.codex_turn_context_fields("pub enum RolloutItem { TurnContext(TurnContextItem) }") is None
+        or "model" not in (d.codex_turn_context_fields("pub enum RolloutItem { TurnContext(TurnContextItem) }") or set()),
+        "codex TurnContextItem absent -> None (caller alarms)",
+    )
 
 
 def main() -> int:


### PR DESCRIPTION
## What

Two tightly-coupled halves from one verification sweep:

**#541 — drift-watch coverage.** Every burn-tier wire field is now watched, each anchor verified against live upstream before pinning: codex `TurnContextItem.{model,effort}` (new struct-field parser + selftest; canonical effort enum confirmed at `openai_models.rs::ReasoningEffort` = none…xhigh/max/ultra + Custom), copilot `ToolExecutionCompleteData.model` (unpkg schema), opencode `SessionInfo.model` (session.ts — the `id` key our decoder reads is current; `modelID` is the message-part struct, not ours), CC ultra markers as docs-appearance watches (closed binary, the sessions-registry precedent).

**CC ultra EXIT.** The full-corpus rescan found `ultra_effort_exit` (×7 vs ×280 enters) — the earlier "no exit marker" claim was a narrow-scan artifact. The decoder now synthesizes the non-max label `"ultra_exit"` for it: last-seen-wins drops the flame **immediately**; the 10-min TTL becomes the backstop for a missed exit rather than the only decay path. Spec corrected.

## Verification

- `check_upstream_drift.py` live run green (all four new watches hit real upstream); selftest extended + green
- preflight 2222/2222
- burn demotion test: `ultra_exit` → Premium (never Top)

Closes #541.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BT3bfjgBPqZE5sqtccZm3v