### PR TITLE
test(harden): pin doctor health-summary, disconnect safety-fold, focus no-ancestor guard

### DIFF
--- a/crates/pixtuoid/src/doctor.rs
+++ b/crates/pixtuoid/src/doctor.rs
@@ -778,25 +778,11 @@ pub fn run(log_path: &std::path::Path) -> anyhow::Result<String> {
 
     // Rolled-up footer: a broken install is locally fixable (reconnect); decode
     // drift is a report-upstream concern — distinct remediation paths.
-    let n = REGISTERED_SOURCES.len();
-    if broken.is_empty() {
-        out.push_str(&format!("\n{n} sources · ✓ all connected installs sound"));
-    } else {
-        let verb = if broken.len() == 1 { "needs" } else { "need" };
-        out.push_str(&format!(
-            "\n{n} sources · ⚠ {} {verb} attention ({}) — reconnect in the Sources panel (press s)",
-            broken.len(),
-            broken.join(", ")
-        ));
-    }
-    if any_drift {
-        out.push_str(
-            " · ⚠ decode drift recorded — may predate a CLI's wire format; report: \
-             https://github.com/IvanWng97/pixtuoid/issues\n",
-        );
-    } else {
-        out.push_str(" · ✓ no decode drift\n");
-    }
+    out.push_str(&health_summary(
+        REGISTERED_SOURCES.len(),
+        &broken,
+        any_drift,
+    ));
     // The #526 focus diagnostic — probe roots come from the SAME default
     // resolution the runtime seeds its watchers with (a --projects-root /
     // --codex-sessions-root override changes the RUNNING app, and doctor
@@ -823,12 +809,79 @@ pub fn run(log_path: &std::path::Path) -> anyhow::Result<String> {
     Ok(out)
 }
 
+/// The rolled-up doctor footer: the broken-install rollup (locally fixable via
+/// reconnect) + the decode-drift note (report-upstream). Split out of the
+/// I/O-heavy `run()` so the user-facing wording — singular/plural verb, the
+/// comma-joined broken list, and the drift branch — is teeth-testable in isolation.
+fn health_summary(n: usize, broken: &[String], any_drift: bool) -> String {
+    let mut out = String::new();
+    if broken.is_empty() {
+        out.push_str(&format!("\n{n} sources · ✓ all connected installs sound"));
+    } else {
+        let verb = if broken.len() == 1 { "needs" } else { "need" };
+        out.push_str(&format!(
+            "\n{n} sources · ⚠ {} {verb} attention ({}) — reconnect in the Sources panel (press s)",
+            broken.len(),
+            broken.join(", ")
+        ));
+    }
+    if any_drift {
+        out.push_str(
+            " · ⚠ decode drift recorded — may predate a CLI's wire format; report: \
+             https://github.com/IvanWng97/pixtuoid/issues\n",
+        );
+    } else {
+        out.push_str(" · ✓ no decode drift\n");
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::io::Write;
     use std::sync::{Arc, Mutex};
     use tracing_subscriber::fmt::MakeWriter;
+
+    #[test]
+    fn health_summary_one_broken_uses_the_singular_verb() {
+        let s = health_summary(9, &["cc·claude-code".to_string()], false);
+        assert!(
+            s.contains("⚠ 1 needs attention (cc·claude-code)"),
+            "singular verb + the broken id: {s:?}"
+        );
+        assert!(s.contains("✓ no decode drift"), "clean-drift branch: {s:?}");
+    }
+
+    #[test]
+    fn health_summary_many_broken_pluralizes_and_comma_joins() {
+        let s = health_summary(
+            9,
+            &["cc·claude-code".to_string(), "cx·codex".to_string()],
+            false,
+        );
+        assert!(
+            s.contains("⚠ 2 need attention (cc·claude-code, cx·codex)"),
+            "plural verb + comma-joined list: {s:?}"
+        );
+    }
+
+    #[test]
+    fn health_summary_clean_installs_with_and_without_drift() {
+        // Exact byte layout for the clean case pins the leading/trailing `\n` and
+        // the ` · ` joiners the extraction must preserve (the substring tests above
+        // deliberately don't, so a whitespace regression would slip past them).
+        let clean = health_summary(9, &[], false);
+        assert_eq!(
+            clean,
+            "\n9 sources · ✓ all connected installs sound · ✓ no decode drift\n"
+        );
+        let drifted = health_summary(9, &[], true);
+        assert!(
+            drifted.contains("⚠ decode drift recorded"),
+            "drift flag surfaces the report note: {drifted:?}"
+        );
+    }
 
     #[test]
     fn linux_activation_backend_covers_every_channel_in_priority_order() {

--- a/crates/pixtuoid/src/focus/mod.rs
+++ b/crates/pixtuoid/src/focus/mod.rs
@@ -449,6 +449,30 @@ mod tests {
         });
         assert!(!called, "silent no-op without a pid");
     }
+
+    #[test]
+    fn focus_agent_no_focusable_ancestor_never_activates() {
+        // resolve yields a pid but the walk finds NO focusable ancestor → the fn
+        // must return without activating. Teeth: a regression that activates the
+        // raw resolved pid (the agent's own process) instead of a walked terminal-
+        // app ancestor would call `activate` here.
+        let t = MockTable {
+            parents: HashMap::new(),
+            focusable: vec![],
+            started: HashMap::new(),
+        };
+        let mut activated: Option<i32> = None;
+        focus_agent(
+            &slot("opencode", "s", Some(pid_id(4242, None))),
+            &NO_PATHS,
+            &t,
+            |p| {
+                activated = Some(p);
+                true
+            },
+        );
+        assert_eq!(activated, None, "no focusable ancestor ⇒ nothing activated");
+    }
 }
 
 /// Live dogfood (manual, `cargo test -p pixtuoid --lib focus -- --ignored`):

--- a/crates/pixtuoid/src/sources.rs
+++ b/crates/pixtuoid/src/sources.rs
@@ -359,15 +359,26 @@ fn apply_one(cfg: &Path, sid: &'static str, action: Action) -> ChangeOutcome {
             Err(e) => ChangeOutcome::Failed(format!("{e:#}")),
         },
         Action::Disconnect => match disconnect(cfg, sid) {
-            // The flag IS disconnected; surface a folded hook-removal failure so a
-            // caller doesn't hide stale hooks behind a clean "disconnected".
-            Ok(DisconnectOutcome::HookRemovalFailed(e)) => {
-                ChangeOutcome::Failed(format!("hooks not removed: {e}"))
-            }
-            Ok(_) => ChangeOutcome::Disconnected,
+            Ok(o) => map_disconnect_outcome(o),
             Err(e) => ChangeOutcome::Failed(format!("{e:#}")),
         },
         Action::NoOp => ChangeOutcome::NoOp,
+    }
+}
+
+/// Map a SUCCESSFUL `disconnect`'s [`DisconnectOutcome`] to the CLI
+/// [`ChangeOutcome`]. Split out of `apply_one` so the load-bearing fold is
+/// teeth-testable apart from the real install FS path: a folded hook-removal
+/// failure MUST surface as `Failed` (with the reason), NEVER a clean
+/// `Disconnected` — else a caller hides stale hooks behind a clean "disconnected".
+fn map_disconnect_outcome(o: DisconnectOutcome) -> ChangeOutcome {
+    match o {
+        DisconnectOutcome::HookRemovalFailed(e) => {
+            ChangeOutcome::Failed(format!("hooks not removed: {e}"))
+        }
+        DisconnectOutcome::FlagOnly | DisconnectOutcome::Uninstalled(_) => {
+            ChangeOutcome::Disconnected
+        }
     }
 }
 
