### PR TITLE
feat(site): display the latest RELEASE tag, not main's in-progress version

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,6 +28,11 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
+        with:
+          # full history: the displayed version = latest release TAG
+          # (astro.config.mjs via config/released-version.mjs); a shallow
+          # tag-less checkout would silently fall back to Cargo.toml
+          fetch-depth: 0
       - uses: actions/setup-node@v7
         with:
           node-version: 26

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -28,6 +28,11 @@ jobs:
         working-directory: site
     steps:
       - uses: actions/checkout@v7
+        with:
+          # full history: the displayed version = latest release TAG
+          # (astro.config.mjs via config/released-version.mjs); a shallow
+          # tag-less checkout would silently fall back to Cargo.toml
+          fetch-depth: 0
       - uses: actions/setup-node@v7
         with:
           node-version: 26

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -17,8 +17,13 @@ Full detail: [`README.md`](README.md).
 `astro build` reads **six files from OUTSIDE `site/`** at build time, and a
 rename/move of any of them FAILS the build:
 
-- the workspace `Cargo.toml` → the displayed version (via `vite.define` in
-  `astro.config.mjs`).
+- the workspace `Cargo.toml` → the displayed version's FALLBACK only: the
+  primary source is the latest RELEASE tag (`git describe --tags --abbrev=0`
+  via `config/released-version.mjs` — main's Cargo.toml runs AHEAD of the
+  released version between a mid-cycle bump and its tag, and the site must
+  advertise what users can actually install). Both CI workflows checkout
+  with `fetch-depth: 0` so the tag path is the one real deploys take;
+  unit-tested in `config/released-version.test.mjs`.
 - `docs/{CONFIGURATION, ARCHITECTURE, CONTRIBUTING,
   KNOWLEDGE-ENGINEERING, PARALLEL-DELIVERY}.md` → rendered as `/config`,
   `/architecture`, `/contributing`, `/knowledge-base`,

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -9,18 +9,28 @@ import { unified } from '@astrojs/markdown-remark';
 import { rewriteCspMeta } from './config/csp-hashes.mjs';
 import rehypeCallouts from './config/rehype-callouts.mjs';
 import { fetchStarCount } from './config/gh-stars.mjs';
+import { latestReleaseTag, resolveDisplayedVersion } from './config/released-version.mjs';
 
-// Single-source the displayed version from the workspace Cargo.toml so the boot
-// intro never goes stale on a release bump. Scope the match to the
-// [workspace.package] table so a dependency's line-anchored `version = "…"` (in a
-// [dependencies.x] sub-table) can't be picked up — and throw rather than silently
-// shipping a bogus version if the parse ever fails.
+// The DISPLAYED version is the latest RELEASE tag — what `cargo install`/brew
+// actually serve — not main's Cargo.toml, which runs AHEAD of the released
+// version between a mid-cycle bump and its release tag (see
+// config/released-version.mjs). The Cargo.toml parse survives as the
+// FALLBACK for tag-less builds (pages.yml/site.yml fetch full history so
+// real deploys never take it). Scope the match to the [workspace.package]
+// table so a dependency's line-anchored `version = "…"` (in a
+// [dependencies.x] sub-table) can't be picked up — and throw rather than
+// silently shipping a bogus fallback if the parse ever fails.
 const cargoToml = readFileSync(fileURLToPath(new URL('../Cargo.toml', import.meta.url)), 'utf8');
 const pkgSection = cargoToml.match(/\[workspace\.package\]([\s\S]*?)(?:\n\[|$)/)?.[1] ?? '';
-const version = pkgSection.match(/^version\s*=\s*"([^"]+)"/m)?.[1];
-if (!version) {
+const cargoVersion = pkgSection.match(/^version\s*=\s*"([^"]+)"/m)?.[1];
+if (!cargoVersion) {
   throw new Error('astro.config: could not parse [workspace.package] version from ../Cargo.toml');
 }
+const { version, source: versionSource } = resolveDisplayedVersion(
+  latestReleaseTag(),
+  cargoVersion
+);
+console.log(`[pixtuoid] displayed version ${version} (from ${versionSource})`);
 
 // Build-time star count (§2): baked like the version — the CSP forbids a
 // runtime fetch. null on any failure; consumers omit the count (never fail).

