### PR TITLE
fix doc/comment drift: 8 stale docs (CAST count, DOOR_GAP, truncation semantics, README, raycast peer, EFFORT_TTL, ...) (audit cluster D)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ config), see **[SECURITY.md](SECURITY.md)**.
 
 ## Contributing
 
-PRs welcome — especially new themes, sprite/decoration polish, and `Source` adapters for agent CLIs we don't support yet (the ten already wired up are in [Supported Tools](#supported-tools)). See **[CONTRIBUTING.md](docs/CONTRIBUTING.md)** for the build/test workflow, conventions, the review process, and how to add a new agent CLI. Architecture and the load-bearing invariants live in [`CLAUDE.md`](CLAUDE.md).
+PRs welcome — especially new themes, sprite/decoration polish, and `Source` adapters for agent CLIs we don't support yet (the ten agent CLIs plus the OpenClaw gateway already wired up are in [Supported Tools](#supported-tools)). See **[CONTRIBUTING.md](docs/CONTRIBUTING.md)** for the build/test workflow, conventions, the review process, and how to add a new agent CLI. Architecture and the load-bearing invariants live in [`CLAUDE.md`](CLAUDE.md).
 
 ## Acknowledgments
 

--- a/crates/pixtuoid-core/CLAUDE.md
+++ b/crates/pixtuoid-core/CLAUDE.md
@@ -131,12 +131,12 @@ the provider-prefixed `model_change` entry are deliberately NOT decoded: the
 bare field matches TOP_MODELS' prefix vocabulary and every turn re-stamps it).
 The reducer caches `slot.model` (last-seen-wins — a mid-session `/model`
 switch tracks) + `slot.effort: EffortObservation{value, seen_at}` (re-stamped
-per sighting; the scene's EFFORT_TTL turns Codex's per-turn field and CC's
+per sighting; the scene's EFFORT_TTL_SECS turns Codex's per-turn field and CC's
 periodic marker into ONE freshness semantic). Unknown id = no-op (a model
 line never registers a session); legitimate on BOTH transports (wire data,
 not liveness). Bounded residual: recent/live-probed files replay from the
 TOP on first sight, so a historical effort marker reads fresh for up to
