### PR TITLE
single-source the character footprint + corridor gates; delete 3 dead Theme roles (audit cluster C)

### DIFF
--- a/crates/pixtuoid-scene/src/layout/compute.rs
+++ b/crates/pixtuoid-scene/src/layout/compute.rs
@@ -1425,8 +1425,13 @@ pub(super) fn compute_waypoints(
 
     // Corridor appliances — stored as centre points (same convention
     // as Pantry/Couch). Painter derives top-left via sub(w/2, h/2).
-    // Sizes: vending 4×6, printer 5×4.
-    if cubicle_aisle.height >= 10 && cubicle_aisle.width > 30 {
+    // Sizes: vending 4×6, printer 5×4. Both gates read `cubicle_aisle.{h,w}`
+    // (== right_{h,w}) so the two siblings can't drift to different identifiers.
+    const VENDING_MIN_AISLE_H: u16 = 10;
+    const VENDING_MIN_AISLE_W: u16 = 30;
+    const PRINTER_MIN_AISLE_H: u16 = 9;
+    const PRINTER_MIN_AISLE_W: u16 = 40;
+    if cubicle_aisle.height >= VENDING_MIN_AISLE_H && cubicle_aisle.width > VENDING_MIN_AISLE_W {
         waypoints.push(Waypoint {
             pos: Point {
                 x: right_x + 5,
@@ -1437,7 +1442,7 @@ pub(super) fn compute_waypoints(
             room_id: None,
         });
     }
-    if cubicle_aisle.height >= 9 && right_w > 40 {
+    if cubicle_aisle.height >= PRINTER_MIN_AISLE_H && cubicle_aisle.width > PRINTER_MIN_AISLE_W {
         waypoints.push(Waypoint {
             pos: Point {
                 x: right_x + right_w.saturating_sub(10),

--- a/crates/pixtuoid-scene/src/pixel_painter/sim.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/sim.rs
@@ -175,9 +175,14 @@ pub(crate) fn sim_step(
                     w.facing,
                     &layout.reachable,
                 );
-                stores
-                    .overlay
-                    .add(stand.x.saturating_sub(4), stand.y.saturating_sub(6), 8, 12);
+                // Reserve the character footprint from the SAME authorities the
+                // sprite anchor uses, not a re-hardcoded 8×12 (drifts on a wider pack).
+                stores.overlay.add(
+                    stand.x.saturating_sub(CHARACTER_SPRITE_W / 2),
+                    stand.y.saturating_sub(WALKING_Y_OFF / 2),
+                    CHARACTER_SPRITE_W,
+                    WALKING_Y_OFF,
+                );
             }
         }
     }

--- a/crates/pixtuoid-scene/src/pixel_painter/sim.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/sim.rs
@@ -152,6 +152,12 @@ pub(crate) fn sim_step(
     // positions across frames, so the signature is stable and the cache hits.
     // Reads only the STATELESS `pose::derive` + stand_point (no dependency on
     // the seated map / ambient), so it's safe up here.
+    // The pack's character sprite width (8 bundled, 10 robot), resolved ONCE and
+    // shared by every anchor AND the occupancy reservation; pack-constant → cache-stable.
+    let char_w = pack
+        .animation("standing")
+        .and_then(|a| a.frames.first())
+        .map_or(CHARACTER_SPRITE_W, |f| f.width());
     stores.overlay.clear();
     for agent in &agents {
         let Some(pose) = pose::derive(agent, now, layout) else {
@@ -175,12 +181,12 @@ pub(crate) fn sim_step(
                     w.facing,
                     &layout.reachable,
                 );
-                // Reserve the character footprint from the SAME authorities the
-                // sprite anchor uses, not a re-hardcoded 8×12 (drifts on a wider pack).
+                // Reserve the pack-resolved footprint (char_w wide, WALKING_Y_OFF
+                // tall) — the SAME width the sprite anchor centers on, not a bare 8.
                 stores.overlay.add(
-                    stand.x.saturating_sub(CHARACTER_SPRITE_W / 2),
+                    stand.x.saturating_sub(char_w / 2),
                     stand.y.saturating_sub(WALKING_Y_OFF / 2),
-                    CHARACTER_SPRITE_W,
+                    char_w,
                     WALKING_Y_OFF,
                 );
             }
@@ -241,7 +247,7 @@ pub(crate) fn sim_step(
         .collect();
 
     let (characters, waypoint_visitors, new_coffee_carriers, occupied_waypoints) =
-        resolve_characters(&agents, &poses, layout, pack, coffee, now);
+        resolve_characters(&agents, &poses, layout, pack, char_w, coffee, now);
 
     let chitchat_bubbles =
         chitchat::update_and_collect(stores.chitchat, floor_idx, &waypoint_visitors, now);
@@ -269,6 +275,7 @@ fn resolve_characters(
     poses: &HashMap<AgentId, Option<Pose>>,
     layout: &Layout,
     pack: &Pack,
+    char_w: u16,
     coffee: &HashMap<AgentId, SystemTime>,
     now: SystemTime,
 ) -> (
@@ -286,15 +293,6 @@ fn resolve_characters(
     // like the meeting room, without overloading the meeting-only `room_id`
     // field (which indexes `meeting_rooms`). Pinned by
     // multi_slot_venues_collapse_to_first_of_their_own_kind.
-    // The pack's character sprite width (8 for the bundled pack, 10 for the
-    // robot pack). All character poses share one width, so resolve it ONCE from
-    // a reference pose and center every anchor on it — a non-8-wide pack would
-    // otherwise blit ~1px off (the anchors hardcoded 8). Fallback to the bundled
-    // default if the pack lacks the reference anim.
-    let char_w = pack
-        .animation("standing")
-        .and_then(|a| a.frames.first())
-        .map_or(CHARACTER_SPRITE_W, |f| f.width());
     for (agent_idx, agent) in agents.iter().enumerate() {
         let Some(desk) = layout.home_desk(agent.desk_index.single_floor_local()) else {
             continue;

--- a/crates/pixtuoid-scene/src/theme/catppuccin.rs
+++ b/crates/pixtuoid-scene/src/theme/catppuccin.rs
@@ -24,11 +24,6 @@ pub static CATPPUCCIN: Theme = Theme {
             g: 71,
             b: 90,
         },
-        baseboard: Rgb {
-            r: 24,
-            g: 24,
-            b: 37,
-        },
         carpet_base: Rgb {
             r: 49,
             g: 50,
@@ -56,11 +51,6 @@ pub static CATPPUCCIN: Theme = Theme {
         },
     },
     office: OfficeColors {
-        room_wall_body: Rgb {
-            r: 49,
-            g: 50,
-            b: 68,
-        },
         room_wall_trim_light: Rgb {
             r: 69,
             g: 71,
@@ -252,11 +242,6 @@ pub static CATPPUCCIN: Theme = Theme {
             r: 68,
             g: 90,
             b: 125,
-        },
-        chair_seat: Rgb {
-            r: 54,
-            g: 55,
-            b: 72,
         },
         chair_trim: Rgb {
             r: 39,

--- a/crates/pixtuoid-scene/src/theme/cyberpunk.rs
+++ b/crates/pixtuoid-scene/src/theme/cyberpunk.rs
@@ -16,11 +16,6 @@ pub static CYBERPUNK: Theme = Theme {
             g: 40,
             b: 70,
         },
-        baseboard: Rgb {
-            r: 15,
-            g: 12,
-            b: 25,
-        },
         carpet_base: Rgb {
             r: 45,
             g: 42,
@@ -48,11 +43,6 @@ pub static CYBERPUNK: Theme = Theme {
         },
     },
     office: OfficeColors {
-        room_wall_body: Rgb {
-            r: 35,
-            g: 28,
-            b: 55,
-        },
         room_wall_trim_light: Rgb {
             r: 70,
             g: 55,
@@ -228,11 +218,6 @@ pub static CYBERPUNK: Theme = Theme {
             r: 30,
             g: 90,
             b: 130,
-        },
-        chair_seat: Rgb {
-            r: 45,
-            g: 40,
-            b: 58,
         },
         chair_trim: Rgb {
             r: 28,

--- a/crates/pixtuoid-scene/src/theme/dracula.rs
+++ b/crates/pixtuoid-scene/src/theme/dracula.rs
@@ -16,11 +16,6 @@ pub static DRACULA: Theme = Theme {
             g: 71,
             b: 90,
         },
-        baseboard: Rgb {
-            r: 30,
-            g: 31,
-            b: 40,
-        },
         carpet_base: Rgb {
             r: 52,
             g: 45,
@@ -48,11 +43,6 @@ pub static DRACULA: Theme = Theme {
         },
     },
     office: OfficeColors {
-        room_wall_body: Rgb {
-            r: 50,
-            g: 52,
-            b: 68,
-        },
         room_wall_trim_light: Rgb {
             r: 68,
             g: 71,
@@ -244,11 +234,6 @@ pub static DRACULA: Theme = Theme {
             r: 70,
             g: 116,
             b: 126,
-        },
-        chair_seat: Rgb {
-            r: 55,
-            g: 56,
-            b: 72,
         },
         chair_trim: Rgb {
             r: 38,

--- a/crates/pixtuoid-scene/src/theme/gruvbox.rs
+++ b/crates/pixtuoid-scene/src/theme/gruvbox.rs
@@ -22,11 +22,6 @@ pub static GRUVBOX: Theme = Theme {
             g: 73,
             b: 69,
         },
-        baseboard: Rgb {
-            r: 29,
-            g: 32,
-            b: 33,
-        },
         carpet_base: Rgb {
             r: 60,
             g: 56,
@@ -54,11 +49,6 @@ pub static GRUVBOX: Theme = Theme {
         },
     },
     office: OfficeColors {
-        room_wall_body: Rgb {
-            r: 60,
-            g: 56,
-            b: 54,
-        },
         room_wall_trim_light: Rgb {
             r: 102,
             g: 92,
@@ -251,11 +241,6 @@ pub static GRUVBOX: Theme = Theme {
             r: 66,
             g: 82,
             b: 76,
-        },
-        chair_seat: Rgb {
-            r: 65,
-            g: 60,
-            b: 56,
         },
         chair_trim: Rgb {
             r: 45,

--- a/crates/pixtuoid-scene/src/theme/mod.rs
+++ b/crates/pixtuoid-scene/src/theme/mod.rs
@@ -42,7 +42,6 @@ pub struct Theme {
 pub struct SurfaceColors {
     pub wall: Rgb,
     pub wall_trim: Rgb,
-    pub baseboard: Rgb,
     pub carpet_base: Rgb,
     pub carpet_light: Rgb,
     pub carpet_dark: Rgb,
@@ -52,7 +51,6 @@ pub struct SurfaceColors {
 
 #[derive(Debug, Clone)]
 pub struct OfficeColors {
-    pub room_wall_body: Rgb,
     pub room_wall_trim_light: Rgb,
     pub room_wall_trim_dark: Rgb,
     pub cubicle_divider: Rgb,
@@ -101,7 +99,6 @@ pub struct FurnitureColors {
     pub rug_accent: Rgb,
     pub magazine: Rgb,
     pub magazine_trim: Rgb,
-    pub chair_seat: Rgb,
     pub chair_trim: Rgb,
     pub coffee_cup: Rgb,
     pub coffee_cup_shadow: Rgb,

--- a/crates/pixtuoid-scene/src/theme/normal.rs
+++ b/crates/pixtuoid-scene/src/theme/normal.rs
@@ -16,11 +16,6 @@ pub static NORMAL: Theme = Theme {
             g: 80,
             b: 100,
         },
-        baseboard: Rgb {
-            r: 40,
-            g: 40,
-            b: 52,
-        },
         carpet_base: Rgb {
             r: 150,
             g: 110,
@@ -48,11 +43,6 @@ pub static NORMAL: Theme = Theme {
         },
     },
     office: OfficeColors {
-        room_wall_body: Rgb {
-            r: 72,
-            g: 74,
-            b: 90,
-        },
         room_wall_trim_light: Rgb {
             r: 110,
             g: 112,
@@ -245,11 +235,6 @@ pub static NORMAL: Theme = Theme {
             r: 50,
             g: 60,
             b: 92,
-        },
-        chair_seat: Rgb {
-            r: 96,
-            g: 68,
-            b: 44,
         },
         chair_trim: Rgb {
             r: 60,

--- a/crates/pixtuoid-scene/src/theme/tokyo_night.rs
+++ b/crates/pixtuoid-scene/src/theme/tokyo_night.rs
@@ -16,11 +16,6 @@ pub static TOKYO_NIGHT: Theme = Theme {
             g: 72,
             b: 104,
         },
-        baseboard: Rgb {
-            r: 18,
-            g: 18,
-            b: 28,
-        },
         carpet_base: Rgb {
             r: 36,
             g: 40,
@@ -48,11 +43,6 @@ pub static TOKYO_NIGHT: Theme = Theme {
         },
     },
     office: OfficeColors {
-        room_wall_body: Rgb {
-            r: 36,
-            g: 40,
-            b: 59,
-        },
         room_wall_trim_light: Rgb {
             r: 65,
             g: 72,
@@ -244,11 +234,6 @@ pub static TOKYO_NIGHT: Theme = Theme {
             r: 60,
             g: 80,
             b: 124,
-        },
-        chair_seat: Rgb {
-            r: 42,
-            g: 46,
-            b: 64,
         },
         chair_trim: Rgb {
             r: 28,


### PR DESCRIPTION
Whole-codebase audit **cluster C** — magic-number/single-source + dead-code (all LOW, behavior-preserving for the bundled pack).

### FIND-04 · single-source + wide-pack correctness
`pixel_painter/sim.rs` re-hardcoded the 8×12 character footprint in the A* occupancy reservation. **First pass** derived it from `CHARACTER_SPRITE_W`/`WALKING_Y_OFF` — but that's identical to the old hardcode, so it single-sourced without fixing the wide-pack case (the online bot's HIGH). **Now** `char_w` (the pack-resolved width `resolve_characters` already computes for the sprite anchor) is resolved ONCE in `sim_step` and threaded into `resolve_characters`, so the occupancy box and every anchor share the one width. `char_w` is pack-constant → the occupancy overlay's cache-signature stays stable. Bundled pack (`char_w == 8`) is byte-identical; a 10-wide `--pack-dir` robot now reserves its real footprint.

### FIND-12 · single-source + misleading-identifier
The two corridor-appliance spawn gates tested the **same** quantity through two identifiers (`cubicle_aisle.width` vs `right_w`) and carried anonymous fit thresholds (10/30/9/40). Both gates now read `cubicle_aisle.{height,width}`; thresholds are named consts.

### FIND-15 · dead-code
Three `Theme` color roles — `SurfaceColors.baseboard`, `OfficeColors.room_wall_body`, `FurnitureColors.chair_seat` — are read by **nothing** (git pickaxe: `room_wall_body`'s last reader went with the #72 frosted-glass conversion, `chair_seat`'s with #556; `baseboard` never had one). Deleted the fields + all 18 per-theme literals.

**semver:** removing 3 pub `Theme` fields is breaking on the `pixtuoid-scene` surface — covered by the already-open **0.15.0** minor over published 0.14.0.

Gates: workspace `clippy -D warnings` clean; **558** scene tests green (insta goldens byte-identical). Part of the 2026-07-14 whole-codebase audit.