### PR TITLE
test: coverage-gap batch from the test-assurance audit

### DIFF
--- a/crates/pixtuoid-core/src/source/copilot.rs
+++ b/crates/pixtuoid-core/src/source/copilot.rs
@@ -778,6 +778,30 @@ mod tests {
     }
 
     #[test]
+    fn shutdown_usage_sums_a_cache_write_bucket_into_fresh() {
+        // The `cache_write` bucket is an INFERRED snake_case key — no fixture
+        // confirms copilot's real spelling (see the arm comment). This pins the
+        // decoder CONTRACT: IF a tokenDetails.cache_write bucket arrives, it counts
+        // toward fresh (input + cache_write + output). The real-shutdown sibling
+        // below carries NO cache_write bucket, so the `.saturating_add(bucket(
+        // "cache_write"))` branch is otherwise never exercised with a nonzero value.
+        let line = r#"{"type":"session.shutdown","data":{"shutdownType":"routine","tokenDetails":{"input":{"tokenCount":11175},"cache_write":{"tokenCount":500},"cache_read":{"tokenCount":1664},"output":{"tokenCount":212}},"currentModel":"gpt-5-mini"},"id":"56992353","timestamp":"2026-06-14T21:38:47.162Z","parentId":"3079df1f"}"#;
+        match &decode(line)[..] {
+            [AgentEvent::SessionEnd { .. }, AgentEvent::Usage {
+                agent_id,
+                fresh_tokens,
+            }] => {
+                assert_eq!(*agent_id, root());
+                assert_eq!(
+                    *fresh_tokens, 11_887,
+                    "fresh = input 11175 + cache_write 500 + output 212 (cache_read excluded)"
+                );
+            }
+            other => panic!("expected [SessionEnd, Usage], got {other:?}"),
+        }
+    }
+
+    #[test]
     fn real_session_shutdown_usage_summary_lands_one_final_delta() {
         // #645: the fixture's real shutdown shape. tokenDetails.input already
         // EXCLUDES cache reads (usage.inputTokens 12839 − cacheReadTokens 1664

--- a/crates/pixtuoid-scene/src/chitchat.rs
+++ b/crates/pixtuoid-scene/src/chitchat.rs
@@ -397,6 +397,31 @@ mod tests {
     }
 
     #[test]
+    fn current_bubble_line_advances_across_turns_not_frozen() {
+        // Teeth for the LINE selection (`line_idx = seed.wrapping_add(turn)`, the
+        // `.1` of the tuple): every round-robin test above asserts only the SPEAKER
+        // (`.0`), so dropping `turn` from the index — freezing every turn on one
+        // quip — goes uncaught. Assert each line is drawn from the pool AND that the
+        // line is not frozen across the exchange.
+        let start = base_time();
+        let chat = ActiveChitchat::new(vk(0), vec![aid("/a"), aid("/b")], start);
+        let lines: Vec<&str> = (0..TURNS)
+            .map(|t| {
+                chat.current_bubble(start + Duration::from_millis(t * TURN_MS))
+                    .unwrap()
+                    .1
+            })
+            .collect();
+        for l in &lines {
+            assert!(CHITCHAT_LINES.contains(l), "{l:?} not in the quip pool");
+        }
+        assert!(
+            lines.iter().collect::<std::collections::HashSet<_>>().len() > 1,
+            "the line must vary across turns (index tracks `turn`), got all {lines:?}"
+        );
+    }
+
+    #[test]
     fn meeting_slots_in_same_room_form_one_conversation() {
         let now = base_time();
         let mut state = HashMap::new();

--- a/crates/pixtuoid-scene/src/floor.rs
+++ b/crates/pixtuoid-scene/src/floor.rs
@@ -1458,6 +1458,36 @@ mod tests {
     }
 
     #[test]
+    fn coffee_record_keeps_stamp_on_a_backward_clock_step() {
+        // Backward clock (now < stored → duration_since errs): `is_ok_and` yields
+        // false → not-expired → the old stamp is KEPT, not rewound. Guards against a
+        // treat-clock-error-as-expired regression that would restart the steam
+        // window (and rewind the stamp) on an NTP/suspend step. The two forward
+        // tests can't catch it — their `duration_since` never errs.
+        let id = AgentId::from_parts("claude-code", "coffee-backclock");
+        let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+        let mut coffee = CoffeeState::new();
+        coffee.record([id], t0);
+        coffee.record([id], t0 - Duration::from_secs(10));
+        assert_eq!(
+            coffee.map().get(&id),
+            Some(&t0),
+            "a backward clock step must keep the original stamp, not rewind it"
+        );
+    }
+
+    #[test]
+    fn floor_capacity_clamps_to_zero_on_a_too_small_buffer() {
+        // A buffer too small for even one cubicle → compute_with_seed None → the
+        // `unwrap_or(0)` clamp. Mutating it to `unwrap()` panics boot-seeding;
+        // `unwrap_or(1)` seeds a phantom desk. A normal buffer fits ≥ 1 desk (the
+        // `> 0` guards an always-None / constant-0 mutant); the exact count is left
+        // to the layout tests — re-deriving it here would just re-run the impl.
+        assert_eq!(floor_capacity(3, 3, 0), 0);
+        assert!(floor_capacity(192, 160, 0) > 0);
+    }
+
+    #[test]
     fn transition_escapes_a_backward_clock_step() {
         let start = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
         let tr = FloorTransition::new(0, 1, start);

--- a/crates/pixtuoid-scene/src/layout/approach.rs
+++ b/crates/pixtuoid-scene/src/layout/approach.rs
@@ -412,16 +412,16 @@ mod tests {
     }
 
     #[test]
-    fn real_layout_obstacle_stand_matches_approach_point() {
-        // The RENDER anchor (stand_point) and the WALK goal (approach_point) MUST
-        // agree for obstacle waypoints — else the AtWaypoint sprite pops from the
-        // side the agent walked to onto a different face on arrival. They diverged
-        // when stand_point lacked approach_point's reachability filter: on a real
-        // floor where the nearest-desk side's first walkable pixel sat in a coarse-
-        // unreachable OBSTACLE_PAD cell, stand kept the near (unreachable) side
-        // while approach picked a farther reachable one (~1 full sprite width pop).
-        // Assert equality across the sizes×seeds×desks that exhibited it.
-        use crate::layout::SceneLayout;
+    fn real_layout_obstacle_stand_is_a_reachable_allowed_off_visual_cell() {
+        // `stand_point ≡ approach_point` is now true BY CONSTRUCTION (stand_point
+        // delegates to approach_point for obstacles), so asserting their equality is
+        // a tautology — `f(X) == f(X)` can't fail whatever approach_point computes.
+        // Instead pin the real invariants of the obstacle branch on live layouts:
+        // the resolved stand cell is walkable, coarse-reachable, on a facing-allowed
+        // (non-back) side, and OUTSIDE the whole visual sprite (clearance derives
+        // from the visual, not the shallow footprint — else the agent stands inside
+        // the sprite). Each sub-assertion can genuinely fail under a regression.
+        use crate::layout::{furniture_def, SceneLayout};
         let obstacle = |k| {
             !matches!(
                 k,
@@ -444,7 +444,7 @@ mod tests {
                 };
                 for &desk in &l.home_desks {
                     for wp in l.waypoints.iter().filter(|w| obstacle(w.kind)) {
-                        let stand = stand_point(
+                        let s = stand_point(
                             wp.kind,
                             wp.pos,
                             l.pantry_counter_size(),
@@ -453,19 +453,49 @@ mod tests {
                             wp.facing,
                             &l.reachable,
                         );
-                        let approach = approach_point(
-                            wp.kind.furniture(),
-                            wp.pos,
-                            wp.facing,
-                            l.pantry_counter_size(),
-                            &l.walkable,
-                            desk,
-                            &l.reachable,
+                        if s == wp.pos {
+                            continue; // "no valid approach" sentinel — nothing to stand on
+                        }
+                        assert!(
+                            l.walkable.is_walkable(s.x, s.y),
+                            "{bw}x{bh} seed {seed}: {:?} stand {s:?} not walkable",
+                            wp.kind
                         );
-                        assert_eq!(
-                            stand, approach,
-                            "{bw}x{bh} seed {seed} desk {desk:?}: {:?} render anchor {stand:?} != walk goal {approach:?}",
-                            wp.kind,
+                        assert!(
+                            l.reachable.reaches(s),
+                            "{bw}x{bh} seed {seed}: {:?} stand {s:?} not coarse-reachable",
+                            wp.kind
+                        );
+                        // A pure single-axis offset from pos → its direction MUST be
+                        // an allowed (non-back) side.
+                        let dx = s.x as i32 - wp.pos.x as i32;
+                        let dy = s.y as i32 - wp.pos.y as i32;
+                        let dir = if dx.abs() >= dy.abs() {
+                            (dx.signum(), 0)
+                        } else {
+                            (0, dy.signum())
+                        };
+                        let def = furniture_def(wp.kind.furniture());
+                        assert!(
+                            def.approach.allows(wp.facing, dir),
+                            "{bw}x{bh} seed {seed}: {:?} stand {s:?} on a FORBIDDEN side {dir:?}",
+                            wp.kind
+                        );
+                        // Clear of the WHOLE visual, not the shallow footprint: the
+                        // offset along the stand axis is ≥ visual/2 + STAND_CLEARANCE.
+                        let ext =
+                            approach_clearance_extent(wp.kind.furniture(), l.pantry_counter_size())
+                                .expect("an obstacle stand cell implies a clearance extent");
+                        let (half, off) = if dx != 0 {
+                            (ext.w as i32 / 2, dx.abs())
+                        } else {
+                            (ext.h as i32 / 2, dy.abs())
+                        };
+                        assert!(
+                            off >= half + STAND_CLEARANCE as i32,
+                            "{bw}x{bh} seed {seed}: {:?} stand {s:?} sits INSIDE its visual \
+                             (off {off} < half {half} + clearance {STAND_CLEARANCE})",
+                            wp.kind
                         );
                     }
                 }

--- a/crates/pixtuoid-scene/src/layout/approach.rs
+++ b/crates/pixtuoid-scene/src/layout/approach.rs
@@ -68,9 +68,11 @@ pub(super) fn obstacle_footprint(kind: WaypointKind, pantry_counter_size: Size) 
 /// reachable allowed side nearest `origin`" scan. Falls back to `pos` (the "no
 /// valid approach" sentinel) exactly where `approach_point` does.
 ///
-/// Equality is now true BY CONSTRUCTION — the old parallel scan (kept equal only
-/// by `real_layout_obstacle_stand_matches_approach_point`, retained as a cheap
-/// guard) is gone.
+/// Equality is now true BY CONSTRUCTION — the old parallel scan is gone, so the
+/// stand-vs-approach equality a dedicated guard once asserted is a tautology now;
+/// that guard was repurposed to pin the obstacle branch's REAL invariants
+/// (walkable / reachable / allowed-side / off-visual) in
+/// `real_layout_obstacle_stand_is_a_reachable_allowed_off_visual_cell`.
 pub fn stand_point(
     kind: WaypointKind,
     pos: Point,
@@ -483,13 +485,21 @@ mod tests {
                         );
                         // Clear of the WHOLE visual, not the shallow footprint: the
                         // offset along the stand axis is ≥ visual/2 + STAND_CLEARANCE.
-                        let ext =
-                            approach_clearance_extent(wp.kind.furniture(), l.pantry_counter_size())
-                                .expect("an obstacle stand cell implies a clearance extent");
-                        let (half, off) = if dx != 0 {
-                            (ext.w as i32 / 2, dx.abs())
+                        // Read the visual from an INDEPENDENT authority (furniture_def /
+                        // the pantry counter size) — NOT `approach_clearance_extent`, the
+                        // fn `approach_point` itself uses to place the cell — so a
+                        // visual→footprint regression there fails HERE (off < visual/2 +
+                        // clearance) instead of shifting both the placement AND this
+                        // oracle together (which would leave it toothless).
+                        let visual = if wp.kind == WaypointKind::Pantry {
+                            l.pantry_counter_size()
                         } else {
-                            (ext.h as i32 / 2, dy.abs())
+                            def.visual
+                        };
+                        let (half, off) = if dx != 0 {
+                            (visual.w as i32 / 2, dx.abs())
+                        } else {
+                            (visual.h as i32 / 2, dy.abs())
                         };
                         assert!(
                             off >= half + STAND_CLEARANCE as i32,
@@ -724,10 +734,11 @@ mod tests {
     }
 
     #[test]
-    fn approach_point_for_obstacle_matches_stand_point_when_reachable() {
-        // For an obstacle on an open-enough field, the approach point is exactly
-        // the stand cell (the reachability filter drops nothing). This pins the
-        // obstacle render (stand_point) ≡ obstacle walk-end (approach_point).
+    fn obstacle_stand_point_resolves_to_a_reachable_walkable_off_center_cell() {
+        // On an open field an obstacle's stand cell must be a walkable, coarse-
+        // reachable cell OFF the blocked center. (stand_point ≡ approach_point is
+        // now true BY CONSTRUCTION — stand_point delegates — so an equality assert
+        // would be a tautology; pin the real properties instead.)
         let pos = Point { x: 50, y: 50 };
         let m = mask_with_obstacle(100, 100, pos, 32, 10);
         let reach = ReachSet::from_mask(&m, Point { x: 5, y: 5 });
@@ -741,22 +752,11 @@ mod tests {
             Facing::South,
             &reach,
         );
+        assert_ne!(sp, pos, "must resolve off the blocked center");
+        assert!(m.is_walkable(sp.x, sp.y), "the stand cell must be walkable");
         assert!(
             reach.reaches(sp),
             "the stand cell must be coarse-reachable here"
-        );
-        assert_eq!(
-            approach_point(
-                Furniture::Pantry,
-                pos,
-                Facing::South,
-                Size { w: 32, h: 10 },
-                &m,
-                origin,
-                &reach,
-            ),
-            sp,
-            "obstacle approach_point must equal stand_point when reachable",
         );
     }
 

--- a/crates/pixtuoid-scene/src/layout/placement_sweep.rs
+++ b/crates/pixtuoid-scene/src/layout/placement_sweep.rs
@@ -1014,25 +1014,33 @@ fn scatter_plants_keep_obstacle_clearance_and_survive_by_sliding() {
             v,
         )
     };
+    // Does the plant box come within PLANT_OBSTACLE_CLEARANCE_PX of the obstacle
+    // box (obs_pos, obs_v)? Inflate the obstacle box by the clearance on every side
+    // and test overlap — the shared predicate the three obstacle families (fish
+    // tank / meeting-trio bodies / obstacle waypoints) each need.
+    let within_clearance = |plant_box: (Point, Size), obs_pos: Point, obs_v: Size| {
+        let m = PLANT_OBSTACLE_CLEARANCE_PX;
+        let (otl, osz) = visual_tl(obs_pos, obs_v);
+        let inflated = (
+            Point {
+                x: otl.x.saturating_sub(m),
+                y: otl.y.saturating_sub(m),
+            },
+            Size {
+                w: osz.w + 2 * m,
+                h: osz.h + 2 * m,
+            },
+        );
+        super::placement::rects_overlap(plant_box, inflated)
+    };
     let mut v = Vec::new();
     sweep(|w, h, seed, l| {
         for p in &l.plants {
             let pv = furniture_def(p.kind.furniture()).visual;
+            let plant_box = visual_tl(p.pos, pv);
             if let Some(t) = l.fish_tank {
                 let tv = furniture_def(Furniture::FishTank).visual;
-                let m = PLANT_OBSTACLE_CLEARANCE_PX;
-                let (ttl, tsz) = visual_tl(t, tv);
-                let inflated = (
-                    Point {
-                        x: ttl.x.saturating_sub(m),
-                        y: ttl.y.saturating_sub(m),
-                    },
-                    Size {
-                        w: tsz.w + 2 * m,
-                        h: tsz.h + 2 * m,
-                    },
-                );
-                if super::placement::rects_overlap(visual_tl(p.pos, pv), inflated) {
+                if within_clearance(plant_box, t, tv) {
                     v.push(format!(
                         "{w}x{h} seed {seed}: plant {:?}@{:?} within clearance of the fish tank @{:?}",
                         p.kind, p.pos, t
@@ -1044,7 +1052,6 @@ fn scatter_plants_keep_obstacle_clearance_and_survive_by_sliding() {
             // (visible at ~110x45).
             for room in &l.meeting_rooms {
                 let Some(trio) = &room.trio else { continue };
-                let m = PLANT_OBSTACLE_CLEARANCE_PX;
                 let bodies = [
                     (
                         trio.sofas[0],
@@ -1057,18 +1064,7 @@ fn scatter_plants_keep_obstacle_clearance_and_survive_by_sliding() {
                     (trio.table, furniture_def(Furniture::MeetingTable).visual),
                 ];
                 for (bpos, bv) in bodies {
-                    let (btl, bsz) = visual_tl(bpos, bv);
-                    let inflated = (
-                        Point {
-                            x: btl.x.saturating_sub(m),
-                            y: btl.y.saturating_sub(m),
-                        },
-                        Size {
-                            w: bsz.w + 2 * m,
-                            h: bsz.h + 2 * m,
-                        },
-                    );
-                    if super::placement::rects_overlap(visual_tl(p.pos, pv), inflated) {
+                    if within_clearance(plant_box, bpos, bv) {
                         v.push(format!(
                             "{w}x{h} seed {seed}: plant {:?}@{:?} within clearance of a trio body @{:?}",
                             p.kind, p.pos, bpos
@@ -1081,19 +1077,7 @@ fn scatter_plants_keep_obstacle_clearance_and_survive_by_sliding() {
                 if def.footprint.is_none() {
                     continue;
                 }
-                let m = PLANT_OBSTACLE_CLEARANCE_PX;
-                let (wtl, wsz) = visual_tl(wp.pos, def.visual);
-                let inflated = (
-                    Point {
-                        x: wtl.x.saturating_sub(m),
-                        y: wtl.y.saturating_sub(m),
-                    },
-                    Size {
-                        w: wsz.w + 2 * m,
-                        h: wsz.h + 2 * m,
-                    },
-                );
-                if super::placement::rects_overlap(visual_tl(p.pos, pv), inflated) {
+                if within_clearance(plant_box, wp.pos, def.visual) {
                     v.push(format!(
                         "{w}x{h} seed {seed}: plant {:?}@{:?} within clearance of {:?}@{:?}",
                         p.kind, p.pos, wp.kind, wp.pos

--- a/crates/pixtuoid-scene/src/layout/rooms/walls.rs
+++ b/crates/pixtuoid-scene/src/layout/rooms/walls.rs
@@ -596,6 +596,37 @@ mod tests {
     }
 
     #[test]
+    fn vertical_wall_meeting_a_horizontal_at_its_bottom_extends_to_fill_the_corner() {
+        // The `y_bot` stitch — the mirror of the north-cap test above. A vertical
+        // divider whose SOUTH end lands on a crossing H-wall row must extend its
+        // blocked footprint DOWN by WALL_THICK_H-1 to fill the inside corner, else
+        // its east columns leave an L-notch (a walkable bite through the divider).
+        // Only the TOP join was under test; this pins the bottom join.
+        let hwall = WallSegment {
+            start: Point { x: 40, y: 80 },
+            end: Point { x: 56, y: 80 },
+        };
+        let vseg = WallSegment {
+            start: Point { x: 56, y: 40 },
+            end: Point { x: 56, y: 80 },
+        };
+        // seg_bot (80) sits on the crossing H-wall row ⇒ the bottom stitch fires.
+        let (o, s) = wall_segment_rect(&vseg, 20, &[hwall, vseg]);
+        assert_eq!(
+            o.y + s.h - 1,
+            80 + (WALL_THICK_H - 1),
+            "south edge extends WALL_THICK_H-1 below seg_bot to fill the inside corner"
+        );
+        // The same segment with NO crossing wall at the bottom stops at seg_bot.
+        let (o2, s2) = wall_segment_rect(&vseg, 20, &[vseg]);
+        assert_eq!(
+            o2.y + s2.h - 1,
+            80,
+            "no crossing wall at the bottom ⇒ footprint ends at seg_bot (no extension)"
+        );
+    }
+
+    #[test]
     fn horizontal_wall_rect_is_full_face_unchanged() {
         // Routed through the same ground_rect for uniformity — geometry must be
         // byte-identical to the pre-refactor hand-rolled rect.

--- a/crates/pixtuoid-scene/src/pet.rs
+++ b/crates/pixtuoid-scene/src/pet.rs
@@ -246,4 +246,25 @@ mod tests {
         assert_eq!(PetKind::Cat.hitbox("unknown"), Size { w: 6, h: 6 });
         assert_eq!(PetKind::Dog.hitbox("unknown"), Size { w: 6, h: 6 });
     }
+
+    #[test]
+    fn is_active_true_within_window_false_after_and_on_a_backward_clock() {
+        use std::time::Duration;
+        let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+        let pet = PetState {
+            petted_at: t0,
+            pet_pos: Point { x: 10, y: 10 },
+            kind: PetKind::Cat,
+            floor_idx: 0,
+        };
+        // Within the freeze window → active.
+        assert!(pet.is_active(t0 + Duration::from_millis(PET_DURATION_MS / 2)));
+        // At/after the window → inactive (the `< PET_DURATION_MS` boundary).
+        assert!(!pet.is_active(t0 + Duration::from_millis(PET_DURATION_MS)));
+        assert!(!pet.is_active(t0 + Duration::from_millis(PET_DURATION_MS + 500)));
+        // Backward clock (now < petted_at): the deliberate `unwrap_or(PET_DURATION_MS+1)`
+        // fallback treats it as EXPIRED, not active — guards that constant against a
+        // `unwrap_or(0)` regression that would freeze the pet on a clock step.
+        assert!(!pet.is_active(t0 - Duration::from_secs(1)));
+    }
 }

--- a/crates/pixtuoid/src/install/mod.rs
+++ b/crates/pixtuoid/src/install/mod.rs
@@ -1425,6 +1425,65 @@ mod tests {
     }
 
     #[test]
+    fn reinstall_heals_a_deleted_extra_artifact_even_on_a_config_no_op() {
+        let _env = crate::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        // Isolate OpenClaw's artifacts under a temp home (never touch ~/.openclaw).
+        let oc_home = tempfile::TempDir::new().unwrap();
+        let _state = EnvVarOverride::set("OPENCLAW_STATE_DIR", oc_home.path());
+        let exe = std::env::current_exe().unwrap();
+        let mut covered = 0;
+        for &t in target::TARGETS {
+            let Some(make) = t.extra_artifacts else {
+                continue;
+            };
+            let tmp = tempfile::TempDir::new().unwrap();
+            let cfg = tmp.path().join("config");
+            install_target(t, Some(cfg.clone()), Some(exe.clone())).unwrap();
+
+            // Delete a wholly-owned artifact + capture its correct (shim-baked)
+            // content. Located via the target's OWN declaration — generic over any
+            // extra_artifacts target.
+            let (victim, want) = make(&exe).unwrap().into_iter().next().unwrap();
+            std::fs::remove_file(&victim).unwrap();
+            assert!(
+                !victim.exists(),
+                "{}: precondition — artifact deleted",
+                t.name
+            );
+
+            // Re-install: the config merge is a SEMANTIC no-op (AlreadyUpToDate)…
+            let r = install_target(t, Some(cfg), Some(exe.clone())).unwrap();
+            assert!(
+                matches!(r.outcome, InstallOutcome::AlreadyUpToDate),
+                "{}: config already current — the heal must fire despite the no-op",
+                t.name
+            );
+            // …yet the deleted artifact is HEALED byte-for-byte. The artifact write
+            // runs BEFORE the `!changed` early-return; moving it after would leave
+            // the file gone. The round-trip/verify tests never delete-then-reinstall,
+            // so only this catches that regression.
+            assert!(
+                victim.exists(),
+                "{}: a no-op re-install must re-create the deleted plugin file",
+                t.name
+            );
+            assert_eq!(
+                std::fs::read_to_string(&victim).unwrap(),
+                want,
+                "{}: the healed artifact must carry the correct baked content",
+                t.name
+            );
+            covered += 1;
+        }
+        assert!(
+            covered >= 1,
+            "expected at least one extra_artifacts target (OpenClaw) — did the registry change?"
+        );
+    }
+
+    #[test]
     fn verify_target_flags_a_missing_event() {
         // An older-pixtuoid install / an upstream schema change that orphaned an
         // event: hand-remove one registered event → "missing hook entries".

--- a/crates/pixtuoid/src/sources.rs
+++ b/crates/pixtuoid/src/sources.rs
@@ -633,6 +633,35 @@ mod tests {
     }
 
     #[test]
+    fn status_from_row_connected_is_present_and_bound_not_persisted_intent() {
+        // The wire `connected` is PRESENT-AND-BOUND (state == Connected), NOT the
+        // persisted `[sources]` intent bit. A NoCli{connected:true} (absent CLI whose
+        // stored intent is "connected") must serialize connected:false AND
+        // cli_present:false — the divergence status_from_row's doc warns about. The
+        // empty-HOME golden only ever produces NoCli{connected:false}+connected:false
+        // rows, so it can't distinguish `matches!(Connected)` from `state.connected()`.
+        let row = |state| ConnectionRow {
+            source_id: "claude-code",
+            label_prefix: "cc",
+            display_name: "Claude Code",
+            state,
+            config_path: None,
+            target: None,
+            health: None,
+        };
+        let connected = status_from_row(&row(ConnState::Connected));
+        assert!(connected.connected, "Connected → wire connected:true");
+        assert!(connected.cli_present, "Connected → present");
+
+        let nocli_intent_on = status_from_row(&row(ConnState::NoCli { connected: true }));
+        assert!(
+            !nocli_intent_on.connected,
+            "NoCli persisted-intent true must NOT leak as wire connected (present-and-bound is false)"
+        );
+        assert!(!nocli_intent_on.cli_present, "an absent CLI is not present");
+    }
+
+    #[test]
     fn registered_id_accepts_known_rejects_unknown() {
         assert_eq!(registered_id("antigravity").unwrap(), "antigravity");
         let err = registered_id("not-a-source").unwrap_err().to_string();


### PR DESCRIPTION
A curated, teeth-verified coverage batch from the whole-codebase test-assurance audit — closing genuinely-uncovered branches, replacing one tautological test, and consolidating a duplicated test helper. No coverage-chasing: each new test fails under a specific plausible mutation of the production code.

## What's in it (3 crates, 9 files)

**pixtuoid-core**
- `copilot`: a `cache_write` bucket sums into fresh tokens (the inferred snake_case key + `.saturating_add` branch, unexercised by the real fixture — framed as a decoder-contract test, not a wire claim).

**pixtuoid (binary)**
- `sources::status_from_row`: the wire `connected` is present-and-bound (`state == Connected`), NOT the persisted-intent bit — a `NoCli{connected:true}` serializes `connected:false` + `cli_present:false`. The empty-HOME golden can't produce that row.
- `install`: a no-op re-install HEALS a deleted extra artifact (the artifact write runs *before* the `!changed` early-return) — delete → reinstall (`AlreadyUpToDate`) → restored, content byte-exact.

**pixtuoid-scene**
- `pet::is_active`: the false + backward-clock branches (the deliberate `unwrap_or(PET_DURATION_MS+1)` treat-as-expired fallback).
- `floor::floor_capacity`: the too-small `unwrap_or(0)` clamp. `CoffeeState::record`: keep-stamp on a backward clock step (guards `is_ok_and`).
- `chitchat::current_bubble`: the LINE selection (every prior test asserted only the speaker; the line-index-tracks-turn path was untested).
- `walls`: the vertical-wall **bottom**-corner stitch (`y_bot`) — only the top twin was under test.
- `approach`: **replaced** the tautological `real_layout_obstacle_stand_matches_approach_point` (`f(X)==f(X)`, equal by construction since `stand_point` delegates) with a real property test — the stand cell is walkable, coarse-reachable, on a facing-allowed side, and clear of the whole visual.
- `placement_sweep`: folded three identical inflate-and-overlap copies into one `within_clearance` closure (behavior byte-identical).

## Two-lens review (done pre-push, findings fixed)
- **MEDIUM** — the replacement `approach` test's "off-visual" sub-assertion had itself re-derived `half` from `approach_clearance_extent` (the fn `approach_point` uses), making it toothless. Fixed to read an independent visual oracle; **mutation-verified** it now goes red on the visual→footprint regression.
- **MEDIUM** — `stand_point`'s rustdoc still named the renamed test; repointed.
- **LOW** — the sibling `approach_point_for_obstacle_matches_stand_point_when_reachable` was itself a tautology; reframed to real invariants.

## Verification
- Full preflight green at the coverage commit (2509 tests). Review-round delta (only `approach.rs`) re-verified: fmt + clippy `-D warnings` clean, 626 scene tests pass.
- Teeth empirically confirmed via source mutation on 5 tests (copilot, status_from_row, walls bottom-corner, approach property, + the fixed off-visual oracle).
- Blast radius: test-only — the sole production-file touch is one `stand_point` rustdoc line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)