-EFFORT_TTL (10 min) after attach before decaying — cosmetic, accepted.
+EFFORT_TTL_SECS (10 min) after attach before decaying — cosmetic, accepted.
 Both fields serde-skipped.
 
 **Focus-jump plumbing (#focus-jump):** the shim fills `_pid` (getppid) into the

--- a/crates/pixtuoid-core/src/source/decoder.rs
+++ b/crates/pixtuoid-core/src/source/decoder.rs
@@ -478,7 +478,8 @@ pub(crate) const MAX_DECODED_FIELD_CHARS: usize = 80;
 /// — where the content ENTERS (CONTRIBUTING pitfall 3), on char boundaries,
 /// never bytes (pitfall 1). Shared by the tool-target cap above and the
 /// Waiting-reason / Rename-label caps (CC + Reasonix) so the sites can't
-/// drift apart.
+/// drift apart. Budget: the `…` is EXCLUDED, so a clipped result is
+/// `max_chars + 1` chars — unlike `widgets::truncate`, which counts it (N).
 pub(crate) fn ellipsize(s: &str, max_chars: usize) -> String {
     let mut out: String = s.chars().take(max_chars).collect();
     if s.chars().count() > max_chars {

--- a/crates/pixtuoid-core/src/state/reducer.rs
+++ b/crates/pixtuoid-core/src/state/reducer.rs
@@ -693,7 +693,7 @@ impl Reducer {
                 // first-sight replay can stamp a HISTORICAL effort marker
                 // with apply-time `now` — a session that used max effort
                 // earlier (but no longer) flames for up to the scene's
-                // EFFORT_TTL (10 min) after attach, then self-heals. Purely
+                // EFFORT_TTL_SECS (10 min) after attach, then self-heals. Purely
                 // cosmetic; model is immune (last-seen-wins, no freshness).
                 // `model` writes only on change (Arc churn); `effort`
                 // re-stamps `now` per sighting — the freshness the scene

--- a/crates/pixtuoid-scene/CLAUDE.md
+++ b/crates/pixtuoid-scene/CLAUDE.md
@@ -112,7 +112,7 @@ src/                (the pixtuoid-scene crate root; default pack at ../sprites/d
 ├── burn.rs         burn tier (model gate × effort split, USER-PINNED): TOP_MODELS prefix table
 │                   (claude-fable/claude-mythos/gpt-5.6-sol — source-verified slugs) × MAX_EFFORTS
 │                   ({ultra,ultrathink,xhigh,max}) → BurnTier{Normal,Premium,Top}; fresh_effort =
-│                   the ONE EFFORT_TTL freshness rule (tier + dossier share it), and it ALSO drops
+│                   the ONE EFFORT_TTL_SECS freshness rule (tier + dossier share it), and it ALSO drops
 │                   CC's decoder-synthesized ultra_exit exit-sentinel so the internal token never
 │                   reaches the dossier — the one source-specific special-case in this otherwise
 │                   source-agnostic table (string = core-owned claude_code::ULTRA_EXIT_LABEL,

--- a/crates/pixtuoid-scene/src/layout/rooms/walls.rs
+++ b/crates/pixtuoid-scene/src/layout/rooms/walls.rs
@@ -31,9 +31,10 @@ pub struct Doorway {
 /// Doorway width in ABSOLUTE pixels — a percentage shrinks to zero on small
 /// terminals, which after the 2-px wall padding leaves no walkable cell for
 /// A* and disconnects the room (the documented lesson behind the old
-/// `DOOR_GAP_V`/`DOOR_GAP_H` pair; one value, one name). 14 gives ≥10 px
-/// effective gap after padding — wide enough that the coarse 4×4 router
-/// grid keeps at least one walkable row through the doorway.
+/// `DOOR_GAP_V`/`DOOR_GAP_H` pair; one value, one name). 14 opens a 13-px gap
+/// (the segment cuts are endpoint-inclusive, so the opening is `ge-gs-1`), and
+/// after the 2-px vertical-wall padding each side that's a 9-px effective gap —
+/// still wide enough that the coarse 4×4 router keeps ≥1 walkable row through it.
 const DOOR_GAP: u16 = 14;
 
 /// Where along its wall run a door sits.

--- a/crates/pixtuoid-scene/src/overlay.rs
+++ b/crates/pixtuoid-scene/src/overlay.rs
@@ -111,7 +111,9 @@ pub fn build_overlay(
 /// disambiguation suffix that the reducer appends to colliding cwds.
 /// Truncates from the base (left side of the `·`), not from the suffix —
 /// otherwise the disambig becomes useless ("TikTok-Android·a" tells us
-/// nothing the base alone wouldn't).
+/// nothing the base alone wouldn't). Budget: fits to EXACTLY `budget` chars,
+/// and the no-`·` fallback plain-truncates with NO ellipsis — distinct from
+/// `decoder::ellipsize` (N+1) and `widgets::truncate` (N, ellipsis-included).
 pub(crate) fn truncate_label(label: &str, budget: usize) -> std::borrow::Cow<'_, str> {
     use std::borrow::Cow;
     if label.chars().count() <= budget {

--- a/crates/pixtuoid-scene/src/pixel_painter/background/mod.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/background/mod.rs
@@ -40,9 +40,9 @@ use super::epoch_ms;
 use super::palette::{blend, blend_rgb, mix_lab};
 
 /// Fractional local hour (`hour + minute/60`, in `0.0..24.0`) for `now`, decoded
-/// via chrono. Shared by the day-ramp / sunset / window-look timers. NB:
-/// `sun_on_wall` keeps its own fallible `.ok()?` decode because it returns an
-/// `Option`; this infallible form (`unwrap_or_default`) suits the rest.
+/// via chrono. THE clock-decode funnel: the day-ramp / sunset / window-look
+/// timers and `sun_on_wall` (via `emitter`) all route through here, so there is
+/// no second decode path.
 fn local_hour_frac(now: std::time::SystemTime) -> f32 {
     use chrono::Timelike;
     let unix_now = now

--- a/crates/pixtuoid-scene/src/pixel_painter/background/mod.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/background/mod.rs
@@ -40,9 +40,10 @@ use super::epoch_ms;
 use super::palette::{blend, blend_rgb, mix_lab};
 
 /// Fractional local hour (`hour + minute/60`, in `0.0..24.0`) for `now`, decoded
-/// via chrono. THE clock-decode funnel: the day-ramp / sunset / window-look
-/// timers and `sun_on_wall` (via `emitter`) all route through here, so there is
-/// no second decode path.
+/// via chrono. The ambient/sky clock-decode funnel: the day-ramp / sunset /
+/// window-look timers and `sun_on_wall` (via `emitter`) all route through here.
+/// (`paint_clock`'s analog hands keep their own decode — they need raw
+/// `hour % 12` / `minute`, not this fractional value.)
 fn local_hour_frac(now: std::time::SystemTime) -> f32 {
     use chrono::Timelike;
     let unix_now = now

--- a/crates/pixtuoid-web/src/script.rs
+++ b/crates/pixtuoid-web/src/script.rs
@@ -41,10 +41,10 @@ pub(crate) const LOOP_MS: u64 = 120_000;
 /// `SOURCE_NAME` consts — a hand-typed string here silently misses the
 /// registry and the label falls back to the RAW string (`claude_code·api`
 /// instead of `cc·api` — a review-caught, test-invisible defect class).
-/// Every slot carries a DISTINCT CLI (8 of the registry's 9 non-daemon
-/// sources — Reasonix is the one omitted; OpenClaw is the 10th, rendered
+/// Every slot carries a DISTINCT CLI (8 of the registry's 10 non-daemon
+/// sources — Reasonix and omp are omitted; OpenClaw is the 11th, rendered
 /// separately as the lobster mascot via `lobster_beats`, never a cast
-/// member): the hero's ten CLI-name chips and the badged sprites below are
+/// member): the hero's CLI-name chips and the badged sprites below are
 /// meant to ECHO each other ("we support these agents"), so the cast should
 /// span the roster instead of repeating one CLI across most of the slots.
 const CAST: &[(&str, &str, &str)] = &[

--- a/crates/pixtuoid/src/tui/widgets/elevator.rs
+++ b/crates/pixtuoid/src/tui/widgets/elevator.rs
@@ -16,11 +16,9 @@ pub(crate) fn paint_elevator_indicator(
     use ratatui::text::Line;
 
     let label = format!(" \u{25b2} F{current_floor} \u{25bc} ");
-    // Measure in display COLUMNS, not bytes: the ▲/▼ arrows are 3-byte
-    // single-column glyphs, so byte length over-counts by 4 — shifting the
-    // label off the door's center and over-widening the clip rect. Matches
-    // the footer's chars().count() convention.
-    let label_w = label.chars().count() as u16;
+    // Display COLUMNS via `display_width` (the width authority, shared with the
+    // footer): the ▲/▼ arrows are 3-byte single-column glyphs (byte len over-counts).
+    let label_w = super::display_width(&label) as u16;
     let door_cell_x = door.x + 8u16.saturating_sub(label_w / 2);
     let door_cell_y = door.y / 2;
     let indicator_y = door_cell_y.saturating_sub(1);

--- a/crates/pixtuoid/src/tui/widgets/mod.rs
+++ b/crates/pixtuoid/src/tui/widgets/mod.rs
@@ -282,7 +282,9 @@ fn centered_in(bounds: Rect, desired_w: u16, desired_h: u16) -> Rect {
 
 /// Truncate to `max` characters (char-safe), appending `…` when clipped. Shared
 /// by the dashboard + connection popup row painters (display-column safe — never
-/// slices a multi-byte glyph).
+/// slices a multi-byte glyph). Budget: the `…` is INCLUDED, so the clipped
+/// output is EXACTLY `max` chars — unlike `decoder::ellipsize`, which excludes
+/// it (N+1).
 fn truncate(s: &str, max: usize) -> String {
     if s.chars().count() <= max {
         return s.to_string();

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for your interest! PRs are welcome — especially **new themes**, sprite and
 decoration polish, and **`Source` adapters** for agent CLIs we don't support yet
-(the ten already wired up are listed in the README).
+(the ten agent CLIs plus the OpenClaw gateway already wired up are listed in the README).
 
 Before you start, read [`CLAUDE.md`](../CLAUDE.md) at the repo root (and the nested
 `crates/*/CLAUDE.md` for the crate you touch). It holds the architecture

--- a/integrations/raycast/CLAUDE.md
+++ b/integrations/raycast/CLAUDE.md
@@ -56,9 +56,12 @@ the wire-shape sharp edge in `crates/pixtuoid/CLAUDE.md`.)
 - **Toolchain bumps must stay within what Raycast DECLARES — check the peers,
   don't guess.** `eslint`/`typescript` are gated by `@raycast/eslint-config`'s
   peerDependencies (2.2.0 declares `eslint ^10`, `typescript <6.1.0` — so
-  eslint 10 + TS 6.0 are in-range); `@types/node` stays on the `22.x` line
-  because `@raycast/api` peers it EXACTLY (22.19.17; Raycast's runtime is
-  Node 22) — dependabot ignores its majors (`.github/dependabot.yml`). And
+  eslint 10 + TS 6.0 are in-range); `@types/node` stays on the `22.x` MAJOR
+  (dependabot bumps minors within it — `.github/dependabot.yml` ignores only
+  the major — so the manifest floats at `^22.x`, currently `^22.20.1`).
+  `@raycast/api`'s exact peer (22.19.17; Raycast's runtime is Node 22) is a
+  warning-level mismatch npm tolerates under the committed lockfile, not a hard
+  pin the manifest must equal. And
   `ray build` type-checks with its OWN bundled tsc (5.6 as of api 1.104.21),
   so `tsconfig.json` must stay parseable by BOTH that and the local TS: the
   TS 6 migration was `moduleResolution: "Bundler"` + an explicit


### PR DESCRIPTION
Whole-codebase audit **cluster D** — eight Family-C drift findings (a doc/comment saying something now false or stale). No behavior change except the elevator `display_width` swap, which is identity for its arrow+digit label.

| # | Where | Was → Now |
|---|---|---|
| FIND-08 | `pixtuoid-web/src/script.rs` | "9 non-daemon, Reasonix omitted, OpenClaw 10th, ten chips" → 10 non-daemon, **Reasonix + omp** omitted, OpenClaw **11th** (omp #520 never reached this sibling crate's comment); dropped the drift-prone chip count |
| FIND-11 | `layout/rooms/walls.rs` | "≥10 px effective gap" → the endpoint-inclusive cut opens 13 px, minus 2-px padding each side = **9 px** |
| FIND-16 | `pixel_painter/background/mod.rs` | `NB: sun_on_wall keeps its own .ok()? decode` (false — routes through `emitter`→this fn) → stated as the single decode funnel |
| FIND-24 | `tui/widgets/elevator.rs` | `chars().count()` + "footer's chars().count() convention" (footer moved to `display_width`) → swapped to the `display_width` authority (identity for this label) |
| FIND-26 | `decoder::ellipsize` / `overlay::truncate_label` / `widgets::truncate` | three parallel docs hiding **divergent** budget semantics (N+1 / exactly-N-no-ellipsis / exactly-N) → each doc now states its rule + contrasts the siblings (no merge — 3 real purposes) |
| FIND-31 | `README.md` | "the ten already wired up" (table lists 11) → "the ten agent CLIs plus the OpenClaw gateway" |
| FIND-14 | `integrations/raycast/CLAUDE.md` | "peers it EXACTLY (22.19.17)" while manifest floats `^22.20.1` → reconciled to the real posture (22.x major pinned, dependabot bumps minors, exact peer is a tolerated npm warning under the lockfile) |
| FIND-32 | 3× CLAUDE.md + `reducer.rs` | named `EFFORT_TTL`, but the only const is `EFFORT_TTL_SECS` → made all four grep-resolvable |

FIND-08's separable **content** gap (omp has a `sources.json` chip but no hero-cast sprite) is a taste call left for you, not touched here — the comment now honestly documents that omp is omitted from the cast.

Gates: `clippy -D warnings` clean; elevator/truncation tests green. Part of the 2026-07-14 whole-codebase audit.