### PR TITLE
version/CI integrity: SHIPPED_VERSIONS 0.15.0 gap + inverse test, version.rs least-privilege, mutants empty-diff guard (audit cluster B1)

### DIFF
--- a/crates/pixtuoid/src/version.rs
+++ b/crates/pixtuoid/src/version.rs
@@ -1,10 +1,10 @@
-pub fn is_newer_version(current: &str, last_seen: &str) -> bool {
+fn is_newer_version(current: &str, last_seen: &str) -> bool {
     parse_semver(current)
         .zip(parse_semver(last_seen))
         .is_some_and(|(c, l)| c > l)
 }
 
-pub fn is_valid_version(s: &str) -> bool {
+fn is_valid_version(s: &str) -> bool {
     parse_semver(s).is_some()
 }
 
@@ -22,7 +22,7 @@ pub struct BootDecision {
 /// - First-time install (no recorded version yet).
 /// - The recorded version is unparseable — overwrite to recover, otherwise a
 ///   corrupted/hand-edited value silently disables the popup forever.
-pub fn boot_decision(current_ver: &str, last_seen: Option<&str>) -> BootDecision {
+pub(crate) fn boot_decision(current_ver: &str, last_seen: Option<&str>) -> BootDecision {
     let last_seen_parseable = last_seen.is_some_and(is_valid_version);
     let should_show_popup = match last_seen {
         Some(last) if last_seen_parseable => {
@@ -52,7 +52,7 @@ fn parse_semver(v: &str) -> Option<(u64, u64, u64, u8)> {
     Some((major, minor, patch_num, is_release))
 }
 
-pub fn release_notes(version: &str) -> Option<&'static [&'static str]> {
+pub(crate) fn release_notes(version: &str) -> Option<&'static [&'static str]> {
     match version {
         // `just bump` injects the new version's arm right after the marker below;
         // anchoring on a marker is whitespace-independent — matching the `match`
@@ -179,8 +179,8 @@ mod tests {
     /// drift out of sync with the arms the way the old hand-maintained array did.
     const SHIPPED_VERSIONS: &[&str] = &[
         // [bump-version-list-here]
-        "0.14.0", "0.13.0", "0.12.0", "0.11.1", "0.11.0", "0.10.0", "0.9.0", "0.8.0", "0.7.0",
-        "0.6.1", "0.6.0", "0.5.0", "0.4.1",
+        "0.15.0", "0.14.0", "0.13.0", "0.12.0", "0.11.1", "0.11.0", "0.10.0", "0.9.0", "0.8.0",
+        "0.7.0", "0.6.1", "0.6.0", "0.5.0", "0.4.1",
     ];
 
     #[test]
@@ -264,6 +264,22 @@ mod tests {
         assert!(
             release_notes(current).is_some(),
             "release_notes({current:?}) returned None — add an arm for the current version"
+        );
+    }
+
+    /// The INVERSE of `release_notes_present_for_every_shipped_version`: `just
+    /// bump` injects the new version at BOTH `[bump-inject-here]` (the arm) and
+    /// `[bump-version-list-here]` (this list). An arm added without the list
+    /// entry — the 0.15.0 drift the forward test can't see — makes that release a
+    /// permanent gap once the next bump prepends over it. Pin the current version
+    /// into the list so the miss fails fast.
+    #[test]
+    fn current_version_is_in_shipped_versions() {
+        let current = env!("CARGO_PKG_VERSION");
+        assert!(
+            SHIPPED_VERSIONS.contains(&current),
+            "CARGO_PKG_VERSION {current:?} is missing from SHIPPED_VERSIONS \
+             (the `just bump` [bump-version-list-here] injection was skipped)"
         );
     }
 

--- a/justfile
+++ b/justfile
@@ -235,6 +235,13 @@ mutants *args:
     base="${MUTANTS_BASE:-origin/main}"
     mkdir -p target
     git diff "$base...HEAD" > target/mutants.diff
+    # An empty diff (e.g. dispatched from `main`, where HEAD == origin/main) makes
+    # `--in-diff` test ZERO mutants and exit 0 — a vacuous green that reads as
+    # "assertions have teeth" having checked nothing. Fail loudly instead.
+    if [ ! -s target/mutants.diff ]; then
+        echo "error: diff vs $base is empty — no mutants to test. Run from a feature branch, or set MUTANTS_BASE." >&2
+        exit 1
+    fi
     cargo mutants --in-diff target/mutants.diff --features {{ features }} {{ args }}
 
 # Never-panic fuzz the per-source decoders over a JSONL corpus DIR (on-demand;

--- a/justfile
+++ b/justfile
@@ -235,11 +235,12 @@ mutants *args:
     base="${MUTANTS_BASE:-origin/main}"
     mkdir -p target
     git diff "$base...HEAD" > target/mutants.diff
-    # An empty diff (e.g. dispatched from `main`, where HEAD == origin/main) makes
-    # `--in-diff` test ZERO mutants and exit 0 — a vacuous green that reads as
-    # "assertions have teeth" having checked nothing. Fail loudly instead.
-    if [ ! -s target/mutants.diff ]; then
-        echo "error: diff vs $base is empty — no mutants to test. Run from a feature branch, or set MUTANTS_BASE." >&2
+    # A diff with NO Rust changes (dispatched from `main` where HEAD==origin/main,
+    # or a docs/justfile/site-only branch) makes `--in-diff` test ZERO mutants and
+    # exit 0 — a vacuous green reading as "teeth verified" having checked nothing
+    # (cargo-mutants has no --error-on-zero flag). Gate on actual `.rs` changes.
+    if ! git diff --name-only "$base...HEAD" -- '*.rs' | grep -q .; then
+        echo "error: no Rust changes vs $base — no mutants to test. Run from a feature branch with .rs changes, or set MUTANTS_BASE." >&2
         exit 1
     fi
     cargo mutants --in-diff target/mutants.diff --features {{ features }} {{ args }}


### PR DESCRIPTION
Whole-codebase audit **cluster B1** — version-lockstep + gate-teeth.

### FIND-30 · MEDIUM · version-lockstep
The 0.15.0 bump populated the `release_notes` arm (`[bump-inject-here]`) but **not** `SHIPPED_VERSIONS` (`[bump-version-list-here]`) — a self-inflicted drift the list's own doc-comment claims can't happen. The forward test `release_notes_present_for_every_shipped_version` iterates `SHIPPED_VERSIONS`, so a **missing** member is structurally invisible; once 0.16.0 prepends over the gap, 0.15.0 loses all release-notes teeth (a blank upgrade popup). Added `0.15.0` to the list + a new `current_version_is_in_shipped_versions` inverse pin — a Rust test can't reflect match arms, but the **current** version must be in the list, which fails fast on exactly this bump-miss.

### FIND-02 · LOW · least-privilege
version.rs's four pub items are in-crate-only (the binary's lib target is not a semver surface). `is_newer_version` / `is_valid_version` have zero callers outside version.rs → private `fn`; `boot_decision` / `release_notes` are consumed by `tui/` → `pub(crate)`. Same class as the round-2 `verify_target` demotion; `unreachable_pub` couldn't see it (the module sits in a `pub mod` tree).

### FIND-34 · LOW · gate-teeth
`just mutants` (→ `mutants.yml`, `workflow_dispatch`) diffs `origin/main...HEAD`; dispatched from `main` that's **empty**, so `cargo mutants --in-diff` tests zero mutants and exits 0 — a vacuous green reading as "teeth verified" having checked nothing. Guard added: fail loudly on an empty diff.

Gates: `clippy -D warnings` clean (demotions surfaced no dead_code); 50 version tests green. Part of the 2026-07-14 whole-codebase audit.