### PR TITLE
fix(scripts): gate gen-readme pix icons on existence + fix experimental-footnote population

### DIFF
--- a/scripts/gen-readme.mjs
+++ b/scripts/gen-readme.mjs
@@ -46,7 +46,7 @@ for (const f of features) {
   if (f.pix && !existsSync(join(root, 'docs', 'images', 'pix-icons', `${f.pix}.png`))) {
     errors.push(
       `feature "${f.name}" declares pix "${f.pix}" but docs/images/pix-icons/${f.pix}.png is missing — ` +
-        `add "${f.pix}" to gen-pix-icons.py's ICONS and run \`just gen-media\`.`
+        `add "${f.pix}" to gen-pix-icons.py's ICONS and run \`just gen-icons\`.`
     );
   }
 }

--- a/scripts/gen-readme.mjs
+++ b/scripts/gen-readme.mjs
@@ -15,7 +15,7 @@
 // runs in the main CI — so the marketing list can never claim "supported" for a
 // source that isn't actually wired (and a newly-wired source forces a manifest
 // update). This script only owns rendering + README/site parity.
-import { readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import process from 'node:process';
@@ -34,6 +34,22 @@ const SITE = 'https://pixtuoid.dev';
 const check = process.argv.includes('--check');
 let readme = readFileSync(readmePath, 'utf8');
 const errors = [];
+
+// Every feature `pix` must resolve to a committed pixel-icon PNG. The site's
+// PixIcon.astro throws at build ONLY for icons rendered through the roster
+// (no-channel rows); a channel-bearing feature reaches this README `<img>` but
+// never PixIcon, so a typo'd / ungenerated `pix` would ship a 404 image past
+// the site build, gen-pix-icons --check (ICONS-only), AND gen-readme-check
+// (README-vs-JSON, not img existence). One existsSync loop closes it for every
+// row regardless of channel routing.
+for (const f of features) {
+  if (f.pix && !existsSync(join(root, 'docs', 'images', 'pix-icons', `${f.pix}.png`))) {
+    errors.push(
+      `feature "${f.name}" declares pix "${f.pix}" but docs/images/pix-icons/${f.pix}.png is missing — ` +
+        `add "${f.pix}" to gen-pix-icons.py's ICONS and run \`just gen-media\`.`
+    );
+  }
+}
 
 // Neutralize only what breaks a GFM table row: `|` splits columns (use the
 // HTML entity — backslash-escaping would itself need backslash escaping first,
@@ -98,11 +114,14 @@ const runsOn = (s) =>
   OS_ORDER.filter((os) => s.platforms?.[os] === 'yes' || s.platforms?.[os] === 'experimental')
     .map((os) => (s.platforms[os] === 'experimental' ? `${OS_LABELS[os]}\\*` : OS_LABELS[os]))
     .join(' · ');
-const hasExperimental = sources.some(
-  (s) => s.status === 'supported' && Object.values(s.platforms || {}).includes('experimental')
-);
-
 const featured = sources.filter((s) => s.status === 'supported' && s.featured);
+// Compute over the population that actually RENDERS the `\*` marker (the
+// featured table, via runsOn), NOT all supported sources — else the footnote
+// could appear with no `\*` referent (a non-featured experimental source would
+// set the flag while the featured table shows no marker).
+const hasExperimental = featured.some((s) =>
+  Object.values(s.platforms || {}).includes('experimental')
+);
 const otherSupported = sources.filter((s) => s.status === 'supported' && !s.featured);
 const planned = sources.filter((s) => s.status === 'planned');
 const link = (s) => `[${cell(s.name)}](${s.url})`;


### PR DESCRIPTION
## What
Two gaps in `scripts/gen-readme.mjs` surfaced by the v2 review (non-rust sweep):

**(1) No pix-icon existence gate.** `iconCell` emits `<img src="docs/images/pix-icons/${pix}.png">` for every feature with a `pix`, with nothing validating the PNG exists. The site's `PixIcon.astro` build-time `import.meta.glob` throw only fires for icons rendered through the roster (no-channel rows); a **channel-bearing** feature reaches this README `<img>` but never `PixIcon`, so a typo'd / ungenerated `pix` would ship a 404 image on GitHub past all three gates (site build, `gen-pix-icons --check` = ICONS-only, `gen-readme-check` = README-vs-JSON). Adds one `existsSync` loop over every feature `pix`.

**(2) `hasExperimental` wrong population.** The flag that emits the `_\* experimental_` footnote scanned **all** supported sources, but the `\*` marker only renders in the **featured** table (via `runsOn`). A non-featured experimental source would set the flag while the featured table shows no `\*` → a dangling footnote. Now computed over `featured`.

Both are currently masked (all 6 `pix` rows are no-channel; both featured sources carry `windows:experimental`), so this is drift-proofing, not a live bug.

## Verification
`node scripts/gen-readme.mjs --check` → exit 0, README in sync, no false pix errors on current data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)