### PR TITLE
refactor(focus): single-source the linux focus-channel selection (#599)

### DIFF
--- a/crates/pixtuoid/src/doctor.rs
+++ b/crates/pixtuoid/src/doctor.rs
@@ -556,8 +556,8 @@ fn activation_backend() -> String {
     #[cfg(target_os = "linux")]
     {
         linux_activation_backend(
-            std::env::var_os("SWAYSOCK").is_some(),
-            std::env::var_os("HYPRLAND_INSTANCE_SIGNATURE").is_some(),
+            std::env::var_os(crate::focus::SWAY_ENV).is_some(),
+            std::env::var_os(crate::focus::HYPRLAND_ENV).is_some(),
             std::env::var_os("WAYLAND_DISPLAY").is_some(),
             std::env::var_os("DISPLAY").is_some(),
         )

--- a/crates/pixtuoid/src/focus/linux.rs
+++ b/crates/pixtuoid/src/focus/linux.rs
@@ -14,6 +14,32 @@
 
 use super::ProcessTable;
 
+// The two IPC-compositor env markers — the SINGLE source `detect_channel`
+// (below) and doctor's `activation_backend` read, so an upstream rename can't
+// drift one of the three copies.
+pub(crate) const SWAY_ENV: &str = "SWAYSOCK";
+pub(crate) const HYPRLAND_ENV: &str = "HYPRLAND_INSTANCE_SIGNATURE";
+
+/// Which pid-addressable focus channel this environment implies. Read ONCE so
+/// `focusable` and `activate_os` can't diverge — a 4th compositor added to one
+/// but missed in the other would report a pid focusable, then silently no-op on
+/// activate.
+enum LinuxFocusChannel {
+    Sway,
+    Hyprland,
+    X11,
+}
+
+fn detect_channel() -> LinuxFocusChannel {
+    if std::env::var_os(SWAY_ENV).is_some() {
+        LinuxFocusChannel::Sway
+    } else if std::env::var_os(HYPRLAND_ENV).is_some() {
+        LinuxFocusChannel::Hyprland
+    } else {
+        LinuxFocusChannel::X11
+    }
+}
+
 pub(crate) struct OsProcessTable;
 
 impl ProcessTable for OsProcessTable {
@@ -26,13 +52,11 @@ impl ProcessTable for OsProcessTable {
     }
 
     fn focusable(&self, pid: i32) -> bool {
-        if std::env::var_os("SWAYSOCK").is_some() {
-            return tree_lists_pid("swaymsg", &["-t", "get_tree"], pid);
+        match detect_channel() {
+            LinuxFocusChannel::Sway => tree_lists_pid("swaymsg", &["-t", "get_tree"], pid),
+            LinuxFocusChannel::Hyprland => tree_lists_pid("hyprctl", &["clients", "-j"], pid),
+            LinuxFocusChannel::X11 => x11_window_of(pid).is_some(),
         }
-        if std::env::var_os("HYPRLAND_INSTANCE_SIGNATURE").is_some() {
-            return tree_lists_pid("hyprctl", &["clients", "-j"], pid);
-        }
-        x11_window_of(pid).is_some()
     }
 }
 
@@ -99,21 +123,19 @@ fn x11_window_of(pid: i32) -> Option<u32> {
 /// sway/hyprland IPC (pid-addressed) when the env marker is present, else
 /// EWMH `_NET_ACTIVE_WINDOW`.
 pub(crate) fn activate_os(pid: i32) -> bool {
-    if std::env::var_os("SWAYSOCK").is_some() {
-        return std::process::Command::new("swaymsg")
+    match detect_channel() {
+        LinuxFocusChannel::Sway => std::process::Command::new("swaymsg")
             .arg(format!("[pid={pid}] focus"))
             .status()
             .map(|s| s.success())
-            .unwrap_or(false);
-    }
-    if std::env::var_os("HYPRLAND_INSTANCE_SIGNATURE").is_some() {
-        return std::process::Command::new("hyprctl")
+            .unwrap_or(false),
+        LinuxFocusChannel::Hyprland => std::process::Command::new("hyprctl")
             .args(["dispatch", "focuswindow", &format!("pid:{pid}")])
             .status()
             .map(|s| s.success())
-            .unwrap_or(false);
+            .unwrap_or(false),
+        LinuxFocusChannel::X11 => x11_activate(pid).unwrap_or(false),
     }
-    x11_activate(pid).unwrap_or(false)
 }
 
 fn x11_activate(pid: i32) -> Option<bool> {

--- a/crates/pixtuoid/src/focus/mod.rs
+++ b/crates/pixtuoid/src/focus/mod.rs
@@ -28,6 +28,8 @@ use pixtuoid_core::AgentSlot;
 
 #[cfg(target_os = "linux")]
 mod linux;
+#[cfg(target_os = "linux")]
+pub(crate) use linux::{HYPRLAND_ENV, SWAY_ENV};
 #[cfg(target_os = "macos")]
 mod macos;
 #[cfg(windows)]


### PR DESCRIPTION
## What
The arch-review completeness sweep's LOW. `focus/linux.rs`'s `focusable` and `activate_os` independently re-branched the same `SWAYSOCK → HYPRLAND_INSTANCE_SIGNATURE → x11` env ladder, and doctor's `activation_backend` read the same markers a third time — a 4th compositor added to `focusable` but missed in `activate_os` would report a pid **focusable**, then silently **no-op** on activate.

`detect_channel() -> LinuxFocusChannel` reads the env **once**; both `focusable` and `activate_os` `match` on it — the pairing is now structural. The two IPC markers are lifted to shared `SWAY_ENV`/`HYPRLAND_ENV` consts that doctor also reads, so a rename can't drift the third mirror.

## Verification note
Linux-only (`cfg(target_os = "linux")`). macOS **parse-checks** it (clippy clean, macOS build intact) but can't type-check the `cfg(linux)` paths (no cross-target std locally) — **CI's Linux runner is the real gate** for the `crate::focus::SWAY_ENV` re-export resolution. Behavior-preserving (identical channel dispatch).

Closes #599.

🤖 Generated with [Claude Code](https://claude.com/claude-code)