### PR TITLE
fix(site): stop the statusline feed ghosting when a hidden tab is refocused

### DIFF
--- a/site/src/components/Statusline.astro
+++ b/site/src/components/Statusline.astro
@@ -105,6 +105,13 @@ const badgeColor = (who: string): string | undefined => {
   const hit = sources.find((s) => s.badge && who.startsWith(s.badge));
   return hit && 'badge_color' in hit ? (hit.badge_color as string) : undefined;
 };
+
+// Feed crossfade timing — single-sourced so the CSS fade (`--feed-fade`, set
+// from FEED_FADE_MS) and the JS out→in gap both derive from ONE value: a fade
+// longer than the gap would re-expose two lines mid-swap (ghosting).
+const FEED_FADE_MS = 300; // the .sl__item opacity transition
+const FEED_SWAP_GAP_MS = FEED_FADE_MS + 50; // fade-out must fully finish before fade-in starts
+const FEED_ROTATE_MS = 6000; // one line every 6s
 ---
 
 <div class="statusline" id="statusline">
@@ -350,8 +357,11 @@ const badgeColor = (who: string): string | undefined => {
     align-items: center;
     gap: 0.5rem;
     opacity: 0;
-    /* must finish inside the rotation's 350ms out→in gap */
-    transition: opacity 0.3s ease;
+    /* the operative fade is JS-set (--feed-fade, from FEED_FADE_MS) so it can
+       never drift past the out→in gap; the 0.3s literal is a never-operative
+       pre-JS default (rotation is JS-only, so the transition never fires before
+       the var is set). Must finish inside that gap. */
+    transition: opacity var(--feed-fade, 0.3s) ease;
   }
   .sl__item.is-on {
     opacity: 1;
@@ -523,6 +533,9 @@ const badgeColor = (who: string): string | undefined => {
     dimResting: DIM_RESTING,
     floorSpyRootMargin: FLOOR_SPY_ROOT_MARGIN,
     bottomClampEpsilonPx: BOTTOM_CLAMP_EPSILON_PX,
+    feedFadeMs: FEED_FADE_MS,
+    feedSwapGapMs: FEED_SWAP_GAP_MS,
+    feedRotateMs: FEED_ROTATE_MS,
   }}
 >
   (function () {
@@ -660,24 +673,40 @@ const badgeColor = (who: string): string | undefined => {
 
     // ── the feed: one item at a time, sequenced fade-out → fade-in (the items
     // are absolutely stacked, so a simultaneous swap double-exposes two lines
-    // mid-transition; reduced motion / user pause: static) ──
+    // mid-transition; reduced motion / user pause / hidden tab: static) ──
     const feedItems = Array.prototype.slice.call(bar.querySelectorAll('.sl__item'));
+    // Single-source the crossfade duration into CSS (inherited by .sl__item) so
+    // the fade and the JS out→in gap (feedSwapGapMs = fade + margin) can't drift.
+    bar.style.setProperty('--feed-fade', feedFadeMs + 'ms');
     let feedTimer = 0;
+    // the pending out→in swap: tracked so a mid-transition stop cancels it — a
+    // hidden tab whose timers kept firing would otherwise replay it on refocus
+    let feedSwap = 0;
     let feedOn = 0;
+    // Exactly one line lit — the crossfade's invariant. Snapping to it on every
+    // stop means a paused/hidden feed can never freeze with two half-faded lines
+    // showing (the ghosting we saw on refocus).
+    function showOnlyFeed(idx) {
+      feedItems.forEach(function (it, i) {
+        it.classList.toggle('is-on', i === idx);
+      });
+    }
     function stopFeed() {
       if (feedTimer) clearInterval(feedTimer);
-      feedTimer = 0;
+      if (feedSwap) clearTimeout(feedSwap);
+      feedTimer = feedSwap = 0;
+      showOnlyFeed(feedOn);
     }
     function startFeed() {
-      if (feedTimer || feedItems.length <= 1 || mq.matches || userPaused) return;
+      if (feedTimer || feedItems.length <= 1 || mq.matches || userPaused || document.hidden) return;
       feedTimer = setInterval(function () {
         feedItems[feedOn].classList.remove('is-on');
         feedOn = (feedOn + 1) % feedItems.length;
-        const next = feedItems[feedOn];
-        setTimeout(function () {
-          next.classList.add('is-on');
-        }, 350);
-      }, 6000);
+        feedSwap = setTimeout(function () {
+          feedSwap = 0;
+          showOnlyFeed(feedOn);
+        }, feedSwapGapMs);
+      }, feedRotateMs);
     }
 
     // ── env readouts ──
@@ -811,6 +840,15 @@ const badgeColor = (who: string): string | undefined => {
         renderAir();
       });
     }
