### PR TITLE
refactor(scene): single-source the board uptime feeder (arch-review MEDIUM)

### DIFF
--- a/crates/pixtuoid-scene/src/board.rs
+++ b/crates/pixtuoid-scene/src/board.rs
@@ -17,6 +17,7 @@
 //! which is why it moved here out of the binary's tui widgets.
 
 use std::collections::BTreeMap;
+use std::time::SystemTime;
 
 use pixtuoid_core::sprite::Rgb;
 use pixtuoid_core::state::{ActivityState, DaemonPresence, DaemonState, MAX_FLOORS};
@@ -100,6 +101,20 @@ pub fn gateway_rollup(daemons: &BTreeMap<String, DaemonPresence>) -> Option<Daem
         .values()
         .map(|p| p.display_state())
         .max_by_key(|s| severity(*s))
+}
+
+/// The oldest in-scene agent's age in seconds — every agent still in the scene
+/// (live or walking out; swept ones are gone). The board's uptime feeder,
+/// single-sourced beside `scene_stats`/`gateway_rollup` so the three painters
+/// (TUI/floating/web) can't drift.
+pub fn scene_uptime_secs(scene: &SceneState, now: SystemTime) -> u64 {
+    scene
+        .agents
+        .values()
+        .filter_map(|a| now.duration_since(a.created_at).ok())
+        .max()
+        .unwrap_or_default()
+        .as_secs()
 }
 
 /// Format a duration in seconds as a compact `"{h}h{m}m"` / `"{m}m"` / `"<1m"`
@@ -268,7 +283,7 @@ pub fn board_mood_segments(counts: StateCounts) -> Vec<BoardSegment> {
 }
 
 /// Assemble the whole board model. `counts` is the SAME `scene_stats` the footer
-/// reads; `uptime_secs` is the oldest live-or-exiting agent's age; `floor` is
+/// reads; `uptime_secs` is [`scene_uptime_secs`] (the oldest in-scene agent's age); `floor` is
 /// `(current, total_floors)` (a single-floor office passes `None`); `gateway` is
 /// the `gateway_rollup` (`None` suppresses the chip). The context separators
 /// (`"  "`) are baked into each following segment so painters just concatenate.
@@ -321,6 +336,47 @@ mod tests {
             board_brand(),
             format!("pixtuoid v{}", env!("CARGO_PKG_VERSION"))
         );
+    }
+
+    #[test]
+    fn uptime_is_the_oldest_in_scene_agent_in_whole_seconds() {
+        use pixtuoid_core::state::{ActivityState, GlobalDeskIndex};
+        use pixtuoid_core::AgentId;
+        use std::path::PathBuf;
+        use std::sync::Arc;
+        use std::time::Duration;
+        fn slot(secs: u64) -> AgentSlot {
+            AgentSlot {
+                agent_id: AgentId::from_transcript_path(&format!("/p/{secs}.jsonl")),
+                source: Arc::from("claude-code"),
+                session_id: Arc::from("s"),
+                cwd: Arc::from(PathBuf::from("/p").as_path()),
+                label: "l".into(),
+                state: ActivityState::Idle,
+                state_started_at: SystemTime::UNIX_EPOCH,
+                last_event_at: SystemTime::UNIX_EPOCH,
+                created_at: SystemTime::UNIX_EPOCH + Duration::from_secs(secs),
+                exiting_at: None,
+                pending_idle_at: None,
+                desk_index: GlobalDeskIndex(0),
+                floor_idx: 0,
+                tool_call_count: 0,
+                active_ms: 0,
+                unknown_cwd: false,
+                parent_id: None,
+                pid: None,
+                model: None,
+                effort: None,
+            }
+        }
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(100);
+        let mut scene = SceneState::uniform(16);
+        for s in [slot(40), slot(10)] {
+            scene.agents.insert(s.agent_id, s);
+        }
+        // Oldest agent created at 10s → 90s uptime; an empty scene → 0.
+        assert_eq!(scene_uptime_secs(&scene, now), 90);
+        assert_eq!(scene_uptime_secs(&SceneState::uniform(16), now), 0);
     }
 
     #[test]

