### PR TITLE
refactor(install): least-privilege the io config-write authority (G audit)

### DIFF
--- a/crates/pixtuoid/src/crash.rs
+++ b/crates/pixtuoid/src/crash.rs
@@ -159,7 +159,7 @@ fn truncate_to_char_boundary(s: &str, max_bytes: usize) -> usize {
 fn crash_log_path() -> PathBuf {
     // Empty XDG_STATE_HOME = unset (see io::nonempty_env) — left unfiltered,
     // "" yields the root-absolute `/pixtuoid/...` (unwritable for non-root).
-    if let Some(state) = pixtuoid::install::io::nonempty_env("XDG_STATE_HOME") {
+    if let Some(state) = pixtuoid::install::nonempty_env("XDG_STATE_HOME") {
         return PathBuf::from(format!("{state}/pixtuoid/crash.log"));
     }
     if let Some(home) = pixtuoid_core::platform::user_home_opt() {

--- a/crates/pixtuoid/src/install/io.rs
+++ b/crates/pixtuoid/src/install/io.rs
@@ -206,12 +206,12 @@ impl ConfigLock {
         read_resolved(&self.target)
     }
 
-    /// [`backup_once`] against the pinned resolution (see [`Self::read`]).
+    /// [`backup_once_resolved`] against the pinned resolution (see [`Self::read`]).
     pub(crate) fn backup_once(&self, suffix: &str) -> Result<Option<PathBuf>> {
         backup_once_resolved(&self.target, suffix)
     }
 
-    /// [`remove_backup`] against the pinned resolution (see [`Self::read`]).
+    /// [`remove_backup_resolved`] against the pinned resolution (see [`Self::read`]).
     pub(crate) fn remove_backup(&self, suffix: &str) -> Result<Option<PathBuf>> {
         remove_backup_resolved(&self.target, suffix)
     }

--- a/crates/pixtuoid/src/install/io.rs
+++ b/crates/pixtuoid/src/install/io.rs
@@ -32,7 +32,7 @@ pub fn nonempty_env(name: &str) -> Option<String> {
 /// comparisons are STRUCTURAL (component-wise), never byte-wise on a `/`-vs-`\`
 /// string — the recurring `windows-test` failure mode. The join also preserves the
 /// home's `OsString` (no lossy round-trip).
-pub fn expand_tilde(value: &str, home: Option<&Path>) -> PathBuf {
+pub(crate) fn expand_tilde(value: &str, home: Option<&Path>) -> PathBuf {
     let v = value.trim();
     match home {
         Some(home) if v == "~" => home.to_path_buf(),
@@ -49,14 +49,14 @@ pub fn expand_tilde(value: &str, home: Option<&Path>) -> PathBuf {
 /// existence check is at worst a false positive. WRITE paths must use
 /// [`home_relative_checked`] — installing into `./.reasonix/...` produces a
 /// file the CLI's global-scope loader never reads.
-pub fn home_relative(rel: &str) -> PathBuf {
+pub(crate) fn home_relative(rel: &str) -> PathBuf {
     let home = pixtuoid_core::platform::user_home_opt().unwrap_or_else(|| ".".into());
     PathBuf::from(home).join(rel)
 }
 
 /// Resolve a `$HOME`-relative path, hard-erroring when no home dir is
 /// resolvable (instead of `home_relative`'s CWD fallback).
-pub fn home_relative_checked(rel: &str) -> Result<PathBuf> {
+pub(crate) fn home_relative_checked(rel: &str) -> Result<PathBuf> {
     checked_home_join(pixtuoid_core::platform::user_home_opt(), rel)
 }
 
@@ -72,7 +72,7 @@ fn checked_home_join(home: Option<String>, rel: &str) -> Result<PathBuf> {
 /// `--hook-path` and is handled by `resolve_hook_binary`'s absolutize-and-warn
 /// arm (returned verbatim from here, a relative value would get embedded into
 /// Codex/Reasonix configs and silently never fire from other cwds).
-pub fn default_hook_binary() -> Result<PathBuf> {
+pub(crate) fn default_hook_binary() -> Result<PathBuf> {
     if let Ok(p) = which::which("pixtuoid-hook") {
         return Ok(p);
     }
@@ -105,7 +105,7 @@ fn sibling(target: &Path, suffix: &str) -> PathBuf {
 /// empty file — the target's parser supplies the empty-document default.
 /// For a locked read→merge→write round use [`ConfigLock::read`] instead, so
 /// the read shares the guard's pinned resolution.
-pub fn read_config(path: &Path) -> Result<String> {
+pub(crate) fn read_config(path: &Path) -> Result<String> {
     read_resolved(&resolve_symlink(path))
 }
 
@@ -161,7 +161,7 @@ fn rename_with_retry(from: &Path, to: &Path) -> std::io::Result<()> {
 /// Residual: an external writer (Claude Code rewriting its own settings.json)
 /// can't honor this lock — it only serializes pixtuoid against pixtuoid.
 #[derive(Debug)]
-pub struct ConfigLock {
+pub(crate) struct ConfigLock {
     /// The symlink-resolved real target — writes go here, never the symlink.
     target: PathBuf,
     file: File,
@@ -172,7 +172,7 @@ pub struct ConfigLock {
 /// contention rather than block — `try_lock` returns
 /// `Err(TryLockError::WouldBlock)` when another install/uninstall holds it.
 /// std-native advisory lock (stable since 1.89, our MSRV).
-pub fn lock_config(path: &Path) -> Result<ConfigLock> {
+pub(crate) fn lock_config(path: &Path) -> Result<ConfigLock> {
     let target = resolve_symlink(path);
     if let Some(parent) = target.parent() {
         std::fs::create_dir_all(parent)?;
@@ -191,7 +191,7 @@ pub fn lock_config(path: &Path) -> Result<ConfigLock> {
 
 impl ConfigLock {
     /// The symlink-resolved real config path this guard locks.
-    pub fn target(&self) -> &Path {
+    pub(crate) fn target(&self) -> &Path {
         &self.target
     }
 
@@ -202,17 +202,17 @@ impl ConfigLock {
     /// otherwise split them across two files — merge input from the NEW
     /// target, write onto the OLD — under a lock that excludes nobody at the
     /// new path.
-    pub fn read(&self) -> Result<String> {
+    pub(crate) fn read(&self) -> Result<String> {
         read_resolved(&self.target)
     }
 
     /// [`backup_once`] against the pinned resolution (see [`Self::read`]).
-    pub fn backup_once(&self, suffix: &str) -> Result<Option<PathBuf>> {
+    pub(crate) fn backup_once(&self, suffix: &str) -> Result<Option<PathBuf>> {
         backup_once_resolved(&self.target, suffix)
     }
 
     /// [`remove_backup`] against the pinned resolution (see [`Self::read`]).
-    pub fn remove_backup(&self, suffix: &str) -> Result<Option<PathBuf>> {
+    pub(crate) fn remove_backup(&self, suffix: &str) -> Result<Option<PathBuf>> {
         remove_backup_resolved(&self.target, suffix)
     }
 
@@ -227,7 +227,7 @@ impl ConfigLock {
     /// content is written — so a user-tightened settings.json (API keys) is
     /// never widened, and a fresh file defaults tight rather than
     /// umask-default. Windows is a no-op (ACLs inherit from the directory).
-    pub fn write_atomic(&self, contents: &str) -> Result<()> {
+    pub(crate) fn write_atomic(&self, contents: &str) -> Result<()> {
         let tmp = sibling(&self.target, "tmp");
         {
             let mut opts = OpenOptions::new();
@@ -267,11 +267,14 @@ impl Drop for ConfigLock {
 /// the write only — callers doing a read→merge→write round must instead take
 /// [`lock_config`] before the read and write via [`ConfigLock::write_atomic`].
 /// Format-agnostic (&str).
-pub fn write_config_atomic(path: &Path, contents: &str) -> Result<()> {
+pub(crate) fn write_config_atomic(path: &Path, contents: &str) -> Result<()> {
     lock_config(path)?.write_atomic(contents)
 }
 
-pub fn backup_once(path: &Path, suffix: &str) -> Result<Option<PathBuf>> {
+// Path-based wrapper (resolve + backup) — production backs up through the
+// held `ConfigLock` (already-resolved target); only tests want the combo.
+#[cfg(test)]
+fn backup_once(path: &Path, suffix: &str) -> Result<Option<PathBuf>> {
     backup_once_resolved(&resolve_symlink(path), suffix)
 }
 
@@ -304,7 +307,8 @@ fn backup_once_resolved(target: &Path, suffix: &str) -> Result<Option<PathBuf>> 
     Ok(Some(bak))
 }
 
-pub fn remove_backup(path: &Path, suffix: &str) -> Result<Option<PathBuf>> {
+#[cfg(test)]
+fn remove_backup(path: &Path, suffix: &str) -> Result<Option<PathBuf>> {
     remove_backup_resolved(&resolve_symlink(path), suffix)
 }
 
@@ -320,14 +324,14 @@ fn remove_backup_resolved(target: &Path, suffix: &str) -> Result<Option<PathBuf>
 /// Whether the bare `pixtuoid-hook` name resolves on PATH. settings.json stores
 /// the bare name for portability, and Claude Code spawns hooks via PATH — so if
 /// this is false the installed hooks silently never fire.
-pub fn hook_on_path() -> bool {
+pub(crate) fn hook_on_path() -> bool {
     which::which("pixtuoid-hook").is_ok()
 }
 
 /// Follow symlink chain to the final target, even if that target doesn't exist
 /// yet (stow creates the link before the dotfiles repo is fully set up).
 /// `canonicalize` fails on a dangling symlink, so we walk `read_link` manually.
-pub fn resolve_symlink(path: &Path) -> PathBuf {
+pub(crate) fn resolve_symlink(path: &Path) -> PathBuf {
     let mut cur = path.to_path_buf();
     for _ in 0..32 {
         match std::fs::symlink_metadata(&cur) {

--- a/crates/pixtuoid/src/install/mod.rs
+++ b/crates/pixtuoid/src/install/mod.rs
@@ -4,7 +4,12 @@ pub mod codex;
 pub mod cursor;
 pub mod hermes;
 mod hook_cmd;
-pub mod io;
+// io is crate-private: its config-write authority (invariant #4) must never be
+// reachable cross-crate. Only the two env filters are re-exported below, so a
+// FUTURE stray `pub` in io trips unreachable_pub (-D warnings) — a compiler
+// tooth, not a review-practice backstop.
+pub(crate) mod io;
+pub use io::{nonempty, nonempty_env};
 pub mod merge;
 pub mod openclaw;
 pub mod opencode;

--- a/crates/pixtuoid/src/logging.rs
+++ b/crates/pixtuoid/src/logging.rs
@@ -35,7 +35,7 @@ pub(crate) fn init(tui_active: bool, log_level: &'static str) {
     // value would "enable" file mode with an unopenable path; treat it as unset
     // via the ONE empty-as-unset env filter (io::nonempty), the same trim
     // semantics XDG_STATE_HOME / XDG_CONFIG_HOME / PIXTUOID_HOOK already use.
-    let explicit_log_file = pixtuoid::install::io::nonempty_env("PIXTUOID_LOG").is_some();
+    let explicit_log_file = pixtuoid::install::nonempty_env("PIXTUOID_LOG").is_some();
 
     if tui_active {
         // Explicit verbosity keeps today's semantics (the full --log-level /
@@ -110,10 +110,10 @@ pub(crate) fn log_file_path() -> PathBuf {
     // shared io::nonempty semantics, kept in lockstep with the
     // `explicit_log_file` read in init() so "file mode enabled" and "which
     // file" can't disagree on a whitespace value.
-    if let Some(p) = pixtuoid::install::io::nonempty_env("PIXTUOID_LOG") {
+    if let Some(p) = pixtuoid::install::nonempty_env("PIXTUOID_LOG") {
         return PathBuf::from(p);
     }
-    if let Some(state) = pixtuoid::install::io::nonempty_env("XDG_STATE_HOME") {
+    if let Some(state) = pixtuoid::install::nonempty_env("XDG_STATE_HOME") {
         return PathBuf::from(format!("{state}/pixtuoid/log"));
     }
     if let Some(home) = pixtuoid_core::platform::user_home_opt() {
@@ -193,7 +193,7 @@ mod tests {
         // The shared io::nonempty filter backs XDG_STATE_HOME here: an
         // unfiltered empty value would route the crash log / runtime log to
         // the root-absolute `/pixtuoid/...`.
-        use pixtuoid::install::io::nonempty;
+        use pixtuoid::install::nonempty;
         assert_eq!(nonempty(None), None);
         assert_eq!(nonempty(Some(String::new())), None);
         assert_eq!(nonempty(Some("   ".into())), None);


### PR DESCRIPTION
## What

Roadmap **G** (whole-codebase combined review) — the single confirmed MEDIUM from a 10-finder + adversarial-verify audit of the entire tree. `install::io` exported ~15 items as `pub` when only `nonempty`/`nonempty_env` are reached cross-crate.

`unreachable_pub` (`-D warnings`) can't catch it: `install` and `io` are `pub` module trees, so every item is pub-reachable. That's the exact blind spot #547 hit on the sibling `verify_target` — which it demoted to `pub(crate)` while missing io.rs's foundation helpers (an incomplete sibling-sweep).

## Change

Demote every io.rs item except the two env filters to `pub(crate)`. The config-write authority (`lock_config`, `ConfigLock` + methods, `write_config_atomic`, `read_config`, `resolve_symlink`, `expand_tilde`, `home_relative*`, `default_hook_binary`, `hook_on_path`) is now unreachable outside the lib crate — **compiler-enforced teeth for invariant #4** (never write `settings.json` directly; route through io).

grep-proven safe: the only cross-crate (bin-target) consumers are `nonempty_env` (crash.rs, logging.rs) and `nonempty` (logging.rs test); no example/integration-test/doctest reaches the rest.

## The demotion earned its keep

`dead_code` then flagged the two **free** `backup_once`/`remove_backup` path-wrappers as used only by tests — production backs up through the held `ConfigLock`'s already-resolved target. Fenced them `#[cfg(test)]` (honest test-only status; the over-broad `pub` had hidden it).

## Gates

Suite 2314/2314, clippy `-D warnings` clean. No public **semver** surface (the bin's lib target isn't a semver surface); no behavior change.

Part of the G audit: all 6 architecture invariants verified holding (zero erosion); design/comment LOWs follow as separate PRs/issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122Ni8ZuDMdqS393ZtwFeE3