### PR TITLE
refactor(install): extend the least-privilege compiler-tooth to every submodule

### DIFF
--- a/crates/pixtuoid/src/install/claude.rs
+++ b/crates/pixtuoid/src/install/claude.rs
@@ -22,7 +22,7 @@ const EVENTS: &[&str] = &[
     "SessionEnd",
 ];
 
-pub fn default_config_path() -> Result<PathBuf> {
+pub(crate) fn default_config_path() -> Result<PathBuf> {
     if let Some(dir) = claude_config_dir() {
         return Ok(dir.join("settings.json"));
     }
@@ -40,7 +40,7 @@ pub fn default_config_path() -> Result<PathBuf> {
 /// through cmd.exe/PowerShell — unportable, PATHEXT-dependent). The orchestrator
 /// already hard-errors if resolution failed (`BinaryStrategy::EmbedAbsolute` on
 /// Windows), so `resolved` is guaranteed to be an absolute path here.
-pub fn hook_command(resolved: &Path, explicit: bool) -> Result<String> {
+pub(crate) fn hook_command(resolved: &Path, explicit: bool) -> Result<String> {
     #[cfg(not(windows))]
     {
         if explicit {
@@ -68,7 +68,7 @@ pub fn hook_command(resolved: &Path, explicit: bool) -> Result<String> {
 /// The `_pixtuoid` sentinel and `matcher` live on the OUTER entry object, not here;
 /// detection/uninstall key on the sentinel, so the shape of this inner object is
 /// irrelevant to the matcher — no uninstall changes needed.
-pub fn hook_entry(cmd: &str, exec_form: bool) -> Value {
+pub(crate) fn hook_entry(cmd: &str, exec_form: bool) -> Value {
     if exec_form {
         json!({ "type": "command", "command": cmd, "args": [] })
     } else {
@@ -80,7 +80,7 @@ pub fn hook_entry(cmd: &str, exec_form: bool) -> Value {
 /// entry (sentinel-tagged), and the shim command is read back for the on-disk
 /// check. The command lives in the OUTER entry's `hooks[0].command` (Unix bare
 /// `pixtuoid-hook` → PATH-resolved soft check; explicit/Windows → absolute).
-pub fn verify_schema(content: &str) -> crate::install::verify::SchemaParse {
+pub(crate) fn verify_schema(content: &str) -> crate::install::verify::SchemaParse {
     use crate::install::verify::{assemble, SchemaParse, ShimRef};
     let Ok(doc) = serde_json::from_str::<Value>(content) else {
         return SchemaParse::broken("settings.json no longer parses as JSON");
@@ -138,7 +138,7 @@ fn claude_shim_ref(entry: &Value) -> crate::install::verify::ShimRef {
     }
 }
 
-pub fn merge_install(content: &str, hook_cmd: &str) -> Result<MergeOutcome> {
+pub(crate) fn merge_install(content: &str, hook_cmd: &str) -> Result<MergeOutcome> {
     // The parse + non-object guard + semantic-`changed` + serialize plumbing is
     // the shared wrapper (its guard is the ONE copy — see merge.rs). Claude's
     // per-event entry is NESTED (`{matcher, hooks:[…]}`) rather than flat, but
@@ -149,7 +149,7 @@ pub fn merge_install(content: &str, hook_cmd: &str) -> Result<MergeOutcome> {
     })
 }
 
-pub fn merge_uninstall(content: &str) -> Result<MergeOutcome> {
+pub(crate) fn merge_uninstall(content: &str) -> Result<MergeOutcome> {
     merge::flat_json_merge_outcome_uninstall(content, |doc| {
         merge::flat_json_merge_uninstall(doc, SENTINEL_KEY)
     })

--- a/crates/pixtuoid/src/install/codewhale.rs
+++ b/crates/pixtuoid/src/install/codewhale.rs
@@ -95,7 +95,7 @@ const CODEWHALE_EVENTS: &[(&str, bool)] = &[
 /// cwd-relative value can't be reconciled between the two processes — only an
 /// absolute override is well-defined. (Upstream additionally rejects `..`; we keep
 /// the value verbatim — a user-set env override is trusted input.)
-pub fn default_config_path() -> Result<PathBuf> {
+pub(crate) fn default_config_path() -> Result<PathBuf> {
     // CodeWhale only TRIMS its overrides (`val.trim()` / `normalize_config_file_path`)
     // — it does NOT `~`-expand — so pass `home: None` (trim-only, #342).
     resolve_config_path(
@@ -162,7 +162,7 @@ fn resolve_config_path(
 /// `CODEWHALE_HOME` (verbatim) else `<HOME-first home>/.codewhale`, and the legacy
 /// `.deepseek` lives under that OS home — so a `HOME`-exporting (or `CODEWHALE_HOME`)
 /// Windows shell probes the dirs CodeWhale actually uses.
-pub fn detect_installed() -> bool {
+pub(crate) fn detect_installed() -> bool {
     let os_home = pixtuoid_core::platform::home_first_dir();
     let modern = match io::nonempty_env("CODEWHALE_HOME").map(|v| io::expand_tilde(&v, None)) {
         Some(h) => Some(h),
@@ -181,18 +181,18 @@ pub fn detect_installed() -> bool {
 ///   `--source` flag; 8.3 short-name substitution for cmd-unsafe paths via the
 ///   shared `hook_cmd::windows`). Err on non-UTF-8 (prevents the
 ///   to_string_lossy dead-hook).
-pub fn hook_command(resolved: &Path, _explicit: bool) -> Result<String> {
+pub(crate) fn hook_command(resolved: &Path, _explicit: bool) -> Result<String> {
     // `_explicit` is Claude's bare-name-vs-absolute switch — CodeWhale always
     // embeds the absolute path, so the flag changes nothing here.
     let p = crate::install::merge::hook_path_str(resolved)?;
     crate::install::hook_cmd::shell_hook_command(p, "codewhale")
 }
 
-pub fn merge_install(content: &str, base_cmd: &str) -> Result<MergeOutcome> {
+pub(crate) fn merge_install(content: &str, base_cmd: &str) -> Result<MergeOutcome> {
     crate::install::merge::toml_merge_outcome(content, |doc| toml_merge_install(doc, base_cmd))
 }
 
-pub fn merge_uninstall(content: &str) -> Result<MergeOutcome> {
+pub(crate) fn merge_uninstall(content: &str) -> Result<MergeOutcome> {
     crate::install::merge::toml_merge_outcome(content, toml_merge_uninstall)
 }
 
@@ -221,7 +221,7 @@ fn managed_entry(event: &str, env_mode: bool, base_cmd: &str) -> toml::Value {
 /// gates ALL hooks — `enabled = false` with entries present is a true
 /// silent-dead the other checks miss). Shim command is shell-form (with a
 /// per-entry ` --event <name>` tail that `shell_shim_ref` strips).
-pub fn verify_schema(content: &str) -> crate::install::verify::SchemaParse {
+pub(crate) fn verify_schema(content: &str) -> crate::install::verify::SchemaParse {
     use crate::install::verify::{assemble, shell_shim_ref, SchemaParse, ShimRef};
     let Ok(doc) = toml::from_str::<toml::Value>(content) else {
         return SchemaParse::broken("config.toml no longer parses as TOML");

--- a/crates/pixtuoid/src/install/codex.rs
+++ b/crates/pixtuoid/src/install/codex.rs
@@ -17,7 +17,7 @@ const CODEX_EVENTS: &[&str] = &[
     "PermissionRequest",
 ];
 
-pub fn default_config_path() -> Result<PathBuf> {
+pub(crate) fn default_config_path() -> Result<PathBuf> {
     // Route through the SAME codex_home() the watcher uses, so the installed-hook
     // config and the watched sessions root can't disagree (and honors CODEX_HOME).
     // codex_home() always yields an absolute path (user_home falls back to the
@@ -51,7 +51,7 @@ pub fn default_config_path() -> Result<PathBuf> {
 ///   (`C:\PROGRA~1\…`, space/metachar-free) and only REJECTS if 8.3 generation is
 ///   disabled on the volume (#195). Ordinary install paths
 ///   (`%USERPROFILE%\.cargo\bin`, npm prefix) skip 8.3 entirely.
-pub fn hook_command(resolved: &Path, _explicit: bool) -> Result<String> {
+pub(crate) fn hook_command(resolved: &Path, _explicit: bool) -> Result<String> {
     // `_explicit` is Claude's bare-name-vs-absolute switch — Codex always
     // embeds the absolute path, so the flag changes nothing here.
     let p = crate::install::merge::hook_path_str(resolved)?;
@@ -62,11 +62,11 @@ pub fn hook_command(resolved: &Path, _explicit: bool) -> Result<String> {
     crate::install::hook_cmd::shell_hook_command(p, "codex")
 }
 
-pub fn merge_install(content: &str, hook_cmd: &str) -> Result<MergeOutcome> {
+pub(crate) fn merge_install(content: &str, hook_cmd: &str) -> Result<MergeOutcome> {
     crate::install::merge::toml_merge_outcome(content, |doc| toml_merge_install(doc, hook_cmd))
 }
 
-pub fn merge_uninstall(content: &str) -> Result<MergeOutcome> {
+pub(crate) fn merge_uninstall(content: &str) -> Result<MergeOutcome> {
     crate::install::merge::toml_merge_outcome(content, toml_merge_uninstall)
 }
 
@@ -88,7 +88,7 @@ fn prune_managed_handlers(group: &mut toml::Value) {
 /// sentinel-tagged handler, and the shim command (shell form,
 /// `PIXTUOID_SOURCE=codex '<abs>'` / `<abs> --source codex`) is read back for
 /// the on-disk check.
-pub fn verify_schema(content: &str) -> crate::install::verify::SchemaParse {
+pub(crate) fn verify_schema(content: &str) -> crate::install::verify::SchemaParse {
     use crate::install::verify::{assemble, shell_shim_ref, SchemaParse, ShimRef};
     let Ok(doc) = toml::from_str::<toml::Value>(content) else {
         return SchemaParse::broken("config.toml no longer parses as TOML");

--- a/crates/pixtuoid/src/install/cursor.rs
+++ b/crates/pixtuoid/src/install/cursor.rs
@@ -64,7 +64,7 @@ const CURSOR_EVENTS: &[&str] = &[
 /// overridden dir while pixtuoid wrote `~/.cursor` (installed, but no sprite). The
 /// home base is `USERPROFILE`-first (Node `os.homedir`; `~/.cursor`, NOT the
 /// Electron IDE's `%APPDATA%\Cursor`).
-pub fn default_config_path() -> Result<PathBuf> {
+pub(crate) fn default_config_path() -> Result<PathBuf> {
     cursor_config_dir()
         .map(|d| d.join("hooks.json"))
         .ok_or_else(|| {
@@ -109,7 +109,7 @@ fn resolve_config_dir(
 /// Reasonix/CodeWhale/opencode probe their CLI dirs. Honors `CURSOR_CONFIG_DIR`/
 /// `XDG_CONFIG_HOME` like the write path, plus the plain `~/.cursor` as a lenient
 /// fallback.
-pub fn detect_installed() -> bool {
+pub(crate) fn detect_installed() -> bool {
     cursor_config_dir().is_some_and(|d| d.exists()) || io::home_relative(".cursor").exists()
 }
 
@@ -121,12 +121,12 @@ pub fn detect_installed() -> bool {
 ///   space/metacharacter path, else reject — #195).
 ///
 /// Err on non-UTF-8 (prevents the to_string_lossy dead-hook).
-pub fn hook_command(resolved: &Path, _explicit: bool) -> Result<String> {
+pub(crate) fn hook_command(resolved: &Path, _explicit: bool) -> Result<String> {
     let p = merge::hook_path_str(resolved)?;
     crate::install::hook_cmd::shell_hook_command(p, "cursor")
 }
 
-pub fn merge_install(content: &str, hook_cmd: &str) -> Result<MergeOutcome> {
+pub(crate) fn merge_install(content: &str, hook_cmd: &str) -> Result<MergeOutcome> {
     // Shared parse + non-object guard + semantic-`changed` + serialize wrapper
     // (the guard's one copy lives in merge.rs). Cursor's `version` field injection
     // rides inside `json_merge_install`.
@@ -135,7 +135,7 @@ pub fn merge_install(content: &str, hook_cmd: &str) -> Result<MergeOutcome> {
     })
 }
 
-pub fn merge_uninstall(content: &str) -> Result<MergeOutcome> {
+pub(crate) fn merge_uninstall(content: &str) -> Result<MergeOutcome> {
     // Shared flat-JSON uninstall: removes managed entries + drops empty event
     // keys / the `hooks` object. `version` is untouched (preserved by design).
     merge::flat_json_merge_outcome_uninstall(content, |doc| {
@@ -156,7 +156,7 @@ fn managed_entry(hook_command: &str) -> Value {
 /// it (module doc) — a hooks.json with intact managed entries but no numeric
 /// `version` loads NO hooks at all, the exact silent-dead class #309 exists to
 /// catch (the CodeWhale `[hooks].enabled = false` twin).
-pub fn verify_schema(content: &str) -> crate::install::verify::SchemaParse {
+pub(crate) fn verify_schema(content: &str) -> crate::install::verify::SchemaParse {
     let mut parse = crate::install::verify::flat_json_verify(content, CURSOR_EVENTS, SENTINEL_KEY);
     // Only reachable on parseable JSON — an unparseable file is already a HARD
     // "no longer parses" issue from flat_json_verify.

--- a/crates/pixtuoid/src/install/hermes.rs
+++ b/crates/pixtuoid/src/install/hermes.rs
@@ -56,7 +56,7 @@ const HERMES_EVENTS: &[&str] = &[
 /// omitted). One named source of truth for both the writer and the verify check.
 const HOOK_TIMEOUT_SECS: i64 = 5;
 
-pub fn default_config_path() -> Result<PathBuf> {
+pub(crate) fn default_config_path() -> Result<PathBuf> {
     pixtuoid_core::source::hermes::hermes_home()
         .map(|d| d.join("config.yaml"))
         .ok_or_else(|| {
@@ -69,13 +69,13 @@ pub fn default_config_path() -> Result<PathBuf> {
 /// purely ours — probing the home DIR is the robust "is Hermes installed" signal
 /// (config.yaml may not exist until `hermes setup`). Mirrors the Cursor/Reasonix
 /// dir-probe rationale.
-pub fn detect_installed() -> bool {
+pub(crate) fn detect_installed() -> bool {
     pixtuoid_core::source::hermes::hermes_home().is_some_and(|d| d.exists())
 }
 
 /// Hermes ARGV-execs the command (no shell), so the bare `'<abs>' --source hermes` exec
 /// form on all platforms. Err on a non-UTF-8 path (prevents the lossy dead-hook).
-pub fn hook_command(resolved: &Path, _explicit: bool) -> Result<String> {
+pub(crate) fn hook_command(resolved: &Path, _explicit: bool) -> Result<String> {
     let p = crate::install::merge::hook_path_str(resolved)?;
     crate::install::hook_cmd::exec_hook_command(p, "hermes")
 }
@@ -177,7 +177,7 @@ fn managed_command(entry: &YamlOwned) -> Option<String> {
     }
 }
 
-pub fn merge_install(content: &str, hook_cmd: &str) -> Result<MergeOutcome> {
+pub(crate) fn merge_install(content: &str, hook_cmd: &str) -> Result<MergeOutcome> {
     let mut root = parse_root_mapping(content)?;
     let mut changed = false;
 
@@ -215,7 +215,7 @@ pub fn merge_install(content: &str, hook_cmd: &str) -> Result<MergeOutcome> {
     })
 }
 
-pub fn merge_uninstall(content: &str) -> Result<MergeOutcome> {
+pub(crate) fn merge_uninstall(content: &str) -> Result<MergeOutcome> {
     let mut root = parse_root_mapping(content)?;
     let hooks_key = ystr("hooks");
     let Some(YamlOwned::Mapping(hooks)) = root.get_mut(&hooks_key) else {
@@ -260,7 +260,7 @@ pub fn merge_uninstall(content: &str) -> Result<MergeOutcome> {
 /// rewrite) is the silent-dead class this catches. NOTE: the Hermes allowlist consent is
 /// deliberately out of scope here — it's the user's to grant in Hermes (module doc), not
 /// an install-soundness property pixtuoid owns.
-pub fn verify_schema(content: &str) -> SchemaParse {
+pub(crate) fn verify_schema(content: &str) -> SchemaParse {
     let root = match parse_root_mapping(content) {
         Ok(r) => r,
         Err(_) => return SchemaParse::broken("config.yaml no longer parses as a YAML mapping"),

--- a/crates/pixtuoid/src/install/merge.rs
+++ b/crates/pixtuoid/src/install/merge.rs
@@ -25,7 +25,7 @@ use serde_json::{json, Map, Value};
 /// Parse JSON config content, treating empty/whitespace-only as the empty
 /// document (`{}`) — the shared rule every JSON target's merge relies on (never
 /// error on empty). The caller wraps the parse error with the real config path.
-pub fn parse_json_or_empty(content: &str) -> anyhow::Result<Value> {
+pub(crate) fn parse_json_or_empty(content: &str) -> anyhow::Result<Value> {
     if content.trim().is_empty() {
         return Ok(json!({}));
     }
@@ -42,7 +42,7 @@ pub fn parse_json_or_empty(content: &str) -> anyhow::Result<Value> {
 /// Serializing a `&str` is infallible in practice, but propagate the error
 /// rather than default to a broken empty path if it ever weren't. `what` names
 /// the target for the error context.
-pub fn bake_hook_path(
+pub(crate) fn bake_hook_path(
     template: &str,
     placeholder: &str,
     hook_path: &str,
@@ -59,7 +59,7 @@ pub fn bake_hook_path(
 /// targets feed the `&str` into `hook_cmd::shell_hook_command`; the embed
 /// targets `.map(str::to_string)` it). A non-UTF-8 path is rejected rather than
 /// `to_string_lossy`'d into a silently-dead hook.
-pub fn hook_path_str(p: &std::path::Path) -> anyhow::Result<&str> {
+pub(crate) fn hook_path_str(p: &std::path::Path) -> anyhow::Result<&str> {
     use anyhow::anyhow;
     p.to_str()
         .ok_or_else(|| anyhow!("pixtuoid-hook path is non-UTF-8: {}", p.display()))
@@ -67,7 +67,7 @@ pub fn hook_path_str(p: &std::path::Path) -> anyhow::Result<&str> {
 
 /// Parse TOML config content, treating empty/whitespace-only as the empty
 /// document. Shared by the TOML targets (Codex/CodeWhale); same empty rule.
-pub fn parse_toml_or_empty(content: &str) -> anyhow::Result<toml::Value> {
+pub(crate) fn parse_toml_or_empty(content: &str) -> anyhow::Result<toml::Value> {
     if content.trim().is_empty() {
         return Ok(toml::Value::Table(toml::value::Table::new()));
     }
@@ -85,7 +85,7 @@ pub fn parse_toml_or_empty(content: &str) -> anyhow::Result<toml::Value> {
 /// decoder. A non-object `hooks` / non-array event is coerced (defensive), matching
 /// the callers' prior inline behavior. Caller-set extras (Cursor's `version`) are
 /// applied before the call and pass through untouched.
-pub fn flat_json_merge_install(
+pub(crate) fn flat_json_merge_install(
     doc: Value,
     events: &[&str],
     sentinel: &str,
@@ -122,7 +122,7 @@ pub fn flat_json_merge_install(
 /// (the sentinel-keyed removal is shape-agnostic — it strips Claude's nested
 /// entries the same way). A target-specific key the install set (Cursor's
 /// `version`) is deliberately preserved — this only touches `hooks`.
-pub fn flat_json_merge_uninstall(mut doc: Value, sentinel: &str) -> Value {
+pub(crate) fn flat_json_merge_uninstall(mut doc: Value, sentinel: &str) -> Value {
     let Some(root) = doc.as_object_mut() else {
         return doc;
     };
@@ -163,7 +163,7 @@ fn is_flat_managed(entry: &Value, sentinel: &str) -> bool {
 /// names the config in the refusal message ("settings" / "hooks.json"). The
 /// non-object guard lives HERE, once, so a future flat-JSON target cannot forget
 /// it and silently re-open the drop-the-user's-document path.
-pub fn flat_json_merge_outcome_install(
+pub(crate) fn flat_json_merge_outcome_install(
     content: &str,
     what: &str,
     mutate: impl FnOnce(Value) -> Value,
@@ -184,7 +184,7 @@ pub fn flat_json_merge_outcome_install(
 /// Deliberately UNGUARDED on a non-object root — uninstall must stay a clean
 /// no-op on a foreign non-object document (`flat_json_merge_uninstall` returns it
 /// unchanged), never error.
-pub fn flat_json_merge_outcome_uninstall(
+pub(crate) fn flat_json_merge_outcome_uninstall(
     content: &str,
     mutate: impl FnOnce(Value) -> Value,
 ) -> anyhow::Result<MergeOutcome> {
@@ -200,7 +200,7 @@ pub fn flat_json_merge_outcome_uninstall(
 /// The TOML analog (Codex/CodeWhale): parse, run `mutate`, package with the same
 /// SEMANTIC `changed` rule. No non-object guard — a TOML root is always a table,
 /// which is why the TOML targets correctly lack the flat-JSON guard.
-pub fn toml_merge_outcome(
+pub(crate) fn toml_merge_outcome(
     content: &str,
     mutate: impl FnOnce(toml::Value) -> toml::Value,
 ) -> anyhow::Result<MergeOutcome> {

--- a/crates/pixtuoid/src/install/mod.rs
+++ b/crates/pixtuoid/src/install/mod.rs
@@ -10,6 +10,9 @@ pub(crate) mod codex;
 pub(crate) mod cursor;
 pub(crate) mod hermes;
 mod hook_cmd;
+// io stays pub(crate) for a STRONGER reason than its siblings: it holds the
+// config-write authority (invariant #4), which must never be cross-crate
+// reachable — only its two env filters (below) are re-exported.
 pub(crate) mod io;
 pub use io::{nonempty, nonempty_env};
 pub(crate) mod merge;

--- a/crates/pixtuoid/src/install/mod.rs
+++ b/crates/pixtuoid/src/install/mod.rs
@@ -1,21 +1,24 @@
-pub mod claude;
-pub mod codewhale;
-pub mod codex;
-pub mod cursor;
-pub mod hermes;
+// The per-CLI installers + merge/verify/target have no cross-crate/cross-target
+// consumers (all callers are in-lib via `crate::install::…`) EXCEPT the two `io`
+// env filters and `target::TARGETS` (the bin's registry walk), so they are
+// `pub(crate) mod` with just those items re-exported — making `unreachable_pub`
+// the compiler tooth for the rest of their item surface (extends #573's io-only
+// tooth). `pub mod install` (lib.rs) stays pub to carry the re-exports.
+pub(crate) mod claude;
+pub(crate) mod codewhale;
+pub(crate) mod codex;
+pub(crate) mod cursor;
+pub(crate) mod hermes;
 mod hook_cmd;
-// io is crate-private: its config-write authority (invariant #4) must never be
-// reachable cross-crate. Only the two env filters are re-exported below, so a
-// FUTURE stray `pub` in io trips unreachable_pub (-D warnings) — a compiler
-// tooth, not a review-practice backstop.
 pub(crate) mod io;
 pub use io::{nonempty, nonempty_env};
-pub mod merge;
-pub mod openclaw;
-pub mod opencode;
-pub mod reasonix;
-pub mod target;
-pub mod verify;
+pub(crate) mod merge;
+pub(crate) mod openclaw;
+pub(crate) mod opencode;
+pub(crate) mod reasonix;
+pub(crate) mod target;
+pub use target::TARGETS;
+pub(crate) mod verify;
 
 use std::path::PathBuf;
 

--- a/crates/pixtuoid/src/install/openclaw.rs
+++ b/crates/pixtuoid/src/install/openclaw.rs
@@ -47,7 +47,10 @@ const PLUGIN_TEMPLATE: &str = include_str!("openclaw_plugin.js");
 /// below, and the list `check_upstream_drift.py` reads for the CI upstream watch.
 /// A rename upstream makes that hook silently stop firing (the plugin registers
 /// by name), so this is the drift surface to watch (defense #4).
-pub const OPENCLAW_EVENTS: &[&str] = &[
+// Test-gated: no prod-Rust caller — its only readers are the consistency test
+// below and `check_upstream_drift.py`'s source-text parse (cfg-agnostic).
+#[cfg(test)]
+pub(crate) const OPENCLAW_EVENTS: &[&str] = &[
     "gateway_start",
     "gateway_stop",
     "session_start",
@@ -137,7 +140,7 @@ fn resolve_openclaw_state_dir(
 /// processes) wins; else prefer an existing `openclaw.json` in the state dir, then
 /// the legacy `clawdbot.json`, else `openclaw.json` for a fresh install (never
 /// shadow a real `clawdbot.json` the gateway still reads).
-pub fn default_config_path() -> Result<PathBuf> {
+pub(crate) fn default_config_path() -> Result<PathBuf> {
     // OPENCLAW_CONFIG_PATH is `~`-expanded too (resolveUserPath, #342).
     let home = pixtuoid_core::platform::home_first_dir();
     Ok(resolve_openclaw_config_path(
@@ -178,7 +181,7 @@ fn plugin_dir() -> Result<PathBuf> {
 /// keying on our artifact would chicken-and-egg (opencode/Reasonix rationale).
 /// With `OPENCLAW_STATE_DIR` set that dir IS the state dir; else probe both the
 /// modern `.openclaw` and the legacy `.clawdbot` under the effective home.
-pub fn detect_installed() -> bool {
+pub(crate) fn detect_installed() -> bool {
     // Normalize the SAME env vars the SAME way `openclaw_state_dir()` does (#342/#344):
     // `~`-expand `OPENCLAW_STATE_DIR`/`OPENCLAW_HOME` against the same home base. Without
     // this, a `~`-prefixed override would install into the EXPANDED dir but probe the
@@ -215,13 +218,13 @@ fn resolve_openclaw_detect(
 
 /// The shim's absolute path, baked into the plugin (the gateway runs it under
 /// Node, no PATH reliance). Err on non-UTF-8 like opencode/Codex.
-pub fn hook_command(resolved: &Path, _explicit: bool) -> Result<String> {
+pub(crate) fn hook_command(resolved: &Path, _explicit: bool) -> Result<String> {
     crate::install::merge::hook_path_str(resolved).map(str::to_string)
 }
 
 /// The wholly-owned plugin dir files (manifest + package.json + entry module).
 /// `extra_artifacts` Target hook: written verbatim on install, shim path baked in.
-pub fn plugin_artifacts(hook_path: &Path) -> Result<Vec<(PathBuf, String)>> {
+pub(crate) fn plugin_artifacts(hook_path: &Path) -> Result<Vec<(PathBuf, String)>> {
     let dir = plugin_dir()?;
     let hook = hook_path
         .to_str()
@@ -249,7 +252,7 @@ fn obj_mut<'a>(v: &'a mut Value, key: &str) -> Result<&'a mut serde_json::Map<St
 /// {allowConversationAccess}}`. `changed` is a semantic (parsed) diff, so a
 /// same-state re-install is a no-op. `_hook_cmd` is unused — the shim path lives
 /// in the plugin file (an `extra_artifact`), not the config.
-pub fn merge_install(content: &str, _hook_cmd: &str) -> Result<MergeOutcome> {
+pub(crate) fn merge_install(content: &str, _hook_cmd: &str) -> Result<MergeOutcome> {
     let dir = plugin_dir()?;
     let dir_str = dir
         .to_str()
@@ -290,7 +293,7 @@ pub fn merge_install(content: &str, _hook_cmd: &str) -> Result<MergeOutcome> {
 /// Remove our registration: drop the plugin-dir path from `plugins.load.paths`
 /// and REMOVE the `plugins.entries.pixtuoid` subtree (revoking the
 /// conversation-access grant — R-P1). A foreign plugin's entries/paths survive.
-pub fn merge_uninstall(content: &str) -> Result<MergeOutcome> {
+pub(crate) fn merge_uninstall(content: &str) -> Result<MergeOutcome> {
     let dir = plugin_dir()?;
     let dir_str = dir.to_str().map(str::to_string);
     let mut root =
@@ -324,7 +327,7 @@ pub fn merge_uninstall(content: &str) -> Result<MergeOutcome> {
 /// enabled `entries.pixtuoid` entry + its `load.paths` dir registration (a
 /// removed/disabled entry = the gateway silently never loads us). Per-source
 /// format knowledge stays here (invariant #3).
-pub fn verify_schema(content: &str) -> crate::install::verify::SchemaParse {
+pub(crate) fn verify_schema(content: &str) -> crate::install::verify::SchemaParse {
     use crate::install::verify::{SchemaParse, ShimRef};
     let Ok(root) = serde_json::from_str::<Value>(content) else {
         return SchemaParse::broken("openclaw.json is not valid JSON — reconnect openclaw");

--- a/crates/pixtuoid/src/install/opencode.rs
+++ b/crates/pixtuoid/src/install/opencode.rs
@@ -89,7 +89,7 @@ fn config_dir_from(oc: Option<&str>, xdg: Option<&str>, home: Option<&str>) -> R
 /// `<config>/plugins/*.{ts,js}`; the anomalyco fork globs `{plugin,plugins}` (so
 /// both work there), but plural is the documented form and the only one canonical
 /// opencode scans, so it's correct for every install.
-pub fn default_config_path() -> Result<PathBuf> {
+pub(crate) fn default_config_path() -> Result<PathBuf> {
     Ok(opencode_config_dir()?.join("plugins").join("pixtuoid.ts"))
 }
 
@@ -101,7 +101,7 @@ pub fn default_config_path() -> Result<PathBuf> {
 /// Mirrors CodeWhale's CLI-dir probe. Uninstall keys on the plugin file existing
 /// (`config_present`, file-existence) and `merge_uninstall` on the
 /// `@pixtuoid-opencode-plugin` sentinel, so removal stays exact regardless.
-pub fn detect_installed() -> bool {
+pub(crate) fn detect_installed() -> bool {
     opencode_config_dir().map(|d| d.exists()).unwrap_or(false)
         || io::home_relative(".local/share/opencode").exists()
 }
@@ -111,14 +111,14 @@ pub fn detect_installed() -> bool {
 /// path, so it must be embedded (no PATH reliance) — Err on non-UTF-8 like
 /// Codex/Reasonix/CodeWhale. `_explicit` (Claude's bare-vs-absolute switch) is
 /// irrelevant: opencode always needs the absolute path.
-pub fn hook_command(resolved: &Path, _explicit: bool) -> Result<String> {
+pub(crate) fn hook_command(resolved: &Path, _explicit: bool) -> Result<String> {
     crate::install::merge::hook_path_str(resolved).map(str::to_string)
 }
 
 /// Render the plugin with the shim path baked in (JSON-encoded → a valid,
 /// escaped JS string literal, so a path with quotes/backslashes can't break the
 /// module). `changed` is a content diff: a same-path re-install is a no-op.
-pub fn merge_install(content: &str, hook_path: &str) -> Result<MergeOutcome> {
+pub(crate) fn merge_install(content: &str, hook_path: &str) -> Result<MergeOutcome> {
     let baked = render_plugin(hook_path)?;
     Ok(MergeOutcome {
         changed: content != baked,
@@ -129,7 +129,7 @@ pub fn merge_install(content: &str, hook_path: &str) -> Result<MergeOutcome> {
 /// Replace our plugin with the sentinel-free no-op stub. `changed` only when the
 /// current content is actually ours (carries the sentinel) — a foreign file, an
 /// already-removed stub, or empty content is a semantic no-op (left untouched).
-pub fn merge_uninstall(content: &str) -> Result<MergeOutcome> {
+pub(crate) fn merge_uninstall(content: &str) -> Result<MergeOutcome> {
     let ours = content.contains(SENTINEL);
     Ok(MergeOutcome {
         changed: ours,
@@ -146,7 +146,7 @@ pub fn merge_uninstall(content: &str) -> Result<MergeOutcome> {
 /// substituted, (3) the baked `HOOK_PATH` literal readable for the on-disk stat.
 /// There is no per-event config to check (the forwarded EventV2 set lives in the
 /// plugin's own code).
-pub fn verify_schema(content: &str) -> crate::install::verify::SchemaParse {
+pub(crate) fn verify_schema(content: &str) -> crate::install::verify::SchemaParse {
     use crate::install::verify::{SchemaParse, ShimRef};
     if !content.contains(SENTINEL) {
         return SchemaParse::broken(

--- a/crates/pixtuoid/src/install/reasonix.rs
+++ b/crates/pixtuoid/src/install/reasonix.rs
@@ -63,7 +63,7 @@ const REASONIX_EVENTS: &[&str] = &[
 /// on Windows (pixtuoid's generic USERPROFILE-first path) lands the hooks where
 /// Reasonix never reads → installed, but no sprite — the same class as
 /// CodeWhale/OpenClaw but on the %APPDATA% (config-dir) axis, not HOME-vs-USERPROFILE.
-pub fn default_config_path() -> Result<PathBuf> {
+pub(crate) fn default_config_path() -> Result<PathBuf> {
     reasonix_home()
         .map(|h| h.join("settings.json"))
         .ok_or_else(|| {
@@ -121,7 +121,7 @@ fn resolve_reasonix_home(
 /// (`reasonix_home` — `%APPDATA%\reasonix` on Windows, `~/.reasonix` elsewhere,
 /// honoring `REASONIX_HOME`); hook/trust users additionally have a `~/.reasonix`
 /// even on Windows. Probe both.
-pub fn detect_installed() -> bool {
+pub(crate) fn detect_installed() -> bool {
     reasonix_home().is_some_and(|d| d.exists()) || io::home_relative(".reasonix").exists()
 }
 
@@ -187,7 +187,7 @@ fn user_config_dir_checked(
 ///   (#195) — a quoted path can't survive cmd /C.
 ///
 /// Err on non-UTF-8 (prevents the to_string_lossy dead-hook).
-pub fn hook_command(resolved: &Path, _explicit: bool) -> Result<String> {
+pub(crate) fn hook_command(resolved: &Path, _explicit: bool) -> Result<String> {
     // `_explicit` is Claude's bare-name-vs-absolute switch — Reasonix always
     // embeds the absolute path, so the flag changes nothing here.
     let p = merge::hook_path_str(resolved)?;
@@ -196,7 +196,7 @@ pub fn hook_command(resolved: &Path, _explicit: bool) -> Result<String> {
     crate::install::hook_cmd::shell_hook_command(p, "reasonix")
 }
 
-pub fn merge_install(content: &str, hook_cmd: &str) -> Result<MergeOutcome> {
+pub(crate) fn merge_install(content: &str, hook_cmd: &str) -> Result<MergeOutcome> {
     // Shared parse + non-object guard + semantic-`changed` + serialize wrapper
     // (the guard's one copy lives in merge.rs).
     merge::flat_json_merge_outcome_install(content, "settings", |doc| {
@@ -204,7 +204,7 @@ pub fn merge_install(content: &str, hook_cmd: &str) -> Result<MergeOutcome> {
     })
 }
 
-pub fn merge_uninstall(content: &str) -> Result<MergeOutcome> {
+pub(crate) fn merge_uninstall(content: &str) -> Result<MergeOutcome> {
     merge::flat_json_merge_outcome_uninstall(content, |doc| {
         merge::flat_json_merge_uninstall(doc, SENTINEL_KEY)
     })
@@ -221,7 +221,7 @@ fn managed_entry(hook_command: &str) -> Value {
 
 /// Install-schema verification (#309) — Reasonix's flat-JSON shape (shared with
 /// Cursor): `hooks.<event>` arrays of `{_pixtuoid, command}`.
-pub fn verify_schema(content: &str) -> crate::install::verify::SchemaParse {
+pub(crate) fn verify_schema(content: &str) -> crate::install::verify::SchemaParse {
     crate::install::verify::flat_json_verify(content, REASONIX_EVENTS, SENTINEL_KEY)
 }
 

--- a/crates/pixtuoid/src/install/target.rs
+++ b/crates/pixtuoid/src/install/target.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 
 /// Builds a target's extra wholly-owned artifacts (absolute path + content) from
 /// the resolved shim path — see `Target::extra_artifacts`.
-pub type ExtraArtifactsFn = fn(hook_path: &Path) -> Result<Vec<(PathBuf, String)>>;
+pub(crate) type ExtraArtifactsFn = fn(hook_path: &Path) -> Result<Vec<(PathBuf, String)>>;
 
 /// How a target resolves the hook binary into its config.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -103,9 +103,9 @@ pub struct Target {
 }
 
 /// Backup suffix — the same constant for every target (not a per-target field).
-pub const BACKUP_SUFFIX: &str = "pixtuoid.bak";
+pub(crate) const BACKUP_SUFFIX: &str = "pixtuoid.bak";
 
-pub const CLAUDE: Target = Target {
+pub(crate) const CLAUDE: Target = Target {
     name: "claude",
     core_source: pixtuoid_core::source::claude_code::SOURCE_NAME,
     display_name: "Claude Code",
@@ -126,7 +126,7 @@ pub const CLAUDE: Target = Target {
     extra_artifacts: None,
 };
 
-pub const CODEX: Target = Target {
+pub(crate) const CODEX: Target = Target {
     name: "codex",
     core_source: pixtuoid_core::source::codex::SOURCE_NAME,
     display_name: "Codex",
@@ -140,7 +140,7 @@ pub const CODEX: Target = Target {
     extra_artifacts: None,
 };
 
-pub const REASONIX: Target = Target {
+pub(crate) const REASONIX: Target = Target {
     name: "reasonix",
     core_source: pixtuoid_core::source::reasonix::SOURCE_NAME,
     display_name: "Reasonix",
@@ -154,7 +154,7 @@ pub const REASONIX: Target = Target {
     extra_artifacts: None,
 };
 
-pub const CODEWHALE: Target = Target {
+pub(crate) const CODEWHALE: Target = Target {
     name: "codewhale",
     core_source: pixtuoid_core::source::codewhale::SOURCE_NAME,
     display_name: "CodeWhale",
@@ -168,7 +168,7 @@ pub const CODEWHALE: Target = Target {
     extra_artifacts: None,
 };
 
-pub const OPENCODE: Target = Target {
+pub(crate) const OPENCODE: Target = Target {
     name: "opencode",
     core_source: pixtuoid_core::source::opencode::SOURCE_NAME,
     display_name: "opencode",
@@ -187,7 +187,7 @@ pub const OPENCODE: Target = Target {
     extra_artifacts: None,
 };
 
-pub const CURSOR: Target = Target {
+pub(crate) const CURSOR: Target = Target {
     name: "cursor",
     core_source: pixtuoid_core::source::cursor::SOURCE_NAME,
     display_name: "Cursor CLI",
@@ -202,7 +202,7 @@ pub const CURSOR: Target = Target {
     extra_artifacts: None,
 };
 
-pub const HERMES: Target = Target {
+pub(crate) const HERMES: Target = Target {
     name: "hermes",
     core_source: pixtuoid_core::source::hermes::SOURCE_NAME,
     display_name: "Hermes Agent",
@@ -220,7 +220,7 @@ pub const HERMES: Target = Target {
     extra_artifacts: None,
 };
 
-pub const OPENCLAW: Target = Target {
+pub(crate) const OPENCLAW: Target = Target {
     name: "openclaw",
     core_source: pixtuoid_core::source::openclaw::SOURCE_NAME,
     display_name: "OpenClaw",
@@ -246,7 +246,10 @@ pub const TARGETS: &[&Target] = &[
     &CLAUDE, &CODEX, &REASONIX, &CODEWHALE, &OPENCODE, &CURSOR, &HERMES, &OPENCLAW,
 ];
 
-pub fn by_name(name: &str) -> Option<&'static Target> {
+// Test-gated: lookup-by-CLI-name has no prod caller (prod joins on the source id
+// via `by_source`); kept for the target-registry tests. Un-gate if prod needs it.
+#[cfg(test)]
+pub(crate) fn by_name(name: &str) -> Option<&'static Target> {
     TARGETS.iter().copied().find(|t| t.name == name)
 }
 
@@ -254,7 +257,7 @@ pub fn by_name(name: &str) -> Option<&'static Target> {
 /// e.g. "claude-code"). This is the correct join for anything keyed on the
 /// source registry (the Sources panel) — `by_name` keys on the CLI-facing
 /// `--target` name, which differs from the source id for Claude.
-pub fn by_source(source_id: &str) -> Option<&'static Target> {
+pub(crate) fn by_source(source_id: &str) -> Option<&'static Target> {
     TARGETS.iter().copied().find(|t| t.core_source == source_id)
 }
 
@@ -262,11 +265,11 @@ pub fn by_source(source_id: &str) -> Option<&'static Target> {
 /// ~/.codex must NOT count as present. Exception: a target whose written file
 /// the CLI never creates itself (Reasonix) supplies a `presence_probe` over
 /// real install markers instead.
-pub fn config_present(path: &Path) -> bool {
+pub(crate) fn config_present(path: &Path) -> bool {
     crate::install::io::resolve_symlink(path).exists()
 }
 
-pub fn is_present(t: &Target) -> bool {
+pub(crate) fn is_present(t: &Target) -> bool {
     match t.presence_probe {
         Some(probe) => probe(),
         // An unresolvable default path (no home dir) means there is no config

--- a/crates/pixtuoid/src/install/verify.rs
+++ b/crates/pixtuoid/src/install/verify.rs
@@ -87,7 +87,7 @@ impl SchemaVerifyResult {
 /// online review). Mirrors `doctor`'s R0615-06 sanitize discipline. The
 /// Sources panel is already safe (ratatui renders control bytes as literals),
 /// but source-sanitizing it too is harmless + future-proof.
-pub fn display_safe(p: &std::path::Path) -> String {
+pub(crate) fn display_safe(p: &std::path::Path) -> String {
     crate::strip_control_chars(&p.display().to_string())
 }
 
@@ -96,7 +96,7 @@ pub fn display_safe(p: &std::path::Path) -> String {
 /// ref extracted from a managed command, and any target-specific extra issues
 /// (e.g. CodeWhale `enabled=false`). Centralizes the issue wording so every
 /// target reports consistently.
-pub fn assemble(
+pub(crate) fn assemble(
     missing_events: &[&str],
     any_managed: bool,
     shim: ShimRef,
@@ -123,7 +123,7 @@ pub fn assemble(
 /// array of `{_pixtuoid: true, command, …}` entries. Shared because the two
 /// targets use the IDENTICAL shape; each passes its own `events` + `sentinel`
 /// (the per-source knowledge), so this is shape-sharing, not a shared decoder.
-pub fn flat_json_verify(content: &str, events: &[&str], sentinel: &str) -> SchemaParse {
+pub(crate) fn flat_json_verify(content: &str, events: &[&str], sentinel: &str) -> SchemaParse {
     let Ok(doc) = serde_json::from_str::<serde_json::Value>(content) else {
         return SchemaParse::broken("hooks config no longer parses as JSON");
     };
@@ -163,7 +163,7 @@ pub fn flat_json_verify(content: &str, events: &[&str], sentinel: &str) -> Schem
 /// ` --event <name>` (CodeWhale). Returns `Absolute` for a real path, `Unknown`
 /// if nothing path-like can be peeled out. Mirrors the read-back
 /// `codex::command_basename_is_hook` already does.
-pub fn shell_shim_ref(command: &str) -> ShimRef {
+pub(crate) fn shell_shim_ref(command: &str) -> ShimRef {
     // Strip the trailing ` --event <name>` (CodeWhale bakes one per entry). Use
     // rsplit_once so a single-quoted PATH that literally contains " --event "
     // keeps that occurrence and only the genuinely-appended tail is removed —

--- a/crates/pixtuoid/src/main.rs
+++ b/crates/pixtuoid/src/main.rs
@@ -230,7 +230,7 @@ fn build_run_config(
 /// and the CLI report. Iterates TARGETS, not REGISTERED_SOURCES: only an
 /// install-bearing source can be install-BROKEN.
 fn warn_broken_installs(connected: &std::collections::HashSet<String>) {
-    for &t in install::target::TARGETS {
+    for &t in install::TARGETS {
         if !connected.contains(t.core_source) {
             continue;
         }


### PR DESCRIPTION
## What
#573 made `io.rs` `pub(crate) mod` so a stray `pub` trips `unreachable_pub` (the compiler tooth for invariant #4). This finishes that sweep for the **per-CLI installers + merge/verify/target** — the remainder the v2 arch-deep sweep flagged (issue #582).

Every one is in-lib-only (callers reach them via `crate::install::…`) **except two items**: `nonempty`/`nonempty_env` (the bin's crash/logging via `pixtuoid::install::…`) and `target::TARGETS` (the bin's registry walk). So each module becomes `pub(crate) mod` with just those two re-exported, and `unreachable_pub -D warnings` now teeth their **whole item surface**. `main.rs`'s one `install::target::TARGETS` moves to the `install::TARGETS` re-export.

> Note: my original issue over-claimed "zero cross-target consumers" — verifying the premise found `main.rs` reaches `target::TARGETS`, so `target` isn't purely in-crate. The re-export handles that one item; the module still gets the tooth for the rest.

## Least-privilege as a dead-code detector (the #573 effect)
Demoting surfaced two items with **no prod-Rust caller**, both fenced `#[cfg(test)]`:
- `OPENCLAW_EVENTS` — only the consistency test + `check_upstream_drift.py`'s source-text parse read it (the Python is cfg-agnostic, so the gate is safe).
- `target::by_name` — test-only; prod joins on the source id via `by_source`.

## Behavior-preserving (visibility only)
`clippy -D warnings` clean (all `unreachable_pub` demoted), 748 lib + 244 install tests green. No runtime change.

Closes #582.

🤖 Generated with [Claude Code](https://claude.com/claude-code)