### PR TITLE
harden socket/env path resolution: XDG absolute-guard, omp trim, config-lock O_NOFOLLOW (audit cluster A)

### DIFF
--- a/crates/pixtuoid-core/src/source/claude_code/native.rs
+++ b/crates/pixtuoid-core/src/source/claude_code/native.rs
@@ -50,8 +50,12 @@ impl ClaudeCodeSource {
         }
         #[cfg(unix)]
         {
+            // XDG spec: absolute-only. Empty → `/pixtuoid.sock` (fatal bind); relative →
+            // shim/daemon cwd mis-rendezvous → treated as unset. Parity with paths.rs.
             if let Ok(dir) = std::env::var("XDG_RUNTIME_DIR") {
-                return PathBuf::from(format!("{dir}/pixtuoid.sock"));
+                if !dir.trim().is_empty() && std::path::Path::new(&dir).is_absolute() {
+                    return PathBuf::from(format!("{dir}/pixtuoid.sock"));
+                }
             }
             // No XDG_RUNTIME_DIR (macOS, bare Linux): a per-user SUBDIR the bind
             // creates 0700-owned-by-us (`hook::unix::ensure_owned_socket_dir`),

--- a/crates/pixtuoid-core/src/source/claude_code/native.rs
+++ b/crates/pixtuoid-core/src/source/claude_code/native.rs
@@ -164,9 +164,8 @@ mod tests {
             PathBuf::from("/run/user/1000/pixtuoid.sock")
         );
 
-        // Set-but-empty / relative XDG_RUNTIME_DIR is invalid per the XDG spec
-        // (absolute-only) — treated as unset, falls to the /tmp subdir, never
-        // `/pixtuoid.sock` (empty) or a cwd-relative path (parity with paths.rs).
+        // Invalid (empty/whitespace/relative) XDG_RUNTIME_DIR is unset per the
+        // XDG absolute-only spec -> /tmp subdir (parity with paths.rs / the shim).
         let uid = rustix::process::getuid().as_raw();
         let tmp_fallback = PathBuf::from(format!("/tmp/pixtuoid-{uid}/pixtuoid.sock"));
         for invalid in ["", "   ", "relative/run"] {

--- a/crates/pixtuoid-core/src/source/claude_code/native.rs
+++ b/crates/pixtuoid-core/src/source/claude_code/native.rs
@@ -121,9 +121,9 @@ impl Source for ClaudeCodeSource {
 mod tests {
     use super::*;
 
-    // The socket-path and default-paths env precedence. All three socket
-    // branches are checked in ONE test because the env vars are process-global —
-    // splitting across tests would race under the default multi-thread runner.
+    // The socket-path and default-paths env precedence. Every socket branch
+    // (incl. the invalid-XDG fallback) is checked in ONE test because the env
+    // vars are process-global — splitting would race under the multi-thread runner.
     // Unix-specific branches (XDG_RUNTIME_DIR + getuid fallback) can only be
     // asserted on Unix; the platform-neutral default_paths check is split into
     // a separate test so it compiles + runs on all platforms.
@@ -164,10 +164,19 @@ mod tests {
             PathBuf::from("/run/user/1000/pixtuoid.sock")
         );
 
+        // Set-but-empty / relative XDG_RUNTIME_DIR is invalid per the XDG spec
+        // (absolute-only) — treated as unset, falls to the /tmp subdir, never
+        // `/pixtuoid.sock` (empty) or a cwd-relative path (parity with paths.rs).
+        let uid = rustix::process::getuid().as_raw();
+        let tmp_fallback = PathBuf::from(format!("/tmp/pixtuoid-{uid}/pixtuoid.sock"));
+        for invalid in ["", "   ", "relative/run"] {
+            std::env::set_var("XDG_RUNTIME_DIR", invalid);
+            assert_eq!(ClaudeCodeSource::default_socket_path(), tmp_fallback);
+        }
+
         // With neither set, fall back to the uid-scoped /tmp SUBDIR socket
         // (#485: the bind creates `/tmp/pixtuoid-{uid}/` 0700-owned-by-us).
         std::env::remove_var("XDG_RUNTIME_DIR");
-        let uid = rustix::process::getuid().as_raw();
         assert_eq!(
             ClaudeCodeSource::default_socket_path(),
             PathBuf::from(format!("/tmp/pixtuoid-{uid}/pixtuoid.sock"))

--- a/crates/pixtuoid-core/src/source/fd_probe.rs
+++ b/crates/pixtuoid-core/src/source/fd_probe.rs
@@ -322,9 +322,18 @@ mod tests {
             .spawn()
             .unwrap();
         let pid = child.id() as i32;
-        let found = pids_by_name("sleep")
-            .expect("a healthy system's proc-table enumeration must succeed")
-            .contains(&pid);
+        // A just-spawned child isn't always named in the proc-table at the first
+        // probe (/proc/<pid>/comm materializes a beat after spawn) — poll ≤500ms.
+        let found = (0..50).any(|_| {
+            if pids_by_name("sleep")
+                .expect("a healthy system's proc-table enumeration must succeed")
+                .contains(&pid)
+            {
+                return true;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+            false
+        });
         let _ = child.kill();
         let _ = child.wait();
         assert!(found, "expected spawned sleep (pid {pid}) in pids_by_name");

--- a/crates/pixtuoid-core/src/source/omp.rs
+++ b/crates/pixtuoid-core/src/source/omp.rs
@@ -79,7 +79,7 @@ pub const SOURCE_NAME: &str = "omp";
 /// relocates to `~/.omp/profiles/<name>/agent` — both deliberately unmirrored
 /// (opt-in minority setups; the watcher just sees an empty default dir).
 pub fn omp_agent_dir() -> PathBuf {
-    match std::env::var_os("PI_CODING_AGENT_DIR").filter(|v| !v.is_empty()) {
+    match crate::platform::nonempty(std::env::var("PI_CODING_AGENT_DIR").ok()) {
         Some(v) => PathBuf::from(v),
         None => PathBuf::from(crate::platform::user_home())
             .join(".omp")
@@ -864,13 +864,16 @@ mod tests {
         std::env::set_var("PI_CODING_AGENT_DIR", "/custom/agent");
         assert_eq!(omp_agent_dir(), PathBuf::from("/custom/agent"));
 
-        // Set-but-empty is treated as unset.
-        std::env::set_var("PI_CODING_AGENT_DIR", "");
-        let dflt = omp_agent_dir();
-        assert!(
-            dflt.ends_with(Path::new(".omp/agent")),
-            "empty override → ~/.omp/agent fallback, got {dflt:?}"
-        );
+        // Set-but-empty OR whitespace-only is treated as unset (trim-based, the
+        // #172 policy — a `"  "` value must not resolve the dir to a relative "  ").
+        for blank in ["", "   "] {
+            std::env::set_var("PI_CODING_AGENT_DIR", blank);
+            let dflt = omp_agent_dir();
+            assert!(
+                dflt.ends_with(Path::new(".omp/agent")),
+                "blank override {blank:?} → ~/.omp/agent fallback, got {dflt:?}"
+            );
+        }
 
         std::env::remove_var("PI_CODING_AGENT_DIR");
         assert!(omp_agent_dir().ends_with(Path::new(".omp/agent")));

--- a/crates/pixtuoid-core/tests/socket_path_parity.rs
+++ b/crates/pixtuoid-core/tests/socket_path_parity.rs
@@ -59,13 +59,26 @@ fn shim_and_daemon_resolve_identical_socket_paths_in_all_three_branches() {
     assert_eq!(shim, daemon, "XDG_RUNTIME_DIR branch diverged");
     assert_eq!(shim, PathBuf::from("/run/user/7/pixtuoid.sock"));
 
+    // Branch 2b: set-but-empty / relative XDG_RUNTIME_DIR is invalid (XDG absolute-
+    // only) → BOTH ignore it, never `/pixtuoid.sock` (empty) or a cwd-relative path.
+    // Safety: getuid is always safe on Unix.
+    let uid = unsafe { libc::getuid() };
+    let tmp_fallback = PathBuf::from(format!("/tmp/pixtuoid-{uid}/pixtuoid.sock"));
+    for invalid in ["", "   ", "relative/run"] {
+        std::env::set_var("XDG_RUNTIME_DIR", invalid);
+        let (shim, daemon) = both();
+        assert_eq!(shim, daemon, "invalid XDG_RUNTIME_DIR {invalid:?} diverged");
+        assert_eq!(
+            shim, tmp_fallback,
+            "invalid XDG_RUNTIME_DIR {invalid:?} must fall to the /tmp subdir"
+        );
+    }
+
     // Branch 3: uid-scoped /tmp SUBDIR fallback on both sides (#485 — the
     // per-user 0700 dir, not a flat squattable `pixtuoid-{uid}.sock`).
     std::env::remove_var("XDG_RUNTIME_DIR");
     let (shim, daemon) = both();
     assert_eq!(shim, daemon, "/tmp-uid fallback branch diverged");
-    // Safety: getuid is always safe on Unix.
-    let uid = unsafe { libc::getuid() };
     assert_eq!(
         shim,
         PathBuf::from(format!("/tmp/pixtuoid-{uid}/pixtuoid.sock"))

--- a/crates/pixtuoid-hook/src/main.rs
+++ b/crates/pixtuoid-hook/src/main.rs
@@ -664,9 +664,8 @@ mod tests {
         std::env::set_var("XDG_RUNTIME_DIR", "/run/user/1000");
         assert_eq!(default_socket_path(), "/run/user/1000/pixtuoid.sock");
 
-        // Arm 2b: set-but-empty / relative XDG_RUNTIME_DIR is invalid (XDG
-        // absolute-only) -> treated as unset -> the /tmp subdir, never
-        // "/pixtuoid.sock" or a cwd-relative path (parity with native.rs).
+        // Arm 2b: invalid (empty/whitespace/relative) XDG_RUNTIME_DIR is unset
+        // per the XDG absolute-only spec -> /tmp subdir (parity with native.rs).
         // Safety: getuid is always safe on Unix.
         let uid = unsafe { libc::getuid() };
         let tmp_fallback = format!("/tmp/pixtuoid-{uid}/pixtuoid.sock");

--- a/crates/pixtuoid-hook/src/main.rs
+++ b/crates/pixtuoid-hook/src/main.rs
@@ -664,12 +664,21 @@ mod tests {
         std::env::set_var("XDG_RUNTIME_DIR", "/run/user/1000");
         assert_eq!(default_socket_path(), "/run/user/1000/pixtuoid.sock");
 
+        // Arm 2b: set-but-empty / relative XDG_RUNTIME_DIR is invalid (XDG
+        // absolute-only) -> treated as unset -> the /tmp subdir, never
+        // "/pixtuoid.sock" or a cwd-relative path (parity with native.rs).
+        // Safety: getuid is always safe on Unix.
+        let uid = unsafe { libc::getuid() };
+        let tmp_fallback = format!("/tmp/pixtuoid-{uid}/pixtuoid.sock");
+        for invalid in ["", "   ", "relative/run"] {
+            std::env::set_var("XDG_RUNTIME_DIR", invalid);
+            assert_eq!(default_socket_path(), tmp_fallback);
+        }
+
         // Arm 3: neither set -> "/tmp/pixtuoid-{uid}/pixtuoid.sock" (#485: the
         // per-user 0700 SUBDIR, not a flat squattable name).
         std::env::remove_var("PIXTUOID_SOCKET");
         std::env::remove_var("XDG_RUNTIME_DIR");
-        // Safety: getuid is always safe on Unix.
-        let uid = unsafe { libc::getuid() };
         assert_eq!(
             default_socket_path(),
             format!("/tmp/pixtuoid-{uid}/pixtuoid.sock")

--- a/crates/pixtuoid-hook/src/paths.rs
+++ b/crates/pixtuoid-hook/src/paths.rs
@@ -18,8 +18,12 @@ pub(crate) fn default_socket_path() -> String {
     }
     #[cfg(unix)]
     {
+        // XDG spec: absolute-only. Empty → `/pixtuoid.sock` (fatal bind); relative →
+        // shim/daemon cwd mis-rendezvous. Non-absolute is invalid → treated as unset.
         if let Ok(dir) = std::env::var("XDG_RUNTIME_DIR") {
-            return format!("{dir}/pixtuoid.sock");
+            if !dir.trim().is_empty() && std::path::Path::new(&dir).is_absolute() {
+                return format!("{dir}/pixtuoid.sock");
+            }
         }
         // No XDG_RUNTIME_DIR (macOS, bare Linux): the socket lives in a per-user
         // subdir the daemon creates 0700-owned-by-us, NOT a flat, world-writable-

--- a/crates/pixtuoid/src/install/io.rs
+++ b/crates/pixtuoid/src/install/io.rs
@@ -211,12 +211,16 @@ pub(crate) fn lock_config(path: &Path) -> Result<ConfigLock> {
         std::fs::create_dir_all(parent)?;
     }
     let lock_path = sibling(&target, "lock");
-    let file = OpenOptions::new()
-        .create(true)
-        .read(true)
-        .write(true)
-        .truncate(false)
-        .open(&lock_path)?;
+    let mut opts = OpenOptions::new();
+    opts.create(true).read(true).write(true).truncate(false);
+    // Parity with the hook socket-lock (hook/unix.rs): a symlink pre-planted at
+    // `<target>.lock` must fail the open, not make us flock an arbitrary file.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.custom_flags(libc::O_NOFOLLOW);
+    }
+    let file = opts.open(&lock_path)?;
     file.try_lock()
         .map_err(|e| anyhow!("could not lock {}: {e}", lock_path.display()))?;
     Ok(ConfigLock { target, file })
@@ -439,6 +443,24 @@ mod tests {
         rename_with_retry(&from, &to).unwrap();
         assert!(!from.exists());
         assert_eq!(std::fs::read_to_string(&to).unwrap(), "hello");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn lock_config_refuses_a_symlinked_lock_file() {
+        // An attacker who can write the config DIR pre-plants `<target>.lock` as a
+        // symlink to a decoy; O_NOFOLLOW must refuse it, not flock the decoy.
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("settings.json");
+        std::fs::write(&target, "{}").unwrap();
+        let lock_path = sibling(&target, "lock");
+        let decoy = dir.path().join("decoy");
+        std::fs::write(&decoy, "x").unwrap();
+        std::os::unix::fs::symlink(&decoy, &lock_path).unwrap();
+        assert!(
+            lock_config(&target).is_err(),
+            "a symlinked <target>.lock must be refused, not followed"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Whole-codebase audit **cluster A** — three N-1-of-N env/path sibling gaps (a guard present on the hardened siblings, missing on one member).

### FIND-18 · MEDIUM · live-repro
Both socket-path resolvers (shim `paths.rs` + daemon `claude_code/native.rs`) guard `PIXTUOID_SOCKET` with `!trim().is_empty()` but read `XDG_RUNTIME_DIR` **bare**. `XDG_RUNTIME_DIR=""` → `/pixtuoid.sock` → bind fails fatally:

```
ERROR source died: opening hook socket lock at /pixtuoid.sock.lock: Read-only file system
```

→ hook plane dead the whole run instead of falling to the safe `/tmp/pixtuoid-{uid}/` subdir. Per the XDG spec the value MUST be **absolute**, so the fix filters for non-empty **and absolute** — which also closes the worse *relative*-path case (`foo` → each process resolves against its OWN cwd → shim and daemon silently rendezvous at different paths, no error at all). Applied identically at both resolvers (parity-pinned); the parity test gains an empty/whitespace/relative branch asserting both fall to `/tmp`.

### FIND-01 · LOW
`omp_agent_dir` read `PI_CODING_AGENT_DIR` via `var_os` + byte-empty filter (a `"  "` value resolved the dir to a relative `"  "`) — the lone sibling not using the trim-based `platform::nonempty` its four peers use (the exact pattern `copilot.rs` documents as a *fixed* bug). Routed through `nonempty`; test gains the whitespace case.

### FIND-29 · LOW
`lock_config` opened `<target>.lock` without `O_NOFOLLOW` while its twin hook socket-lock (`hook/unix.rs`) has it. Added for parity (lock content is never read → behavior-identical except symlink refusal). New symlink-refusal test.

Gates: `clippy -D warnings` clean; parity/omp/lock tests green. Part of the 2026-07-14 whole-codebase audit (deferred design items → #603/#604).