### PR TITLE
feat(omp): assistant-message model → burn-tier parity

### DIFF
--- a/crates/pixtuoid-core/CLAUDE.md
+++ b/crates/pixtuoid-core/CLAUDE.md
@@ -125,7 +125,10 @@ backstops a missed exit; the sentinel is display-suppressed by
 `burn::fresh_effort`, so the dossier never renders it) — plus the SessionStart
 hook's optional `model` field;
 Codex `turn_context` model+effort verbatim; copilot per-tool `data.model`
-(attributed to the ACTING agent); opencode `session.created` `info.model.id`.
+(attributed to the ACTING agent); opencode `session.created` `info.model.id`;
+omp assistant messages' bare `model` (#545 — the separate `provider` field and
+the provider-prefixed `model_change` entry are deliberately NOT decoded: the
+bare field matches TOP_MODELS' prefix vocabulary and every turn re-stamps it).
 The reducer caches `slot.model` (last-seen-wins — a mid-session `/model`
 switch tracks) + `slot.effort: EffortObservation{value, seen_at}` (re-stamped
 per sighting; the scene's EFFORT_TTL turns Codex's per-turn field and CC's

--- a/crates/pixtuoid-core/src/source/omp.rs
+++ b/crates/pixtuoid-core/src/source/omp.rs
@@ -588,6 +588,16 @@ mod tests {
         // An empty/missing model must not mint a phantom observation.
         let empty = r#"{"type":"message","id":"m3","timestamp":"t","message":{"role":"assistant","model":"","content":[],"timestamp":3}}"#;
         assert!(decode(empty).is_empty());
+        // A content-ABSENT message (defensive: pi-ai types.ts requires
+        // `content`, so this can't occur on real wire) still stamps the model
+        // — pins the let-else early return's `Ok(out)`, not `Ok(vec![])`.
+        let no_content = r#"{"type":"message","id":"m4","timestamp":"t","message":{"role":"assistant","model":"claude-fable-5","timestamp":4}}"#;
+        match &decode(no_content)[..] {
+            [AgentEvent::ModelInfo { model: Some(m), .. }] => {
+                assert_eq!(m.as_str(), "claude-fable-5");
+            }
+            other => panic!("expected one ModelInfo, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/pixtuoid-core/src/source/omp.rs
+++ b/crates/pixtuoid-core/src/source/omp.rs
@@ -220,10 +220,29 @@ pub fn decode_omp_line(transcript_path: &str, source: &str, v: Value) -> Result<
             match msg.get("role").and_then(|r| r.as_str()) {
                 // Assistant content blocks carry the tool CALLS.
                 Some("assistant") => {
-                    let Some(blocks) = msg.get("content").and_then(|c| c.as_array()) else {
-                        return Ok(vec![]);
-                    };
                     let mut out = Vec::new();
+                    // Model identity rides EVERY assistant message (pi-ai
+                    // types.ts: AssistantMessage requires provider+model) —
+                    // the burn-tier carrier (#545). The BARE `model` field,
+                    // never the provider-prefixed `model_change` form, so
+                    // TOP_MODELS prefix matching sees the same vocabulary
+                    // CC/codex/copilot emit; the reducer's last-seen-wins
+                    // dedups the per-turn re-stamp.
+                    if let Some(model) = msg
+                        .get("model")
+                        .and_then(|m| m.as_str())
+                        .filter(|m| !m.is_empty())
+                    {
+                        out.push(AgentEvent::ModelInfo {
+                            agent_id: acting,
+                            model: Some(ellipsize(model, MAX_DECODED_FIELD_CHARS)),
+                            effort: None,
+                        });
+                    }
+                    // A blocks-less/text-only turn still stamps the model.
+                    let Some(blocks) = msg.get("content").and_then(|c| c.as_array()) else {
+                        return Ok(out);
+                    };
                     // `ask` (the built-in user-question tool) BLOCKS on human
                     // input: its Start is followed by a Waiting so the session
                     // renders waiting, not active. The Start binds the
@@ -289,6 +308,9 @@ pub fn decode_omp_line(transcript_path: &str, source: &str, v: Value) -> Result<
         }
         // title / title_change / model_change / compaction / session_init /
         // custom_message / thinking_level_change / … — not sprite-visible.
+        // (model_change stays undecoded even though the burn tier reads model:
+        // its value is the provider-prefixed combined form, and every assistant
+        // message re-stamps the bare `model` anyway — one turn's lag at most.)
         _ => vec![],
     };
     Ok(out)
@@ -533,6 +555,39 @@ mod tests {
             }
             other => panic!("expected one ActivityStart, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn assistant_message_surfaces_model_info_for_the_burn_tier() {
+        // Every assistant message carries the BARE `model` (+ a separate
+        // `provider`) — pi-ai types.ts requires both. The bare field is the
+        // burn-tier carrier (#545): the same shape CC/codex/copilot emit, so
+        // TOP_MODELS prefix matching sees one vocabulary (the
+        // provider-prefixed `model_change` form is deliberately NOT decoded);
+        // the reducer's last-seen-wins dedups the per-turn re-stamp.
+        let line = r#"{"type":"message","id":"m1","parentId":null,"timestamp":"t","message":{"role":"assistant","provider":"kimi-code","model":"kimi-for-coding","content":[{"type":"toolCall","id":"t1","name":"bash","arguments":{"command":"ls"}}],"timestamp":1}}"#;
+        match &decode(line)[..] {
+            [AgentEvent::ModelInfo {
+                agent_id,
+                model: Some(model),
+                effort: None,
+            }, AgentEvent::ActivityStart { .. }] => {
+                assert_eq!(*agent_id, root());
+                assert_eq!(model.as_str(), "kimi-for-coding");
+            }
+            other => panic!("expected ModelInfo then ActivityStart, got {other:?}"),
+        }
+        // A text-only assistant turn still stamps the model.
+        let text_only = r#"{"type":"message","id":"m2","parentId":null,"timestamp":"t","message":{"role":"assistant","provider":"anthropic","model":"claude-fable-5","content":[{"type":"text","text":"done"}],"timestamp":2}}"#;
+        match &decode(text_only)[..] {
+            [AgentEvent::ModelInfo { model: Some(m), .. }] => {
+                assert_eq!(m.as_str(), "claude-fable-5");
+            }
+            other => panic!("expected one ModelInfo, got {other:?}"),
+        }
+        // An empty/missing model must not mint a phantom observation.
+        let empty = r#"{"type":"message","id":"m3","timestamp":"t","message":{"role":"assistant","model":"","content":[],"timestamp":3}}"#;
+        assert!(decode(empty).is_empty());
     }
 
     #[test]

--- a/crates/pixtuoid-core/src/state/mod.rs
+++ b/crates/pixtuoid-core/src/state/mod.rs
@@ -368,9 +368,10 @@ pub struct AgentSlot {
     pub pid: Option<crate::source::PidIdentity>,
     /// The RAW model string last observed on this agent's wire (CC assistant
     /// lines / Codex turn_context / copilot per-tool / opencode
-    /// session.created) — last-seen-wins, so a mid-session `/model` switch
-    /// tracks. Interpretation (the burn-tier tables) lives in the scene layer;
-    /// this stays uninterpreted wire truth. serde-skipped (goldens quiet).
+    /// session.created / omp assistant messages) — last-seen-wins, so a
+    /// mid-session `/model` switch tracks. Interpretation (the burn-tier
+    /// tables) lives in the scene layer; this stays uninterpreted wire truth.
+    /// serde-skipped (goldens quiet).
     #[serde(
         with = "opt_arc_str_serde",
         skip_serializing_if = "Option::is_none",

--- a/crates/pixtuoid-core/tests/sources/snapshots/sources__conformance__omp__2026-07-10T18-00-00-000Z_01990000-0000-7000-8000-000000000001.snap
+++ b/crates/pixtuoid-core/tests/sources/snapshots/sources__conformance__omp__2026-07-10T18-00-00-000Z_01990000-0000-7000-8000-000000000001.snap
@@ -8,6 +8,10 @@ expression: events
     session_id: 2026-07-10T18-00-00-000Z_01990000-0000-7000-8000-000000000001/FixtureCaptureChild
     cwd: /home/user/demo-project
     parent_id: 10340979680718815602
+- ModelInfo:
+    agent_id: 15994559954055168040
+    model: kimi-for-coding
+    effort: ~
 - ActivityStart:
     agent_id: 15994559954055168040
     tool_use_id: tool_AAAAAAAAAAAAAAAAAAAAAAAA
@@ -17,6 +21,14 @@ expression: events
 - ActivityEnd:
     agent_id: 15994559954055168040
     tool_use_id: tool_AAAAAAAAAAAAAAAAAAAAAAAA
+- ModelInfo:
+    agent_id: 15994559954055168040
+    model: kimi-for-coding
+    effort: ~
+- ModelInfo:
+    agent_id: 15994559954055168040
+    model: kimi-for-coding
+    effort: ~
 - ActivityStart:
     agent_id: 15994559954055168040
     tool_use_id: tool_BBBBBBBBBBBBBBBBBBBBBBBB

--- a/crates/pixtuoid-core/tests/sources/snapshots/sources__conformance__omp__ask-round.snap
+++ b/crates/pixtuoid-core/tests/sources/snapshots/sources__conformance__omp__ask-round.snap
@@ -8,6 +8,10 @@ expression: events
     session_id: 2026-07-10T09-00-00-000Z_01990000-0000-7000-8000-000000000003
     cwd: /home/user/demo-project
     parent_id: ~
+- ModelInfo:
+    agent_id: 13129151737719962286
+    model: claude-fable-5
+    effort: ~
 - ActivityStart:
     agent_id: 13129151737719962286
     tool_use_id: toolu_01CCCCCCCCCCCCCCCCCCCCCC
@@ -20,6 +24,10 @@ expression: events
 - ActivityEnd:
     agent_id: 13129151737719962286
     tool_use_id: toolu_01CCCCCCCCCCCCCCCCCCCCCC
+- ModelInfo:
+    agent_id: 13129151737719962286
+    model: claude-fable-5
+    effort: ~
 - SessionEnd:
     agent_id: 13129151737719962286
     as_child: false

--- a/crates/pixtuoid-core/tests/sources/snapshots/sources__conformance__omp__tool-run.snap
+++ b/crates/pixtuoid-core/tests/sources/snapshots/sources__conformance__omp__tool-run.snap
@@ -8,6 +8,10 @@ expression: events
     session_id: 2026-07-10T08-00-00-000Z_01990000-0000-7000-8000-000000000002
     cwd: /home/user/demo-project
     parent_id: ~
+- ModelInfo:
+    agent_id: 18204718967867458238
+    model: claude-fable-5
+    effort: ~
 - ActivityStart:
     agent_id: 18204718967867458238
     tool_use_id: toolu_01AAAAAAAAAAAAAAAAAAAAAA
@@ -17,6 +21,10 @@ expression: events
 - ActivityEnd:
     agent_id: 18204718967867458238
     tool_use_id: toolu_01AAAAAAAAAAAAAAAAAAAAAA
+- ModelInfo:
+    agent_id: 18204718967867458238
+    model: claude-fable-5
+    effort: ~
 - SessionEnd:
     agent_id: 18204718967867458238
     as_child: false

--- a/crates/pixtuoid/src/tui/widgets/tooltip.rs
+++ b/crates/pixtuoid/src/tui/widgets/tooltip.rs
@@ -204,7 +204,7 @@ pub(crate) fn paint_hover_tooltip(
         format!("\u{25a4} {}", short_cwd(&agent.cwd)),
         dim,
     )));
-    // The LLM brain, when the wire told us (CC/Codex/copilot/opencode) — RAW
+    // The LLM brain, when the wire told us (CC/Codex/copilot/opencode/omp) — RAW
     // model string, with the effort suffixed only while FRESH (the same
     // burn-TTL the flame reads, so the text can't outlive the fire). Sources
     // without a model channel simply skip the row.

--- a/scripts/check_upstream_drift.py
+++ b/scripts/check_upstream_drift.py
@@ -418,13 +418,14 @@ OMP_EXIT_DIAG_URL = (
 )
 # The message-level names (roles + tool-call block shape) live in the pi-ai LLM
 # types: `role:"assistant"`/`"toolResult"`, the `"toolCall"` content-block type
-# (quoted TS literals), plus the result's `toolCallId` back-reference and the
-# call's `arguments` (property keys).
+# (quoted TS literals), plus the result's `toolCallId` back-reference, the
+# call's `arguments`, and the assistant message's bare `model` (the burn-tier
+# carrier, #545 — AssistantMessage requires it) as property keys.
 OMP_AI_TYPES_URL = (
     "https://raw.githubusercontent.com/can1357/oh-my-pi/main/packages/ai/src/types.ts"
 )
 OMP_MESSAGE_LITERALS = {"assistant", "toolResult", "toolCall"}
-OMP_MESSAGE_FIELDS = {"toolCallId", "arguments"}
+OMP_MESSAGE_FIELDS = {"toolCallId", "arguments", "model"}
 # The ask tool (#519): its toolCall NAME is STATE-bearing — decode_omp_line
 # maps an assistant `ask` block to Waiting — and the first question's text
 # feeds the Waiting reason. Checked against the tool's own source (`readonly


### PR DESCRIPTION
Closes #545. omp assistant messages carry a separate `provider` + a BARE `model` (pi-ai `types.ts` requires both — live-verified at HEAD); the decoder now emits `AgentEvent::ModelInfo { model, effort: None }` from that field, riding the existing burn pipeline unchanged:

- **Burn compat** (the ask): bare `model` = the same vocabulary CC/codex/copilot emit → `TOP_MODELS` prefix match works directly (`claude-fable-5` flames ember exactly like CC's); reducer last-seen-wins dedups the per-turn re-stamp; unknown-id no-op both transports (pre-pinned). No effort channel on the omp wire → top models ride Premium, never Top — honest.
- The provider-prefixed `model_change` entry stays undecoded (redundant — one turn's lag at most; its combined `kimi-code/kimi-for-coding` form would dodge the prefix table). WHY documented at the `_ =>` arm + core CLAUDE.md.
- TDD unit tests (ModelInfo+ActivityStart ordering / text-only turn / empty-model phantom filter / content-absent branch pin); 3 conformance snaps gain the ModelInfo rows their fixtures always carried (2/2/3).
- Drift-watch: `model` joins `OMP_MESSAGE_FIELDS` (ai/types.ts vanish watch).
- Docs: core CLAUDE.md burn source list; `AgentSlot::model` field doc + dossier comment enumerations synced.

Local two-lens: correctness APPROVE (0 defects, upstream re-fetched, burn chain traced, mutation-teeth verified), design APPROVE-WITH-NITS (2 doc LOWs — applied) + the correctness NIT (content-absent pin — applied). `just preflight` exit 0 (2266/2266); drift selftest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BT3bfjgBPqZE5sqtccZm3v