### PR TITLE
release: 0.14.0 — curated in-app notes (full-cycle scope)

### DIFF
--- a/crates/pixtuoid/src/version.rs
+++ b/crates/pixtuoid/src/version.rs
@@ -59,9 +59,11 @@ pub fn release_notes(version: &str) -> Option<&'static [&'static str]> {
         // brace would silently break if the indentation ever shifted.
         // [bump-inject-here]
         "0.14.0" => Some(&[
-            "Click an agent, land in its terminal — clicking a sprite (or pressing f on the dashboard's selected agent) brings the terminal app hosting that session to the foreground, on macOS, Windows and Linux; if the terminal can't be found, nothing happens — no popups, no errors",
-            "Works across the fleet — hook-connected CLIs are located through the session's own process, Claude Code and Codex through their recycle-guarded liveness registries, so a stale or reused pid never yanks the wrong window forward",
-            "The old click-to-pin tooltip is retired in its favor — hovering a sprite still shows the full dossier, one click now means \"take me there\"",
+            "Click an agent, land in its terminal — clicking a sprite (or pressing f on the dashboard's selected agent) brings that session's terminal app to the foreground on macOS, Windows and Linux; it's located through the session's own process, so a stale or reused pid never yanks the wrong window forward",
+            "Top models wear their tier — agents running a frontier model now sport ember hair and a flame crown, so the office's horsepower reads at a glance, and the flames light and snuff the instant a session switches models",
+            "New agent supported — Oh My Pi (omp) sessions show up as om· pixel-art coworkers, wired in like every other CLI, with full model burn-tier parity",
+            "Crisper text everywhere — the old 8×8 bitmap font is retired: every name badge, label, and the neon wall board now render anti-aliased across the terminal, the floating window, and the web hero",
+            "Sturdier under the hood — a whole-codebase review pass (correctness, naming, wire-decoding), a burn-tier upstream-drift watch, and focus-jump pid recycle-guards; the office looks the same, just steadier",
         ]),
         "0.13.0" => Some(&[
             "New agent supported — Hermes Agent (Nous Research) sessions now show up as animated pixel-art coworkers in the office, wired in like every other CLI",


### PR DESCRIPTION
Drafts the **0.14.0** release. The version was already bumped to 0.14.0 at #532 (focus-jump), which drafted focus-jump-only in-app notes; four more feature themes landed on top since. This curates `release_notes("0.14.0")` to the full v0.13.0..HEAD scope.

## In-app upgrade-popup notes (5 highlights)
1. **Focus-jump** — click a sprite / press `f` → that session's terminal to the foreground (mac/Win/Linux), located via the session's own process (recycle-guarded).
2. **Model burn-tier flames** — frontier-model agents get ember hair + a flame crown; lights/snuffs on model switch (#540/#542/#544).
3. **New agent: Oh My Pi (omp)** — `om·` coworkers, full burn-tier parity (#520/#546).
4. **AA text everywhere** — the 8×8 bitmap font retired; badges/labels/neon board render anti-aliased across terminal, floating window, and web hero (#521/#523).
5. **Under-the-hood hardening** — whole-codebase review pass, burn-tier drift watch, focus-jump recycle-guards (#516/#544/#547).

App features only — the site→pixtuoid.dev move + Working-Building redesign stay out of the in-app popup, per the 0.13.0 precedent.

## Release mechanics
- **No media regen** — `just gen-check` is clean (office stills already regenerated to 0.14.0 during the cycle; notes are popup text, not baked into any still).
- Versions consistent (all crates `version.workspace = true` → 0.14.0); `notes-curated` ✓; version/release-notes-completeness tests ✓; pre-push preflight green.
- **Stops before the tag.** After merge, the human runs `git tag v0.14.0 && git push origin v0.14.0` — the irreversible crates.io + homebrew publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xxFWw2cafxi4x65NxVzES