### PR TITLE
refactor: two G-audit design nits — appliance painters + scan-state struct (#576)

### DIFF
--- a/crates/pixtuoid-core/src/source/jsonl/mod.rs
+++ b/crates/pixtuoid-core/src/source/jsonl/mod.rs
@@ -111,6 +111,37 @@ struct WatchCtx<'a> {
     live: &'a Arc<Mutex<HashSet<String>>>,
 }
 
+/// The persistent scan-state bundle threaded through every `run_scan_pass`
+/// (initial seed / 250ms rescan / 60s poll). Created once in `run` and borrowed
+/// `&mut` by each pass; the vouch and pid-binding maps also serve the
+/// instant-exit arm directly (see `run`'s `exit_rx` branch).
+struct ScanState {
+    /// Negative-vouch confirmations: a probe-missing id must stay missing for
+    /// `NEGATIVE_VOUCH_MIN_SPAN` before its exit is emitted (guards a probe
+    /// blip from ending a live session).
+    vouch: NegativeVouch,
+    /// pid → the session ids a healthy probe snapshot bound to it
+    /// (`ProbeSnapshot::pid_of` folded by `refresh_probe_snapshot`) — the
+    /// join the instant-exit arm uses to translate an OS exit into
+    /// SessionEnds. Entries leave on exit (whole pid), negative-vouch
+    /// confirm (single id, see `unbind_session`), or a rebind migration
+    /// (the snapshot observes the id under a different pid).
+    pid_bindings: HashMap<i32, HashSet<String>>,
+    /// Latches the root-scan's persistent-error breadcrumb (warn once per
+    /// failure streak, info on recovery — the `FailureLatch` convention).
+    root_health: FailureLatch,
+}
+
+impl ScanState {
+    fn new(negative_vouch_min_span: Duration) -> Self {
+        Self {
+            vouch: NegativeVouch::new(negative_vouch_min_span),
+            pid_bindings: HashMap::new(),
+            root_health: FailureLatch::default(),
+        }
+    }
+}
+
 pub struct JsonlWatcher {
     root: PathBuf,
     initial_window: Duration,
@@ -230,13 +261,10 @@ impl JsonlWatcher {
     /// healthy. The initial seed + the 250ms rescan + the 60s poll all run this
     /// SAME sequence; only the seed skips the un-claim drain (`drain = false` —
     /// nothing has been pushed at startup). `decoders` is `Copy`.
-    #[allow(clippy::too_many_arguments)]
     async fn run_scan_pass(
         &self,
         ctx: &WatchCtx<'_>,
-        vouch: &mut NegativeVouch,
-        pid_bindings: &mut HashMap<i32, HashSet<String>>,
-        root_health: &mut FailureLatch,
+        scan_state: &mut ScanState,
         exit_watch: Option<&ExitWatch>,
         unclaims: Option<&ChildEndUnclaims>,
         decoders: SourceDecoders,
@@ -244,8 +272,8 @@ impl JsonlWatcher {
     ) {
         let healthy = refresh_probe_snapshot(
             self.liveness_probe.as_ref(),
-            vouch,
-            pid_bindings,
+            &mut scan_state.vouch,
+            &mut scan_state.pid_bindings,
             exit_watch,
             decoders,
             ctx,
@@ -254,7 +282,7 @@ impl JsonlWatcher {
         if drain {
             drain_child_end_unclaims(unclaims, decoders, ctx).await;
         }
-        scan_root(&self.root, decoders, ctx, root_health).await;
+        scan_root(&self.root, decoders, ctx, &mut scan_state.root_health).await;
         if healthy {
             emit_proof_of_life(ctx.live, ctx.source, ctx.tx).await;
         }
@@ -269,7 +297,10 @@ impl JsonlWatcher {
         // the latest snapshot. Starts empty — the seed refresh fills it before
         // the first scan.
         let live: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
-        let mut vouch = NegativeVouch::new(self.negative_vouch_min_span);
+        // The persistent scan-state bundle (vouch + pid→ids bindings + root-scan
+        // health latch), threaded `&mut` through every `run_scan_pass` and read
+        // directly by the instant-exit arm below.
+        let mut scan_state = ScanState::new(self.negative_vouch_min_span);
 
         // Instant exit (#223 rung 2): a probed watcher spawns ONE detached
         // ExitWatch thread (kqueue NOTE_EXIT / pidfd+poll) so a bound OS
@@ -294,14 +325,6 @@ impl JsonlWatcher {
         // reintroduce the wasted poll; that residual is accepted.)
         let _exit_keepalive = exit_watch.is_none().then(|| exit_tx.clone());
         drop(exit_tx);
-        // pid → the session ids a healthy probe snapshot bound to it
-        // (`ProbeSnapshot::pid_of` folded by `refresh_probe_snapshot`) — the
-        // join the instant-exit arm uses to translate an OS exit into
-        // SessionEnds. Entries leave on exit (whole pid), negative-vouch
-        // confirm (single id, see `unbind_session`), or a rebind migration
-        // (the snapshot observes the id under a different pid).
-        let mut pid_bindings: HashMap<i32, HashSet<String>> = HashMap::new();
-        let mut root_health = FailureLatch::default();
 
         let (notify_tx, mut notify_rx) = tokio::sync::mpsc::unbounded_channel::<PathBuf>();
         let mut notify_health = FailureLatch::default();
@@ -374,9 +397,7 @@ impl JsonlWatcher {
             };
             self.run_scan_pass(
                 &ctx,
-                &mut vouch,
-                &mut pid_bindings,
-                &mut root_health,
+                &mut scan_state,
                 exit_watch.as_ref(),
                 unclaims.as_ref(),
                 decoders,
@@ -427,13 +448,13 @@ impl JsonlWatcher {
                 _ = &mut rescan_delay, if !rescan_done => {
                     rescan_done = true;
                     self.run_scan_pass(
-                        &ctx, &mut vouch, &mut pid_bindings, &mut root_health,
+                        &ctx, &mut scan_state,
                         exit_watch.as_ref(), unclaims.as_ref(), decoders, true,
                     ).await;
                 }
                 _ = poll.tick() => {
                     self.run_scan_pass(
-                        &ctx, &mut vouch, &mut pid_bindings, &mut root_health,
+                        &ctx, &mut scan_state,
                         exit_watch.as_ref(), unclaims.as_ref(), decoders, true,
                     ).await;
                 }
@@ -442,14 +463,14 @@ impl JsonlWatcher {
                     // died. Translate through the pid→ids binding; an
                     // unknown pid (already unbound by a negative-vouch
                     // confirm, or a duplicate event) is a no-op.
-                    if let Some(ids) = pid_bindings.remove(&pid) {
+                    if let Some(ids) = scan_state.pid_bindings.remove(&pid) {
                         for id in ids {
                             debug!("instant exit: pid {pid} died; emitting SessionEnd for {id}");
                             emit_session_exit(&id, decoders, &ctx).await;
                             // The next healthy snapshot will see the id gone
                             // anyway; forget it NOW so the negative vouch
                             // can't re-confirm the exit we just emitted.
-                            vouch.forget(&id);
+                            scan_state.vouch.forget(&id);
                         }
                     }
                 }

--- a/crates/pixtuoid-scene/CLAUDE.md
+++ b/crates/pixtuoid-scene/CLAUDE.md
@@ -212,7 +212,8 @@ src/                (the pixtuoid-scene crate root; default pack at ../sprites/d
                     the per-pose anchor fns take `sprite_w` — the pack's character width,
                     resolved ONCE per frame [8 bundled / 10 robot] — so a non-8-wide pack centers correctly),
                     furniture.rs (meeting table, area rug + entry/bar mats, side table,
-                                  kitchen island, fish tank, meeting chair),
+                                  kitchen island, fish tank, meeting chair, corridor
+                                  appliances: vending machine/printer/coat rack),
                     glass.rs (frosted-glass room-divider walls: consts + stitch + paint_glass_wall_h/v),
                     seat.rs (SeatView orientation single-source + seat_sprite + settle_seat_view + paint_character_at),
                     debug_overlay.rs (#[cfg(debug_assertions)] mask/approach/route overlay — the `w` toggle),

--- a/crates/pixtuoid-scene/src/pixel_painter/drawable.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/drawable.rs
@@ -30,8 +30,8 @@ use super::effects::{
 use super::epoch_ms;
 use super::frame_at;
 use super::furniture::{
-    paint_area_rug, paint_fish_tank, paint_kitchen_island, paint_meeting_chair,
-    paint_meeting_table, paint_side_table,
+    paint_area_rug, paint_coat_rack, paint_fish_tank, paint_kitchen_island, paint_meeting_chair,
+    paint_meeting_table, paint_printer, paint_side_table, paint_vending_machine,
 };
 use super::paint_character_at;
 use crate::frame_cache::FrameCache;
@@ -860,116 +860,10 @@ pub(super) fn paint_drawable(
             }
         }
         DrawableKind::VendingMachine { pos, busy } => {
-            let body = theme.appliance.vending_body;
-            let panel = theme.appliance.vending_panel;
-            let drinks = theme.appliance.vending_drinks;
-            let vx = pos.x.saturating_sub(2);
-            let vy = pos.y.saturating_sub(3);
-            for dy in 0..6u16 {
-                for dx in 0..4u16 {
-                    let px = vx + dx;
-                    let py = vy + dy;
-                    if px < buf.width() && py < buf.height() {
-                        let color = if dy == 0 {
-                            panel
-                        } else if (1..=3).contains(&dy) && (1..=2).contains(&dx) {
-                            let idx = ((dy - 1) * 2 + (dx - 1)) as usize;
-                            if idx < drinks.len() {
-                                drinks[idx]
-                            } else {
-                                body
-                            }
-                        } else if (dx, dy) == VENDING_PICKUP_SLOT {
-                            theme.appliance.vending_trim
-                        } else if dy == 5 {
-                            theme.appliance.vending_dark
-                        } else {
-                            body
-                        };
-                        buf.put(px, py, color);
-                    }
-                }
-            }
-
-            if *busy {
-                // Feedback drop (B-4): a product cell goes dark and its can
-                // lands in the pickup slot; the product rotates per cycle.
-                const DROP_CYCLE_MS: u64 = 3_000;
-                const DROP_STEP_MS: u64 = 500;
-                let t = epoch_ms(now);
-                let phase = (t % DROP_CYCLE_MS) / DROP_STEP_MS; // 0..6
-                let pick = ((t / DROP_CYCLE_MS) % drinks.len() as u64) as u16;
-                let (ddx, ddy) = (1 + pick % 2, 1 + pick / 2);
-                let mut put = |x: u16, y: u16, c| {
-                    if x < buf.width() && y < buf.height() {
-                        buf.put(x, y, c);
-                    }
-                };
-                if (1..=4).contains(&phase) {
-                    put(vx + ddx, vy + ddy, theme.appliance.vending_dark);
-                }
-                if (2..=4).contains(&phase) {
-                    let can = drinks[(pick as usize) % drinks.len()];
-                    put(vx + VENDING_PICKUP_SLOT.0, vy + VENDING_PICKUP_SLOT.1, can);
-                }
-            }
+            paint_vending_machine(buf, *pos, *busy, now, theme);
         }
         DrawableKind::Printer { pos, busy } => {
-            let body_white = theme.appliance.printer_body;
-            let top_dark = theme.appliance.printer_top;
-            let glass = theme.appliance.printer_glass;
-            let paper = theme.appliance.printer_paper;
-            let tray = theme.appliance.printer_tray;
-            let px0 = pos.x.saturating_sub(2);
-            let py0 = pos.y.saturating_sub(2);
-            for dy in 0..4u16 {
-                for dx in 0..5u16 {
-                    let px = px0 + dx;
-                    let py = py0 + dy;
-                    if px < buf.width() && py < buf.height() {
-                        let color = if dy == 0 {
-                            if (1..=3).contains(&dx) {
-                                glass
-                            } else {
-                                top_dark
-                            }
-                        } else if dy == 3 {
-                            if (1..=3).contains(&dx) {
-                                paper
-                            } else {
-                                tray
-                            }
-                        } else if dx == 0 || dx == 4 {
-                            tray
-                        } else {
-                            body_white
-                        };
-                        buf.put(px, py, color);
-                    }
-                }
-            }
-
-            if *busy {
-                // Feedback eject (B-4): a page slides out below the tray while
-                // an agent stands here, rests, then clears. One cell per step.
-                const PAGE_CYCLE_MS: u64 = 2_400;
-                const PAGE_STEP_MS: u64 = 300;
-                let phase = (epoch_ms(now) % PAGE_CYCLE_MS) / PAGE_STEP_MS; // 0..8
-                let rows = match phase {
-                    1 => 1,
-                    2..=6 => 2,
-                    _ => 0,
-                };
-                for dy in 0..rows {
-                    for dx in 1..=3u16 {
-                        let px = px0 + dx;
-                        let py = py0 + 4 + dy;
-                        if px < buf.width() && py < buf.height() {
-                            buf.put(px, py, paper);
-                        }
-                    }
-                }
-            }
+            paint_printer(buf, *pos, *busy, now, theme);
         }
         DrawableKind::Pet {
             kind,
@@ -1056,40 +950,7 @@ pub(super) fn paint_drawable(
             paint_meeting_chair(buf, *pos, *back_west, theme);
         }
         DrawableKind::CoatRack { pos } => {
-            let (cx, cy) = (pos.x, pos.y);
-            let pole = theme.furniture.wood_trim;
-            let base = theme.furniture.wood_top;
-            let coats = theme.appliance.coats;
-            // Pole (1px wide, 8 tall).
-            for dy in 0..8u16 {
-                let py = cy + dy;
-                if py < buf.height() && cx < buf.width() {
-                    buf.put(cx, py, pole);
-                }
-            }
-            // Base (3px wide) at the rack's south row.
-            let by = cy + 7;
-            for dx in 0..3u16 {
-                let px = cx.saturating_sub(1) + dx;
-                if px < buf.width() && by < buf.height() {
-                    buf.put(px, by, base);
-                }
-            }
-            // Coat blobs (2×2 blocks on alternating hooks).
-            for (i, &coat_color) in coats.iter().enumerate() {
-                let hook_y = cy + 1 + (i as u16) * 2;
-                let side: i16 = if i % 2 == 0 { -1 } else { 1 };
-                let hx = (cx as i16 + side) as u16;
-                for dy in 0..2u16 {
-                    for dx in 0..2u16 {
-                        let px = hx.wrapping_add(if side < 0 { dx.wrapping_sub(1) } else { dx });
-                        let py = hook_y + dy;
-                        if px < buf.width() && py < buf.height() {
-                            buf.put(px, py, coat_color);
-                        }
-                    }
-                }
-            }
+            paint_coat_rack(buf, *pos, theme);
         }
     }
 }

--- a/crates/pixtuoid-scene/src/pixel_painter/furniture.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/furniture.rs
@@ -540,3 +540,185 @@ pub(super) const MEETING_FABRIC_LIT: Rgb = Rgb {
     g: 0x8e,
     b: 0x98,
 };
+
+/// Vending machine (centred at `pos`) — a 4×6 body: drinks panel on top, a 2×3
+/// grid of themed cans, and the pickup slot. When `busy` (an agent stands at
+/// the waypoint), a product cell darkens and its can lands in the pickup slot
+/// each cycle (feedback drop B-4). Pickup-slot cell reuses `VENDING_PICKUP_SLOT`
+/// — the one authority the pixel test also derives from.
+pub(super) fn paint_vending_machine(
+    buf: &mut RgbBuffer,
+    pos: crate::layout::Point,
+    busy: bool,
+    now: std::time::SystemTime,
+    theme: &crate::theme::Theme,
+) {
+    let body = theme.appliance.vending_body;
+    let panel = theme.appliance.vending_panel;
+    let drinks = theme.appliance.vending_drinks;
+    let vx = pos.x.saturating_sub(2);
+    let vy = pos.y.saturating_sub(3);
+    for dy in 0..6u16 {
+        for dx in 0..4u16 {
+            let px = vx + dx;
+            let py = vy + dy;
+            if px < buf.width() && py < buf.height() {
+                let color = if dy == 0 {
+                    panel
+                } else if (1..=3).contains(&dy) && (1..=2).contains(&dx) {
+                    let idx = ((dy - 1) * 2 + (dx - 1)) as usize;
+                    if idx < drinks.len() {
+                        drinks[idx]
+                    } else {
+                        body
+                    }
+                } else if (dx, dy) == super::drawable::VENDING_PICKUP_SLOT {
+                    theme.appliance.vending_trim
+                } else if dy == 5 {
+                    theme.appliance.vending_dark
+                } else {
+                    body
+                };
+                buf.put(px, py, color);
+            }
+        }
+    }
+
+    if busy {
+        // Feedback drop (B-4): a product cell goes dark and its can
+        // lands in the pickup slot; the product rotates per cycle.
+        const DROP_CYCLE_MS: u64 = 3_000;
+        const DROP_STEP_MS: u64 = 500;
+        let t = super::epoch_ms(now);
+        let phase = (t % DROP_CYCLE_MS) / DROP_STEP_MS; // 0..6
+        let pick = ((t / DROP_CYCLE_MS) % drinks.len() as u64) as u16;
+        let (ddx, ddy) = (1 + pick % 2, 1 + pick / 2);
+        let mut put = |x: u16, y: u16, c| {
+            if x < buf.width() && y < buf.height() {
+                buf.put(x, y, c);
+            }
+        };
+        if (1..=4).contains(&phase) {
+            put(vx + ddx, vy + ddy, theme.appliance.vending_dark);
+        }
+        if (2..=4).contains(&phase) {
+            let can = drinks[(pick as usize) % drinks.len()];
+            put(
+                vx + super::drawable::VENDING_PICKUP_SLOT.0,
+                vy + super::drawable::VENDING_PICKUP_SLOT.1,
+                can,
+            );
+        }
+    }
+}
+
+/// Printer (centred at `pos`) — a 5×4 body: dark lid with a glass strip, white
+/// chassis, and an output tray with paper. When `busy`, a page slides out below
+/// the tray, rests, then clears each cycle (feedback eject B-4).
+pub(super) fn paint_printer(
+    buf: &mut RgbBuffer,
+    pos: crate::layout::Point,
+    busy: bool,
+    now: std::time::SystemTime,
+    theme: &crate::theme::Theme,
+) {
+    let body_white = theme.appliance.printer_body;
+    let top_dark = theme.appliance.printer_top;
+    let glass = theme.appliance.printer_glass;
+    let paper = theme.appliance.printer_paper;
+    let tray = theme.appliance.printer_tray;
+    let px0 = pos.x.saturating_sub(2);
+    let py0 = pos.y.saturating_sub(2);
+    for dy in 0..4u16 {
+        for dx in 0..5u16 {
+            let px = px0 + dx;
+            let py = py0 + dy;
+            if px < buf.width() && py < buf.height() {
+                let color = if dy == 0 {
+                    if (1..=3).contains(&dx) {
+                        glass
+                    } else {
+                        top_dark
+                    }
+                } else if dy == 3 {
+                    if (1..=3).contains(&dx) {
+                        paper
+                    } else {
+                        tray
+                    }
+                } else if dx == 0 || dx == 4 {
+                    tray
+                } else {
+                    body_white
+                };
+                buf.put(px, py, color);
+            }
+        }
+    }
+
+    if busy {
+        // Feedback eject (B-4): a page slides out below the tray while
+        // an agent stands here, rests, then clears. One cell per step.
+        const PAGE_CYCLE_MS: u64 = 2_400;
+        const PAGE_STEP_MS: u64 = 300;
+        let phase = (super::epoch_ms(now) % PAGE_CYCLE_MS) / PAGE_STEP_MS; // 0..8
+        let rows = match phase {
+            1 => 1,
+            2..=6 => 2,
+            _ => 0,
+        };
+        for dy in 0..rows {
+            for dx in 1..=3u16 {
+                let px = px0 + dx;
+                let py = py0 + 4 + dy;
+                if px < buf.width() && py < buf.height() {
+                    buf.put(px, py, paper);
+                }
+            }
+        }
+    }
+}
+
+/// Meeting-room coat rack (centred on `pos`, the pole top): a 1px pole over a
+/// 3px base, with 2×2 coat blobs on alternating hooks. Pole/base reuse the wood
+/// family; the coats are their own themed accents.
+pub(super) fn paint_coat_rack(
+    buf: &mut RgbBuffer,
+    pos: crate::layout::Point,
+    theme: &crate::theme::Theme,
+) {
+    let (cx, cy) = (pos.x, pos.y);
+    let pole = theme.furniture.wood_trim;
+    let base = theme.furniture.wood_top;
+    let coats = theme.appliance.coats;
+    // Pole (1px wide, 8 tall).
+    for dy in 0..8u16 {
+        let py = cy + dy;
+        if py < buf.height() && cx < buf.width() {
+            buf.put(cx, py, pole);
+        }
+    }
+    // Base (3px wide) at the rack's south row.
+    let by = cy + 7;
+    for dx in 0..3u16 {
+        let px = cx.saturating_sub(1) + dx;
+        if px < buf.width() && by < buf.height() {
+            buf.put(px, by, base);
+        }
+    }
+    // Coat blobs (2×2 blocks on alternating hooks).
+    for (i, &coat_color) in coats.iter().enumerate() {
+        let hook_y = cy + 1 + (i as u16) * 2;
+        let side: i16 = if i % 2 == 0 { -1 } else { 1 };
+        let hx = (cx as i16 + side) as u16;
+        for dy in 0..2u16 {
+            for dx in 0..2u16 {
+                let px = hx.wrapping_add(if side < 0 { dx.wrapping_sub(1) } else { dx });
+                let py = hook_y + dy;
+                if px < buf.width() && py < buf.height() {
+                    buf.put(px, py, coat_color);
+                }
+            }
+        }
+    }
+}

--- a/crates/pixtuoid-scene/src/pixel_painter/furniture.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/furniture.rs
@@ -1,5 +1,6 @@
 //! Standalone furniture paint helpers — meeting table, area rug,
-//! side table, kitchen island, and the procedural
+//! side table, kitchen island, fish tank, meeting chair, the corridor
+//! appliances (vending machine, printer, coat rack), and the procedural
 //! room-fill decor (notice board, doormat, water cooler, trash bin).
 //!
 //! Extracted from `mod.rs` to keep the orchestrator focused on


### PR DESCRIPTION
Closes #576 — the three bundled G-audit design nits. Two implemented; one assessed and declined (below).

## (a) Extract inline appliance painters into furniture.rs

`paint_drawable` painted the vending/printer/coat-rack cells **inline** while the module's convention (and furniture.rs's stated purpose) is that per-furniture geometry lives in furniture.rs (`paint_kitchen_island`, `paint_meeting_chair`, `paint_fish_tank`, …). Moved the three arm bodies **verbatim** into `pub(super) fn paint_vending_machine / paint_printer / paint_coat_rack`; the arms are now thin one-liners mirroring the existing `MeetingChair` arm. **No visibility widening** — the shared `VENDING_PICKUP_SLOT` (already `pub(crate)`) and `epoch_ms` (already `pub(super)`, furniture.rs already calls `super::epoch_ms`) are reused via their existing paths.

## (c) Bundle run_scan_pass's out-params into a ScanState struct

`run_scan_pass` carried 8 params under `#[allow(clippy::too_many_arguments)]`; three (`vouch`, `pid_bindings`, `root_health`) are `&mut` out-params. Verified they're a genuine **Data Clump** (not the disjoint `compute_waypoints` case): they're `let mut` locals created together in the watch-loop setup and threaded through **every** `run_scan_pass` call — cohesive persistent-scan-state. Bundled into `struct ScanState { vouch, pid_bindings, root_health }`; `run_scan_pass` now takes `&mut ScanState` (8 → 6 params, **`#[allow]` removed**). Behavior-identical — same values, same mutation order.

## (b) X11 pid→window caching — ASSESSED, DECLINED

The finding: `ancestor_walk` calls `focusable(pid)` per level, and on X11 each opens a fresh connection + re-fetches `_NET_CLIENT_LIST` + scans `_NET_WM_PID`. The redundancy is real (~50–100 X round-trips vs ~35 for a map built once, at walk depth ~2–3 × ~10–30 windows). **Declined** anyway:
- **Imperceptible gain**: local-socket X round-trips are ~tens of µs; ~100 of them is single-digit ms on a **rare, deliberate, human-initiated** focus click. YAGNI.
- **A memoized pid→window map introduces a NEW silent-failure mode** the current design is immune to: if the first `focusable` scan transiently fails (connect error → empty map cached), every later level returns false → the walk finds no terminal → a **silent focus no-op**. Per-level re-connect naturally retries; a cache poisons on the first failure.
- `focus/linux.rs` is **codecov-ignored, untestable platform glue** — no oracle would catch that regression.

Net: trading untested stateful glue with a new poisoned-cache failure vector for an imperceptible µs win is a bad deal. (A per-instance `OnceCell` under `&self` would keep the trait shape, so this is a value/risk call, not a structural blocker — easy to revisit if the walk ever deepens or focus becomes hot.)

## Gates

`just preflight` green (**2310/2310**, clippy `-D warnings` incl. unreachable_pub); `just gen-check` green — **no media regeneration** (confirms (a) is a byte-identical render move); zero `.snap`/media churn; test-count parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122Ni8ZuDMdqS393ZtwFeE3
