### PR TITLE
fix: two latent bugs found by the test-assurance audit (label-blank + meeting-chair badge)

### DIFF
--- a/crates/pixtuoid-core/src/source/claude_code.rs
+++ b/crates/pixtuoid-core/src/source/claude_code.rs
@@ -178,14 +178,19 @@ pub fn decode_cc_line(transcript_path: &str, source: &str, v: Value) -> Result<V
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty())
     {
-        // Capped at decode (CONTRIBUTING pitfall 3): `attributionAgent` is
-        // transcript content, and the label persists in slot state for the
-        // session's lifetime.
-        let label = ellipsize(
-            name.rsplit(':').next().unwrap_or(name),
-            MAX_DECODED_FIELD_CHARS,
-        );
-        out.push(AgentEvent::Rename { agent_id, label });
+        // Strip a `namespace:` prefix, keeping the segment after the LAST colon.
+        // A trailing colon ("ns:") splits to an EMPTY segment — the guard above
+        // only checked the PRE-split value, so without re-checking here it would
+        // emit `Rename { label: "" }` and blank the sprite label for the whole
+        // session (the exact harm the empty-string guard exists to prevent).
+        let seg = name.rsplit(':').next().unwrap_or(name);
+        if !seg.is_empty() {
+            // Capped at decode (CONTRIBUTING pitfall 3): `attributionAgent` is
+            // transcript content, and the label persists in slot state for the
+            // session's lifetime.
+            let label = ellipsize(seg, MAX_DECODED_FIELD_CHARS);
+            out.push(AgentEvent::Rename { agent_id, label });
+        }
     }
 
     // Burn-tier effort observation: CC stamps a PERIODIC reminder attachment

--- a/crates/pixtuoid-core/tests/reducer/activity.rs
+++ b/crates/pixtuoid-core/tests/reducer/activity.rs
@@ -260,11 +260,15 @@ fn active_ms_does_not_double_count_on_duplicate_activity_end() {
     // Flush to idle
     r.tick(&mut scene, t1 + Duration::from_secs(3));
     let slot = scene.agents.get(&id).unwrap();
-    // Should be ~2-3s, not ~4-6s (double-counted)
-    assert!(
-        slot.active_ms < 5000,
-        "active_ms looks double-counted: {}",
-        slot.active_ms
+    // EXACTLY 2600ms = ONE active span from t0 to the last end signal (t1+600).
+    // The 2nd ActivityEnd is deliberately PAST the hook-wins window (so NOT
+    // deduped): it re-arms pending-idle to t1+600, EXTENDING the single span —
+    // it must not fold a SECOND span (~4600ms), which is the double-count this
+    // test guards. The old `< 5000` bound accepted both the true 2600 AND a
+    // gross ~4600 double-fold, so it pinned nothing tight.
+    assert_eq!(
+        slot.active_ms, 2600,
+        "active_ms should be the single t0→t1+600 span (2600ms), not double-counted"
     );
 }
 

--- a/crates/pixtuoid-core/tests/sources/decode/mod.rs
+++ b/crates/pixtuoid-core/tests/sources/decode/mod.rs
@@ -161,6 +161,25 @@ fn cc_empty_attribution_agent_emits_no_rename() {
     );
 }
 
+// A TRAILING-colon attributionAgent ("ns:") splits to an EMPTY segment after the
+// last colon — it must NOT emit a label-blanking Rename either. The pre-split
+// emptiness guard doesn't catch it; the post-split check in decode_cc_line does.
+#[test]
+fn cc_trailing_colon_attribution_agent_emits_no_rename() {
+    let events = decode_cc_line(
+        "/p/parent.jsonl",
+        "claude-code",
+        json!({"type": "assistant", "attributionAgent": "ns:", "message": {"content": []}}),
+    )
+    .unwrap();
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::Rename { .. })),
+        "trailing-colon attributionAgent must not emit a (label-blanking) Rename, got {events:?}"
+    );
+}
+
 // Codex subagents (`spawn_agent`) signal their lifecycle ONLY via the
 // SubagentStart/SubagentStop hooks: the subagent's own rollout renders the
 // sprite but is keyed flat (no `/subagents/` path), so it can't learn its

--- a/crates/pixtuoid-scene/src/pixel_painter/anchors.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/anchors.rs
@@ -166,8 +166,18 @@ pub fn character_anchor(
                 wp_obj.facing,
                 &layout.reachable,
             );
