### PR TITLE
chore(release): expand the 0.15.0 release notes to the full cycle scope

### DIFF
--- a/crates/pixtuoid/src/version.rs
+++ b/crates/pixtuoid/src/version.rs
@@ -63,7 +63,8 @@ pub(crate) fn release_notes(version: &str) -> Option<&'static [&'static str]> {
             "Pantry v2 — a kitchen island with bartender slots and a snack shelf join the pantry; per-desk trash bins retire (the pantry keeps the office's one bin)",
             "Appliances come alive — the printer ejects pages and the vending machine drops a can while an agent stands there; the water cooler glugs on its own",
             "The web hero zooms in — the landing-page office renders at a closer camera (and the app's own 1F layout), so sprites finally read at a glance",
-            "Sturdier under the hood — furniture declares how each piece meets the floor in one place (a sprite resize can't drift a walkable edge), and a generative placement sweep guards every size the office lays out",
+            "Rock-solid placement — furniture now declares how it meets the floor in one place (a sprite resize can't drift a walkable edge), and a generative placement sweep guards every size the office lays out, so nothing lands on a wall or blocks a path",
+            "Sturdier and safer under the hood — a sustained whole-codebase review sweep (correctness, security, performance) with symlink-race-safe config writes and stricter environment-path handling; the office looks the same, just harder to knock over",
         ]),
         "0.14.0" => Some(&[
             "Click an agent, land in its terminal — clicking a sprite (or pressing f on the dashboard's selected agent) brings that session's terminal app to the foreground on macOS, Windows and Linux; it's located through the session's own process, so a stale or reused pid never yanks the wrong window forward",


### PR DESCRIPTION
Drafting the **0.15.0 release**. The version was bumped mid-cycle at #550 (the
first commit of the cycle), so the `release_notes("0.15.0")` arm only covered
the first-half office/layout overhaul. This re-curates it to the full
`v0.14.0..HEAD` scope (56 commits) — the in-app "What's new" popup + the
GitHub release body both read this arm.

**Notes-only** — no version change, so the `CARGO_PKG_VERSION`-baked stills are
untouched (`gen-check` proven green locally, so no `just gen`, per the runbook).
App-facing highlights only; the site node-26 bump + dependency work stay out of
the in-app upgrade popup (0.13.0 precedent).

## The change (2 of 6 bullets)

- **Bullet 5 reworded** → "Rock-solid placement" (the GroundAlign + generative
  placement-sweep robustness story, stated as a user-facing guarantee).
- **New bullet 6** → "Sturdier and safer under the hood" — the second-half
  hardening arc that was missing: the sustained whole-codebase review sweep
  (correctness/security/performance), symlink-race-safe atomic config writes
  (#591/#605), and stricter XDG env-path handling (#610).

Bullets 1–4 (office overhaul, pantry v2, appliances, web-hero zoom) unchanged.

## Verification

- `cargo test -p pixtuoid --lib version::` — 22/22 green (incl.
  `release_notes_present_for_every_shipped_version`).
- `just gen-check` — green (stills current; notes-only touches no pixel).
- Full `just preflight` runs on push.
- The `release notes curated` CI guard passes (no `TODO: curate` marker).

## After merge

This finishes the 0.15.0 **draft**. Publishing stays a human step: after this
merges, tag `v0.15.0` and push it to fire `release.yml` (crates.io + homebrew +
npm via OIDC) — irreversible, human-owned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