@@ -693,6 +704,22 @@ mod tests {
         let connected = set(&["antigravity"]);
         let freeze = freeze_for_skip(["antigravity", "codex"], &connected, |_| false);
         assert_eq!(freeze, vec![("antigravity", true), ("codex", false)]);
+    }
+
+    #[test]
+    fn map_disconnect_outcome_surfaces_a_folded_hook_removal_failure() {
+        // The safety fold: a disconnect whose flag flipped but whose hooks did NOT
+        // get removed must surface as Failed (with the reason), never a clean
+        // Disconnected — else a caller hides stale hooks behind "disconnected".
+        match map_disconnect_outcome(DisconnectOutcome::HookRemovalFailed("boom".into())) {
+            ChangeOutcome::Failed(m) => assert_eq!(m, "hooks not removed: boom"),
+            other => panic!("expected Failed, got {other:?}"),
+        }
+        // A clean disconnect (flag-only) maps to a plain Disconnected.
+        assert!(matches!(
+            map_disconnect_outcome(DisconnectOutcome::FlagOnly),
+            ChangeOutcome::Disconnected
+        ));
     }
 
     #[test]


### PR DESCRIPTION
The honest outcome of the "chase 100% coverage" deep-dive: the codebase is already well-tested where it counts. Most of the remaining ~3.5% is **untestable-by-nature** (kqueue/`EVFILT` syscall errors, jsonl/grok async+socket glue, `/dev/tty` + rodio device I/O) or **e2e-covered-but-uncounted** (`status()`/`detect()` via the `cli_json` subprocess, which in-process llvm-cov doesn't attribute). Rather than write coverage-theater, this closes the **3 genuinely load-bearing gaps** — 2 via a small pure-extraction that also improves the design.

## Changes

- **doctor.rs** — extract `health_summary(n, broken, any_drift)` out of the I/O-heavy `run()`. 3 teeth tests pin the user-facing wording (singular/plural verb, comma-joined broken list, decode-drift branch) + an exact-byte-layout assertion for the clean case. Was inline + untestable.
- **sources.rs** — extract `map_disconnect_outcome(DisconnectOutcome)` out of `apply_one`. Teeth test on the **safety fold**: a folded hook-removal failure must surface as `Failed` (with reason), NEVER a clean `Disconnected` — else stale hooks hide behind "disconnected". Expanding `Ok(_)` → `FlagOnly | Uninstalled(_)` makes a future variant a **compile error** here instead of a silent remap.
- **focus/mod.rs** — `focus_agent_no_focusable_ancestor_never_activates`: pins that a resolved pid with no focusable ancestor activates **nothing** (guards against activating the agent's own pid instead of a walked terminal-app ancestor).

## Verification
- Both extractions **behavior-identical** (full preflight green, 2514 tests).
- All 3 teeth **mutation-verified** (dropped verb / safety-fold collapse / raw-pid activation each turn the test red).
- **Two-lens review**: both APPROVE-WITH-NITS; the higher-value nit (exact byte-layout pin) folded in.
- No `pub` surface change (binary lib target isn't a semver surface).

Deliberately did NOT chase syscall-error / device-glue / e2e-covered lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)