### PR TITLE
refactor: comment-discipline overhaul — strip process-history/dated-provenance, pin present-tense assertions (G audit)

### DIFF
--- a/crates/pixtuoid-core/src/source/claude_code.rs
+++ b/crates/pixtuoid-core/src/source/claude_code.rs
@@ -189,7 +189,7 @@ pub fn decode_cc_line(transcript_path: &str, source: &str, v: Value) -> Result<V
     }
 
     // Burn-tier effort observation: CC stamps a PERIODIC reminder attachment
-    // while ultra-class effort is active (verified live 2026-07-10: re-fires
+    // while ultra-class effort is active (re-fires
     // every ~dozen prompts for the whole ultra span) plus an EXIT marker on
     // leaving it — the wire carries no effort VALUE, so the arm synthesizes
     // each marker's own label. The `/effort` picker's chosen level is
@@ -403,7 +403,7 @@ mod tests {
     #[test]
     fn ultra_effort_attachments_become_effort_observations() {
         // The periodic ultra reminder carries no wire VALUE — the arm
-        // synthesizes the marker's own label (verified live 2026-07-10).
+        // synthesizes the marker's own label.
         for (kind, label) in [
             ("ultra_effort_enter", "ultra"),
             ("ultrathink_effort", "ultrathink"),

--- a/crates/pixtuoid-core/src/source/codewhale.rs
+++ b/crates/pixtuoid-core/src/source/codewhale.rs
@@ -7,7 +7,7 @@
 //! the shim there. But CodeWhale's hooks DON'T hand the command a CC-shaped JSON payload
 //! on stdin — identity travels as `DEEPSEEK_*` ENV VARS (verified against
 //! `crates/tui/src/hooks.rs::HookContext::to_env_vars` @0.8.59, and a live
-//! capture 2026-06-12), and only `message_submit`/`turn_end`/`subagent_*` pass
+//! capture), and only `message_submit`/`turn_end`/`subagent_*` pass
 //! any stdin at all. So the shim runs in **env-mode** (`pixtuoid-hook --event
 //! <name>`): it reads the env vars and synthesizes this envelope, which arrives
 //! on the shared hook socket stamped `_pixtuoid_source: "codewhale"`:

--- a/crates/pixtuoid-core/src/source/codex.rs
+++ b/crates/pixtuoid-core/src/source/codex.rs
@@ -291,7 +291,7 @@ mod tests {
 
     #[test]
     fn turn_context_surfaces_model_and_effort_verbatim() {
-        // Shape sanitized from a LIVE rollout (2026-07-10); effort appears
+        // Shape sanitized from a LIVE rollout; effort appears
         // only on reasoning turns.
         let v = serde_json::json!({
             "type": "turn_context",

--- a/crates/pixtuoid-core/src/source/copilot.rs
+++ b/crates/pixtuoid-core/src/source/copilot.rs
@@ -310,7 +310,7 @@ mod tests {
 
     #[test]
     fn execution_complete_surfaces_the_per_tool_model() {
-        // Byte-real shape (capture 2026-05-22): data.model rides every
+        // Byte-real shape (from a real capture): data.model rides every
         // tool.execution_complete.
         let line = r#"{"type":"tool.execution_complete","data":{"toolCallId":"t1","model":"claude-haiku-4.5","success":true},"id":"e1","timestamp":"ts","parentId":null}"#;
         let evs = decode_copilot_line(

--- a/crates/pixtuoid-core/src/source/cursor.rs
+++ b/crates/pixtuoid-core/src/source/cursor.rs
@@ -19,7 +19,7 @@
 //! here (the custom decoder runs FIRST, before the shared CC-shaped field
 //! requirements). Cursor's envelope reuses CC's `hook_event_name` field NAME
 //! but with **camelCase values** — wire shape verified against a real
-//! `cursor-agent -p` capture (2026-06-14):
+//! `cursor-agent -p` capture shape:
 //!
 //! ```json
 //! {"hook_event_name":"preToolUse","session_id":"c7cef226-…","cwd":"",
@@ -98,7 +98,7 @@ pub fn decode_cursor_hook_payload(v: &Value) -> Result<Vec<AgentEvent>> {
         .and_then(|s| s.as_str())
         .ok_or_else(|| anyhow!("cursor payload missing hook_event_name"))?;
     // The workspace path: the top-level `cwd` is EMPTY/absent in CLI hook
-    // payloads (capture-verified 2026-06-14) — `workspace_roots[0]` is the real
+    // payloads (from a real capture) — `workspace_roots[0]` is the real
     // one. Used for the label + the SessionStart/Identity cwd, NOT the AgentId key.
     let workspace = obj
         .get("cwd")
@@ -204,7 +204,7 @@ pub(crate) fn decode_cursor_hook_custom(v: &Value) -> Result<Option<Vec<AgentEve
 /// renders session-only (no in-CLI delegation signal).
 fn cursor_tool_detail(tool: &str, args: Option<&Value>) -> ToolDetail {
     // Subagent dispatch: Cursor's `Task` tool carries a `subagent_type`
-    // (capture-verified 2026-06-14, e.g. "code-explorer") — the SAME stable
+    // (from a real capture, e.g. "code-explorer") — the SAME stable
     // semantic signal CC's `make_tool_detail` keys on. Show "Delegating" on the
     // parent while the children work. (The children run as INDEPENDENT sessions
     // with no parent-link in the stream — see the module doc — so this is the

--- a/crates/pixtuoid-core/src/source/decoder.rs
+++ b/crates/pixtuoid-core/src/source/decoder.rs
@@ -231,7 +231,7 @@ pub fn decode_hook_payload(v: Value) -> Result<Vec<AgentEvent>> {
     // Burn-tier effort observation (CC): tool-context hook payloads carry an
     // `effort: {level}` object (documented in hooks.md — low/medium/high/
     // xhigh/max; ULTRACODE mode "is not a distinct level and reports as
-    // xhigh", also exported as $CLAUDE_EFFORT — live-verified 2026-07-10).
+    // xhigh", also exported as $CLAUDE_EFFORT).
     // Codex hook payloads carry no such field — absent = emit nothing. This
     // is the primary CC effort channel (per tool event, verbatim vocabulary);
     // the transcript's periodic ultra attachment markers are the JSONL twin.
@@ -496,7 +496,7 @@ mod tests {
     #[test]
     fn tool_hooks_surface_the_effort_level() {
         // hooks.md: tool-context payloads carry `effort:{level}`; ultracode
-        // reports as "xhigh" (live-verified via $CLAUDE_EFFORT 2026-07-10).
+        // reports as "xhigh" (exported via $CLAUDE_EFFORT).
         for event in ["PreToolUse", "PostToolUse"] {
             let v = serde_json::json!({
                 "hook_event_name": event,
@@ -1067,9 +1067,9 @@ mod tests {
         // notification_decodes_to_identity_plus_waiting above ("permission?").
     }
 
-    // Review round (lens-1/lens-2 converged): the cwd is transcript/hook
-    // content too, and a SLASHLESS crafted value makes the whole string the
-    // basename — the chokepoint shared by all three derivers must cap it.
+    // The cwd is transcript/hook content too, and a SLASHLESS crafted value
+    // makes the whole string the basename — the chokepoint shared by all three
+    // derivers must cap it.
     #[test]
     fn cwd_basename_label_caps_a_content_derived_basename() {
         let long = "é".repeat(MAX_DECODED_FIELD_CHARS * 10);
@@ -1182,9 +1182,9 @@ mod tests {
         );
     }
 
-    // Review round (lens-3): tool_name is wire/transcript content landing in
-    // Active.detail → the unbounded headless summary — capped in the Generic
-    // display like its target.
+    // tool_name is wire/transcript content landing in Active.detail → the
+    // unbounded headless summary — capped in the Generic display like its
+    // target.
     #[test]
     fn generic_tool_name_is_capped_in_the_display() {
         let long = "T".repeat(MAX_DECODED_FIELD_CHARS * 10);

--- a/crates/pixtuoid-core/src/source/hermes.rs
+++ b/crates/pixtuoid-core/src/source/hermes.rs
@@ -12,7 +12,7 @@
 //! - **Hermes shell hooks** (`~/.hermes/config.yaml`, or `$HERMES_HOME/config.yaml`)
 //!   — shell commands fired on lifecycle/tool events, JSON on stdin. THIS is the
 //!   seam: connecting Hermes in the Connection panel (`s`) registers the shim under
-//!   the `hooks:` block. Wire shape verified against a real capture (2026-07-03):
+//!   the `hooks:` block. Wire shape verified against a real capture:
 //!
 //! ```json
 //! {"hook_event_name":"pre_tool_call","tool_name":"terminal",

--- a/crates/pixtuoid-core/src/source/omp.rs
+++ b/crates/pixtuoid-core/src/source/omp.rs
@@ -7,11 +7,11 @@
 //! Sources panel shows `om·` as a no-target flag-flip row.
 //!
 //! Grounded in the upstream source @ v16.3.12 (`can1357/oh-my-pi`, commit
-//! ff1fe5f, 2026-07-09) — pin comments below cite the upstream files —
-//! and byte-real anchored against a live omp 16.4.0 install (2026-07-10):
+//! ff1fe5f) — pin comments below cite the upstream files —
+//! and byte-real anchored against a live omp 16.4.0 install:
 //! the conformance fixtures under `tests/sources/fixtures/omp/` are
 //! sanitized captures (a real `omp -p` run and a real `task`-subagent child
-//! file at 16.4.0; a real interactive ask round captured 2026-07-05), and
+//! file at 16.4.0; a real interactive ask round), and
 //! the registry row's `verified_version` is that install's `omp --version`.
 //!
 //! Wire shape (upstream `packages/coding-agent/src/session/`):

--- a/crates/pixtuoid-core/src/source/opencode.rs
+++ b/crates/pixtuoid-core/src/source/opencode.rs
@@ -394,7 +394,7 @@ mod tests {
             .expect("at least one event")
     }
 
-    // Real shape, captured from opencode.db's event table (PONG run 2026-06-13):
+    // Real shape, captured from opencode.db's event table:
     // session.created.1 → {sessionID, info:{id, slug, projectID, directory, …}}.
     #[test]
     fn session_created_keys_on_stable_session_id() {

--- a/crates/pixtuoid-core/src/source/registry.rs
+++ b/crates/pixtuoid-core/src/source/registry.rs
@@ -475,7 +475,7 @@ const REASONIX: SourceDescriptor = SourceDescriptor {
 /// `DEEPSEEK_*` env vars the shim folds into `cwd`/`tool`/`tool_args`), so the
 /// custom decoder claims every event and the shared id-key branch is never
 /// reached. Keyed on cwd because `session_id` is inconsistent across events
-/// (live-verified 2026-06-12) — see `source/codewhale.rs`.
+/// — see `source/codewhale.rs`.
 const CODEWHALE: SourceDescriptor = SourceDescriptor {
     name: codewhale::SOURCE_NAME,
     label_prefix: "cw",
@@ -489,7 +489,7 @@ const CODEWHALE: SourceDescriptor = SourceDescriptor {
         },
         caps: SourceCaps {
             // session_end fires on a clean TUI quit carrying DEEPSEEK_WORKSPACE
-            // (verified live 2026-06-12) — best-effort counts.
+            // — best-effort counts.
             has_exit_signal: true,
             // message_submit re-emits SessionStart (the decode maps it so) —
             // a swept-but-live session walks back in on the next prompt.
@@ -553,7 +553,7 @@ const OPENCODE: SourceDescriptor = SourceDescriptor {
 const OPENCLAW: SourceDescriptor = SourceDescriptor {
     name: openclaw::SOURCE_NAME,
     label_prefix: "ok",
-    // Byte-real capture anchor (2026-06-15): `openclaw 2026.6.6`.
+    // Byte-real capture anchor: `openclaw 2026.6.6`.
     verified_version: "2026.6.6",
     version_probe: Some(&["openclaw", "--version"]),
     kind: SourceKind::Daemon {
@@ -619,8 +619,8 @@ const CURSOR: SourceDescriptor = SourceDescriptor {
             custom: Some(cursor::decode_cursor_hook_custom),
         },
         caps: SourceCaps {
-            // `sessionEnd` FIRES on clean completion (capture-verified 2026-06-14:
-            // `reason:"completed"`) — best-effort counts, CC/Reasonix class. Abrupt
+            // `sessionEnd` FIRES on clean completion (`reason:"completed"`) —
+            // best-effort counts, CC/Reasonix class. Abrupt
             // exits (no PID exposed) fall to the generic stale-sweep.
             has_exit_signal: true,
             // Each `cursor-agent` invocation is a NEW session_id, so a stale-swept
@@ -651,7 +651,7 @@ const CURSOR: SourceDescriptor = SourceDescriptor {
 const HERMES: SourceDescriptor = SourceDescriptor {
     name: hermes::SOURCE_NAME,
     label_prefix: "hm",
-    verified_version: "0.18.0", // `Hermes Agent v0.18.0 (2026.7.1)`; wire captured 2026-07-03
+    verified_version: "0.18.0", // captured banner: `Hermes Agent v0.18.0 (2026.7.1)`
     version_probe: Some(&["hermes", "--version"]),
     kind: SourceKind::Agent {
         transcript: None, // hook-only: no transcript for the walker to watch
@@ -686,7 +686,7 @@ const HERMES: SourceDescriptor = SourceDescriptor {
 const OMP: SourceDescriptor = SourceDescriptor {
     name: omp::SOURCE_NAME,
     label_prefix: "om",
-    // Byte-real capture anchor (2026-07-10): `omp/16.4.0` (`omp --version`);
+    // Byte-real capture anchor: `omp/16.4.0` (`omp --version`);
     // the omp fixtures are sanitized captures from that install.
     verified_version: "16.4.0",
     version_probe: Some(&["omp", "--version"]),

--- a/crates/pixtuoid-core/src/state/mod.rs
+++ b/crates/pixtuoid-core/src/state/mod.rs
@@ -991,10 +991,12 @@ mod tests {
     #[test]
     fn floor_range_clamps_oob_index() {
         let s = SceneState::uniform(4);
-        // floor_idx >= MAX_FLOORS should clamp to last floor
         let last = s.floor_range(MAX_FLOORS - 1);
         let oob = s.floor_range(MAX_FLOORS + 10);
-        assert_eq!(last, oob);
+        assert_eq!(
+            last, oob,
+            "an OOB floor index clamps to the last floor's range"
+        );
     }
 
     #[test]

--- a/crates/pixtuoid-core/src/state/reducer.rs
+++ b/crates/pixtuoid-core/src/state/reducer.rs
@@ -936,31 +936,16 @@ impl Reducer {
                 // silently dropped it).
                 fsm::resurrect_in_place(slot, now);
                 // Evict the dead life's correlation state, exactly as
-                // `sweep_exited` would have if the corpse had GC'd
-                // before this start — per map:
-                // - active_tasks: a leftover tuid can NEVER drain (its
-                //   End belongs to the dead life), so it would keep
-                //   suppress_subagent_leak eating every hook event of
-                //   the new life. On a #228 false-exit resurrect the
-                //   old delegation may still be live, but its subtree
-                //   was already cascade_exit'd by the SessionEnd (only
-                //   the root resurrects); an out-of-window JSONL
-                //   replay of its Start re-inserts (a fresh first
-                //   insert) and its End then drains + re-arms b1 —
-                //   safe: the fire-time emptiness check holds and the
-                //   old subtree is already exiting. A transient hook
-                //   misattribution beats permanent suppression.
-                // - gated_before_waiting: a dead life's gate could
-                //   false-resolve a future Waiting via resolves_wait.
-                // - pending_b1_cascades: an armed cascade from the old
-                //   drain would fire into the NEW life's fresh subtree.
-                // recent_proof_of_life deliberately SURVIVES: a vouch
-                // asserts the owning process is alive, and a
-                // resurrecting slot is the one case where that is true
-                // by definition (sweep_exited evicts it only because
-                // the SLOT is gone). The hook-recency maps
-                // (recent_hook_tool_uses / _session_ends) are
-                // TTL-bounded and not per-slot state — gc owns them.
+                // `sweep_exited` would have if the corpse had GC'd before this
+                // start: a leftover active_tasks entry keeps
+                // suppress_subagent_leak eating the new life's hooks, a stale
+                // gate could false-resolve a future Waiting, and an armed b1
+                // cascade would fire into the fresh subtree. recent_proof_of_life
+                // deliberately SURVIVES — a resurrecting slot is by definition
+                // still alive; the TTL-bounded hook-recency maps are gc's, not
+                // per-slot. Pinned by
+                // resurrect_in_place_clears_stale_active_tasks_so_fresh_session_hooks_apply
+                // + resurrect_in_place_cancels_stale_pending_b1_cascade.
                 self.corr.active_tasks.remove(&agent_id);
                 self.corr.gated_before_waiting.remove(&agent_id);
                 self.pending_b1_cascades.remove(&agent_id);

--- a/crates/pixtuoid-hook/src/main.rs
+++ b/crates/pixtuoid-hook/src/main.rs
@@ -76,8 +76,8 @@ fn main() -> Result<()> {
         // stdin — a blind `read_to_string(stdin)` would BLOCK (and tool_call_before
         // runs synchronously, freezing the user's tool call until the hook
         // timeout). So when `--event` is present we build the envelope from env
-        // and NEVER touch stdin. Verified against CodeWhale 0.8.59
-        // hooks.rs::execute_sync_inner + a live capture (2026-06-12).
+        // and NEVER touch stdin. Mirrors CodeWhale 0.8.59's
+        // `hooks.rs::execute_sync_inner`.
         Some(event) => Value::Object(env_payload(&event)),
         None => {
             let mut buf = String::new();
@@ -205,10 +205,9 @@ fn env_payload_from(
     // CodeWhale runs the hook with current_dir = its working dir (= the
     // workspace), and DEEPSEEK_WORKSPACE is UNSET for a fresh `codewhale`
     // launched without `-C` until the workspace resolves — so `session_start`
-    // would otherwise carry no cwd and never register a sprite (caught by live
-    // testing 2026-06-13; the `-C` capture + unit tests masked it). The
-    // fallback resolves to the same path the workspace eventually does, so all
-    // of a session's events coalesce on one AgentId.
+    // would otherwise carry no cwd and never register a sprite. The fallback
+    // resolves to the same path the workspace eventually does, so all of a
+    // session's events coalesce on one AgentId.
     if let Some(cwd) = get("DEEPSEEK_WORKSPACE")
         .filter(|v| !v.is_empty())
         .or_else(|| cwd_fallback.filter(|v| !v.is_empty()))
@@ -598,10 +597,10 @@ mod tests {
 
     #[test]
     fn env_payload_falls_back_to_cwd_when_workspace_unset() {
-        // The live-testing bug (2026-06-13): a fresh `codewhale` without `-C` has
-        // no DEEPSEEK_WORKSPACE at session_start, so the cwd-less envelope was
-        // dropped (no sprite). CodeWhale runs the hook with current_dir = its
-        // working dir, so the shim must fall back to that. R0613-05.
+        // A fresh `codewhale` without `-C` has no DEEPSEEK_WORKSPACE at
+        // session_start, so a cwd-less envelope would be dropped (no sprite).
+        // CodeWhale runs the hook with current_dir = its working dir, so the
+        // shim must fall back to that.
         let no_ws: std::collections::HashMap<&str, String> =
             [("DEEPSEEK_TOOL_NAME", "exec_shell".to_string())]
                 .into_iter()

--- a/crates/pixtuoid-scene/src/burn.rs
+++ b/crates/pixtuoid-scene/src/burn.rs
@@ -1,6 +1,6 @@
 //! Burn tier — how expensive an agent's LLM brain is, as a VISUAL fact.
 //!
-//! The model is the GATE, effort is the SPLIT (user-pinned 2026-07-10): only
+//! The model is the GATE, effort is the SPLIT (user-pinned): only
 //! the [`TOP_MODELS`] ever color at all — at ordinary/unknown effort they get
 //! ember-red hair ([`BurnTier::Premium`]); with a FRESH max-class effort
 //! ([`MAX_EFFORTS`], within [`EFFORT_TTL_SECS`]) the hair catches fire
@@ -22,8 +22,8 @@ use pixtuoid_core::AgentSlot;
 /// `claude-fable` covers `claude-fable-5` and its successors) — the tradeoff
 /// is that a future CHEAPER variant sharing a prefix (a hypothetical
 /// `gpt-5.6-sol-mini`) would wrongly burn until a Normal-override row is
-/// added ABOVE its family line. No such slug exists today. Source-verified 2026-07-10: `gpt-5.6-sol` is the flagship slug
-/// in openai/codex `models-manager/models.json` (terra/luna miss the prefix
+/// added ABOVE its family line. No such slug exists today. `gpt-5.6-sol` is the
+/// flagship slug in openai/codex `models-manager/models.json` (terra/luna miss the prefix
 /// naturally); fable/mythos are Anthropic's Mythos-class ids on CC's wire.
 const TOP_MODELS: &[&str] = &["claude-fable", "claude-mythos", "gpt-5.6-sol"];
 

--- a/crates/pixtuoid-scene/src/floor.rs
+++ b/crates/pixtuoid-scene/src/floor.rs
@@ -315,10 +315,10 @@ fn frame_epilogue(
 /// THE shared headless frame seam: scene → `RgbBuffer`, one floor, one frame —
 /// prologue (buffer sizing, layout, router zone), the pixel pass, and the
 /// bookkeeping epilogue (coffee-carrier persistence + the door-anim clamp
-/// refresh) in ONE compiler-owned place. Before this seam the epilogue was
-/// mirrored by convention across the consumers and drifted twice for real
-/// (a dropped-carriers bug in the TUI transition path; the web hero shipping
-/// without eviction at all — the loop-2 teleport, #423).
+/// refresh) in ONE compiler-owned place, because a convention-mirrored
+/// epilogue drifts across consumers — the #423 class, concrete enough to
+/// have bitten twice (a dropped-carriers bug in the TUI transition path; the
+/// web hero without eviction — the loop-2 teleport).
 ///
 /// Consumers: the TUI floor-slide (`TuiRenderer::render_transition`), the
 /// floating window (`OfficeRenderer::render`), and the web hero

--- a/crates/pixtuoid-scene/src/floor.rs
+++ b/crates/pixtuoid-scene/src/floor.rs
@@ -343,8 +343,7 @@ fn frame_epilogue(
 /// the full live scene by contract); only a projected-scene consumer like the
 /// TUI slide still calls this fn raw and owns its own eviction.
 /// The IMMUTABLE per-frame render inputs — the read-only cluster threaded
-/// through [`render_floor`] / [`FloorSession::render`] (was a 9-arg positional
-/// tail behind the mutable stores). The MUTABLE per-floor stores
+/// through [`render_floor`] / [`FloorSession::render`]. The MUTABLE per-floor stores
 /// (`fctx`/`buf`/`coffee`/`chitchat`) stay SEPARATE params on `render_floor`: a
 /// painter that composes floors (the TUI) borrows those disjointly per floor via
 /// `split_at_mut`, so they can't fold into one bundle. `buf_w`/`buf_h` fold into
@@ -397,8 +396,8 @@ pub fn render_floor(
         chitchat_state: chitchat,
         debug_walkable,
     });
-    // The epilogue the consumers used to mirror by hand — now ONE definition
-    // (carrier stamping + the door-cosmetic clamp) shared with observe().
+    // The shared epilogue (carrier stamping + the door-cosmetic clamp) — ONE
+    // definition shared with observe().
     frame_epilogue(fctx, coffee, result.new_coffee_carriers, now);
     Some(layout)
 }
@@ -457,13 +456,11 @@ impl PerOffice {
     }
 }
 
-/// The OWNED painter session: the persistent bundle every painter used to
-/// hand-roll — {[`FloorCtx`], `RgbBuffer`, [`CoffeeState`], chitchat map} plus
-/// the dual `evict_missing` protocol — hoisted behind one type. Each painter
-/// drifted on exactly that convention once: the floating window never evicted
-/// (a slow per-agent leak for the window's lifetime) and the web hero shipped
-/// without eviction at all (the loop-2 teleport, #423). One floor + one
-/// office: the single-floor painters (`floating::offscreen::OfficeRenderer`,
+/// The OWNED painter session: bundles {[`FloorCtx`], `RgbBuffer`,
+/// [`CoffeeState`], chitchat map} plus the dual `evict_missing` protocol behind
+/// one type, so a painter can't hand-roll (and silently skip) the eviction — a
+/// skipped eviction leaks per-agent state or teleports a recurring agent. One
+/// floor + one office: the single-floor painters (`floating::offscreen::OfficeRenderer`,
 /// `pixtuoid-web::Office`) own a `FloorSession`; a multi-floor painter (the
 /// TUI) composes `Vec<`[`PerFloor`]`>` + one [`PerOffice`] and drives
 /// [`render_floor`] / `draw_scene` itself.
@@ -496,8 +493,7 @@ impl FloorSession {
     /// when the size can't lay out.
     ///
     /// `scene` MUST be the full live scene — the session evicts against it,
-    /// so a painter can no longer forget the eviction (the drift class behind
-    /// the floating leak and the web loop-2 teleport). A consumer rendering
+    /// so a painter can't skip the eviction. A consumer rendering
     /// PROJECTED single-floor scenes (the TUI floor slide) stays on
     /// [`render_floor`] directly and runs the eviction against the full scene
     /// itself.
@@ -719,11 +715,10 @@ pub fn num_floors(scene: &SceneState) -> usize {
 
 /// One agent projected onto a floor by [`build_floor_scene`]: the slot — its
 /// `desk_index` still the ORIGINAL global allocation — paired with its desk in
-/// the floor's OWN local space, typed as such (`FloorLocalDeskIndex`, the #209
-/// currency). The projection used to write the floor-local offset back into
-/// `AgentSlot.desk_index` mid-flight, making that field's GLOBAL type a lie
-/// until [`project_floor_scene`] re-hosted the slot; the pair keeps the
-/// currency honest up to the re-host.
+/// the floor's OWN local space, typed as such (`FloorLocalDeskIndex`). Holding
+/// the floor-local offset in a SEPARATE `desk` field, rather than writing it
+/// back into `AgentSlot.desk_index`, keeps that field's GLOBAL type honest
+/// until [`project_floor_scene`] re-hosts the slot.
 pub struct ProjectedSlot {
     pub slot: AgentSlot,
     pub desk: FloorLocalDeskIndex,
@@ -1490,11 +1485,10 @@ mod tests {
 
     #[test]
     fn floor_session_render_owns_the_dual_eviction() {
-        // The drift classes that actually shipped: the floating painter never
-        // evicted (per-agent motion/cache/coffee leaked for the window's
-        // lifetime) and the web hero forgot eviction entirely (the loop-2
-        // teleport). FloorSession::render runs BOTH halves itself, so a
-        // painter can no longer forget either one.
+        // FloorSession::render runs BOTH halves of the dual eviction itself —
+        // the render caches (motion/pose/frame) and the coffee cup — so a
+        // painter can't skip one and leak per-agent state or teleport a
+        // recurring agent.
         let pack = crate::embedded_pack::test_default_pack();
         let theme = crate::theme::theme_by_name("normal").expect("normal theme exists");
         let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);

--- a/crates/pixtuoid-scene/src/layout/mask.rs
+++ b/crates/pixtuoid-scene/src/layout/mask.rs
@@ -186,29 +186,21 @@ pub(super) fn build_walkable_mask(
     let baseboard_top = buf_h.saturating_sub(BASEBOARD_H);
     mask.mark_blocked(0, baseboard_top, buf_w, BASEBOARD_H, 0);
 
-    // Interior walls. Stardew-style fake-3D perspective:
-    //   • horizontal walls (E-W) show their FACE — WALL_THICK_H px tall so the
-    //     wall reads as having real mass/height when viewed from the north
-    //     room (clearly thicker than the edge-on vertical).
-    //   • vertical walls (N-S) are seen EDGE-ON — WALL_THICK_V px thin footprint
-    //     (the renderer draws it 3 px wide; visual-wider-than-footprint per the
-    //     top-down ground-projection rule).
-    // Wall padding is ASYMMETRIC by orientation — driven by the coarse 4×4
-    // router grid (`pathfind::cell_walkable`: a cell is walkable when ≥8 of its
-    // 16 px are open), NOT by clearance:
-    //   • HORIZONTAL (E-W) walls are WALL_THICK_H=6 px tall. 6 contiguous blocked
-    //     px already fill a routing cell, so the wall is impassable with pad=0 —
-    //     and you stand FLUSH against its south face, so any pad is pure red bloat
-    //     (a 6px wall read as 10px). pad=0.
-    //   • VERTICAL (N-S) walls are WALL_THICK_V=1 px edge-on (top-down ground
-    //     projection, invariant #6). A 1px-wide blocked strip is INVISIBLE to the
-    //     coarse grid — every straddling cell keeps ≥12/16 px walkable, so A*
-    //     routes STRAIGHT THROUGH the wall. It needs OBSTACLE_PAD_PX (→5px blocked)
-    //     to drive the wall's whole cell-column under the threshold. This is the
-    //     original design: DOOR_GAP=14 is sized for "≥10px effective gap after
-    //     [this] padding" (see rooms/walls.rs). The 1px FOOTPRINT is unchanged
-    //     (characters still stand right next to the 3px visual); the pad is a
-    //     routing-only clearance band, not a wider wall.
+    // Interior walls, Stardew-style fake-3D: horizontal (E-W) walls show their
+    // FACE (WALL_THICK_H px tall, real mass viewed from the north room); vertical
+    // (N-S) walls are seen EDGE-ON (WALL_THICK_V px thin footprint, drawn wider
+    // than it blocks per the top-down ground-projection rule, invariant #6).
+    //
+    // Wall padding is ASYMMETRIC by orientation, driven by the coarse router grid
+    // (`pathfind::cell_walkable`), NOT by clearance:
+    //   • HORIZONTAL faces are thick enough to fill a routing cell on their own,
+    //     so they're impassable at pad=0 — and you stand FLUSH against the south
+    //     face, so any pad is pure red bloat.
+    //   • VERTICAL walls are a 1px edge-on strip the coarse grid can't see, so A*
+    //     would route STRAIGHT THROUGH; OBSTACLE_PAD_PX is a routing-only
+    //     clearance band (the FOOTPRINT stays 1px — characters still stand right
+    //     next to the 3px visual), sized against DOOR_GAP in rooms/walls.rs.
+    // Pinned by pathfind::vertical_wall_is_impassable_except_through_the_door.
     for seg in room_walls {
         let (origin, size) = wall_segment_rect(seg, top_margin);
         // Vertical walls are 1px edge-on — invisible to the coarse grid without

--- a/crates/pixtuoid-scene/src/layout/placement.rs
+++ b/crates/pixtuoid-scene/src/layout/placement.rs
@@ -43,10 +43,6 @@ pub fn anchored_top_left(anchor: Anchor, pos: Point, w: u16, h: u16) -> Point {
     }
 }
 
-/// The y-sort key for a sprite of height `h` anchored at `pos`: its south
-/// (front) base ROW. Derived from [`anchored_top_left`] so it can NEVER drift
-/// from where the sprite actually blits (`origin.y + h - 1`). For `Center` this
-/// equals the legacy `pos.y + center_pin_south_offset(h)` (i.e. `(h-1)/2`).
 /// Half-open AABB intersection of two `(top_left, size)` rects. Lives here —
 /// the geometry-primitive module — so the placement sweep's overlap invariant
 /// and production collision checks (the whiteboard-vs-desk drop in compute.rs)
@@ -89,6 +85,10 @@ pub(super) fn overlaps_within_clearance(
     rects_overlap(probe, (grown_tl, grown))
 }
 
+/// The y-sort key for a sprite of height `h` anchored at `pos`: its south
+/// (front) base ROW. Derived from [`anchored_top_left`] so it can NEVER drift
+/// from where the sprite actually blits (`origin.y + h - 1`). For `Center` this
+/// equals the legacy `pos.y + center_pin_south_offset(h)` (i.e. `(h-1)/2`).
 pub fn z_sort_row(anchor: Anchor, pos: Point, h: u16) -> u16 {
     anchored_top_left(anchor, pos, 0, h)
         .y

--- a/crates/pixtuoid-scene/src/layout/placement_sweep.rs
+++ b/crates/pixtuoid-scene/src/layout/placement_sweep.rs
@@ -734,9 +734,8 @@ fn desk_capacity_obeys_the_request_law() {
 fn every_kind_is_placed_somewhere_in_the_sweep() {
     // Existential coverage: every registered role-enum variant must appear in
     // at least ONE swept layout — a kind that never places is dead weight (or
-    // a placement-site regression). Allowlist: BulletinBoard — owner ruled it
-    // stays unplaced (2026-07-13, B-3 mock round); registered for pack
-    // authors.
+    // a placement-site regression). Allowlist: BulletinBoard stays unplaced by
+    // design (registered for pack authors).
     use std::collections::BTreeSet;
     let mut seen: BTreeSet<String> = BTreeSet::new();
     sweep(|_, _, _, l| {

--- a/crates/pixtuoid-scene/src/layout/tests.rs
+++ b/crates/pixtuoid-scene/src/layout/tests.rs
@@ -999,9 +999,9 @@ fn meeting_table_ends_are_chair_seats_not_stands() {
 
 #[test]
 fn coat_rack_yields_to_the_east_chair_in_narrow_fitted_rooms() {
-    // Arc-final audit catch (PR #561): on fitted rooms ≲40 wide the rack's
-    // coats (west reach cx−2) overprinted the east chair body + its sitter.
-    // The rack yields in that geometry; bare rooms and roomy floors keep it.
+    // On fitted rooms ≲40 wide the rack's coats (west reach cx−2) would
+    // overprint the east chair body + its sitter, so the rack yields in that
+    // geometry; bare rooms and roomy floors keep it.
     let narrow = SceneLayout::compute(120, 160, Some(TEST_DEFAULT_DESKS)).expect("fits");
     let r = &narrow.meeting_rooms[0];
     assert!(r.trio.is_some(), "120x160 hosts a fitted room");

--- a/crates/pixtuoid-scene/src/pixel_painter/effects.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/effects.rs
@@ -204,7 +204,7 @@ pub(super) fn paint_waiting_bubble(buf: &mut RgbBuffer, anchor: Point, theme: &T
 /// The Top-tier flame crown (`burn::BurnTier::Top`) — a 2-frame flicker above
 /// the sprite's hair, painted AFTER the character blit so it rides every pose
 /// (seated/walking/standing) through the one `paint_character_at` seam. The
-/// aesthetic is the user-ratified mockup (2026-07-10): tips capped ≤2 px above
+/// aesthetic is the user-ratified mockup: tips capped ≤2 px above
 /// the hair top so the flame never collides with the name-badge row; the
 /// asymmetric two-frame flicker is what reads as fire, not a hat. INTEGER
 /// phase division before any float (the epoch-ms-as-f32 freeze sharp edge).

--- a/crates/pixtuoid-scene/src/pixel_painter/mod.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/mod.rs
@@ -529,22 +529,19 @@ fn paint_frame(
     // Procedural room fill — small pixel items that make rooms feel lived-in.
     // Ground footprint rule: walkable mask is NOT affected by these (they're
     // small items characters can walk around or over).
-    // EVERY meeting room (#555: dense room 1 used to render bare — the
-    // decor all keyed room 0).
+    // Per-room decor: EVERY meeting room, keyed by its own bounds (not room 0).
     for mr in ctx.layout.meeting_rooms.iter().map(|r| r.bounds) {
         furniture::paint_notice_board(ctx.buf, mr, ctx.theme);
 
-        // Coat rack is now a y-sorted DrawableKind::CoatRack (pushed in the
-        // drawable pass) so characters in front occlude it / behind it are
-        // occluded — was painted here in the background pass, always under
-        // every character.
+        // Coat rack is a y-sorted DrawableKind::CoatRack (pushed in the drawable
+        // pass) so characters in front occlude it and those behind are occluded.
 
         furniture::paint_doormat(ctx.buf, mr, ctx.theme);
     }
     // Soft goods (decor arc) paint FIRST: floor-level mats sit under every
     // upright pantry fixture — on a narrow pantry the entry mat's box reaches
-    // the water-cooler column, and mats-after-cooler clipped the cooler's
-    // west edge (lens-1 catch at 120x160).
+    // the water-cooler column, and mats-after-cooler would clip the cooler's
+    // west edge.
     furniture::paint_pantry_entry_mat(ctx.buf, ctx.layout, ctx.theme);
     furniture::paint_island_bar_mat(ctx.buf, ctx.layout, ctx.theme);
     if let Some(pr) = ctx.layout.pantry.map(|p| p.bounds) {

--- a/crates/pixtuoid-scene/src/pixel_painter/palette.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/palette.rs
@@ -464,13 +464,16 @@ pub(super) fn recolor_frame(frame: &Frame, pal: &Palette, base_pal: &Palette) ->
 /// toward grey, bias toward a dull blood-red, then dim. Transparent stays
 /// transparent (handled by `degraded_frame`).
 pub(super) fn degraded_pixel(c: Rgb) -> Rgb {
+    // Fraction of saturation drained toward grey — enough to read as UNWELL
+    // without going fully monochrome (the dull-red bias below still shows).
+    const SATURATION_DRAIN: f32 = 0.55;
     let lum = ((c.r as f32) * 0.30 + (c.g as f32) * 0.59 + (c.b as f32) * 0.11) as u8;
     let gray = Rgb {
         r: lum,
         g: lum,
         b: lum,
     };
-    let desat = blend_rgb(c, gray, 0.55); // drain saturation
+    let desat = blend_rgb(c, gray, SATURATION_DRAIN);
     let sick = Rgb {
         r: 150,
         g: 40,

--- a/crates/pixtuoid-scene/src/pixel_painter/sim.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/sim.rs
@@ -276,10 +276,11 @@ fn resolve_characters(
     let mut new_coffee_carriers: Vec<AgentId> = Vec::new();
     let mut wp_rank: HashMap<usize, usize> = HashMap::new();
     let mut waypoint_visitors: Vec<chitchat::Visitor> = Vec::new();
-    // All 3 lounge-couch seat waypoints collapse to ONE chitchat venue (keyed
-    // on the first couch's index) so the couch hosts a single group
-    // conversation like the meeting room — without overloading the
-    // meeting-only `room_id` field (which indexes `meeting_rooms`).
+    // The lounge-couch seat waypoints collapse to ONE chitchat venue (keyed on
+    // the first couch's index) so the couch hosts a single group conversation
+    // like the meeting room, without overloading the meeting-only `room_id`
+    // field (which indexes `meeting_rooms`). Pinned by
+    // multi_slot_venues_collapse_to_first_of_their_own_kind.
     // The pack's character sprite width (8 for the bundled pack, 10 for the
     // robot pack). All character poses share one width, so resolve it ONCE from
     // a reference pose and center every anchor on it — a non-8-wide pack would

--- a/crates/pixtuoid-scene/src/pixel_painter/tests.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/tests.rs
@@ -778,9 +778,9 @@ fn seated_foot_cell_settles_exactly_on_the_render_anchor() {
                 );
             }
             // The chair occupant SITS (SeatView::Front), so its settle/render
-            // pair with the SEAT anchor like the sofas — the stands-era
-            // waypoint_anchor pairing left the seated sprite hovering 5 rows
-            // above its chair (lens-1 frame-census catch, PR #561).
+            // pair with the SEAT anchor like the sofas: pairing it with the
+            // waypoint anchor instead would leave the seated sprite hovering
+            // rows above its chair.
             let s = seated_foot_cell(Furniture::MeetingChair, pos).expect("occupies_pos seat");
             assert_eq!(
                 walking_anchor(s, w),
@@ -2545,8 +2545,8 @@ fn chair_sitter_bottom_row_lands_on_its_z_key_overlapping_the_chair_body() {
     // seat render anchor (pos.y − SEAT_RENDER_Y_OFF) + the REAL seated
     // sprite's height − 1 must land exactly on SeatView::Front's z-key row
     // (pos.y + 2) — which sits INSIDE the 7-row chair body, so the sitter
-    // visibly occupies the cushion. The z-key tests alone passed while the
-    // sprite hovered 5 rows above the chair (lens-1 frame-census catch).
+    // visibly occupies the cushion. The z-key tests alone pass even when the
+    // sprite hovers rows above the chair, so this pins the full identity.
     use crate::layout::{Facing, Point, WaypointKind, SEAT_RENDER_Y_OFF};
     let pack = crate::embedded_pack::load_sprite_pack(None).expect("embedded pack");
     let view = SeatView::of(WaypointKind::MeetingChair, Facing::West);

--- a/crates/pixtuoid/examples/snapshot/proof.rs
+++ b/crates/pixtuoid/examples/snapshot/proof.rs
@@ -62,11 +62,10 @@ const CODA_FONT_PX: f32 = 12.0;
 const CODA_LINE_H: u32 = 18;
 const CODA_PAD: u32 = 10;
 // The "captured"/"happened in a terminal" framing (here + the `~ captured
-// claude code session` panel title below) is owner-adjudicated DELIBERATE
-// (PR #512 disposition): the timeline is authored — the statusline-ticker
-// disjointness pin REQUIRES authored strings — and the load-bearing half of
-// the claim is engine truth (the right pane replays through the real
-// decode_cc_line → Reducer → renderer). Don't re-flag as an overclaim.
+// claude code session` panel title below) is DELIBERATE: the timeline is
+// authored — the statusline-ticker disjointness pin REQUIRES authored strings
+// — and the load-bearing half of the claim is engine truth (the right pane
+// replays through the real decode_cc_line → Reducer → renderer).
 const CODA_TEXT: &str = "the left pane happened in a terminal. the right pane is the same \
 event stream, drawn by the same engine -- nothing is mocked.";
 

--- a/crates/pixtuoid/src/doctor.rs
+++ b/crates/pixtuoid/src/doctor.rs
@@ -242,9 +242,9 @@ fn win_path_eq(a: &str, b: &str) -> bool {
 
 /// Per-source diagnostics rollup — the SHARED source of truth the Connection
 /// panel (the board), the boot preflight, and `run` (the CLI report) all read,
-/// so the surfaces can't drift apart and no check runs twice (the
-/// health-consolidation arc / #309). Scope is the CHEAP signals: install-schema
-/// soundness (#309) + decode drift. Version skew stays report-only (the
+/// so the surfaces can't drift apart and no check runs twice. Scope is the
+/// CHEAP signals: install-schema soundness + decode drift. Version skew stays
+/// report-only (the
 /// `<cli> --version` probe, up to 5s each, is too costly for an interactive
 /// panel-open across N sources, and is advisory); live activity + transport
 /// death stay the panel's per-frame facets.
@@ -310,7 +310,7 @@ pub struct DoctorSourceRow {
     /// anchor), from the source's `SourceDescriptor`.
     pub verified_version: &'static str,
     pub scan: LogScanResult,
-    /// Install-schema soundness (#309) — `Some` only when hooks are installed;
+    /// Install-schema soundness — `Some` only when hooks are installed;
     /// `None` = not checked (no target / not installed). A non-sound result
     /// flips the verdict glyph to `⚠` and prints the reason on an indented `↳`
     /// continuation line.
@@ -318,7 +318,7 @@ pub struct DoctorSourceRow {
 }
 
 /// A dotted-run major at or above this looks like a YEAR/date token, not a semver
-/// major — used to skip a date prefix in favor of a real version (#307).
+/// major — used to skip a date prefix in favor of a real version.
 const IMPLAUSIBLE_MAJOR: u64 = 1000;
 
 /// Extract a `MAJOR.MINOR[.PATCH]` tuple from a `--version` banner. Tolerant:
@@ -326,7 +326,7 @@ const IMPLAUSIBLE_MAJOR: u64 = 1000;
 /// check then silently no-ops rather than alarming on garbage). A bare integer
 /// (`2026`) is NOT a version (needs at least `MAJOR.MINOR`).
 ///
-/// Banner-order robust (#307): a banner can print a dotted DATE/build token
+/// Banner-order robust: a banner can print a dotted DATE/build token
 /// before the semver (`Built 2026.06.04 — v1.2.3`). Selection order:
 ///   1. a `v`/`V`-prefixed run wins (an explicit version marker);
 ///   2. else the first run with a plausible (< `IMPLAUSIBLE_MAJOR`) major,
@@ -598,7 +598,7 @@ fn linux_activation_backend(sway: bool, hyprland: bool, wayland: bool, x11: bool
     }
 }
 
-/// The focus-jump block of the report (#526): the activation backend + which
+/// The focus-jump block of the report: the activation backend + which
 /// pid channel each source family rides, with the transcript-family probe
 /// roots checked on disk. Pure over the probed facts; the family buckets come
 /// straight from the registry (a new source lands in the right bucket with no

--- a/crates/pixtuoid/src/install/hermes.rs
+++ b/crates/pixtuoid/src/install/hermes.rs
@@ -3,7 +3,7 @@
 //! Writes the `hooks:` block into `<hermes-home>/config.yaml` (`~/.hermes/config.yaml`
 //! by default; `HERMES_HOME` relocates it verbatim — see
 //! `pixtuoid_core::source::hermes::hermes_home`). Hermes runs each hook `command` by
-//! ARGV-EXEC (quote-aware word-split, NO shell — capture-verified 2026-07-03: the
+//! ARGV-EXEC (quote-aware word-split, NO shell — capture-verified: the
 //! env-prefix form yields "command not found", and `|`/`>` arrive as literal argv), so
 //! the command is the bare `'<abs>' --source hermes` exec form on all platforms (via
 //! `hook_cmd::exec_hook_command`), NOT Codex's Unix env-prefix.

--- a/crates/pixtuoid/src/install/openclaw.rs
+++ b/crates/pixtuoid/src/install/openclaw.rs
@@ -13,7 +13,7 @@
 //!      `plugins.load.paths += [<plugin-dir>]` and `plugins.entries.pixtuoid =
 //!      { enabled: true, hooks: { allowConversationAccess: true } }`.
 //!
-//! Capture-confirmed (2026-06-15): `openclaw plugins install --link <dir>` +
+//! Capture-confirmed: `openclaw plugins install --link <dir>` +
 //! `enable` writes EXACTLY those config keys to openclaw.json (no separate
 //! registry), so the install is a pure `ConfigLock` write — no subprocess. The
 //! `allowConversationAccess` grant un-gates `before_agent_run`/`agent_end` (the

--- a/crates/pixtuoid/src/tui/connection/tests.rs
+++ b/crates/pixtuoid/src/tui/connection/tests.rs
@@ -255,7 +255,7 @@ fn build_rows_makes_every_source_with_a_target_actionable() {
 fn every_no_target_row_has_an_explicit_display_name_not_the_raw_id() {
     // A NO-TARGET source's display name comes from `display_name_for`, which must
     // have an explicit arm — its `other => other` fallthrough leaks the lowercase
-    // registry id into the panel name column + prompts (the PR #292 `copilot` nit).
+    // registry id into the panel name column + prompts.
     // Target-bearing rows are exempt: they use `Target.display_name`, which may be
     // a deliberate lowercase brand (e.g. "opencode"). Mechanized so the next
     // no-target source fails loudly.

--- a/crates/pixtuoid/src/tui/widgets/hud.rs
+++ b/crates/pixtuoid/src/tui/widgets/hud.rs
@@ -1023,11 +1023,10 @@ mod hud_tests {
         assert!(!any_glyph, "dismissed popup must paint nothing");
     }
 
-    // Regression: the elevator indicator measured its label by BYTE length.
-    // " ▲ F1 ▼ " is 8 display columns but 12 bytes (the arrows are 3-byte
-    // single-column glyphs), so the centering anchor `door.x + 8 - w/2`
-    // landed 2 cells left of the door's center. Same byte-vs-column class
-    // already fixed in the footer / tooltips (PR #210); this site was missed.
+    // The elevator indicator must center by DISPLAY COLUMNS, not byte length:
+    // " ▲ F1 ▼ " is 8 columns but 12 bytes (the arrows are 3-byte single-column
+    // glyphs), so a byte-length anchor `door.x + 8 - w/2` lands 2 cells left of
+    // the door's center.
     #[test]
     fn elevator_indicator_centers_by_display_columns_not_bytes() {
         use ratatui::backend::TestBackend;


### PR DESCRIPTION
## What

Roadmap **G** Phase 3 — the systematic comment overhaul per the owner-ratified comment discipline (Ousterhout ch.12-13 / Google style / comment-drift study), driven by the whole-codebase audit's comment census. Behavior-preserving: comments + one named const only.

## The discipline applied

- **(c) process-history / dated provenance → stripped** (belongs in commit messages): "verified 2026-06-11", "capture-verified 2026-06-14", "PR #561 catch", "lens-1 frame-census catch", "owner ruled (2026-07-13)", raw review-ledger ids (R0613-05), bare issue tags (#307/#309/#526). Kept every load-bearing anchor (commit hash, version, source-table name) and the WHY the comment was attached to.
- **(a) present-tense code-state assertions → moved to test pins**: e.g. reducer's "a leftover tuid can NEVER drain" now cites `resurrect_in_place_clears_stale_active_tasks…`; mask's numeric routing prose cites `vertical_wall_is_impassable_except_through_the_door`; sim's "All 3 lounge seats collapse" cites `multi_slot_venues_collapse_to_first_of_their_own_kind`.
- **history-framed prose → present tense**: floor.rs's "used to"/"no longer" narration (6 sites) reframed to describe what the code does now.
- **(e) magic number → named**: palette.rs's inline `0.55` desaturation ratio → `const SATURATION_DRAIN` (byte-identical; the degraded-mascot tests confirm no golden churn).
- **public-doc correctness**: `z_sort_row` (a cross-crate `pub` fn) shipped **undocumented** — its rustdoc had been stranded above `rects_overlap` by an earlier extraction. Moved to its owner.

## Scope completeness (stale-grep == 0)

The census sampled 20 files; the final commit finishes the **dated-capture-stamp class tree-wide** (the same stamp can't be stripped in registry.rs but kept in cursor.rs). After the sweep, no dated provenance stamp remains in any in-code comment except the deliberate exemptions:
- The `hook_runtime.rs verified 2026-06-11` provenance — **mirrored across three sites** (`pixtuoid-core/CLAUDE.md:190` **and** `:193`, `reducer.rs:805`, and the test `tests/reducer/child_ledger.rs:363`). It's an UPSTREAM-source-inspection date (when codex-rs's hook_runtime.rs behavior was verified) — a genuinely date-meaningful drift anchor, not "verified live" of our own decode. All three carry it verbatim; stripping any one desyncs the mirror. Review-refuted as deliberate.
- the R0615/R0618 review-ledger family — **anchored in `pixtuoid/CLAUDE.md`** (same exemption class).
- spec-doc path filenames (the date is part of a real path) and all test/fixture data.

## Exemptions honored

All `CLAUDE.md` prose (the repo's deliberate knowledge-density house style) and all pixel-art paint-coordinate tables (art-data) left untouched.

## Gates

`just preflight` green (2314/2314, clippy `-D warnings`); **zero `.snap`/media churn** (no pixels move); the one const is byte-identical.

**Merge owner-gated** (G is outside the standing 0..E auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122Ni8ZuDMdqS393ZtwFeE3