--- a/crates/pixtuoid-web/src/lib.rs
+++ b/crates/pixtuoid-web/src/lib.rs
@@ -338,15 +338,9 @@ impl Office {
 
         // Board — the SAME `pixtuoid_scene::board` model the TUI + floating use.
         let counts = pixtuoid_scene::board::scene_stats(&self.scene);
-        let oldest = self
-            .scene
-            .agents
-            .values()
-            .filter_map(|a| now.duration_since(a.created_at).ok())
-            .max()
-            .unwrap_or_default();
         let gateway = pixtuoid_scene::board::gateway_rollup(self.scene.daemons());
-        let board = pixtuoid_scene::board::build_board(counts, oldest.as_secs(), None, gateway);
+        let uptime = pixtuoid_scene::board::scene_uptime_secs(&self.scene, now);
+        let board = pixtuoid_scene::board::build_board(counts, uptime, None, gateway);
 
         let mut out = String::from("{\"labels\":[");
         for (i, el) in labels.iter().enumerate() {

--- a/crates/pixtuoid/src/floating/offscreen.rs
+++ b/crates/pixtuoid/src/floating/offscreen.rs
@@ -115,14 +115,9 @@ impl OfficeRenderer {
     /// cross-floor breadcrumb); uptime is the oldest live-or-exiting agent's age.
     pub fn board(&self, scene: &SceneState, now: SystemTime) -> pixtuoid_scene::board::BoardModel {
         let counts = pixtuoid_scene::board::scene_stats(scene);
-        let oldest = scene
-            .agents
-            .values()
-            .filter_map(|a| now.duration_since(a.created_at).ok())
-            .max()
-            .unwrap_or_default();
         let gateway = pixtuoid_scene::board::gateway_rollup(scene.daemons());
-        pixtuoid_scene::board::build_board(counts, oldest.as_secs(), None, gateway)
+        let uptime = pixtuoid_scene::board::scene_uptime_secs(scene, now);
+        pixtuoid_scene::board::build_board(counts, uptime, None, gateway)
     }
 }
 

--- a/crates/pixtuoid/src/floating/offscreen.rs
+++ b/crates/pixtuoid/src/floating/offscreen.rs
@@ -112,7 +112,7 @@ impl OfficeRenderer {
     /// Build the neon wall-board model for the current scene — the SAME
     /// backend-agnostic `pixtuoid_scene::board` model the TUI footer/board and the
     /// wasm hero use. Floating shows one floor at a time, so `floor = None` (no
-    /// cross-floor breadcrumb); uptime is the oldest live-or-exiting agent's age.
+    /// cross-floor breadcrumb); uptime is `board::scene_uptime_secs`.
     pub fn board(&self, scene: &SceneState, now: SystemTime) -> pixtuoid_scene::board::BoardModel {
         let counts = pixtuoid_scene::board::scene_stats(scene);
         let gateway = pixtuoid_scene::board::gateway_rollup(scene.daemons());

--- a/crates/pixtuoid/src/tui/widgets/wall_board.rs
+++ b/crates/pixtuoid/src/tui/widgets/wall_board.rs
@@ -67,15 +67,9 @@ pub(crate) fn paint_wall_display(
     // The board's TEXT is the backend-agnostic `pixtuoid_scene::board` model (so
     // floating/wasm build the SAME content); this painter only maps each tone to a
     // ratatui color + owns the cell-space L1 right-flush.
-    let oldest = scene
-        .agents
-        .values()
-        .filter_map(|a| now.duration_since(a.created_at).ok())
-        .max()
-        .unwrap_or_default();
     let model = pixtuoid_scene::board::build_board(
         counts,
-        oldest.as_secs(),
+        pixtuoid_scene::board::scene_uptime_secs(scene, now),
         floor_info.map(|fi| (fi.current, fi.total_floors)),
         gateway,
     );


### PR DESCRIPTION
## What
The whole-codebase architecture review's **one confirmed structural debt**: the board's uptime derivation was copy-pasted **verbatim** into all three painters (`wall_board.rs`, floating `offscreen.rs`, web `lib.rs`) with **no parity test** — while its two sibling feeders (`scene_stats`, `gateway_rollup`) are single-sourced in `board.rs` precisely *"so the surfaces can't drift."* The lone breach of the repo's own anti-drift spine.

## Fix
- Add `board::scene_uptime_secs(scene, now)` beside its siblings; the three painters now call it. **Parity is now structural** (one definition) — stronger than a test.
- Reconcile the `build_board` doc ("oldest live-or-exiting agent's age") with the code (it iterates every in-scene agent — live or walking out).
- Unit test pinning the oldest-in-whole-seconds semantics + the empty→0 default.

## Behavior-preserving
Identical board output — `clippy -D warnings` clean; scene/binary/web build; board test green. The committed wasm blob is unchanged (self-consistent; `gen-wasm-check` passes) and behavior-identical.

From the whole-codebase architecture review (deep-module lens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)