### PR TITLE
feat(#645): decode copilot's session.shutdown usage summary into one final Usage delta

### DIFF
--- a/crates/pixtuoid-core/CLAUDE.md
+++ b/crates/pixtuoid-core/CLAUDE.md
@@ -155,9 +155,13 @@ SESSION's total burn, live-calibrated 2026-07); Codex `token_count`
 INCLUDES the cached share so fresh input = input − cached, saturating;
 reasoning is additive); omp assistant `message.usage` (per-turn; `input`
 EXCLUDES cache — fixture-verified `totalTokens = input + output + cacheRead
-+ cacheWrite` — so fresh = input + cacheWrite + output). Copilot carries
-usage ONLY as a `session.shutdown` summary — one giant delta as the agent
-walks out, near-zero display value — DEFERRED, not absent (#645). The other
++ cacheWrite` — so fresh = input + cacheWrite + output); copilot's ONE usage
+wire is the `session.shutdown` summary (#645) — decoded as a final Usage
+BEFORE the SessionEnd in the same vec (the reducer applies in order, so the
+counter lands before the slot flips exiting; the tower/sheet never flash
+from it — exiting desks paint no tower — the payoff is an honest dossier Σ
+on the walk-out hover; `tokenDetails.input` already EXCLUDES cache reads,
+fixture-verified 12839 − 1664 = 11175). The other
 8 sources genuinely carry no usage wire; their desks never grow paper. Both
 slot fields serde-skipped at zero/None (`tokens_used` flat like
 `tool_call_count`; the last reading bundled as `UsageObservation{delta,

--- a/crates/pixtuoid-core/CLAUDE.md
+++ b/crates/pixtuoid-core/CLAUDE.md
@@ -157,11 +157,14 @@ reasoning is additive); omp assistant `message.usage` (per-turn; `input`
 EXCLUDES cache — fixture-verified `totalTokens = input + output + cacheRead
 + cacheWrite` — so fresh = input + cacheWrite + output); copilot's ONE usage
 wire is the `session.shutdown` summary (#645) — decoded as a final Usage
-BEFORE the SessionEnd in the same vec (the reducer applies in order, so the
-counter lands before the slot flips exiting; the tower/sheet never flash
-from it — exiting desks paint no tower — the payoff is an honest dossier Σ
-on the walk-out hover; `tokenDetails.input` already EXCLUDES cache reads,
-fixture-verified 12839 − 1664 = 11175). The other
+AFTER the SessionEnd in the same vec. The flash-safety is the PAINTER's
+exiting filter (an exiting desk paints no tower/sheet), not the event order
+— the counter lands on the slot either way (cascade_exit keeps the slot for
+the GC window); SessionEnd-first just makes the one theoretically
+observable intermediate frame an already-exiting slot (defense-in-depth).
+Payoff: an honest dossier Σ on the walk-out hover. `tokenDetails.input`
+already EXCLUDES cache reads (arithmetic pinned by the copilot shutdown
+usage test). The other
 8 sources genuinely carry no usage wire; their desks never grow paper. Both
 slot fields serde-skipped at zero/None (`tokens_used` flat like
 `tool_call_count`; the last reading bundled as `UsageObservation{delta,

--- a/crates/pixtuoid-core/src/source/copilot.rs
+++ b/crates/pixtuoid-core/src/source/copilot.rs
@@ -281,17 +281,24 @@ pub fn decode_copilot_line(
             tool_use_id: None,
         }],
         // Token-meter usage (#645): copilot's ONLY usage wire is this
-        // shutdown summary — one final delta as the session ends. The desk
-        // tower/sheet never flash from it (the SessionEnd right after marks
-        // the slot exiting, and exiting desks paint no tower); the payoff is
-        // the dossier's Σ total staying honest on the walk-out hover.
-        // `tokenDetails.input.tokenCount` already EXCLUDES cache reads
-        // (fixture-verified: usage.inputTokens 12839 − cacheReadTokens 1664 =
-        // tokenDetails.input 11175), so fresh = input + cache_write (absent
-        // at zero) + output. Usage FIRST: the reducer applies in order, and
-        // the counter must land before the slot flips to exiting.
+        // shutdown summary — one final delta as the session ends.
+        // `tokenDetails.input` already EXCLUDES cache reads (the arithmetic
+        // is pinned by `real_session_shutdown_usage_summary_lands_one_final_
+        // delta`), so fresh = input + cache_write (inferred snake_case key
+        // from the sibling `cache_read`; unconfirmed — no fixture carries a
+        // nonzero bucket, and a differently-spelled key only UNDERcounts) +
+        // output. No walk-out flash: the painter suppresses the tower/sheet
+        // for any EXITING desk (the occupant filter's `exiting_at.is_none()`)
+        // — NOT the event order; the counter lands on the slot either way,
+        // since cascade_exit keeps the slot for the GC window. SessionEnd
+        // FIRST is defense-in-depth on top: the one theoretically observable
+        // intermediate state is then the already-exiting slot, which paints
+        // nothing. Payoff: an honest dossier Σ on the walk-out hover.
         "session.shutdown" => {
-            let mut evs = Vec::new();
+            let mut evs = vec![AgentEvent::SessionEnd {
+                agent_id: root,
+                as_child: false,
+            }];
             if let Some(details) = data
                 .and_then(|d| d.get("tokenDetails"))
                 .and_then(|t| t.as_object())
@@ -313,10 +320,6 @@ pub fn decode_copilot_line(
                     });
                 }
             }
-            evs.push(AgentEvent::SessionEnd {
-                agent_id: root,
-                as_child: false,
-            });
             evs
         }
         // Everything else (ephemeral streaming, assistant.*, hook.*, user.message,
