### PR TITLE
refactor(scene): deepen FloorSession — absorb overlay/board glue + export frame_epilogue (#595)

### DIFF
--- a/crates/pixtuoid-scene/CLAUDE.md
+++ b/crates/pixtuoid-scene/CLAUDE.md
@@ -229,7 +229,12 @@ src/                (the pixtuoid-scene crate root; default pack at ../sprites/d
 > compiler-owned "scene → RgbBuffer" frame: prologue (buffer sizing, layout,
 > router zone), the pixel pass (itself two-phase: `sim_step` → paint, see
 > `pixel_painter/sim.rs` above), and the bookkeeping epilogue (`CoffeeState`
-> carrier persistence + the door-anim clamp). The persistent bundle every
+> carrier persistence + the door-anim clamp). It also single-sources the
+> label-overlay (`overlay`) and wall-board (`board`) derivations: `render`
+> captures the frame's `Layout` internally so `overlay` builds against the SAME
+> geometry the sprite pass used — a mismatched layout/route pair is
+> unrepresentable, not merely discouraged, and the web + floating painters drop
+> their duplicated `last_layout` capture. The persistent bundle every
 > painter used to hand-roll — {FloorCtx, RgbBuffer, CoffeeState, chitchat} +
 > the dual `evict_missing` protocol — is now the `FloorSession` type
 > (`PerFloor` + `PerOffice` halves): each painter drifted on exactly that
@@ -252,7 +257,8 @@ src/                (the pixtuoid-scene crate root; default pack at ../sprites/d
 > `tui::renderer::draw_scene` (the terminal half-block flush): it needs the
 > full `PixelPassResult` (pet/mascot positions, chitchat bubbles) and holds
 > only immutable coffee borrows mid-flush, routing its bookkeeping through the
-> same `CoffeeState`/`FloorCtx::evict_missing` types. A FOURTH painter starts
+> pub `frame_epilogue` seam (the same `CoffeeState`/door-anim step the session
+> runs — no longer hand-copied, closing the #423 drift class). A FOURTH painter starts
 > from `FloorSession`, not by re-rolling the bundle. The terminal flush +
 > widgets + footer live in the binary's `tui/`; the chunky-upscale blit is the
 > binary's `floating/`; the RGBA blit to canvas is `pixtuoid-web`'s. Keep

--- a/crates/pixtuoid-scene/src/floor.rs
+++ b/crates/pixtuoid-scene/src/floor.rs
@@ -306,8 +306,10 @@ fn frame_prologue(
 
 /// The shared per-frame EPILOGUE: stamp this frame's new coffee carriers and
 /// refresh the door-cosmetic clamp. Same ONE-definition rationale as
-/// [`frame_prologue`].
-fn frame_epilogue(
+/// [`frame_prologue`] — `pub` so the TUI's `draw_scene` (on the raw
+/// `render_to_rgb_buffer` path, which can't call `render_floor`/`observe`) runs
+/// THIS seam instead of re-inlining the two operations (the #423 drift class).
+pub fn frame_epilogue(
     fctx: &mut FloorCtx,
     coffee: &mut CoffeeState,
     carriers: impl IntoIterator<Item = pixtuoid_core::AgentId>,
@@ -472,6 +474,10 @@ impl PerOffice {
 pub struct FloorSession {
     pub floor: PerFloor,
     pub office: PerOffice,
+    /// The layout the last `render` laid out — [`FloorSession::overlay`] builds
+    /// labels against IT (not a caller-supplied one), so a painter can't pass a
+    /// layout that disagrees with the sprite pass.
+    last_layout: Option<Arc<crate::layout::Layout>>,
 }
 
 impl FloorSession {
@@ -479,6 +485,7 @@ impl FloorSession {
         Self {
             floor: PerFloor::new(),
             office: PerOffice::default(),
+            last_layout: None,
         }
     }
 
@@ -504,12 +511,49 @@ impl FloorSession {
     /// itself.
     pub fn render(&mut self, inputs: FrameInputs) -> Option<Arc<crate::layout::Layout>> {
         self.evict_missing(inputs.scene);
-        render_floor(
+        let layout = render_floor(
             &mut self.floor.ctx,
             &mut self.floor.buf,
             &mut self.office.coffee,
             &mut self.office.chitchat,
             inputs,
+        );
+        self.last_layout = layout.clone();
+        layout
+    }
+
+    /// Agent labels for the LAST rendered frame, built against THIS session's
+    /// layout + route state — a painter can't hand a mismatched layout/route_ctx
+    /// pair (the coherence the seam otherwise proves by hand, per painter). Empty
+    /// before the first `render`. `hovered` highlights one agent; the single-floor
+    /// painters pass `None`.
+    pub fn overlay(
+        &mut self,
+        scene: &SceneState,
+        now: SystemTime,
+        hovered: Option<AgentId>,
+    ) -> Vec<crate::overlay::LabelElement> {
+        let Some(layout) = self.last_layout.as_deref() else {
+            return Vec::new();
+        };
+        let mut rctx = self.floor.ctx.route_ctx();
+        crate::overlay::build_overlay(scene, layout, now, &mut rctx, hovered)
+    }
+
+    /// The neon wall-board model for `scene` — the same `board` feeders the TUI
+    /// footer reads, single-sourced. `floor` is `(current, total)`, or `None` for
+    /// a single-floor office (no cross-floor breadcrumb).
+    pub fn board(
+        &self,
+        scene: &SceneState,
+        now: SystemTime,
+        floor: Option<(usize, usize)>,
+    ) -> crate::board::BoardModel {
+        crate::board::build_board(
+            crate::board::scene_stats(scene),
+            crate::board::scene_uptime_secs(scene, now),
+            floor,
+            crate::board::gateway_rollup(scene.daemons()),
         )
     }
 

--- a/crates/pixtuoid-web/src/lib.rs
+++ b/crates/pixtuoid-web/src/lib.rs
@@ -15,7 +15,6 @@
 
 mod script;
 
-use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use wasm_bindgen::prelude::*;
@@ -31,7 +30,7 @@ use crate::script::{hero_script, hire_beats, lobster_beats, Beat, PresenceBeat, 
 
 use pixtuoid_scene::embedded_pack::load_sprite_pack;
 use pixtuoid_scene::floor::{floor_capacity, FloorMeta, FloorSession, FrameInputs};
-use pixtuoid_scene::layout::{Layout, Size, CHARACTER_SPRITE_W};
+use pixtuoid_scene::layout::{Size, CHARACTER_SPRITE_W};
 use pixtuoid_scene::theme::{Theme, ALL_THEMES};
 
 /// A scheduled one-shot event for a visitor hire — an absolute-time
@@ -170,10 +169,6 @@ pub struct Office {
     /// Applied each `step` (see the force_weather invariant) so two Offices sharing
     /// the one wasm module never fight over the thread-local override.
     weather_override: Option<String>,
-    /// The layout the LAST `render` computed — captured so `overlay_json` builds
-    /// the name-badge overlay against the SAME geometry the sprite pass used
-    /// (labels align 1:1 with the painted characters). `None` before the first step.
-    last_layout: Option<Arc<Layout>>,
 }
 
 #[wasm_bindgen]
@@ -204,7 +199,6 @@ impl Office {
             last_now: None,
             caps_size: None,
             weather_override: None,
-            last_layout: None,
         })
     }
 
@@ -326,21 +320,10 @@ impl Office {
         };
         let theme = self.theme;
 
-        // Labels — built against the LAST render's layout + this session's route
-        // state (disjoint field borrows of `self`), so they align 1:1 with the sprites.
-        let labels = match self.last_layout.as_deref() {
-            Some(layout) => {
-                let mut rctx = self.session.floor.ctx.route_ctx();
-                pixtuoid_scene::overlay::build_overlay(&self.scene, layout, now, &mut rctx, None)
-            }
-            None => Vec::new(),
-        };
-
-        // Board — the SAME `pixtuoid_scene::board` model the TUI + floating use.
-        let counts = pixtuoid_scene::board::scene_stats(&self.scene);
-        let gateway = pixtuoid_scene::board::gateway_rollup(self.scene.daemons());
-        let uptime = pixtuoid_scene::board::scene_uptime_secs(&self.scene, now);
-        let board = pixtuoid_scene::board::build_board(counts, uptime, None, gateway);
+        // Labels + board — both delegated to the session, which owns the layout
+        // the sprite pass used + the route state (shared with the floating painter).
+        let labels = self.session.overlay(&self.scene, now, None);
+        let board = self.session.board(&self.scene, now, None);
 
         let mut out = String::from("{\"labels\":[");
         for (i, el) in labels.iter().enumerate() {
@@ -480,7 +463,7 @@ impl Office {
             floor_seed: self.seed,
             ..FloorMeta::for_floor(0, 1)
         };
-        self.last_layout = self.session.render(FrameInputs {
+        self.session.render(FrameInputs {
             scene: &self.scene,
             pack: &self.pack,
             theme: self.theme,

--- a/crates/pixtuoid/src/floating/offscreen.rs
+++ b/crates/pixtuoid/src/floating/offscreen.rs
@@ -11,14 +11,13 @@
 //! per-frame caches + persistent office state — coffee cups, group chitchat — plus the
 //! dual eviction) across frames so motion stays continuous.
 
-use std::sync::Arc;
 use std::time::SystemTime;
 
 use pixtuoid_core::sprite::{format::Pack, Rgb, RgbBuffer};
 use pixtuoid_core::state::SceneState;
 
 use pixtuoid_scene::floor::{FloorMeta, FloorSession, FrameInputs};
-use pixtuoid_scene::layout::{Layout, Size};
+use pixtuoid_scene::layout::Size;
 use pixtuoid_scene::theme::Theme;
 
 /// Pack an `Rgb` into the softbuffer word format, `0x00RRGGBB` (XRGB) — the ONE
@@ -39,17 +38,12 @@ pub(crate) fn pack_xrgb(c: Rgb) -> u32 {
 /// continuous (no walk-flash).
 pub struct OfficeRenderer {
     session: FloorSession,
-    /// The layout the LAST `render` computed — captured so `labels` can build the
-    /// name-badge overlay against the SAME geometry the sprite pass used (labels
-    /// align 1:1 with the painted characters). `None` before the first render.
-    last_layout: Option<Arc<Layout>>,
 }
 
 impl OfficeRenderer {
     pub fn new() -> Self {
         Self {
             session: FloorSession::new(),
-            last_layout: None,
         }
     }
 
@@ -75,12 +69,11 @@ impl OfficeRenderer {
         // per-agent eviction (this painter historically never evicted — a
         // slow per-agent leak, invisible in pixels because gone agents aren't
         // painted — now structural: render() runs it), then buffer sizing,
-        // layout, the pixel pass, and the coffee/door-anim epilogue. The
-        // returned layout is captured for `labels` — the name-badge overlay
-        // must be built against the SAME geometry the sprite pass used.
-        // active_pet stays None: click-to-pet needs window pointer
-        // hit-testing (deferred); the WANDERING floor pet is wired.
-        self.last_layout = self.session.render(FrameInputs {
+        // layout, the pixel pass, the coffee/door-anim epilogue, AND capturing
+        // the layout so `labels` builds the overlay against the SAME geometry
+        // the sprite pass used. active_pet stays None: click-to-pet needs window
+        // pointer hit-testing (deferred); the WANDERING floor pet is wired.
+        self.session.render(FrameInputs {
             scene,
             pack,
             theme,
@@ -102,22 +95,14 @@ impl OfficeRenderer {
         scene: &SceneState,
         now: SystemTime,
     ) -> Vec<pixtuoid_scene::overlay::LabelElement> {
-        let Some(layout) = self.last_layout.as_deref() else {
-            return Vec::new();
-        };
-        let mut rctx = self.session.floor.ctx.route_ctx();
-        pixtuoid_scene::overlay::build_overlay(scene, layout, now, &mut rctx, None)
+        // Floating has no agent-hover yet → hovered = None.
+        self.session.overlay(scene, now, None)
     }
 
-    /// Build the neon wall-board model for the current scene — the SAME
-    /// backend-agnostic `pixtuoid_scene::board` model the TUI footer/board and the
-    /// wasm hero use. Floating shows one floor at a time, so `floor = None` (no
-    /// cross-floor breadcrumb); uptime is `board::scene_uptime_secs`.
+    /// The neon wall-board model for the current scene — one floor, so `floor =
+    /// None`. Delegates to `FloorSession::board` (shared with the web painter).
     pub fn board(&self, scene: &SceneState, now: SystemTime) -> pixtuoid_scene::board::BoardModel {
-        let counts = pixtuoid_scene::board::scene_stats(scene);
-        let gateway = pixtuoid_scene::board::gateway_rollup(scene.daemons());
-        let uptime = pixtuoid_scene::board::scene_uptime_secs(scene, now);
-        pixtuoid_scene::board::build_board(counts, uptime, None, gateway)
+        self.session.board(scene, now, None)
     }
 }
 

--- a/crates/pixtuoid/src/floating/offscreen.rs
+++ b/crates/pixtuoid/src/floating/offscreen.rs
@@ -65,14 +65,8 @@ impl OfficeRenderer {
         floor_meta: FloorMeta,
         floor_pet: Option<&pixtuoid_scene::pet::Pet>,
     ) -> &RgbBuffer {
-        // The session owns the whole frame (#423 → FloorSession): the dual
-        // per-agent eviction (this painter historically never evicted — a
-        // slow per-agent leak, invisible in pixels because gone agents aren't
-        // painted — now structural: render() runs it), then buffer sizing,
-        // layout, the pixel pass, the coffee/door-anim epilogue, AND capturing
-        // the layout so `labels` builds the overlay against the SAME geometry
-        // the sprite pass used. active_pet stays None: click-to-pet needs window
-        // pointer hit-testing (deferred); the WANDERING floor pet is wired.
+        // active_pet stays None: click-to-pet needs window pointer hit-testing
+        // (deferred); the WANDERING floor pet is wired. The rest is the session's.
         self.session.render(FrameInputs {
             scene,
             pack,
@@ -95,7 +89,6 @@ impl OfficeRenderer {
         scene: &SceneState,
         now: SystemTime,
     ) -> Vec<pixtuoid_scene::overlay::LabelElement> {
-        // Floating has no agent-hover yet → hovered = None.
         self.session.overlay(scene, now, None)
     }
 

--- a/crates/pixtuoid/src/tui/tui_renderer/mod.rs
+++ b/crates/pixtuoid/src/tui/tui_renderer/mod.rs
@@ -772,11 +772,14 @@ impl<B: Backend<Error: Send + Sync + 'static>> TuiRenderer<B> {
         let new_coffee_carriers = std::mem::take(&mut draw_ctx.new_coffee_carriers);
         // drop draw_ctx here so we can re-borrow the floors freely.
         drop(draw_ctx);
-        // Recompute door_anim_max_ms from the motion map for the NEXT frame.
-        self.floors[self.current_floor]
-            .ctx
-            .recompute_door_anim_max_ms(now);
-        self.office.coffee.record(new_coffee_carriers, now);
+        // The shared after-frame seam (coffee stamp + door-anim clamp) — the same
+        // frame_epilogue render_floor/observe run, not a hand-copy (#423).
+        pixtuoid_scene::floor::frame_epilogue(
+            &mut self.floors[self.current_floor].ctx,
+            &mut self.office.coffee,
+            new_coffee_carriers,
+            now,
+        );
         if let Ok(ref layout_opt) = result {
             self.cached_layout = layout_opt.clone();
             // Ok(None) = draw_scene painted footer-only (compute failed at this


### PR DESCRIPTION
The two **Strong** deepenings from the `/improve-codebase-architecture` pass — one theme: *the deep FloorSession/frame bundle still leaked two pieces to consumers that hand-rolled them.*

## (1) FloorSession absorbs the overlay/board glue
The floating painter and the web `Office` each held a `last_layout` field + the same `build_overlay(layout, rctx, …)` + `scene_stats`/`scene_uptime_secs`/`gateway_rollup`/`build_board` glue next to their `FloorSession` — **two adapters** re-proving the label↔layout↔rctx coherence by hand (the interface lets a caller pass a layout and route_ctx that don't correspond). Hoist `last_layout` into `FloorSession` (it already returns + memoizes the layout) and add `overlay(scene, now, hovered)` + `board(scene, now, floor)`. Both painters delete their field + glue; the coherence invariant moves **into** the type that owns both the layout and the route_ctx.

## (2) Export `frame_epilogue`
The scene already extracted the after-frame contract (coffee stamp + door clamp) to kill the #423 drift class — but it was a **private** `fn`, so the TUI's `draw_scene` (the raw-`render_to_rgb_buffer` path that can't call `render_floor`/`observe`) re-inlined the two ops by hand. Promote to `pub`; the TUI runs the seam. **3 sites → 1.**

## Behavior-preserving
`clippy -D warnings` clean · `semver-checks: no update required` (new `pub fn`, minor-compatible over the published 0.14.0) · **full workspace suite green with byte-identical insta goldens** · scene/floating/web board+label tests green. wasm blob unchanged (behavior-identical, self-consistent).

Closes #595 (the two deepenings; the `publish_scene`/`DrawCtx` micro-cleanups the Explore rated non-deepenings can follow opportunistically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)