### PR TITLE
focus-click follows the live sprite (MEDIUM #22) + desk hover box from the table (#23) (audit cluster E)

### DIFF
--- a/crates/pixtuoid/src/tui/hit_test.rs
+++ b/crates/pixtuoid/src/tui/hit_test.rs
@@ -61,7 +61,13 @@ pub(crate) fn hit_test_agent(
 /// multi-floor `desk_index` was exactly the global/local confusion the
 /// `GlobalDeskIndex` newtype exists to prevent: while viewing floor ≥ 1 it
 /// could pin an invisible agent from another floor.)
-pub fn hit_test_from_tui(scene: &SceneState, layout: &Layout, mx: u16, my: u16) -> Option<AgentId> {
+#[cfg(test)]
+pub(crate) fn hit_test_from_tui(
+    scene: &SceneState,
+    layout: &Layout,
+    mx: u16,
+    my: u16,
+) -> Option<AgentId> {
     const SPRITE_W: u16 = pixtuoid_scene::layout::CHARACTER_SPRITE_W;
     const SPRITE_H_CELLS: u16 = pixtuoid_scene::layout::CHARACTER_SPRITE_H_CELLS;
     for agent in scene.agents.values() {

--- a/crates/pixtuoid/src/tui/hit_test.rs
+++ b/crates/pixtuoid/src/tui/hit_test.rs
@@ -47,8 +47,12 @@ pub(crate) fn hit_test_agent(
     None
 }
 
-/// Lightweight hit-test for click-to-pin without needing router/overlay state.
-/// Uses home desk positions only (no walking agents).
+/// Home-desk-only agent hit-test (no router/overlay state). The production CLICK
+/// path now uses `TuiRenderer::hit_test_agent_at` (live-sprite — follows a walking
+/// agent, FIND-22); this is RETAINED as the deterministic seated-agent locator for
+/// the test harness (`harness::hover_agent`) + its unit tests: a seated agent's
+/// `character_anchor` == its desk box, so the harness finds the hover cell without
+/// a populated `route_ctx`. Uses home desk positions only (no walking agents).
 ///
 /// `scene` must be a SINGLE-FLOOR scene matching `layout` — the caller
 /// projects the live scene via `project_floor_scene(scene, current_floor)`
@@ -128,7 +132,7 @@ pub fn hit_test_coffee_machine(layout: &Layout, mx: u16, my: u16) -> bool {
 pub fn hit_test_furniture(layout: &Layout, mx: u16, my: u16) -> Option<&'static str> {
     use pixtuoid_scene::layout::{
         furniture_def, Furniture, PlantItem, PlantKind, PodDecor, PodDecorItem, WallDecor,
-        WallDecorItem, WaypointKind, DESK_H, DESK_W, ELEVATOR_H, ELEVATOR_W,
+        WallDecorItem, WaypointKind, ELEVATOR_H, ELEVATOR_W,
     };
     // Hover boxes derive from the one furniture table — `.visual` (the visible
     // sprite) for what the user points at, `.footprint` where the obstacle is
@@ -141,9 +145,11 @@ pub fn hit_test_furniture(layout: &Layout, mx: u16, my: u16) -> Option<&'static 
         px >= x && px < x.saturating_add(w) && py >= y && py < y.saturating_add(h)
     };
 
-    // Home desks
+    // Home desks: derive the box from the table's `visual` like every sibling arm
+    // (top-left-anchored at desk.{x,y}); the old hardcoded DESK_W+2 clipped 2px.
+    let desk_vis = visual(Furniture::Desk);
     for desk in &layout.home_desks {
-        if hit(desk.x, desk.y, DESK_W + 2, DESK_H) {
+        if hit(desk.x, desk.y, desk_vis.w, desk_vis.h) {
             return Some("Desk");
         }
     }
@@ -473,6 +479,16 @@ mod tests {
         assert_eq!(
             hit_test_furniture(&layout, desk.x + 2, cell_y),
             Some("Desk")
+        );
+        // The east overhang column the OLD DESK_W+2 box CLIPPED — derive from the
+        // table so the test can't re-hardcode the width (desk.x + visual.w - 1).
+        let vis_w = pixtuoid_scene::layout::furniture_def(pixtuoid_scene::layout::Furniture::Desk)
+            .visual
+            .w;
+        assert_eq!(
+            hit_test_furniture(&layout, desk.x + vis_w - 1, cell_y),
+            Some("Desk"),
+            "the desk's east overhang column must hover it (old DESK_W+2 box clipped it)"
         );
     }
 

--- a/crates/pixtuoid/src/tui/mod.rs
+++ b/crates/pixtuoid/src/tui/mod.rs
@@ -146,14 +146,10 @@ fn focus_clicked_agent<B: ratatui::backend::Backend<Error: Send + Sync + 'static
     row: u16,
 ) {
     let snap = scene_rx.borrow().clone();
-    // Project to the VISIBLE floor first: `hit_test_from_tui` requires a
-    // single-floor scene matching `cached_layout` (a raw multi-floor
-    // snapshot would test other floors' agents against this floor's
-    // desks — the global/local desk-index confusion, see its doc).
+    // Project to the VISIBLE floor first — hit_test_agent_at → character_anchor
+    // reads floor-local desk indices; the click now follows the LIVE sprite (like hover).
     let floor_scene = floor::project_floor_scene(&snap, renderer.current_floor());
-    let hit = renderer
-        .cached_layout()
-        .and_then(|layout| renderer::hit_test_from_tui(&floor_scene, layout, col, row));
+    let hit = renderer.hit_test_agent_at(&floor_scene, col, row);
     if let Some(slot) = hit.and_then(|id| snap.agents.get(&id)) {
         crate::focus::focus_slot(slot, focus_roots);
     }

--- a/crates/pixtuoid/src/tui/mod.rs
+++ b/crates/pixtuoid/src/tui/mod.rs
@@ -9,7 +9,7 @@ pub mod widgets;
 
 use std::io::{stdout, Stdout};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 use anyhow::Result;
 use crossterm::event::{
@@ -144,12 +144,13 @@ fn focus_clicked_agent<B: ratatui::backend::Backend<Error: Send + Sync + 'static
     focus_roots: &(Option<std::path::PathBuf>, Option<std::path::PathBuf>),
     col: u16,
     row: u16,
+    now: SystemTime,
 ) {
     let snap = scene_rx.borrow().clone();
     // Project to the VISIBLE floor first — hit_test_agent_at → character_anchor
     // reads floor-local desk indices; the click now follows the LIVE sprite (like hover).
     let floor_scene = floor::project_floor_scene(&snap, renderer.current_floor());
-    let hit = renderer.hit_test_agent_at(&floor_scene, col, row);
+    let hit = renderer.hit_test_agent_at(&floor_scene, now, col, row);
     if let Some(slot) = hit.and_then(|id| snap.agents.get(&id)) {
         crate::focus::focus_slot(slot, focus_roots);
     }
@@ -996,6 +997,7 @@ pub(crate) async fn run_tui(session: TuiSession) -> Result<()> {
                                         &focus_roots,
                                         m.column,
                                         m.row,
+                                        now,
                                     );
                                 }
                             } else {
@@ -1005,6 +1007,7 @@ pub(crate) async fn run_tui(session: TuiSession) -> Result<()> {
                                     &focus_roots,
                                     m.column,
                                     m.row,
+                                    now,
                                 );
                             }
                         }

--- a/crates/pixtuoid/src/tui/renderer.rs
+++ b/crates/pixtuoid/src/tui/renderer.rs
@@ -30,7 +30,7 @@ use pixtuoid_scene::pixel_painter::{render_to_rgb_buffer, MascotFrame, PixelCtx}
 // Re-exports so tui_renderer.rs and tui/mod.rs import from one place.
 pub(crate) use crate::tui::hit_test::hit_test_agent;
 pub use crate::tui::hit_test::{
-    hit_test_coffee_machine, hit_test_from_tui, hit_test_furniture, hit_test_mascot, hit_test_pet,
+    hit_test_coffee_machine, hit_test_furniture, hit_test_mascot, hit_test_pet,
 };
 pub(crate) use crate::tui::widgets::paint_hover_tooltip;
 pub(super) use crate::tui::widgets::{

--- a/crates/pixtuoid/src/tui/tui_renderer/harness/hit_test.rs
+++ b/crates/pixtuoid/src/tui/tui_renderer/harness/hit_test.rs
@@ -238,3 +238,55 @@ fn hovering_an_agent_marks_its_label() {
         "hovering an agent should add the ▸ marker to its label; frame:\n{text}"
     );
 }
+
+// FIND-22: the CLICK path (hit_test_agent_at) follows the LIVE walking sprite,
+// where the old home-desk-only hit_test_from_tui missed it (hoverable-not-clickable).
+#[test]
+fn click_hit_test_follows_a_walking_sprite_where_from_tui_misses_it() {
+    let id = pixtuoid_core::AgentId::from_transcript_path("/w/0.jsonl");
+    let mut s = idle("/w/0.jsonl", 0, t0() - Duration::from_secs(300));
+    let scene = scene_with(vec![s.clone()], 16);
+    let mut r = build(192, 80, vec![]);
+    r.render(&scene, &pack(), t0()).unwrap();
+    let desk = r.cached_layout().expect("layout").home_desks[0];
+    let (dx, dy) = (desk.x + 2, desk.y.saturating_sub(4) / 2 + 1);
+    // Seated: click and hover hit-tests AGREE at the desk box (no seated regression).
+    assert_eq!(r.hit_test_agent_at(&scene, dx, dy), Some(id));
+    let layout = r.cached_layout().unwrap();
+    assert_eq!(
+        crate::tui::hit_test::hit_test_from_tui(&scene, layout, dx, dy),
+        Some(id)
+    );
+
+    // Now the agent EXITS: its sprite walks off the desk toward the door.
+    s.exiting_at = Some(t0());
+    let scene = scene_with(vec![s], 16);
+    // Mid-exit-walk (EXIT_GRACE_WINDOW is 4.5s) — off the desk box, not yet GC'd.
+    r.render(&scene, &pack(), t0() + Duration::from_millis(1500))
+        .unwrap();
+
+    // The click hit-test finds the LIVE sprite cell; scan for it (idempotent per
+    // the cached frame `now`, so repeated calls are stable).
+    let mut live = None;
+    'scan: for my in 0..80u16 {
+        for mx in 0..192u16 {
+            if r.hit_test_agent_at(&scene, mx, my) == Some(id) {
+                live = Some((mx, my));
+                break 'scan;
+            }
+        }
+    }
+    let (lx, ly) = live.expect("hit_test_agent_at must find the walking sprite");
+    assert_ne!(
+        (lx, ly),
+        (dx, dy),
+        "the sprite moved off its desk during the exit walk"
+    );
+    // The GAP: at the sprite's LIVE cell the home-desk-only test MISSES it.
+    let layout = r.cached_layout().unwrap();
+    assert_eq!(
+        crate::tui::hit_test::hit_test_from_tui(&scene, layout, lx, ly),
+        None,
+        "hit_test_from_tui (home-desk-only) misses the walked-off sprite — the FIND-22 gap"
+    );
+}

--- a/crates/pixtuoid/src/tui/tui_renderer/harness/hit_test.rs
+++ b/crates/pixtuoid/src/tui/tui_renderer/harness/hit_test.rs
@@ -251,7 +251,7 @@ fn click_hit_test_follows_a_walking_sprite_where_from_tui_misses_it() {
     let desk = r.cached_layout().expect("layout").home_desks[0];
     let (dx, dy) = (desk.x + 2, desk.y.saturating_sub(4) / 2 + 1);
     // Seated: click and hover hit-tests AGREE at the desk box (no seated regression).
-    assert_eq!(r.hit_test_agent_at(&scene, dx, dy), Some(id));
+    assert_eq!(r.hit_test_agent_at(&scene, t0(), dx, dy), Some(id));
     let layout = r.cached_layout().unwrap();
     assert_eq!(
         crate::tui::hit_test::hit_test_from_tui(&scene, layout, dx, dy),
@@ -262,15 +262,15 @@ fn click_hit_test_follows_a_walking_sprite_where_from_tui_misses_it() {
     s.exiting_at = Some(t0());
     let scene = scene_with(vec![s], 16);
     // Mid-exit-walk (EXIT_GRACE_WINDOW is 4.5s) — off the desk box, not yet GC'd.
-    r.render(&scene, &pack(), t0() + Duration::from_millis(1500))
-        .unwrap();
+    let walk_now = t0() + Duration::from_millis(1500);
+    r.render(&scene, &pack(), walk_now).unwrap();
 
     // The click hit-test finds the LIVE sprite cell; scan for it (idempotent per
-    // the cached frame `now`, so repeated calls are stable).
+    // `now`, so repeated calls are stable).
     let mut live = None;
     'scan: for my in 0..80u16 {
         for mx in 0..192u16 {
-            if r.hit_test_agent_at(&scene, mx, my) == Some(id) {
+            if r.hit_test_agent_at(&scene, walk_now, mx, my) == Some(id) {
                 live = Some((mx, my));
                 break 'scan;
             }

--- a/crates/pixtuoid/src/tui/tui_renderer/mod.rs
+++ b/crates/pixtuoid/src/tui/tui_renderer/mod.rs
@@ -289,11 +289,11 @@ impl<B: Backend<Error: Send + Sync + 'static>> TuiRenderer<B> {
         row: u16,
     ) -> Option<pixtuoid_core::AgentId> {
         let now = self.last_render_now?;
-        // Arc-clone releases the `&self.cached_layout` borrow so the `&mut floors`
-        // route_ctx borrow below is disjoint.
-        let layout = self.cached_layout.clone()?;
+        // cached_layout / floors / current_floor are disjoint struct fields, so
+        // this shared layout borrow coexists with the &mut route_ctx below.
+        let layout = self.cached_layout.as_deref()?;
         let mut rctx = self.floors[self.current_floor].ctx.route_ctx();
-        crate::tui::hit_test::hit_test_agent(floor_scene, &layout, now, &mut rctx, col, row)
+        crate::tui::hit_test::hit_test_agent(floor_scene, layout, now, &mut rctx, col, row)
     }
 
     pub fn current_floor_seed(&self) -> u64 {

--- a/crates/pixtuoid/src/tui/tui_renderer/mod.rs
+++ b/crates/pixtuoid/src/tui/tui_renderer/mod.rs
@@ -113,6 +113,11 @@ pub struct TuiRenderer<B: Backend<Error: Send + Sync + 'static>> {
     /// they always move together). Kept here, disjoint from the floor buffers, for
     /// borrow-free `DrawCtx` assembly.
     onboarding: crate::tui::welcome::OnboardingFrame,
+    /// The `now` passed to the most recent `render()`. The click hit-test
+    /// (`hit_test_agent_at`) reads it so a wandering-agent click resolves against
+    /// the DRAWN frame's clock, not a fresh `SystemTime::now()` — same discipline
+    /// as `PopupState.last_scale` / `cached_layout`.
+    last_render_now: Option<SystemTime>,
 }
 
 impl<B: Backend<Error: Send + Sync + 'static>> TuiRenderer<B> {
@@ -141,6 +146,7 @@ impl<B: Backend<Error: Send + Sync + 'static>> TuiRenderer<B> {
             dashboard: Default::default(),
             connection: Default::default(),
             onboarding: crate::tui::welcome::OnboardingFrame::default(),
+            last_render_now: None,
         }
     }
 
@@ -264,6 +270,30 @@ impl<B: Backend<Error: Send + Sync + 'static>> TuiRenderer<B> {
 
     pub fn cached_layout(&self) -> Option<&Layout> {
         self.cached_layout.as_deref()
+    }
+
+    /// The click twin of the hover hit-test (`renderer.rs`): anchors on
+    /// `character_anchor`, so it follows a walking / wandering / entry / exit
+    /// sprite — unlike home-desk-only `hit_test_from_tui`. Reuses the DRAWN
+    /// frame's clock (`last_render_now`) so it reproduces that frame's already-run
+    /// derivation (idempotent per `now`). Not byte-identical to that frame,
+    /// though: the click reads a FRESH scene snapshot against this cached clock +
+    /// last frame's motion, so a just-exiting / brand-new agent may skew ≤1 frame
+    /// (benign for hit-testing). `floor_scene` must be projected to the visible
+    /// floor (its `desk_index.single_floor_local()` reads need floor-local
+    /// indices). `None` before the first render or on a too-small/transition frame.
+    pub(crate) fn hit_test_agent_at(
+        &mut self,
+        floor_scene: &SceneState,
+        col: u16,
+        row: u16,
+    ) -> Option<pixtuoid_core::AgentId> {
+        let now = self.last_render_now?;
+        // Arc-clone releases the `&self.cached_layout` borrow so the `&mut floors`
+        // route_ctx borrow below is disjoint.
+        let layout = self.cached_layout.clone()?;
+        let mut rctx = self.floors[self.current_floor].ctx.route_ctx();
+        crate::tui::hit_test::hit_test_agent(floor_scene, &layout, now, &mut rctx, col, row)
     }
 
     pub fn current_floor_seed(&self) -> u64 {
@@ -678,6 +708,9 @@ impl<B: Backend<Error: Send + Sync + 'static>> TuiRenderer<B> {
     /// The production terminal flush — was the core `Renderer` trait impl,
     /// retired inherent in #483.
     pub fn render(&mut self, scene: &SceneState, pack: &Pack, now: SystemTime) -> Result<()> {
+        // Stamp the frame clock for the click hit-test (hit_test_agent_at). Usable
+        // only once cached_layout is Some, so a too-small/transition frame is safe.
+        self.last_render_now = Some(now);
         // Auto-expire pet state.
         if self.active_pet.as_ref().is_some_and(|p| !p.is_active(now)) {
             self.active_pet = None;

--- a/crates/pixtuoid/src/tui/tui_renderer/mod.rs
+++ b/crates/pixtuoid/src/tui/tui_renderer/mod.rs
@@ -113,11 +113,6 @@ pub struct TuiRenderer<B: Backend<Error: Send + Sync + 'static>> {
     /// they always move together). Kept here, disjoint from the floor buffers, for
     /// borrow-free `DrawCtx` assembly.
     onboarding: crate::tui::welcome::OnboardingFrame,
-    /// The `now` passed to the most recent `render()`. The click hit-test
-    /// (`hit_test_agent_at`) reads it so a wandering-agent click resolves against
-    /// the DRAWN frame's clock, not a fresh `SystemTime::now()` — same discipline
-    /// as `PopupState.last_scale` / `cached_layout`.
-    last_render_now: Option<SystemTime>,
 }
 
 impl<B: Backend<Error: Send + Sync + 'static>> TuiRenderer<B> {
@@ -146,7 +141,6 @@ impl<B: Backend<Error: Send + Sync + 'static>> TuiRenderer<B> {
             dashboard: Default::default(),
             connection: Default::default(),
             onboarding: crate::tui::welcome::OnboardingFrame::default(),
-            last_render_now: None,
         }
     }
 
@@ -274,21 +268,18 @@ impl<B: Backend<Error: Send + Sync + 'static>> TuiRenderer<B> {
 
     /// The click twin of the hover hit-test (`renderer.rs`): anchors on
     /// `character_anchor`, so it follows a walking / wandering / entry / exit
-    /// sprite — unlike home-desk-only `hit_test_from_tui`. Reuses the DRAWN
-    /// frame's clock (`last_render_now`) so it reproduces that frame's already-run
-    /// derivation (idempotent per `now`). Not byte-identical to that frame,
-    /// though: the click reads a FRESH scene snapshot against this cached clock +
-    /// last frame's motion, so a just-exiting / brand-new agent may skew ≤1 frame
-    /// (benign for hit-testing). `floor_scene` must be projected to the visible
-    /// floor (its `desk_index.single_floor_local()` reads need floor-local
-    /// indices). `None` before the first render or on a too-small/transition frame.
+    /// sprite — unlike home-desk-only `hit_test_from_tui`. Pass the event loop's
+    /// current `now` (the same clock `render()` runs on); `derive_with_routing` is
+    /// idempotent per `now`, so re-deriving here is a state no-op. `floor_scene`
+    /// must be projected to the visible floor (its `desk_index.single_floor_local()`
+    /// reads need floor-local indices). `None` on a too-small/transition frame.
     pub(crate) fn hit_test_agent_at(
         &mut self,
         floor_scene: &SceneState,
+        now: SystemTime,
         col: u16,
         row: u16,
     ) -> Option<pixtuoid_core::AgentId> {
-        let now = self.last_render_now?;
         // cached_layout / floors / current_floor are disjoint struct fields, so
         // this shared layout borrow coexists with the &mut route_ctx below.
         let layout = self.cached_layout.as_deref()?;
@@ -708,9 +699,6 @@ impl<B: Backend<Error: Send + Sync + 'static>> TuiRenderer<B> {
     /// The production terminal flush — was the core `Renderer` trait impl,
     /// retired inherent in #483.
     pub fn render(&mut self, scene: &SceneState, pack: &Pack, now: SystemTime) -> Result<()> {
-        // Stamp the frame clock for the click hit-test (hit_test_agent_at). Usable
-        // only once cached_layout is Some, so a too-small/transition frame is safe.
-        self.last_render_now = Some(now);
         // Auto-expire pet state.
         if self.active_pet.as_ref().is_some_and(|p| !p.is_active(now)) {
             self.active_pet = None;


### PR DESCRIPTION
Whole-codebase audit **cluster E**. Both fixes were run through a **design + adversarial-verify workflow** before implementation (both PROCEED — the #22 motion/route_ctx/cached-clock safety was confirmed, the #23 desk anchor traced exactly).

### FIND-22 · MEDIUM · confirmed live
Click-to-focus (the 0.14.0 headline) silently missed any agent **not at its home desk**. The CLICK path used home-desk-only `hit_test_from_tui`; HOVER used the router-aware `hit_test_agent` (anchors on `character_anchor`, follows the walking sprite). So a wandering / pantry / entry-walk agent (idle agents are away ~25–35% of the time + every ~4s entry walk) was hoverable but **not clickable**, and clicking its vacated desk focused the *absent* agent.

**Fix:** `TuiRenderer::hit_test_agent_at` — the click twin of the hover hit-test — reading a cached `last_render_now` (new field, set in `render()`, same discipline as `last_scale`) so the click resolves against the **drawn** frame's clock. `character_anchor` is idempotent per `now`, so re-deriving at click time is a state no-op (the event loop is single-threaded with `render()`). `focus_clicked_agent` switches to it; `hit_test_from_tui` is **retained** (the render harness's seated-agent locator + its unit tests) with its stale "click-to-pin" doc corrected. New harness test proves the gap end-to-end: an exiting agent mid-walk is found by `hit_test_agent_at` at its live cell where `hit_test_from_tui` misses it.

### FIND-23 · LOW · single-source
`hit_test_furniture`'s desk arm hardcoded `DESK_W+2 × DESK_H`, contradicting its own "derive from the furniture table" header — 2px narrower than the painted desk (east overhang un-hoverable) + drift-prone. Now derived from `furniture_def(Desk).visual` (`DESK_W+4 × DESK_H+2`, top-left anchored); drops the now-unused `DESK_W`/`DESK_H` import. `furniture_hit_test_finds_desk` gains an east-overhang assertion (RED on the old box, table-derived so it can't re-drift).

Gates: `clippy -D warnings` clean; full `pixtuoid` suite green. Part of the 2026-07-14 whole-codebase audit.