### PR TITLE
chore(ci): repin cargo-deny-action v2.0.20 → v2.1.1

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -15,6 +15,6 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
-      - uses: EmbarkStudios/cargo-deny-action@v2.0.20 # v2.1.0 (2026-07-13) broke: musl toolchain override + "unrecognized subcommand" — repin when fixed upstream
+      - uses: EmbarkStudios/cargo-deny-action@v2.1.1 # explicit pin: the floating @v2 broke 2026-07-13 (v2.1.0 shift-5 ate the subcommand; v2.1.1 fixed same-day) — bump deliberately, not via the tag
         with:
           command: check advisories

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
-      - uses: EmbarkStudios/cargo-deny-action@v2.0.20 # v2.1.0 (2026-07-13) broke: musl toolchain override + "unrecognized subcommand" — repin when fixed upstream
+      - uses: EmbarkStudios/cargo-deny-action@v2.1.1 # explicit pin: the floating @v2 broke 2026-07-13 (v2.1.0 shift-5 ate the subcommand; v2.1.1 fixed same-day) — bump deliberately, not via the tag
         with:
           # Advisories run daily in audit.yml; this PR gate checks the rest.
           # Keep in sync with the justfile `deny` recipe.


### PR DESCRIPTION
## What

Roadmap **D** (deps). Moves the cargo-deny-action pin forward now that upstream fixed the breakage that forced the v2.0.20 emergency pin this morning.

## Evidence chain (verified via the GitHub API before repinning)

- v2.1.0 (2026-07-13T09:32Z) deprecated the `use-git-cli` input but left `shift 5` in `entrypoint.sh` — the subcommand got eaten → "unrecognized subcommand" (+ musl toolchain override noise). Deterministic breakage of the floating `@v2`.
- v2.1.1 (2026-07-13T10:35Z, upstream PR#116) restores `shift 4`. Compare-API diff inspected: the fix is exactly the argument-shift correction.
- This PR's own `deny` CI job runs the pinned action — a green run IS the empirical proof.

The pin stays an **explicit release tag** (not the floating `@v2` that broke us), with the WHY in the comment at both use-sites.

## Rest of roadmap D — blocked upstream (checked 2026-07-13)

- **#441 (winit 0.31):** still beta — crates.io `max_stable_version` = 0.30.13, `0.31.0-beta.2` untouched since 2026-03. The issue's own unblock condition (stable release) is unmet.
- **#440 (3 deny ignores):** wayland-scanner 0.31.10 (the *latest* stable) still requires `quick-xml ^0.39` → RUSTSEC-2026-0194/0195 not clearable; the ttf-parser chain (RUSTSEC-2026-0192) waits on winit 0.31 (winit 0.30.13 pins `sctk-adwaita ^0.10.1`). All three ignores stay; dated status comments going on both issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122Ni8ZuDMdqS393ZtwFeE3