### PR TITLE
experiment(#441): migrate floating painter to winit 0.31-beta (objc2 0.6 unification) [DO NOT MERGE]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,14 +8,6 @@ updates:
       rust-deps:
         patterns: ["*"]
     open-pull-requests-limit: 5
-    ignore:
-      # objc2-app-kit MUST track winit's stack (see crates/pixtuoid/Cargo.toml):
-      # winit 0.30.x still pulls 0.2.x on objc2 0.5.x, so a 0.3+ bump would build
-      # a SECOND objc2 stack beside winit's AND break the activate API. Allow only
-      # 0.2.x patch bumps until winit itself moves to objc2 0.6.
-      - dependency-name: "objc2-app-kit"
-        update-types:
-          ["version-update:semver-minor", "version-update:semver-major"]
 
   - package-ecosystem: github-actions
     directory: /

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -133,7 +133,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -255,11 +255,21 @@ dependencies = [
 
 [[package]]
 name = "block2"
-version = "0.5.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
- "objc2 0.5.2",
+ "objc2",
+]
+
+[[package]]
+name = "borsh"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
 ]
 
 [[package]]
@@ -318,26 +328,25 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calloop"
-version = "0.13.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
+checksum = "4dbf9978365bac10f54d1d4b04f7ce4427e51f71d61f2fe15e3fed5166474df7"
 dependencies = [
  "bitflags 2.13.0",
- "log",
  "polling",
- "rustix 0.38.44",
+ "rustix 1.1.4",
  "slab",
- "thiserror 1.0.69",
+ "tracing",
 ]
 
 [[package]]
 name = "calloop-wayland-source"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
+checksum = "138efcf0940a02ebf0cc8d1eff41a1682a46b431630f4c52450d6265876021fa"
 dependencies = [
  "calloop",
- "rustix 0.38.44",
+ "rustix 1.1.4",
  "wayland-backend",
  "wayland-client",
 ]
@@ -513,44 +522,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core-graphics"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "core-graphics-types",
- "foreign-types",
- "libc",
-]
-
-[[package]]
-name = "core-graphics-types"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "libc",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -723,19 +698,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "dispatch"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
-
-[[package]]
 name = "dispatch2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.13.0",
- "objc2 0.6.4",
+ "objc2",
 ]
 
 [[package]]
@@ -854,7 +823,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -963,33 +932,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "foreign-types"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
-dependencies = [
- "foreign-types-macros",
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-macros"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "fsevent-sys"
@@ -1386,6 +1328,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyboard-types"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fbe853b403ae61a04233030ae8a79d94975281ed9770a1f9e246732b534b28d"
+dependencies = [
+ "bitflags 2.13.0",
+ "serde",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1693,7 +1645,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1754,22 +1706,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc-sys"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
-
-[[package]]
-name = "objc2"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
-dependencies = [
- "objc-sys",
- "objc2-encode",
-]
-
-[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1780,54 +1716,45 @@ dependencies = [
 
 [[package]]
 name = "objc2-app-kit"
-version = "0.2.2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.13.0",
  "block2",
  "libc",
- "objc2 0.5.2",
+ "objc2",
+ "objc2-cloud-kit",
  "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-core-image",
- "objc2-foundation 0.2.2",
- "objc2-quartz-core 0.2.2",
+ "objc2-core-text",
+ "objc2-core-video",
+ "objc2-foundation",
+ "objc2-quartz-core",
 ]
 
 [[package]]
 name = "objc2-cloud-kit"
-version = "0.2.2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
- "objc2 0.5.2",
- "objc2-core-location",
- "objc2-foundation 0.2.2",
-]
-
-[[package]]
-name = "objc2-contacts"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
-dependencies = [
- "block2",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
 name = "objc2-core-data"
-version = "0.2.2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -1837,8 +1764,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.13.0",
+ "block2",
  "dispatch2",
- "objc2 0.6.4",
+ "objc2",
 ]
 
 [[package]]
@@ -1849,33 +1777,45 @@ checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.13.0",
  "dispatch2",
- "objc2 0.6.4",
+ "libc",
+ "objc2",
  "objc2-core-foundation",
  "objc2-io-surface",
 ]
 
 [[package]]
 name = "objc2-core-image"
-version = "0.2.2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
 dependencies = [
- "block2",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
- "objc2-metal",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
-name = "objc2-core-location"
-version = "0.2.2"
+name = "objc2-core-text"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "block2",
- "objc2 0.5.2",
- "objc2-contacts",
- "objc2-foundation 0.2.2",
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -1886,25 +1826,13 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-foundation"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
-dependencies = [
- "bitflags 2.13.0",
- "block2",
- "dispatch",
- "libc",
- "objc2 0.5.2",
-]
-
-[[package]]
-name = "objc2-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.0",
- "objc2 0.6.4",
+ "block2",
+ "objc2",
  "objc2-core-foundation",
 ]
 
@@ -1915,45 +1843,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
  "bitflags 2.13.0",
- "objc2 0.6.4",
+ "objc2",
  "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-link-presentation"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
-dependencies = [
- "block2",
- "objc2 0.5.2",
- "objc2-app-kit",
- "objc2-foundation 0.2.2",
-]
-
-[[package]]
-name = "objc2-metal"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
-dependencies = [
- "bitflags 2.13.0",
- "block2",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
-]
-
-[[package]]
-name = "objc2-quartz-core"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
-dependencies = [
- "bitflags 2.13.0",
- "block2",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
- "objc2-metal",
 ]
 
 [[package]]
@@ -1963,64 +1854,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
  "bitflags 2.13.0",
- "objc2 0.6.4",
+ "objc2",
  "objc2-core-foundation",
- "objc2-foundation 0.3.2",
-]
-
-[[package]]
-name = "objc2-symbols"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
-dependencies = [
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
+ "objc2-foundation",
 ]
 
 [[package]]
 name = "objc2-ui-kit"