@@ -776,17 +779,17 @@ mod tests {
 
     #[test]
     fn real_session_shutdown_usage_summary_lands_one_final_delta() {
-        // #645: the fixture's real shutdown shape — tokenDetails.input already
+        // #645: the fixture's real shutdown shape. tokenDetails.input already
         // EXCLUDES cache reads (usage.inputTokens 12839 − cacheReadTokens 1664
-        // = 11175), so fresh = 11175 + 0 (no cache_write bucket) + 212. The
-        // Usage must precede the SessionEnd: the reducer applies in order and
-        // the counter has to land before the slot flips to exiting.
+        // = 11175 — THE authoritative arithmetic pin), so fresh = 11175 + 0
+        // (no cache_write bucket) + 212, never 13_051 (summing cache_read in
+        // would break this). SessionEnd first — defense-in-depth, see the arm.
         let line = r#"{"type":"session.shutdown","data":{"shutdownType":"routine","tokenDetails":{"input":{"tokenCount":11175},"cache_read":{"tokenCount":1664},"output":{"tokenCount":212}},"currentModel":"gpt-5-mini"},"id":"56992353","timestamp":"2026-06-14T21:38:47.162Z","parentId":"3079df1f"}"#;
         match &decode(line)[..] {
-            [AgentEvent::Usage {
+            [AgentEvent::SessionEnd { agent_id, as_child }, AgentEvent::Usage {
                 agent_id: u_id,
                 fresh_tokens,
-            }, AgentEvent::SessionEnd { agent_id, as_child }] => {
+            }] => {
                 assert_eq!(*u_id, root());
                 assert_eq!(
                     *fresh_tokens, 11_387,
@@ -795,7 +798,7 @@ mod tests {
                 assert_eq!(*agent_id, root());
                 assert!(!*as_child);
             }
-            other => panic!("expected [Usage, SessionEnd], got {other:?}"),
+            other => panic!("expected [SessionEnd, Usage], got {other:?}"),
         }
     }
 

--- a/crates/pixtuoid-core/src/source/copilot.rs
+++ b/crates/pixtuoid-core/src/source/copilot.rs
@@ -280,10 +280,45 @@ pub fn decode_copilot_line(
             agent_id: root,
             tool_use_id: None,
         }],
-        "session.shutdown" => vec![AgentEvent::SessionEnd {
-            agent_id: root,
-            as_child: false,
-        }],
+        // Token-meter usage (#645): copilot's ONLY usage wire is this
+        // shutdown summary — one final delta as the session ends. The desk
+        // tower/sheet never flash from it (the SessionEnd right after marks
+        // the slot exiting, and exiting desks paint no tower); the payoff is
+        // the dossier's Σ total staying honest on the walk-out hover.
+        // `tokenDetails.input.tokenCount` already EXCLUDES cache reads
+        // (fixture-verified: usage.inputTokens 12839 − cacheReadTokens 1664 =
+        // tokenDetails.input 11175), so fresh = input + cache_write (absent
+        // at zero) + output. Usage FIRST: the reducer applies in order, and
+        // the counter must land before the slot flips to exiting.
+        "session.shutdown" => {
+            let mut evs = Vec::new();
+            if let Some(details) = data
+                .and_then(|d| d.get("tokenDetails"))
+                .and_then(|t| t.as_object())
+            {
+                let bucket = |k: &str| {
+                    details
+                        .get(k)
+                        .and_then(|b| b.get("tokenCount"))
+                        .and_then(|n| n.as_u64())
+                        .unwrap_or(0)
+                };
+                let fresh = bucket("input")
+                    .saturating_add(bucket("cache_write"))
+                    .saturating_add(bucket("output"));
+                if fresh > 0 {
+                    evs.push(AgentEvent::Usage {
+                        agent_id: root,
+                        fresh_tokens: fresh,
+                    });
+                }
+            }
+            evs.push(AgentEvent::SessionEnd {
+                agent_id: root,
+                as_child: false,
+            });
+            evs
+        }
         // Everything else (ephemeral streaming, assistant.*, hook.*, user.message,
         // session.* metadata) is not a sprite-visible lifecycle change → ignore.
         _ => vec![],
@@ -727,6 +762,8 @@ mod tests {
 
     #[test]
     fn real_session_shutdown_ends_the_root() {
+        // A tokenDetails-less shutdown (older wire / crashy teardown) still
+        // ends the session — no Usage, no panic.
         let line = r#"{"type":"session.shutdown","data":{"shutdownType":"routine","totalPremiumRequests":1},"id":"220c4131","timestamp":"2026-05-22T06:17:01.077Z","parentId":"cd21bd01"}"#;
         match &decode(line)[..] {
             [AgentEvent::SessionEnd { agent_id, as_child }] => {
@@ -734,6 +771,31 @@ mod tests {
                 assert!(!*as_child, "a root shutdown is NOT a child end");
             }
             other => panic!("expected root SessionEnd, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn real_session_shutdown_usage_summary_lands_one_final_delta() {
+        // #645: the fixture's real shutdown shape — tokenDetails.input already
+        // EXCLUDES cache reads (usage.inputTokens 12839 − cacheReadTokens 1664
+        // = 11175), so fresh = 11175 + 0 (no cache_write bucket) + 212. The
+        // Usage must precede the SessionEnd: the reducer applies in order and
+        // the counter has to land before the slot flips to exiting.
+        let line = r#"{"type":"session.shutdown","data":{"shutdownType":"routine","tokenDetails":{"input":{"tokenCount":11175},"cache_read":{"tokenCount":1664},"output":{"tokenCount":212}},"currentModel":"gpt-5-mini"},"id":"56992353","timestamp":"2026-06-14T21:38:47.162Z","parentId":"3079df1f"}"#;
+        match &decode(line)[..] {
+            [AgentEvent::Usage {
+                agent_id: u_id,
+                fresh_tokens,
+            }, AgentEvent::SessionEnd { agent_id, as_child }] => {
+                assert_eq!(*u_id, root());
+                assert_eq!(
+                    *fresh_tokens, 11_387,
+                    "fresh = input 11175 + output 212, cache_read excluded"
+                );
+                assert_eq!(*agent_id, root());
+                assert!(!*as_child);
+            }
+            other => panic!("expected [Usage, SessionEnd], got {other:?}"),
         }
     }
 

--- a/crates/pixtuoid-core/tests/sources/snapshots/sources__conformance__copilot__permission.snap
+++ b/crates/pixtuoid-core/tests/sources/snapshots/sources__conformance__copilot__permission.snap
@@ -28,6 +28,9 @@ expression: events
     agent_id: 4184320534004752587
     model: gpt-5-mini
     effort: ~
+- Usage:
+    agent_id: 4184320534004752587
+    fresh_tokens: 11387
 - SessionEnd:
     agent_id: 4184320534004752587
     as_child: false

--- a/crates/pixtuoid-core/tests/sources/snapshots/sources__conformance__copilot__permission.snap
+++ b/crates/pixtuoid-core/tests/sources/snapshots/sources__conformance__copilot__permission.snap
@@ -28,9 +28,9 @@ expression: events
     agent_id: 4184320534004752587
     model: gpt-5-mini
     effort: ~
-- Usage:
-    agent_id: 4184320534004752587
-    fresh_tokens: 11387
 - SessionEnd:
     agent_id: 4184320534004752587
     as_child: false
+- Usage:
+    agent_id: 4184320534004752587
+    fresh_tokens: 11387


### PR DESCRIPTION
Follow-up to #646: copilot's only usage wire is the `session.shutdown` summary — now decoded as one final `AgentEvent::Usage` so the dossier's Σ total is honest on the walk-out hover (and any future aggregate surface gets real data).

Closes #645

## What
- `session.shutdown` arm: reads `data.tokenDetails` buckets — fresh = `input` + `cache_write` + `output`. `tokenDetails.input` already EXCLUDES cache reads (fixture-verified: `usage.inputTokens 12839 − cacheReadTokens 1664 = 11175`, pinned by the new test). `cache_write` key is inferred from the sibling `cache_read` spelling (no fixture carries a nonzero bucket; a misspelled key only undercounts) — noted in the WHY.
- **SessionEnd FIRST, Usage second** (both lenses converged): the counter lands either way (the reducer's Usage arm updates any live slot; `cascade_exit` keeps the slot for the GC window), and flash-safety comes from the PAINTER's exiting filter — SessionEnd-first is defense-in-depth so the one theoretically observable intermediate watch frame is an already-exiting slot, which paints nothing.
- tokenDetails-less shutdowns (older wire / crashy teardown) still end the session silently; zero readings skipped; `as_u64` + saturating adds throughout.
- Conformance snapshot regenerated (the permission fixture's real shutdown now emits the final Usage).

## Review
Two lenses, both APPROVE-WITH-NITS, findings all terminal: the original 'Usage must land before exiting' rationale was FALSE (traced by both lenses independently) → WHY rewritten at all three sites + order flipped to the strictly-safer form; fixture arithmetic deduped to the one test pin; cache_write inference noted. Sibling sweep confirmed the shutdown summary is copilot's ONLY on-disk usage wire (no double-count possible). Gates: preflight exit 0 (2468 tests) at the fold head; no semver surface (reuses the #632 Usage event); no look change (no gen surface renders copilot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3RzzFkUjKCvgHz9fHNGW7