### PR TITLE
fix(core): breadcrumb the copilot/omp missing-pairing-key drops

### DIFF
--- a/crates/pixtuoid-core/src/source/copilot.rs
+++ b/crates/pixtuoid-core/src/source/copilot.rs
@@ -149,8 +149,12 @@ pub fn decode_copilot_line(
             }]
         }
         "tool.execution_start" => {
-            let Some(d) = data else { return Ok(vec![]) };
+            let Some(d) = data else {
+                crate::source::drift::missing_field(source, "tool.execution_start", "data");
+                return Ok(vec![]);
+            };
             let Some(tool_call_id) = str_at(d, "toolCallId") else {
+                crate::source::drift::missing_field(source, "tool.execution_start", "toolCallId");
                 return Ok(vec![]);
             };
             let tool_name = str_at(d, "toolName").unwrap_or_else(|| {
@@ -165,8 +169,16 @@ pub fn decode_copilot_line(
             }]
         }
         "tool.execution_complete" => {
-            let Some(d) = data else { return Ok(vec![]) };
+            let Some(d) = data else {
+                crate::source::drift::missing_field(source, "tool.execution_complete", "data");
+                return Ok(vec![]);
+            };
             let Some(tool_call_id) = str_at(d, "toolCallId") else {
+                crate::source::drift::missing_field(
+                    source,
+                    "tool.execution_complete",
+                    "toolCallId",
+                );
                 return Ok(vec![]);
             };
             let mut out = vec![AgentEvent::ActivityEnd {
@@ -382,6 +394,35 @@ mod tests {
                 assert_eq!(*agent_id, root(), "empty agentId must key to the root");
             }
             other => panic!("expected one ActivityStart, got {other:?}"),
+        }
+    }
+
+    /// A `tool.execution_start` whose `data` lacks the REQUIRED `toolCallId`
+    /// (the ActivityStart/End pairing key) is dropped — but must leave a
+    /// `missing_field` drift breadcrumb like its sibling gates (`session.start`
+    /// `sessionId`, `toolName`), so an upstream field rename surfaces in
+    /// `pixtuoid doctor` instead of a copilot sprite that connects but silently
+    /// never animates tools.
+    #[test]
+    fn missing_tool_call_id_drops_with_a_drift_breadcrumb() {
+        let out = crate::test_capture::capture_logs(|| {
+            let line = r#"{"type":"tool.execution_start","data":{"toolName":"bash"}}"#;
+            assert!(
+                decode(line).is_empty(),
+                "an unkeyable tool start yields no event"
+            );
+        });
+        for needle in [
+            crate::source::drift::TARGET,
+            "missing_field",
+            "tool.execution_start",
+            "toolCallId",
+            SOURCE_NAME,
+        ] {
+            assert!(
+                out.contains(needle),
+                "missing {needle:?} in captured log:\n{out}"
+            );
         }
     }
 

--- a/crates/pixtuoid-core/src/source/omp.rs
+++ b/crates/pixtuoid-core/src/source/omp.rs
@@ -291,6 +291,11 @@ pub fn decode_omp_line(transcript_path: &str, source: &str, v: Value) -> Result<
                 // A tool result closes its call.
                 Some("toolResult") => {
                     let Some(tool_call_id) = msg.get("toolCallId").and_then(|i| i.as_str()) else {
+                        // The ActivityEnd pairing key — its absence is drift on a
+                        // lifecycle event we're committed to decoding (mirror of the
+                        // toolCall `id` gate above), and an unkeyable End can never
+                        // close its Start (leaks Active forever). Breadcrumb, then drop.
+                        crate::source::drift::missing_field(source, "toolResult", "toolCallId");
                         return Ok(vec![]);
                     };
                     vec![AgentEvent::ActivityEnd {
@@ -784,6 +789,25 @@ mod tests {
         }
     }
 
+    /// A `toolResult` missing its `toolCallId` (the ActivityEnd pairing key) is
+    /// dropped — an unkeyable End can't close its Start — but must leave a
+    /// `missing_field` breadcrumb, the mirror of the `toolCall` `id` gate above.
+    /// It is NOT an ignorable line (it's a lifecycle event we decode), so it does
+    /// not belong in the "ignored, not panicked" bundle.
+    #[test]
+    fn toolresult_without_id_drops_with_a_drift_breadcrumb() {
+        let no_id = r#"{"type":"message","id":"m7","parentId":null,"timestamp":"t","message":{"role":"toolResult","toolName":"read","content":[],"timestamp":1}}"#;
+        let out = crate::test_capture::capture_logs(|| {
+            assert!(decode(no_id).is_empty(), "un-keyable toolResult → no event");
+        });
+        for needle in [crate::source::drift::TARGET, "missing_field", "toolResult"] {
+            assert!(
+                out.contains(needle),
+                "no toolResult breadcrumb: missing {needle:?}\n{out}"
+            );
+        }
+    }
+
     #[test]
     fn tool_execution_start_custom_entry_is_deliberately_ignored() {
         // Duplicates the assistant toolCall block with the SAME toolCallId
@@ -803,8 +827,6 @@ mod tests {
             r#"{"type":"session_init","id":"x","parentId":null,"timestamp":"t","systemPrompt":"…","task":"…","tools":[]}"#,
             r#"{"type":"message","id":"x","parentId":null,"timestamp":"t","message":{"role":"user","content":"hi","timestamp":1}}"#,
             r#"{"type":"message","id":"x","parentId":null,"timestamp":"t","message":{"role":"bashExecution","command":"ls","output":"","exitCode":0,"timestamp":1}}"#,
-            // toolResult without a toolCallId is un-keyable.
-            r#"{"type":"message","id":"x","parentId":null,"timestamp":"t","message":{"role":"toolResult","toolName":"read","content":[],"timestamp":1}}"#,
             // message entry with no message object.
             r#"{"type":"message","id":"x","parentId":null,"timestamp":"t"}"#,
             // custom entry of an unrelated customType.

--- a/crates/pixtuoid-core/src/source/omp.rs
+++ b/crates/pixtuoid-core/src/source/omp.rs
@@ -259,8 +259,12 @@ pub fn decode_omp_line(transcript_path: &str, source: &str, v: Value) -> Result<
                         .iter()
                         .filter(|b| b.get("type").and_then(|t| t.as_str()) == Some("toolCall"))
                     {
-                        // Un-keyable calls are dropped (can't be closed).
+                        // Un-keyable calls are dropped (can't be closed) — but
+                        // breadcrumb it: `id` is a REQUIRED pairing key on a
+                        // toolCall block we're committed to decoding, so its
+                        // absence is upstream drift, not a line we ignore.
                         let Some(id) = b.get("id").and_then(|i| i.as_str()) else {
+                            crate::source::drift::missing_field(source, "toolCall", "id");
                             continue;
                         };
                         let name = b.get("name").and_then(|n| n.as_str()).unwrap_or_else(|| {

--- a/crates/pixtuoid-core/src/source/omp.rs
+++ b/crates/pixtuoid-core/src/source/omp.rs
@@ -750,12 +750,22 @@ mod tests {
 
     #[test]
     fn tool_call_without_id_is_dropped_and_without_name_still_starts() {
-        // No block id → un-keyable (its result could never close it) → drop.
+        // No block id → un-keyable (its result could never close it) → drop,
+        // but the drop must leave a `missing_field` breadcrumb (`id` is a
+        // REQUIRED pairing key on a block we're committed to decoding).
         let no_id = r#"{"type":"message","id":"m5","parentId":null,"timestamp":"t","message":{"role":"assistant","content":[{"type":"toolCall","name":"bash","arguments":{}}],"timestamp":1}}"#;
-        assert!(decode(no_id).is_empty(), "un-keyable toolCall → no event");
+        let out = crate::test_capture::capture_logs(|| {
+            assert!(decode(no_id).is_empty(), "un-keyable toolCall → no event");
+        });
+        for needle in [crate::source::drift::TARGET, "missing_field", "toolCall"] {
+            assert!(
+                out.contains(needle),
+                "no id breadcrumb: missing {needle:?}\n{out}"
+            );
+        }
         // Missing name → drift breadcrumb + empty name; "" is not "task".
         let no_name = r#"{"type":"message","id":"m6","parentId":null,"timestamp":"t","message":{"role":"assistant","content":[{"type":"toolCall","id":"t6","arguments":{}}],"timestamp":1}}"#;
-        match &decode(no_name)[..] {
+        let out = crate::test_capture::capture_logs(|| match &decode(no_name)[..] {
             [AgentEvent::ActivityStart {
                 tool_use_id,
                 detail: Some(d),
@@ -765,6 +775,12 @@ mod tests {
                 assert!(!d.is_task());
             }
             other => panic!("expected one ActivityStart, got {other:?}"),
+        });
+        for needle in [crate::source::drift::TARGET, "missing_field", "toolCall"] {
+            assert!(
+                out.contains(needle),
+                "no name breadcrumb: missing {needle:?}\n{out}"
+            );
         }
     }
 


### PR DESCRIPTION
## What
`copilot`'s `tool.execution_start` / `tool.execution_complete` and `omp`'s `toolCall` block dropped their event with a bare `Ok(vec![])` / `continue` when the **required pairing key** (`toolCallId` / `id`) — or the `data` object — was absent, emitting **no `drift::missing_field` breadcrumb**. Their own sibling gates already breadcrumb (`session.start` `sessionId` at copilot.rs:136, `toolName` at :161, omp `toolCall` `name`), so this was an inconsistency.

## Why it matters
`drift::missing_field` is the signal `pixtuoid doctor`'s drift tally + the Sources-panel health scan key on. If upstream renames `data.toolCallId` (the copilot header documents live 1.0.62 wire churn), every tool line silently returns empty: a copilot sprite that **connects but never animates tools**, with no diagnostic anywhere — the exact silent-failure class the drift layer exists to eliminate.

## The fix
Emit `drift::missing_field(source, <event>, <field>)` before each drop. The **drop stays** — an unkeyable `ActivityStart` can't be closed and would leak `Active` forever (documented at omp.rs:262). Covers the missing-`data` and missing-`toolCallId` gates on both copilot arms + omp's missing-`id`.

## Test
Red-first `missing_tool_call_id_drops_with_a_drift_breadcrumb`: a `tool.execution_start` with `data` but no `toolCallId` is dropped **and** bumps the breadcrumb (asserts the stable `target` + `event` + `field` + `source`), via the existing `test_capture::capture_logs` harness the drift tests use.

## Provenance
From the v2 whole-codebase review (error-handling deep-sweep). Local: clippy `-D warnings` clean; 66 copilot/omp tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)