+            // MUST mirror the SPRITE anchor arm in `sim.rs::resolve_characters`
+            // (Couch | MeetingSofa | MeetingChair → back_couch_anchor): the label
+            // rides the sprite 1:1, so a kind the sprite anchors with
+            // `back_couch_anchor` but the label with `waypoint_anchor` floats the
+            // badge `WALKING_Y_OFF − SEAT_RENDER_Y_OFF = 5` px above the sitter.
+            // MeetingChair was moved to the seat anchor for the sprite but its
+            // label twin was missed (sibling-set drift). Pinned by
+            // `character_anchor_seat_kinds_use_the_back_couch_anchor_like_the_sprite`.
             match kind {
-                WaypointKind::Couch | WaypointKind::MeetingSofa => back_couch_anchor(stand, w),
+                WaypointKind::Couch | WaypointKind::MeetingSofa | WaypointKind::MeetingChair => {
+                    back_couch_anchor(stand, w)
+                }
                 _ => waypoint_anchor(stand, w),
             }
         }

--- a/crates/pixtuoid-scene/src/pixel_painter/anchors.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/anchors.rs
@@ -173,7 +173,7 @@ pub fn character_anchor(
             // badge `WALKING_Y_OFF − SEAT_RENDER_Y_OFF = 5` px above the sitter.
             // MeetingChair was moved to the seat anchor for the sprite but its
             // label twin was missed (sibling-set drift). Pinned by
-            // `character_anchor_seat_kinds_use_the_back_couch_anchor_like_the_sprite`.
+            // `character_anchor_meeting_chair_label_tracks_the_seat_sprite_not_5px_high`.
             match kind {
                 WaypointKind::Couch | WaypointKind::MeetingSofa | WaypointKind::MeetingChair => {
                     back_couch_anchor(stand, w)

--- a/crates/pixtuoid-scene/src/pixel_painter/tests.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/tests.rs
@@ -3193,3 +3193,90 @@ fn one_meeting_sofa_still_seats_three_agents_at_once() {
         "one sofa must seat 3 agents at once; peaked at {max_on_sofa}"
     );
 }
+
+/// Regression: the name-badge (`character_anchor`) must ride the SAME anchor as
+/// the SPRITE (`sim.rs::resolve_characters`) for a seat kind. MeetingChair
+/// drifted — its sprite moved to `back_couch_anchor` but its label stayed on
+/// `waypoint_anchor`, floating the badge `WALKING_Y_OFF − SEAT_RENDER_Y_OFF = 5`
+/// px above the sitter. Ranged reach: any AtWaypoint seat kind whose sprite uses
+/// the seat anchor must have its label there too.
+#[test]
+fn character_anchor_meeting_chair_label_tracks_the_seat_sprite_not_5px_high() {
+    use crate::layout::{stand_point, WaypointKind, TEST_DEFAULT_DESKS};
+    use crate::pose::{Pose, RouteCtx};
+    use std::time::Duration;
+
+    let pack = crate::embedded_pack::test_default_pack();
+    let layout = Layout::compute_with_seed(192, 160, Some(TEST_DEFAULT_DESKS), 0).expect("fits");
+    let now0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+    let mut scene = SceneState::uniform(64);
+    for i in 0..TEST_DEFAULT_DESKS {
+        let id = pixtuoid_core::AgentId::from_transcript_path(&format!("/p/mc{i}.jsonl"));
+        let mut slot = make_slot(id, ActivityState::Idle);
+        let started = now0 - Duration::from_secs(5 + (i as u64 * 11) % 80);
+        slot.created_at = started;
+        slot.state_started_at = started;
+        slot.last_event_at = started;
+        slot.desk_index = GlobalDeskIndex(i);
+        scene.agents.insert(id, slot);
+    }
+    let coffee = HashMap::new();
+    let mut owned = OwnedSimStores::new();
+    let mut checked = false;
+    for step in 0..4_000u64 {
+        let now = now0 + Duration::from_millis(250 * step);
+        let frame = {
+            let mut stores = owned.stores();
+            sim_step(&mut stores, &scene, &layout, &pack, &coffee, 0, now)
+        };
+        let mc = frame.poses.iter().find_map(|(id, p)| match p {
+            Some(Pose::AtWaypoint {
+                wp,
+                kind: WaypointKind::MeetingChair,
+            }) => Some((*id, *wp)),
+            _ => None,
+        });
+        let Some((id, wp)) = mc else { continue };
+        let agent = scene.agents.get(&id).unwrap();
+        let desk = layout
+            .home_desk(agent.desk_index.single_floor_local())
+            .unwrap();
+        let w = &layout.waypoints[wp];
+        let stand = stand_point(
+            w.kind,
+            w.pos,
+            layout.pantry_counter_size(),
+            &layout.walkable,
+            desk,
+            w.facing,
+            &layout.reachable,
+        );
+        // Idempotent re-derive at the same `now` (sim_step already stamped
+        // last_advanced_at, so no wander transition fires here).
+        let label = {
+            let mut rctx = RouteCtx {
+                router: &mut owned.router,
+                overlay: &owned.overlay,
+                history: &mut owned.history,
+                motion: &mut owned.motion,
+            };
+            character_anchor(agent, &layout, now, &mut rctx).expect("chair sitter is visible")
+        };
+        let seat = back_couch_anchor(stand, CHARACTER_SPRITE_W);
+        let walk = waypoint_anchor(stand, CHARACTER_SPRITE_W);
+        assert!(
+            (label.y as i32 - seat.y as i32).abs() <= 1,
+            "meeting-chair label y {} must track the seat sprite anchor {} (±breath), not float above",
+            label.y,
+            seat.y
+        );
+        assert!(
+            (label.y as i32 - walk.y as i32).abs() >= 4,
+            "meeting-chair label must NOT sit on the 5px-high waypoint_anchor {} (the bug)",
+            walk.y
+        );
+        checked = true;
+        break;
+    }
+    assert!(checked, "no meeting-chair sitter appeared in 1000s of sim");
+}


### PR DESCRIPTION
## What

A test-assurance audit of the codebase surfaced **two latent bugs** (not test gaps — actual defects), each fixed here with a teeth-verified regression test, plus one too-loose assertion tightened. Correctness-only; the coverage-gap tests the audit also found will follow in a separate PR.

## Bug 1 — trailing-colon `attributionAgent` blanks the sprite label

`decode_cc_line`'s guard `.filter(|s| !s.is_empty())` checks the **pre-split** value, but `name.rsplit(':').next().unwrap_or(name)` on a trailing colon (`"ns:"`) yields `""` → emits `Rename { label: "" }`, blanking the sprite label for the whole session — the exact harm the empty-string guard exists to prevent (the reducer's Rename arm has no backstop). Re-check the **post-split** segment; skip the Rename when empty.

Pinned by `cc_trailing_colon_attribution_agent_emits_no_rename` (teeth-verified: fails without the fix).

## Bug 2 — meeting-chair name badge floats 5px above the sitter

`character_anchor` (the name-badge position) maps `Couch | MeetingSofa => back_couch_anchor` but `MeetingChair` fell into `_ => waypoint_anchor`. The **sprite** (`sim.rs::resolve_characters`) renders MeetingChair grouped with Couch/MeetingSofa at `back_couch_anchor`. Since `WALKING_Y_OFF(12) − SEAT_RENDER_Y_OFF(7) = 5`, a head-of-table chair sitter's badge floated 5px above its sprite for the whole dwell (couch/meeting-sofa sitters were correct). Classic sibling-set drift: MeetingChair moved to the seat anchor for the sprite, the label twin wasn't updated in lockstep — quietly breaking the CLAUDE.md "labels align 1:1 with painted sprites" contract for the two head-of-table chairs.

Pinned by `character_anchor_meeting_chair_label_tracks_the_seat_sprite_not_5px_high` (teeth-verified: without the fix the label lands at y=63 vs the sprite's y=68).

## Teeth — `active_ms` double-count assertion

`active_ms_does_not_double_count_on_duplicate_activity_end` asserted `active_ms < 5000`, which accepts BOTH the correct 2600ms AND a gross ~4600ms double-fold. Tightened to `assert_eq!(2600)`. (Verifying revealed 2600 is correct, not the 2000 a static read assumed: the 2nd `ActivityEnd` is deliberately past the hook-wins window, so it's not deduped — it extends the single active span to t1+600.)

## Audit verdict

The suite is genuinely well-tested — a mutation sample on `token_meter`/`burn` returned **0 survivors**, and a static assertion scan was clean (6/2509 assertion-less, all legit no-panic tests). These were 2 real bugs hiding in untested branches, not a coverage problem.

Gates: `just preflight` exit 0 (2493 passed) · `just gen-check` exit 0 (the label move drifted no baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