+    // A hidden tab freezes CSS transitions but keeps setInterval/setTimeout
+    // firing — the office render loop already stops on hide (OfficeBackdrop),
+    // but this ambient ticker was still free-running, so its queued is-on swaps
+    // all replayed their fades at once on refocus (ghosted double text). Stop
+    // the rotation while hidden and resync on return.
+    document.addEventListener('visibilitychange', function () {
+      if (document.hidden) stopFeed();
+      else startFeed();
+    });
     startFeed();
   })();
 </script>

--- a/site/src/components/Statusline.astro
+++ b/site/src/components/Statusline.astro
@@ -110,7 +110,8 @@ const badgeColor = (who: string): string | undefined => {
 // from FEED_FADE_MS) and the JS out→in gap both derive from ONE value: a fade
 // longer than the gap would re-expose two lines mid-swap (ghosting).
 const FEED_FADE_MS = 300; // the .sl__item opacity transition
-const FEED_SWAP_GAP_MS = FEED_FADE_MS + 50; // fade-out must fully finish before fade-in starts
+const FEED_SWAP_MARGIN_MS = 50; // headroom so the fade-out fully finishes before the fade-in starts
+const FEED_SWAP_GAP_MS = FEED_FADE_MS + FEED_SWAP_MARGIN_MS; // out→in gap (must outlast the fade)
 const FEED_ROTATE_MS = 6000; // one line every 6s
 ---
 

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -1831,6 +1831,46 @@ test('the feed hides itself, rather than show an unreadably short fragment, at a
   await expect(page.locator('.sl__feed')).toBeVisible();
 });
 
