### PR TITLE
test(scene): give simplify_polyline + cell_in_zone mutation teeth

### DIFF
--- a/crates/pixtuoid-scene/src/pathfind.rs
+++ b/crates/pixtuoid-scene/src/pathfind.rs
@@ -462,6 +462,33 @@ mod tests {
         assert_eq!(s.len(), 3);
     }
 
+    // A DIAGONAL run (nonzero dx AND dy) exercises the collinearity determinant's
+    // x-delta terms, which an axis-aligned run zeroes out (dy_in=dy_out=0 makes
+    // the determinant 0 regardless of dx). Off-origin so the `here.x - prev.x`
+    // subtraction can't be hidden by a `prev` of 0. A 3-point input also pins the
+    // `len < 3` boundary: a `<= 3`/`== 3` early-return would leave this uncollapsed.
+    #[test]
+    fn simplify_collapses_diagonal_collinear() {
+        let pts = vec![
+            Point { x: 1, y: 1 },
+            Point { x: 3, y: 3 },
+            Point { x: 5, y: 5 },
+        ];
+        assert_eq!(simplify_polyline(pts).len(), 2);
+    }
+
+    // The complement: a genuine 3-point corner must SURVIVE (determinant != 0),
+    // so the collapse above can't be a degenerate "always drops the midpoint".
+    #[test]
+    fn simplify_keeps_genuine_corner() {
+        let pts = vec![
+            Point { x: 0, y: 0 },
+            Point { x: 2, y: 0 },
+            Point { x: 2, y: 2 },
+        ];
+        assert_eq!(simplify_polyline(pts).len(), 3);
+    }
+
     #[test]
     fn routes_around_meeting_room_wall() {
         let l = make_layout();
@@ -845,6 +872,47 @@ mod tests {
             height: 10,
         };
         assert!(!cell_in_zone(Some(zone), 20, 20));
+    }
+
+    // A cell center landing EXACTLY on the exclusive far edge (x+width / y+height)
+    // is OUTSIDE — the bound is a strict `<`. The zone edge is derived from
+    // `cell_center` so the alignment holds regardless of CELL_SIZE. Without this,
+    // a `<`->`<=` mutation is invisible (no on-edge cell is ever tested).
+    #[test]
+    fn cell_in_zone_false_on_exclusive_edges() {
+        let right_edge = cell_center(2, 1).x;
+        let zone_x = Bounds {
+            x: 0,
+            y: 0,
+            width: right_edge,
+            height: 40,
+        };
+        assert!(!cell_in_zone(Some(zone_x), 2, 1));
+
+        let bottom_edge = cell_center(1, 2).y;
+        let zone_y = Bounds {
+            x: 0,
+            y: 0,
+            width: 40,
+            height: bottom_edge,
+        };
+        assert!(!cell_in_zone(Some(zone_y), 1, 2));
+    }
+
+    // Inside on ONE axis but outside on the other is OUTSIDE — the four bounds
+    // are AND-joined. The both-axes-outside test above leaves an `&&`->`||`
+    // mutation on the middle joins invisible (F||F is still F); a single-axis
+    // miss (T on one pair, F on the other) is what makes the conjunction observable.
+    #[test]
+    fn cell_in_zone_false_when_outside_on_one_axis_only() {
+        let zone = Bounds {
+            x: 0,
+            y: 0,
+            width: 10,
+            height: 10,
+        };
+        assert!(!cell_in_zone(Some(zone), 20, 1)); // outside x, inside y
+        assert!(!cell_in_zone(Some(zone), 1, 20)); // inside x, outside y
     }
 
     #[test]

--- a/crates/pixtuoid-scene/src/pathfind.rs
+++ b/crates/pixtuoid-scene/src/pathfind.rs
@@ -915,6 +915,22 @@ mod tests {
         assert!(!cell_in_zone(Some(zone), 1, 20)); // inside x, outside y
     }
 
+    // The complement of the exclusive-edge test: a cell center landing EXACTLY
+    // on the INCLUSIVE near edge (x / y) is INSIDE — the lower bound is `>=`.
+    // Without this a `>=`->`>` mutation on either lower bound survives (the
+    // mirror of the `<`->`<=` gap above; sibling-set-spans-axes).
+    #[test]
+    fn cell_in_zone_true_on_inclusive_lower_edges() {
+        let near = cell_center(1, 1);
+        let zone = Bounds {
+            x: near.x,
+            y: near.y,
+            width: 40,
+            height: 40,
+        };
+        assert!(cell_in_zone(Some(zone), 1, 1));
+    }
+
     #[test]
     fn cell_walkable_on_open_mask() {
         let mask = WalkableMask::new_open(100, 100);


### PR DESCRIPTION
## What
`cargo-mutants` left **9 surviving mutants** across two hot-path A* helpers in `pathfind.rs`:
- `simplify_polyline` (runs on every reconstructed path) — 5 survivors: the `len < 3` boundary (`<`→`<=`/`==`) and the x-delta subtractions in the collinearity determinant (`-`→`+`/`/`).
- `cell_in_zone` (drives the corridor-hugging cost discount) — 4 survivors: the two middle `&&`→`||` and the two `<`→`<=` far-edge bounds.

## Why they survived
The existing tests can't observe them:
- `simplify_collapses_collinear` feeds an **axis-aligned** run, so `dy_in=dy_out=0` zeroes the determinant regardless of the x-delta terms, and it never passes a **3-point** polyline (the `len < 3` boundary is never exercised).
- `cell_in_zone_true/false` probe only a deep-interior cell and a **both-axes-outside** cell — with `F||F` still `F`, a middle `&&`→`||` is invisible, and no cell center ever lands exactly on the exclusive far edge, so `<`→`<=` is invisible.

## The fix (pure test additions — production byte-identical)
- `simplify_collapses_diagonal_collinear` — off-origin diagonal (nonzero dx **and** dy), so the determinant's x-deltas matter and the subtraction can't be hidden by a zero operand; being 3-point also pins the `len < 3` boundary.
- `simplify_keeps_genuine_corner` — the complement, so the collapse can't degenerate to "always drop the midpoint".
- `cell_in_zone_false_on_exclusive_edges` — cell center on `x+width` / `y+height` (edge derived from `cell_center`, so it holds regardless of `CELL_SIZE`).
- `cell_in_zone_false_when_outside_on_one_axis_only` — inside-one-axis/outside-the-other, making the `&&` conjunction observable.

## Verification
Scoped `cargo mutants -f pathfind.rs -F 'simplify_polyline|cell_in_zone'`: **43 mutants → 42 caught, 1 unviable, 0 survived** (was 9 survived).

From the v2 whole-codebase review (test-assurance deep-sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)