--- a/site/config/released-version.mjs
+++ b/site/config/released-version.mjs
@@ -1,0 +1,45 @@
+// The version the site DISPLAYS: the latest *released* tag, not main's
+// in-progress Cargo.toml version. Between a mid-cycle bump (e.g. #550's
+// 0.15.0, the ambient-audio 0.16.0) and its release tag, main's Cargo.toml
+// runs AHEAD of what `cargo install`/brew actually serves — showing that
+// pre-release number on pixtuoid.dev advertised a version nobody could
+// install. Tag-first fixes the honesty gap; the Cargo.toml version stays
+// the FALLBACK for builds without tag history.
+//
+// Pure kernel + impure shell split (the csp-hashes/gh-stars pattern) so the
+// precedence and validation are unit-testable without a git repo.
+
+import { execSync } from 'node:child_process';
+
+/** `vX.Y.Z`-shaped tag (the repo's release-tag format), capture the bare version. */
+const RELEASE_TAG = /^v(\d+\.\d+\.\d+)$/;
+
+/**
+ * Latest release tag reachable from HEAD, or null when git/tag history is
+ * unavailable (shallow CI checkout without fetch-depth: 0, tarball builds).
+ * Callers fall back to the Cargo.toml version — pages.yml/site.yml fetch
+ * full history so the REAL deploys never take the fallback.
+ */
+export function latestReleaseTag() {
+  try {
+    return execSync('git describe --tags --abbrev=0', {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the displayed version: a well-formed `vX.Y.Z` tag wins; anything
+ * else (null, malformed, non-release tags) falls back to `cargoVersion`.
+ * Returns `{ version, source }` so the build can log which path it took.
+ */
+export function resolveDisplayedVersion(tag, cargoVersion) {
+  const m = typeof tag === 'string' ? tag.trim().match(RELEASE_TAG) : null;
+  if (m) {
+    return { version: m[1], source: 'tag' };
+  }
+  return { version: cargoVersion, source: 'cargo-toml' };
+}

--- a/site/config/released-version.test.mjs
+++ b/site/config/released-version.test.mjs
@@ -1,0 +1,36 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { resolveDisplayedVersion } from './released-version.mjs';
+
+test('a release tag wins over the cargo version (the mid-cycle-bump gap)', () => {
+  // main bumped to 0.16.0 but the latest RELEASE is v0.15.0 — show 0.15.0
+  assert.deepEqual(resolveDisplayedVersion('v0.15.0', '0.16.0'), {
+    version: '0.15.0',
+    source: 'tag',
+  });
+});
+
+test('at the release tag itself the two agree', () => {
+  assert.deepEqual(resolveDisplayedVersion('v0.16.0', '0.16.0'), {
+    version: '0.16.0',
+    source: 'tag',
+  });
+});
+
+test('missing tag history falls back to Cargo.toml', () => {
+  assert.deepEqual(resolveDisplayedVersion(null, '0.16.0'), {
+    version: '0.16.0',
+    source: 'cargo-toml',
+  });
+});
+
+test('a malformed or non-release tag falls back rather than shipping garbage', () => {
+  for (const bad of ['nightly', 'v1.2', 'v1.2.3-rc1', '0.15.0', 'v0.15.0-9-gabc123', '']) {
+    assert.equal(resolveDisplayedVersion(bad, '0.16.0').source, 'cargo-toml', bad);
+  }
+});
+
+test('surrounding whitespace from the git call is tolerated', () => {
+  assert.equal(resolveDisplayedVersion('v0.15.0\n', '0.16.0').version, '0.15.0');
+});


### PR DESCRIPTION
pixtuoid.dev now shows the version users can actually install (the latest `vX.Y.Z` tag) instead of main's Cargo.toml — which runs AHEAD between a mid-cycle bump and its release (0.15.0 did this for its whole cycle; 0.16.0 starts today with #634's semver-forced bump).

- `site/config/released-version.mjs`: tag-first (`git describe --tags --abbrev=0`) with the Cargo.toml parse as the tag-less fallback; pure kernel split out + unit-tested (`node:test`, 5 cases: tag-wins / agree-at-tag / null-fallback / malformed-tag-fallback / whitespace).
- `pages.yml` + `site.yml`: `fetch-depth: 0` so real deploys always take the tag path (checkout@v7's default shallow clone has NO tags — the silent-fallback trap).
- `site/CLAUDE.md` cross-boundary note updated.

Verified: `npm run verify` green; build logs `[pixtuoid] displayed version 0.15.0 (from tag)`.

Owner-requested after the release-branch workflow discussion — closes the trunk-based honesty gap without a long-lived dev branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)