### PR TITLE
fix: remove leaked RAW_HOOK_PROBE debug line from handle_conn

### DIFF
--- a/crates/pixtuoid-core/src/source/hook/mod.rs
+++ b/crates/pixtuoid-core/src/source/hook/mod.rs
@@ -236,8 +236,6 @@ pub(crate) async fn handle_conn(
                 if line.trim().is_empty() {
                     continue;
                 }
-                // TEMP wire probe (not for commit): dump the raw payload.
-                tracing::warn!("RAW_HOOK_PROBE: {line}");
                 let v: serde_json::Value = match serde_json::from_str(&line) {
                     Ok(v) => v,
                     Err(e) => {


### PR DESCRIPTION
Removes the 2-line TEMP wire probe that leaked into merged main via the docs-only commit `417010f` (PR #542): a diagnostic leftover in the shared hook-socket `handle_conn` that logged **every raw hook payload, uncapped, at `warn!`** — bypassing the `ellipsize(MAX_DECODED_FIELD_CHARS)` posture every other raw-content path follows.

Flagged **HIGH** by PR #542's final online review round (17:11Z, on `417010f`), which landed after the merge gate had been read from a stale pre-compaction snapshot — the merge should not have happened with that finding open. This PR is the fix-forward.

- Pure 2-line deletion; no behavior beyond removing the log line.
- `grep -rn 'RAW_HOOK_PROBE\|TEMP wire probe' crates/` → clean.
- `just preflight` → exit 0, 2224/2224 passed.
- Exposure: main-only for ~30 min, 0.14.0 untagged, nothing released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BT3bfjgBPqZE5sqtccZm3v