### PR TITLE
refactor(scene): name build_walkable_mask's obstacle inventory as MaskObstacles (#596)

### DIFF
--- a/crates/pixtuoid-scene/src/layout/compute.rs
+++ b/crates/pixtuoid-scene/src/layout/compute.rs
@@ -535,24 +535,24 @@ pub(super) fn compute_with_seed(
         .filter_map(|p| settle_plant(p, &home_desks, &waypoints, &singleton_rects, &cubicle_band))
         .collect();
 
-    let walkable = mask::build_walkable_mask(
+    let walkable = mask::build_walkable_mask(&mask::MaskObstacles {
         buf_w,
         buf_h,
         top_margin,
         door,
-        &home_desks,
-        &meeting_rooms,
+        home_desks: &home_desks,
+        meeting_rooms: &meeting_rooms,
         kitchen_island,
-        &waypoints,
-        &plants,
+        waypoints: &waypoints,
+        plants: &plants,
         floor_lamp,
         lounge_side_table,
         fish_tank,
-        &wall_decor,
-        &pod_decor,
-        &room_walls,
+        wall_decor: &wall_decor,
+        pod_decor: &pod_decor,
+        room_walls: &room_walls,
         pantry_counter_size,
-    );
+    });
 
     // Coarse reachable component, seeded from the door (where agents enter, so
     // always in the main component); fall back to a home desk, then buffer

--- a/crates/pixtuoid-scene/src/layout/mask.rs
+++ b/crates/pixtuoid-scene/src/layout/mask.rs
@@ -143,24 +143,50 @@ pub(super) fn wall_segment_rect(seg: &WallSegment, top_margin: u16) -> (Point, S
 }
 
 #[allow(clippy::too_many_arguments)]
-pub(super) fn build_walkable_mask(
-    buf_w: u16,
-    buf_h: u16,
-    top_margin: u16,
-    door: Option<Point>,
-    home_desks: &[Point],
-    meeting_rooms: &[MeetingRoom],
-    kitchen_island: Option<Point>,
-    waypoints: &[Waypoint],
-    plants: &[PlantItem],
-    floor_lamp: Option<Point>,
-    lounge_side_table: Option<Point>,
-    fish_tank: Option<Point>,
-    wall_decor: &[WallDecorItem],
-    pod_decor: &[PodDecorItem],
-    room_walls: &[WallSegment],
-    pantry_counter_size: Size,
-) -> WalkableMask {
+/// The placed-piece inventory the mask stamps — a NAMED input so the five
+/// interchangeable `Option<Point>` pieces (door/kitchen_island/floor_lamp/
+/// lounge_side_table/fish_tank) can't be positionally swapped, and so
+/// `build_walkable_mask` destructures it with NO `..` (a new field added here
+/// must then be handled by the mask, not silently walked through).
+pub(super) struct MaskObstacles<'a> {
+    pub(super) buf_w: u16,
+    pub(super) buf_h: u16,
+    pub(super) top_margin: u16,
+    pub(super) door: Option<Point>,
+    pub(super) home_desks: &'a [Point],
+    pub(super) meeting_rooms: &'a [MeetingRoom],
+    pub(super) kitchen_island: Option<Point>,
+    pub(super) waypoints: &'a [Waypoint],
+    pub(super) plants: &'a [PlantItem],
+    pub(super) floor_lamp: Option<Point>,
+    pub(super) lounge_side_table: Option<Point>,
+    pub(super) fish_tank: Option<Point>,
+    pub(super) wall_decor: &'a [WallDecorItem],
+    pub(super) pod_decor: &'a [PodDecorItem],
+    pub(super) room_walls: &'a [WallSegment],
+    pub(super) pantry_counter_size: Size,
+}
+
+pub(super) fn build_walkable_mask(obs: &MaskObstacles) -> WalkableMask {
+    let &MaskObstacles {
+        buf_w,
+        buf_h,
+        top_margin,
+        door,
+        home_desks,
+        meeting_rooms,
+        kitchen_island,
+        waypoints,
+        plants,
+        floor_lamp,
+        lounge_side_table,
+        fish_tank,
+        wall_decor,
+        pod_decor,
+        room_walls,
+        pantry_counter_size,
+    } = obs;
+
     let mut mask = WalkableMask::new_open(buf_w, buf_h);
 
     // Block the north wall band down to the WALL VISUAL bottom (top_wall_h),
@@ -558,24 +584,24 @@ mod tests {
             kind: WallDecor::Whiteboard,
             pos,
         }];
-        let mask = build_walkable_mask(
-            120,
-            96,
-            20,
-            None,
-            &[],
-            &[],
-            None,
-            &[],
-            &[],
-            None,
-            None,
-            None,
-            &wall_decor,
-            &[],
-            &[],
-            Size { w: 20, h: 8 },
-        );
+        let mask = build_walkable_mask(&MaskObstacles {
+            buf_w: 120,
+            buf_h: 96,
+            top_margin: 20,
+            door: None,
+            home_desks: &[],
+            meeting_rooms: &[],
+            kitchen_island: None,
+            waypoints: &[],
+            plants: &[],
+            floor_lamp: None,
+            lounge_side_table: None,
+            fish_tank: None,
+            wall_decor: &wall_decor,
+            pod_decor: &[],
+            room_walls: &[],
+            pantry_counter_size: Size { w: 20, h: 8 },
+        });
         let def = furniture_def(Furniture::Whiteboard);
         let sprite_h = def.visual.h; // 11
         let base = pos.y + sprite_h - 1; // TopLeft south row

--- a/crates/pixtuoid-scene/src/layout/mask.rs
+++ b/crates/pixtuoid-scene/src/layout/mask.rs
@@ -142,7 +142,6 @@ pub(super) fn wall_segment_rect(seg: &WallSegment, top_margin: u16) -> (Point, S
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 /// The placed-piece inventory the mask stamps — a NAMED input so the five
 /// interchangeable `Option<Point>` pieces (door/kitchen_island/floor_lamp/
 /// lounge_side_table/fish_tank) can't be positionally swapped, and so


### PR DESCRIPTION
The arch-review **Worth exploring** item. `build_walkable_mask` took **16 positional args**, five of them interchangeable `Option<Point>` (`door`/`kitchen_island`/`floor_lamp`/`lounge_side_table`/`fish_tank`) — any two swappable with no compile error, the interface nearly as wide as the enumeration it drives.

Bundle them into a named `MaskObstacles<'a>` borrow-struct built once at the `compute.rs` call site; `build_walkable_mask` destructures it with **no `..`**. The five `Option<Point>` become named fields (no positional swap), the interface shrinks 16 → 1, and a field added to `MaskObstacles` must be handled by the mask (the no-`..` destructure) **and** set by the caller (the struct literal) — compile-time, not just the generative sweep's test-time parity.

> Incremental (not Strong) per the review: the mask runs *during* `SceneLayout` construction, so the input is a borrow-view, and the sweep already backstops mask≡pieces at test-time — this buys compile-time safety + a named interface. Full `pieces()`-unification (a new `SceneLayout` piece forcing a mask stamp) is a further step.

Behavior-preserving: `clippy -D warnings` clean; 103 mask/walkable/layout tests green.

Closes #596.

🤖 Generated with [Claude Code](https://claude.com/claude-code)