-version = "0.2.2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
- "objc2 0.5.2",
- "objc2-cloud-kit",
- "objc2-core-data",
- "objc2-core-image",
- "objc2-core-location",
- "objc2-foundation 0.2.2",
- "objc2-link-presentation",
- "objc2-quartz-core 0.2.2",
- "objc2-symbols",
- "objc2-uniform-type-identifiers",
- "objc2-user-notifications",
-]
-
-[[package]]
-name = "objc2-uniform-type-identifiers"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
-dependencies = [
- "block2",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
-]
-
-[[package]]
-name = "objc2-user-notifications"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
-dependencies = [
- "bitflags 2.13.0",
- "block2",
- "objc2 0.5.2",
- "objc2-core-location",
- "objc2-foundation 0.2.2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2664,15 +2512,6 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
@@ -2776,7 +2615,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2874,9 +2713,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sctk-adwaita"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec"
+checksum = "1dd3accc0f3f4bbaf2c9e1957a030dc582028130c67660d44c0a0345a22ca69b"
 dependencies = [
  "ab_glyph",
  "log",
@@ -3068,9 +2907,9 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
+checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
 dependencies = [
  "bitflags 2.13.0",
  "calloop",
@@ -3079,13 +2918,15 @@ dependencies = [
  "libc",
  "log",
  "memmap2",
- "rustix 0.38.44",
- "thiserror 1.0.69",
+ "rustix 1.1.4",
+ "thiserror 2.0.18",
  "wayland-backend",
  "wayland-client",
  "wayland-csd-frame",
  "wayland-cursor",
  "wayland-protocols",
+ "wayland-protocols-experimental",
+ "wayland-protocols-misc",
  "wayland-protocols-wlr",
  "wayland-scanner",
  "xkeysym",
@@ -3093,11 +2934,12 @@ dependencies = [
 
 [[package]]
 name = "smol_str"
-version = "0.2.2"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
 dependencies = [
- "serde",
+ "borsh",
+ "serde_core",
 ]
 
 [[package]]
@@ -3131,7 +2973,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3147,11 +2989,11 @@ dependencies = [
  "js-sys",
  "memmap2",
  "ndk",
- "objc2 0.6.4",
+ "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation 0.3.2",
- "objc2-quartz-core 0.3.2",
+ "objc2-foundation",
+ "objc2-quartz-core",
  "raw-window-handle",
  "redox_syscall 0.5.18",
  "rustix 1.1.4",
@@ -3237,7 +3079,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3250,7 +3092,7 @@ dependencies = [
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3509,6 +3351,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3855,6 +3698,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-protocols-experimental"
+version = "20250721.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40a1f863128dcaaec790d7b4b396cc9b9a7a079e878e18c47e6c2d2c5a8dcbb1"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-misc"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9567599ef23e09b8dad6e429e5738d4509dfc46b3b21f32841a304d16b29c8"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
 name = "wayland-protocols-plasma"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4032,7 +3901,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4098,15 +3967,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4267,51 +4127,224 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winit"
-version = "0.30.13"
+version = "0.31.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6755fa58a9f8350bd1e472d4c3fcc25f824ec358933bba33306d0b63df5978d"
+checksum = "2879d2854d1a43e48f67322d4bd097afcb6eb8f8f775c8de0260a71aea1df1aa"
 dependencies = [
- "ahash",
- "android-activity",
- "atomic-waker",
  "bitflags 2.13.0",
- "block2",
- "bytemuck",
- "calloop",
  "cfg_aliases",
- "concurrent-queue",
- "core-foundation",
- "core-graphics",
  "cursor-icon",
  "dpi",
- "js-sys",
+ "libc",
+ "raw-window-handle",
+ "rustix 1.1.4",
+ "smol_str",
+ "tracing",
+ "winit-android",
+ "winit-appkit",
+ "winit-common",
+ "winit-core",
+ "winit-orbital",
+ "winit-uikit",
+ "winit-wayland",
+ "winit-web",
+ "winit-win32",
+ "winit-x11",
+]
+
+[[package]]
+name = "winit-android"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d9c0d2cd93efec3a9f9ad819cfaf0834782403af7c0d248c784ec0c61761df"
+dependencies = [
+ "android-activity",
+ "bitflags 2.13.0",
+ "dpi",
+ "ndk",
+ "raw-window-handle",
+ "smol_str",
+ "tracing",
+ "winit-core",
+]
+
+[[package]]
+name = "winit-appkit"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21310ca07851a49c348e0c2cc768e36b52ca65afda2c2354d78ed4b90074d8aa"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2",
+ "dispatch2",
+ "dpi",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-video",
+ "objc2-foundation",
+ "raw-window-handle",
+ "smol_str",
+ "tracing",
+ "winit-common",
+ "winit-core",
+]
+
+[[package]]
+name = "winit-common"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45375fbac4cbb77260d83a30b1f9d8105880dbac99a9ae97f56656694680ff69"
+dependencies = [
+ "memmap2",
+ "objc2",
+ "objc2-core-foundation",
+ "smol_str",
+ "tracing",
+ "winit-core",
+ "x11-dl",
+ "xkbcommon-dl",
+]
+
+[[package]]
+name = "winit-core"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4f0ccd7abb43740e2c6124ac7cae7d865ecec74eec63783e8922577ac232583"
+dependencies = [
+ "bitflags 2.13.0",
+ "cursor-icon",
+ "dpi",
+ "keyboard-types",
+ "raw-window-handle",
+ "smol_str",
+ "web-time",
+]
+
+[[package]]
+name = "winit-orbital"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51ea1fb262e7209f265f12bd0cc792c399b14355675e65531e9c8a87db287d46"
+dependencies = [
+ "bitflags 2.13.0",
+ "dpi",
+ "orbclient",
+ "raw-window-handle",
+ "redox_syscall 0.5.18",
+ "smol_str",
+ "tracing",
+ "winit-core",
+]
+
+[[package]]
+name = "winit-uikit"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680a356e798837d8eb274d4556e83bceaf81698194e31aafc5cfb8a9f2fab643"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2",
+ "dispatch2",
+ "dpi",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "raw-window-handle",
+ "smol_str",
+ "tracing",
+ "winit-common",
+ "winit-core",
+]
+
+[[package]]
+name = "winit-wayland"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce5afb2ba07da603f84b722c95f9f9396d2cedae3944fb6c0cda4a6f88de545"
+dependencies = [
+ "ahash",
+ "bitflags 2.13.0",
+ "calloop",
+ "cursor-icon",
+ "dpi",
  "libc",
  "memmap2",
- "ndk",
- "objc2 0.5.2",
- "objc2-app-kit",
- "objc2-foundation 0.2.2",
- "objc2-ui-kit",
- "orbclient",
- "percent-encoding",
- "pin-project",
  "raw-window-handle",
- "redox_syscall 0.4.1",
- "rustix 0.38.44",
+ "rustix 1.1.4",
  "sctk-adwaita",
  "smithay-client-toolkit",
  "smol_str",
  "tracing",
- "unicode-segmentation",
- "wasm-bindgen",
- "wasm-bindgen-futures",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
  "wayland-protocols-plasma",
+ "winit-common",
+ "winit-core",
+]
+
+[[package]]
+name = "winit-web"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c2490a953fb776fbbd5e295d54f1c3847f4f15b6c3929ec53c09acda6487a92"
+dependencies = [
+ "atomic-waker",
+ "bitflags 2.13.0",
+ "concurrent-queue",
+ "cursor-icon",
+ "dpi",
+ "js-sys",
+ "pin-project",
+ "raw-window-handle",
+ "smol_str",
+ "tracing",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-sys",
  "web-time",
- "windows-sys 0.52.0",
+ "winit-core",
+]
+
+[[package]]
+name = "winit-win32"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644ea78af0e858aa3b092e5d1c67c41995a98220c81813f1353b28bc8bb91eaa"
+dependencies = [
+ "bitflags 2.13.0",
+ "cursor-icon",
+ "dpi",
+ "raw-window-handle",
+ "smol_str",
+ "tracing",
+ "unicode-segmentation",
+ "windows-sys 0.59.0",
+ "winit-core",
+]
+
+[[package]]
+name = "winit-x11"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa5b600756534c7041aa93cd0d244d44b09fca1b89e202bd1cd80dd9f3636c46"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytemuck",
+ "calloop",
+ "cursor-icon",
+ "dpi",
+ "libc",
+ "percent-encoding",
+ "raw-window-handle",
+ "rustix 1.1.4",
+ "smol_str",
+ "tracing",
+ "winit-common",
+ "winit-core",
  "x11-dl",
  "x11rb",
  "xkbcommon-dl",
@@ -4444,6 +4477,7 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "x11rb-protocol",
+ "xcursor",
 ]
 
 [[package]]

--- a/crates/pixtuoid/Cargo.toml
+++ b/crates/pixtuoid/Cargo.toml
@@ -56,7 +56,11 @@ open               = "5"
 # invariant #1). winit = the frameless always-on-top window + main-thread event loop;
 # softbuffer = CPU blit of the office RgbBuffer into it (no GPU). Both rust-windowing,
 # share raw-window-handle 0.6, MSRV ≤ 1.89.
-winit              = "0.30"
+# NOTE: 0.31 is still BETA (per-platform crate split; `Window`/`ActiveEventLoop` are
+# traits now, pointer events, `can_create_surfaces`). Adopted here to unify the objc2
+# stack (winit-appkit 0.31 = objc2 0.6 / app-kit 0.3), collapsing #441's duplicate
+# families. Move to the plain "0.31" caret once it ships stable.
+winit              = "0.31.0-beta.2"
 softbuffer         = "0.4"
 clap_complete = "4.6.5"
 clap_mangen = "0.3.0"
@@ -68,16 +72,13 @@ clap_mangen = "0.3.0"
 libc = "0.2"
 
 # Focus-jump activation (focus/macos.rs): NSRunningApplication activate — plain
-# Cocoa, zero TCC. Pinned to the SAME objc2 stack winit already pulls (0.2.x on
-# objc2 0.5.2 per Cargo.lock) so the bindings don't double-compile — the same
-# discipline pixtuoid-hook's windows-sys comment enshrines. This MUST track
-# winit's objc2-app-kit major, not float ahead: a lone bump to 0.3.x drags in a
-# whole SECOND objc2 stack (0.6 core + 0.3 app-kit/foundation/quartz) beside
-# winit's, regressing exactly that no-double-compile invariant AND breaking the
-# activate API — so dependabot is told to ignore it (.github/dependabot.yml)
-# until winit itself moves.
+# Cocoa, zero TCC. Pinned to the SAME objc2 stack winit pulls (0.3.x on objc2 0.6
+# via winit-appkit 0.31) so the bindings don't double-compile — the same discipline
+# pixtuoid-hook's windows-sys comment enshrines. Keep this in lockstep with winit's
+# objc2-app-kit major (the #624 dependabot-ignore + 0.2.x hold is dropped on this
+# branch now that winit itself has moved).
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-app-kit = { version = "0.2.2", features = ["NSRunningApplication", "libc"] }
+objc2-app-kit = { version = "0.3.2", features = ["NSRunningApplication", "libc"] }
 
 # Focus-jump on Linux (focus/linux.rs): the EWMH _NET_ACTIVE_WINDOW protocol
 # needs an X11 client; x11rb is already in-tree transitively via winit.

--- a/crates/pixtuoid/src/floating/mod.rs
+++ b/crates/pixtuoid/src/floating/mod.rs
@@ -28,7 +28,7 @@ use winit::event_loop::EventLoop;
 use crate::config;
 use crate::runtime::driver::{build_source_set, reducer_task};
 use crate::runtime::{ConnectedSources, RunConfig};
-use window::{FloatingApp, FloatingEvent};
+use window::FloatingApp;
 
 /// The not-yet-surfaced tail of the grow-only `SourceDeath` watch Vec, advancing
 /// `seen` past it — the pure half of the health-bridge dedup ("tracked by count:
@@ -113,7 +113,9 @@ pub fn run(cfg: RunConfig) -> Result<()> {
     let _source_handles = manager.spawn_with_health(tx, health_tx);
 
     // --- the window event loop (main thread) ---
-    let mut builder = EventLoop::<FloatingEvent>::with_user_event();
+    // winit 0.31: no typed user-event loop — `EventLoop::builder()` + a payload-free
+    // proxy `wake_up()`.
+    let mut builder = EventLoop::builder();
     #[cfg(target_os = "macos")]
     {
         // Accessory: no Dock icon, doesn't steal focus — an ambient companion.
@@ -125,15 +127,13 @@ pub fn run(cfg: RunConfig) -> Result<()> {
         .context("building the floating event loop")?;
     let proxy = event_loop.create_proxy();
 
-    // Bridge: a new scene → a repaint. Breaks cleanly when the window closes
-    // (`send_event` → `EventLoopClosed`) or the reducer drops its sender — never unwraps.
+    // Bridge: a new scene → a repaint. `wake_up()` is infallible (a no-op once the loop
+    // closes), so the task ends when the reducer drops its sender or the runtime shuts down.
     {
         let mut scene_rx = scene_rx.clone();
         rt.spawn(async move {
             while scene_rx.changed().await.is_ok() {
-                if proxy.send_event(FloatingEvent::SceneChanged).is_err() {
-                    break;
-                }
+                proxy.wake_up();
             }
         });
     }
@@ -155,7 +155,7 @@ pub fn run(cfg: RunConfig) -> Result<()> {
         });
     }
 
-    let mut app = FloatingApp::new(
+    let app = FloatingApp::new(
         floating_cfg,
         theme,
         pack,
@@ -164,8 +164,9 @@ pub fn run(cfg: RunConfig) -> Result<()> {
         scene_rx,
         floor_caps,
     );
+    // winit 0.31: run_app takes the handler BY VALUE (was `&mut app`).
     event_loop
-        .run_app(&mut app)
+        .run_app(app)
         .context("running the floating window event loop")?;
     Ok(())
 }

--- a/crates/pixtuoid/src/floating/window.rs
+++ b/crates/pixtuoid/src/floating/window.rs
@@ -1,12 +1,12 @@
 //! The `winit` + `softbuffer` window for `pixtuoid floating`.
 //!
-//! `FloatingApp` is the `ApplicationHandler`: on `Resumed` it creates ONE frameless,
+//! `FloatingApp` is the `ApplicationHandler`: on `can_create_surfaces` it creates ONE frameless,
 //! always-on-top window + a `softbuffer` surface; it renders the latest `watch`ed scene
 //! to a DOWNSCALED office `RgbBuffer` via [`OfficeRenderer`] (~window/SCALE) then
 //! nearest-neighbor upscales it into the surface (CPU, `0x00RRGGBB`) so the pixel-art
-//! office stays chunky/legible instead of 1:1-tiny. Redraw is event-driven (a
-//! `FloatingEvent::SceneChanged` from the pipeline
-//! bridge) plus a ~30fps animation tick WHILE agents OR a live gateway daemon (the OpenClaw
+//! office stays chunky/legible instead of 1:1-tiny. Redraw is event-driven (a proxy
+//! `wake_up()` from the pipeline bridge on each scene change)
+//! plus a ~30fps animation tick WHILE agents OR a live gateway daemon (the OpenClaw
 //! lobster mascot in `scene.daemons`) are present (motion is time-driven); with no agents and
 //! every daemon Down it drops to a slow ~1fps ambient tick (keeping the time-driven
 //! clock/weather/lightning/day-night/pet alive without the 30fps cost), never fully idle.
@@ -26,23 +26,16 @@ use pixtuoid_core::state::{DaemonLiveness, SceneState, MAX_FLOORS};
 use tokio::sync::watch;
 use winit::application::ApplicationHandler;
 use winit::dpi::{LogicalSize, PhysicalPosition};
-use winit::event::{ElementState, MouseButton, WindowEvent};
+use winit::event::{ButtonSource, ElementState, MouseButton, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, ControlFlow};
-use winit::window::{ResizeDirection, Window, WindowId, WindowLevel};
+use winit::window::{ResizeDirection, Window, WindowAttributes, WindowId, WindowLevel};
 
 use super::offscreen::OfficeRenderer;
 use crate::config::{self, FloatingConfig};
 use pixtuoid_scene::floor::FloorMeta;
 use pixtuoid_scene::theme::Theme;
 
-/// Wake reasons delivered to the winit loop from the background tokio pipeline.
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum FloatingEvent {
-    /// The reducer published a new scene — repaint.
-    SceneChanged,
-}
-
-/// The floating window app: window + surface (created lazily on `Resumed`), the office
+/// The floating window app: window + surface (created lazily on `can_create_surfaces`), the office
 /// renderer (owns cross-frame caches), the live scene receiver, and the per-floor desk
 /// capacity atomics it keeps in sync with the rendered office.
 pub(crate) struct FloatingApp {
@@ -60,10 +53,11 @@ pub(crate) struct FloatingApp {
     last_caps_size: Option<(u16, u16)>,
     /// Latest cursor position (physical px) — for the corner resize hit-test on click.
     cursor: PhysicalPosition<f64>,
-    window: Option<Rc<Window>>,
+    // winit 0.31: `Window` is a trait (per-platform impls), so hold it as `Rc<dyn Window>`.
+    window: Option<Rc<dyn Window>>,
     // softbuffer's `Context` must outlive the `Surface` it spawned, so keep both.
-    context: Option<softbuffer::Context<Rc<Window>>>,
-    surface: Option<softbuffer::Surface<Rc<Window>, Rc<Window>>>,
+    context: Option<softbuffer::Context<Rc<dyn Window>>>,
+    surface: Option<softbuffer::Surface<Rc<dyn Window>, Rc<dyn Window>>>,
 }
 
 /// Click within this many physical px of the bottom-right corner = resize, else move.
@@ -110,7 +104,9 @@ impl FloatingApp {
         let Some(window) = &self.window else {
             return;
         };
-        let logical = window.inner_size().to_logical::<f64>(window.scale_factor());
+        let logical = window
+            .surface_size()
+            .to_logical::<f64>(window.scale_factor());
         let pos = window.outer_position().ok();
         if let Err(e) = config::save_floating(
             &self.config_path,
@@ -132,7 +128,7 @@ impl FloatingApp {
         let Some(window) = self.window.clone() else {
             return;
         };
-        let size = window.inner_size();
+        let size = window.surface_size();
         let (win_w, win_h) = (size.width, size.height);
         let (Some(nw), Some(nh)) = (NonZeroU32::new(win_w), NonZeroU32::new(win_h)) else {
             return; // a 0-area window: nothing to draw
@@ -232,31 +228,36 @@ fn sync_floor_caps(floor_caps: &[AtomicUsize; MAX_FLOORS], buf_w: u16, buf_h: u1
 /// Does the saved window rect `(x, y, w, h)` overlap ANY currently-connected monitor?
 /// Thin winit binding over the pure [`super::geometry::window_visible_on_monitors`] (the
 /// overlap logic + empty-list guard is unit-tested there; this just pulls the monitor rects).
-fn position_on_a_monitor(event_loop: &ActiveEventLoop, x: i32, y: i32, w: u32, h: u32) -> bool {
+fn position_on_a_monitor(event_loop: &dyn ActiveEventLoop, x: i32, y: i32, w: u32, h: u32) -> bool {
     super::geometry::window_visible_on_monitors(
         (x, y, w, h),
-        event_loop.available_monitors().map(|m| {
-            let (pos, size) = (m.position(), m.size());
-            (pos.x, pos.y, size.width, size.height)
+        // winit 0.31: MonitorHandle::position is now Option, and the pixel size comes
+        // from the current video mode — skip any monitor missing either (Web/headless).
+        event_loop.available_monitors().filter_map(|m| {
+            let pos = m.position()?;
+            let size = m.current_video_mode()?.size();
+            Some((pos.x, pos.y, size.width, size.height))
         }),
     )
 }
 
-impl ApplicationHandler<FloatingEvent> for FloatingApp {
-    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+impl ApplicationHandler for FloatingApp {
+    // winit 0.31 moved window/surface creation out of `resumed` into the required
+    // `can_create_surfaces` (called once it's safe to spawn a surface-backed window).
+    fn can_create_surfaces(&mut self, event_loop: &dyn ActiveEventLoop) {
         if self.window.is_some() {
-            return; // already created — a re-resume must not spawn a second window
+            return; // already created — a re-call must not spawn a second window
         }
-        let mut attrs = Window::default_attributes()
+        let mut attrs = WindowAttributes::default()
             .with_title("pixtuoid")
             .with_decorations(false)
             .with_resizable(true)
             .with_window_level(WindowLevel::AlwaysOnTop)
-            .with_inner_size(LogicalSize::new(
+            .with_surface_size(LogicalSize::new(
                 self.cfg.width as f64,
                 self.cfg.height as f64,
             ))
-            .with_min_inner_size(LogicalSize::new(
+            .with_min_surface_size(LogicalSize::new(
                 config::FLOATING_MIN_W as f64,
                 config::FLOATING_MIN_H as f64,
             ));
@@ -271,17 +272,28 @@ impl ApplicationHandler<FloatingEvent> for FloatingApp {
         }
         #[cfg(target_os = "macos")]
         {
-            use winit::platform::macos::WindowAttributesExtMacOS;
-            attrs = attrs.with_has_shadow(true).with_titlebar_hidden(true);
+            // winit 0.31: per-platform attrs are a struct attached via
+            // `with_platform_attributes`, not extension methods on WindowAttributes.
+            use winit::platform::macos::WindowAttributesMacOS;
+            attrs = attrs.with_platform_attributes(Box::new(
+                WindowAttributesMacOS::default()
+                    .with_has_shadow(true)
+                    .with_titlebar_hidden(true),
+            ));
         }
         #[cfg(target_os = "windows")]
         {
             // No taskbar button — it's an ambient overlay, not a primary window.
-            use winit::platform::windows::WindowAttributesExtWindows;
-            attrs = attrs.with_skip_taskbar(true);
+            // winit 0.31: `WindowAttributesWindows::with_skip_taskbar` (source-verified
+            // against winit-win32 0.31.0-beta.2); attached via `with_platform_attributes`
+            // like macOS. Compiled only by the `windows-check`/`windows-test` CI gates.
+            use winit::platform::windows::WindowAttributesWindows;
+            attrs = attrs.with_platform_attributes(Box::new(
+                WindowAttributesWindows::default().with_skip_taskbar(true),
+            ));
         }
-        let window = match event_loop.create_window(attrs) {
-            Ok(w) => Rc::new(w),
+        let window: Rc<dyn Window> = match event_loop.create_window(attrs) {
+            Ok(w) => Rc::from(w),
             Err(e) => {
                 tracing::error!("pixtuoid floating: failed to create window: {e}");
                 event_loop.exit();
@@ -304,7 +316,7 @@ impl ApplicationHandler<FloatingEvent> for FloatingApp {
                 return;
             }
         };
-        // `cfg.opacity` is parsed + clamped but NOT applied in v1: winit 0.30 exposes no
+        // `cfg.opacity` is parsed + clamped but NOT applied in v1: winit 0.31 exposes no
         // per-window opacity, and softbuffer writes opaque XRGB (no alpha). Honest no-op —
         // real translucency needs a native shim or a wgpu surface (deferred, see spec §11).
         window.request_redraw();
@@ -313,19 +325,17 @@ impl ApplicationHandler<FloatingEvent> for FloatingApp {
         self.surface = Some(surface);
     }
 
-    fn user_event(&mut self, _event_loop: &ActiveEventLoop, event: FloatingEvent) {
-        match event {
-            FloatingEvent::SceneChanged => {
-                if let Some(window) = &self.window {
-                    window.request_redraw();
-                }
-            }
+    // winit 0.31: the typed user-event channel is gone — a proxy `wake_up()` (no payload)
+    // wakes the loop here. Our only wake reason is "scene changed → repaint".
+    fn proxy_wake_up(&mut self, _event_loop: &dyn ActiveEventLoop) {
+        if let Some(window) = &self.window {
+            window.request_redraw();
         }
     }
 
     fn window_event(
         &mut self,
-        event_loop: &ActiveEventLoop,
+        event_loop: &dyn ActiveEventLoop,
         _window_id: WindowId,
         event: WindowEvent,
     ) {
@@ -335,22 +345,22 @@ impl ApplicationHandler<FloatingEvent> for FloatingApp {
                 event_loop.exit();
             }
             WindowEvent::RedrawRequested => self.redraw(),
-            WindowEvent::Resized(_) => {
+            WindowEvent::SurfaceResized(_) => {
                 if let Some(window) = &self.window {
                     window.request_redraw();
                 }
             }
-            WindowEvent::CursorMoved { position, .. } => self.cursor = position,
-            WindowEvent::MouseInput {
+            WindowEvent::PointerMoved { position, .. } => self.cursor = position,
+            WindowEvent::PointerButton {
                 state: ElementState::Pressed,
-                button: MouseButton::Left,
+                button: ButtonSource::Mouse(MouseButton::Left),
                 ..
             } => {
                 // Frameless: a left-press drags the window, EXCEPT near the bottom-right
                 // corner, which resizes (the OS takes over until release). Errors are
                 // non-fatal (some platforms refuse outside a real press).
                 if let Some(window) = &self.window {
-                    let size = window.inner_size();
+                    let size = window.surface_size();
                     let near_corner = super::geometry::near_resize_corner(
                         (self.cursor.x, self.cursor.y),
                         (size.width, size.height),
@@ -367,7 +377,7 @@ impl ApplicationHandler<FloatingEvent> for FloatingApp {
         }
     }
 
-    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+    fn about_to_wait(&mut self, event_loop: &dyn ActiveEventLoop) {
         // Agents animate continuously (walk/breathe — time-driven), so tick ~30fps WHILE
         // any agent is present. When the office is EMPTY we don't go fully idle: the
         // time-driven AMBIENT layer (clock hands, weather cycle, lightning, day/night

--- a/crates/pixtuoid/src/focus/macos.rs
+++ b/crates/pixtuoid/src/focus/macos.rs
@@ -32,30 +32,26 @@ impl ProcessTable for OsProcessTable {
     fn focusable(&self, pid: i32) -> bool {
         // A REGULAR activation policy = a real Dock app (the terminal);
         // shells/daemons have no NSRunningApplication or are Prohibited.
-        // SAFETY: plain Cocoa class-method calls on valid arguments; objc2's
-        // 0.2-generation bindings mark every msg-send unsafe.
-        unsafe {
-            NSRunningApplication::runningApplicationWithProcessIdentifier(pid)
-                .is_some_and(|app| app.activationPolicy() == NSApplicationActivationPolicy::Regular)
-        }
+        // objc2 0.6 marks these plain class-method calls safe (0.2 required `unsafe`).
+        NSRunningApplication::runningApplicationWithProcessIdentifier(pid)
+            .is_some_and(|app| app.activationPolicy() == NSApplicationActivationPolicy::Regular)
     }
 }
 
 /// Bring the app owning `pid` to the foreground. Returns whether macOS
 /// accepted the request (a `false` is the caller's silent-no-op path).
 pub(crate) fn activate_os(pid: i32) -> bool {
-    // SAFETY: plain Cocoa calls on a valid pid; see `focusable`.
-    unsafe {
-        NSRunningApplication::runningApplicationWithProcessIdentifier(pid)
-            .map(|app| {
-                // ActivateIgnoringOtherApps is deprecated on 14+ but still
-                // honored; the plain no-options activate() is "cooperative"
-                // and drops the request while the user interacts elsewhere.
-                #[allow(deprecated)]
-                app.activateWithOptions(
-                    objc2_app_kit::NSApplicationActivationOptions::NSApplicationActivateIgnoringOtherApps,
-                )
-            })
-            .unwrap_or(false)
-    }
+    // objc2 0.6 marks these calls safe (0.2 required `unsafe`).
+    NSRunningApplication::runningApplicationWithProcessIdentifier(pid)
+        .map(|app| {
+            // ActivateIgnoringOtherApps is deprecated on 14+ but still
+            // honored; the plain no-options activate() is "cooperative"
+            // and drops the request while the user interacts elsewhere.
+            // (objc2 0.6 dropped the redundant `NSApplication…` const prefix.)
+            #[allow(deprecated)]
+            app.activateWithOptions(
+                objc2_app_kit::NSApplicationActivationOptions::ActivateIgnoringOtherApps,
+            )
+        })
+        .unwrap_or(false)
 }


### PR DESCRIPTION
> **⚠️ DRAFT — do not merge.** This depends on `winit = "0.31.0-beta.2"`, a
> pre-release windowing lib. Kept open as WIP for **#441** so CI exercises the
> **Windows gates** (`check-windows` / `windows-test`) my local macOS build
> can't cover. Land it only once winit 0.31 ships **stable**.

## What this does

Migrates the floating-window painter from winit 0.30 to **winit 0.31.0-beta.2**,
which completes winit's own move to the **objc2 0.6** stack. That collapses all
of #441's duplicate objc2 families in one shot:

- `objc2` 0.5.2 — gone (only 0.6.x remains)
- `objc2-app-kit` / `objc2-foundation` 0.2.2 — gone (0.3.x / winit's)
- `objc2-core-graphics` 0.23 — gone
- `bitflags` 1.3.2 — orphaned/dropped

On `main` we pin `objc2-app-kit` to winit-0.30's `0.2.2` and tell dependabot to
ignore its bumps precisely because a lone bump ahead of winit builds a **second**
full objc2 stack and breaks the AppKit activate API. This branch is the other
half: once winit moves, our direct `objc2-app-kit` pin moves with it and the
dependabot `ignore` is dropped.

## API migration map (winit 0.30 → 0.31)

- `ApplicationHandler` is non-generic; window creation `resumed` → **`can_create_surfaces`**
- typed user-event → payload-free **`proxy.wake_up()`** (`EventLoop::builder()` replaces `with_user_event()`)
- `Window` / `ActiveEventLoop` are **traits** — `Rc<dyn Window>`, `&dyn ActiveEventLoop`, `create_window` → `Box<dyn Window>` (wrapped via `Rc::from`)
- `WindowEvent` renames: `Resized`→`SurfaceResized`, `CursorMoved`→`PointerMoved{source}`, `MouseInput`→`PointerButton{button: ButtonSource::Mouse(..)}`
- `inner_size()` → `surface_size()`
- `MonitorHandle::position()` now returns `Option`; size via `current_video_mode()?.size()`
- per-platform attrs are structs (`WindowAttributesMacOS` / `WindowAttributesWindows`) attached via `with_platform_attributes(Box<dyn PlatformWindowAttributes>)`
- `run_app(app)` takes the app **by value**
- objc2 0.6: `NSApplicationActivateIgnoringOtherApps` → `ActivateIgnoringOtherApps`; the `runningApplicationWithProcessIdentifier` / `activateWithOptions` msg-sends became **safe** (dropped `unsafe`)

softbuffer 0.4.8 still works unchanged (`winit` keeps `impl HasWindowHandle for dyn Window`).

## Verified (macOS)

- builds clean; `just clippy` clean
- full suite green (756 + 14 + 22 tests)
- render intact (floating window opens, positions on monitor, resizes, click-to-focus)

## Not yet verified

- **Windows** — this draft exists so CI runs `check-windows` + `windows-test`.

Refs #441.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