+test('the feed pauses while the tab is hidden — no ghosted double-exposure on refocus', async ({
+  page,
+}) => {
+  // A hidden tab freezes CSS transitions but NOT setInterval/setTimeout. If the
+  // crossfading feed kept rotating while hidden, its queued out→in `is-on` class
+  // swaps would replay their opacity fades AT ONCE on refocus — two lines
+  // double-exposed (the ghosting bug). The rotation must stop while hidden and
+  // resync on return; at every point exactly one item is lit.
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await gotoLive(page);
+  await expect(page.locator('.sl__item.is-on')).toHaveCount(1);
+
+  const litIndex = () =>
+    page.evaluate(() =>
+      Array.from(document.querySelectorAll('.sl__item')).findIndex((el) =>
+        el.classList.contains('is-on')
+      )
+    );
+  const before = await litIndex();
+  expect(before).toBeGreaterThanOrEqual(0);
+
+  // Force the tab "hidden" (the handler reads document.hidden) and wait past one
+  // 6s rotation: with the fix the rotation is paused, so the SAME single line
+  // stays lit; with the bug it advances (and would ghost on show).
+  await page.evaluate(() => {
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => true });
+    document.dispatchEvent(new Event('visibilitychange'));
+  });
+  await page.waitForTimeout(6500);
+  await expect(page.locator('.sl__item.is-on')).toHaveCount(1);
+  expect(await litIndex()).toBe(before); // rotation truly paused while hidden
+
+  // Refocus: still exactly one lit, no double-exposure.
+  await page.evaluate(() => {
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => false });
+    document.dispatchEvent(new Event('visibilitychange'));
+  });
+  await expect(page.locator('.sl__item.is-on')).toHaveCount(1);
+});
+
 test('footer separators never strand alone at a wrap boundary', async ({ page }) => {
   // Each "·" is grouped with the item it introduces into ONE flex item
   // (.footer__grp), so flex-wrap can only break BETWEEN groups. Pin the

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -1849,16 +1849,28 @@ test('the feed pauses while the tab is hidden — no ghosted double-exposure on 
         el.classList.contains('is-on')
       )
     );
-  const before = await litIndex();
-  expect(before).toBeGreaterThanOrEqual(0);
 
-  // Force the tab "hidden" (the handler reads document.hidden) and wait past one
-  // 6s rotation: with the fix the rotation is paused, so the SAME single line
-  // stays lit; with the bug it advances (and would ghost on show).
-  await page.evaluate(() => {
+  // Force the tab "hidden" (the handler reads document.hidden) AND read the lit
+  // line in the SAME synchronous evaluate: dispatching visibilitychange runs
+  // stopFeed → showOnlyFeed, so exactly one item is lit and no rotation timer is
+  // pending. Reading here (not before the stop) is deterministic — it can't land
+  // in the fade gap (findIndex → -1) or race a free-running 6s tick.
+  const before = await page.evaluate(() => {
     Object.defineProperty(document, 'hidden', { configurable: true, get: () => true });
     document.dispatchEvent(new Event('visibilitychange'));
+    return Array.from(document.querySelectorAll('.sl__item')).findIndex((el) =>
+      el.classList.contains('is-on')
+    );
   });
+  expect(before).toBeGreaterThanOrEqual(0);
+
+  // A pix:paused{false} can fire WHILE hidden (OfficeBackdrop dispatches it on a
+  // reduced-motion toggle) — startFeed's document.hidden guard must refuse to
+  // re-arm the rotation behind a hidden tab. Then wait past one 6s rotation:
+  // with the fix nothing advances; with the bug the interval keeps ticking.
+  await page.evaluate(() =>
+    document.dispatchEvent(new CustomEvent('pix:paused', { detail: { paused: false } }))
+  );
   await page.waitForTimeout(6500);
   await expect(page.locator('.sl__item.is-on')).toHaveCount(1);
   expect(await litIndex()).toBe(before); // rotation truly paused while hidden
@@ -1867,6 +1879,14 @@ test('the feed pauses while the tab is hidden — no ghosted double-exposure on 
   await page.evaluate(() => {
     Object.defineProperty(document, 'hidden', { configurable: true, get: () => false });
     document.dispatchEvent(new Event('visibilitychange'));
+  });
+  await expect(page.locator('.sl__item.is-on')).toHaveCount(1);
+
+  // stopFeed collapses any accidental multi-lit state to exactly one line: force
+  // an illegal 2+-lit state, then a stop (user pause) must snap it back to one.
+  await page.evaluate(() => {
+    document.querySelectorAll('.sl__item').forEach((el) => el.classList.add('is-on'));
+    document.dispatchEvent(new CustomEvent('pix:paused', { detail: { paused: true } }));
   });
   await expect(page.locator('.sl__item.is-on')).toHaveCount(1);
 });


### PR DESCRIPTION
## What

The footer statusline's PR-feed ticker sometimes shows **ghosted double-exposed text** — two lines overlapping — when you tab away and come back.

## Root cause

The ticker crossfades absolutely-stacked `.sl__item` spans by animating `opacity`, sequenced with a wall-clock gap so only one line is ever visible. The office render loop stops itself on `visibilitychange`, but the feed ticker's `setInterval` did **not** — and a hidden tab **freezes CSS transitions while keeping `setInterval`/`setTimeout` firing**. So the queued `is-on` class swaps all replay their fades *at once* on refocus: two lines double-exposed.

## The fix (`Statusline.astro`)

1. **Pause the rotation while `document.hidden`** and resync on return — mirrors `OfficeBackdrop`'s own `visibilitychange` stop. (The `document.hidden` guard in `startFeed` also fixes a page *loaded* in a background tab, which used to start accumulating the ghost immediately.)
2. **Hardened `stopFeed()`** — cancels the pending out→in swap timeout (previously an untracked, leaking `setTimeout`) and snaps to exactly one lit line via `showOnlyFeed()`, so no stop path can strand two half-faded lines.
3. **Single-sourced the fade↔gap coupling** — the CSS fade (`--feed-fade`) and the JS out→in gap both derive from one `FEED_FADE_MS` (`gap = FEED_FADE_MS + FEED_SWAP_MARGIN_MS`), killing the latent drift where a longer CSS fade would re-expose two lines even without tab-switching.

## Tests

Playwright regression in `smoke.spec.ts`: force `document.hidden` → wait past one rotation → the lit line is unchanged and exactly one is lit → refocus → still one. Additional assertions pin the two secondary defenses (the `startFeed` `document.hidden` guard against a `pix:paused{false}`-while-hidden re-arm; the `stopFeed` multi-lit collapse). Each verified **RED under its exact named mutation, GREEN restored**.

## Review

Two-lens merge-gate review (correctness + design), both **APPROVE-WITH-NITS**. All findings driven to a terminal state: 3 FIXED (named `FEED_SWAP_MARGIN_MS`; made the test's `before` read deterministic; added the two secondary-defense assertions), 1 REFUTED-with-trace (an optional `site/CLAUDE.md` note — nothing there is now false; internal impl detail, not an architecture/API change). Sibling sweep confirmed the feed ticker is the *only* vulnerable surface — dust/clips/vibing/backdrop/elevator are rAF-driven or already handled.

Gates: `just site-check` ✅ · `just site-e2e` ✅ (75 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvavzxtnQ1iddt36argJ1B
