### PR TITLE
fix(site): retry the shared wasm init so a transient fetch drop self-heals

### DIFF
--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -269,7 +269,11 @@ display-line authority (`starText`), unit-tested on its null-stars arm since
   call via `window.__pixWasm` — the generated glue's `__wbg_init` guards only the
   already-resolved instance, not an in-flight promise, so independent `mod.default()`
   calls racing before either resolves instantiate two separate wasm instances that
-  stomp the single module-global `wasm`. Schema: `kind:"live"`
+  stomp the single module-global `wasm`. A bounded retry (2×, 400ms backoff) wraps
+  that shared init for transient wasm-fetch resilience, but stays INSIDE the one
+  `__pixWasm` promise — a per-consumer retry would reintroduce the very
+  double-instantiate race above (the retry consts are pinned equal across the two
+  boot scripts by `config/wasm-init-consts.test.mjs`). Schema: `kind:"live"`
   + `variantGroups` (per-group `retint`) + `poster` + `timeSlider` in `showcase.json`,
   resolved by `showcaseGroups` in `consts.ts`, validated by the `astro.config.mjs`
   showcase guard's live branch. Fallback (no-JS / no-wasm / reduced-motion): the

--- a/site/config/wasm-init-consts.test.mjs
+++ b/site/config/wasm-init-consts.test.mjs
@@ -1,0 +1,32 @@
+// The bounded wasm-init retry lives in TWO is:inline scripts that share no JS
+// module scope — OfficeBackdrop's boot() and Showcase's bootCanvas() — so its
+// consts are duplicated by necessity (an is:inline script can't `import` a
+// shared const at runtime). Only ONE copy ever executes per page (the
+// `window.__pixWasm ||` short-circuit picks whichever consumer boots first), so
+// a drift is runtime-inert — but a one-sided retune would silently make the
+// retry budget depend on which consumer booted first. Pin the two copies equal
+// so the "keep in sync" comment is a fact, not a hope (the repo magic-number
+// convention: duplicated cross-boundary consts are pinned by a test, not a
+// comment alone).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const read = (rel) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)), 'utf8');
+const FILES = ['../src/components/OfficeBackdrop.astro', '../src/components/Showcase.astro'];
+
+for (const name of ['WASM_INIT_RETRIES', 'WASM_INIT_BACKOFF_MS']) {
+  test(`${name} is identical across both wasm-init boot scripts`, () => {
+    const values = FILES.map((rel) => {
+      const m = read(rel).match(new RegExp(`const ${name} = (\\d+)`));
+      assert.ok(m, `${rel} must declare ${name}`);
+      return m[1];
+    });
+    assert.equal(
+      values[0],
+      values[1],
+      `${name} drifted between OfficeBackdrop.astro and Showcase.astro`
+    );
+  });
+}

--- a/site/src/components/OfficeBackdrop.astro
+++ b/site/src/components/OfficeBackdrop.astro
@@ -1038,19 +1038,17 @@ import { asset, DIM_RESTING } from '../consts';
       // Office built against the losing instance reading the wrong linear
       // memory forever. Memoize ONE shared init promise on `window` so every
       // consumer awaits the same instantiation (site/CLAUDE.md VIBING entry).
-      // A transient drop on the ~874KB wasm fetch — a flaky link, or a brief
-      // glue/wasm cache-desync during a Pages deploy (max-age=600, unhashed
-      // names) — used to STRAND the office on the poster until a manual reload:
-      // the rejected init promise was memoized on window and never retried.
-      // Retry the import+instantiate a bounded number of times with backoff so a
-      // recoverable blip self-heals; only once WASM_INIT_RETRIES exhaust does the
-      // promise reject (→ poster, the deliberate no-wasm fallback). The retry
-      // stays INSIDE this one shared promise on purpose — both live-office
-      // consumers (this backdrop + Showcase VIBING) must keep awaiting a SINGLE
-      // instantiation, so a per-consumer retry would reintroduce the
-      // double-instantiate race __pixWasm exists to close. Keep the retry factory
-      // in sync with Showcase.astro's bootCanvas() (separate is:inline scopes —
-      // no shared const, so the two copies are pinned by this comment).
+      // A transient drop on the ~874KB wasm-binary fetch (a flaky link) used to
+      // strand the office on the poster until a manual reload — the rejected
+      // init promise was memoized on window and never retried. Retry
+      // import+instantiate a bounded number of times with backoff so a
+      // recoverable blip self-heals; on exhaustion the promise rejects → poster
+      // (the deliberate no-wasm fallback). Scope: this re-fetches the binary; a
+      // first-load GLUE-import() failure is import-map-cached and not covered.
+      // The retry MUST stay INSIDE this one shared promise — a per-consumer
+      // retry would reintroduce the double-instantiate race __pixWasm closes
+      // (site/CLAUDE.md, VIBING entry). Retry consts mirror Showcase.astro's
+      // bootCanvas(), pinned by config/wasm-init-consts.test.mjs.
       window.__pixWasm =
         window.__pixWasm ||
         (function initSharedWasm() {
@@ -1106,7 +1104,7 @@ import { asset, DIM_RESTING } from '../consts';
           markEngineResolved();
         });
     }
-    // Defer the ~740KB wasm fetch OUT of the render-critical window: kick it
+    // Defer the ~874KB wasm fetch OUT of the render-critical window: kick it
     // after `load`, at idle, so it stops competing with the above-fold poster /
     // fonts / CSS (LCP is the H1 text). The bg-tone cover holds until the first
     // frame lands (~0.5–1s later on fast links), then the office FLOOR-ROLLS in

--- a/site/src/components/OfficeBackdrop.astro
+++ b/site/src/components/OfficeBackdrop.astro
@@ -1038,13 +1038,42 @@ import { asset, DIM_RESTING } from '../consts';
       // Office built against the losing instance reading the wrong linear
       // memory forever. Memoize ONE shared init promise on `window` so every
       // consumer awaits the same instantiation (site/CLAUDE.md VIBING entry).
+      // A transient drop on the ~874KB wasm fetch — a flaky link, or a brief
+      // glue/wasm cache-desync during a Pages deploy (max-age=600, unhashed
+      // names) — used to STRAND the office on the poster until a manual reload:
+      // the rejected init promise was memoized on window and never retried.
+      // Retry the import+instantiate a bounded number of times with backoff so a
+      // recoverable blip self-heals; only once WASM_INIT_RETRIES exhaust does the
+      // promise reject (→ poster, the deliberate no-wasm fallback). The retry
+      // stays INSIDE this one shared promise on purpose — both live-office
+      // consumers (this backdrop + Showcase VIBING) must keep awaiting a SINGLE
+      // instantiation, so a per-consumer retry would reintroduce the
+      // double-instantiate race __pixWasm exists to close. Keep the retry factory
+      // in sync with Showcase.astro's bootCanvas() (separate is:inline scopes —
+      // no shared const, so the two copies are pinned by this comment).
       window.__pixWasm =
         window.__pixWasm ||
-        import(wasmJsUrl).then(function (m) {
-          return m.default().then(function () {
-            return m;
-          });
-        });
+        (function initSharedWasm() {
+          const WASM_INIT_RETRIES = 2; // extra attempts after the first
+          const WASM_INIT_BACKOFF_MS = 400;
+          function attempt(left) {
+            return import(wasmJsUrl)
+              .then(function (m) {
+                return m.default().then(function () {
+                  return m;
+                });
+              })
+              .catch(function (err) {
+                if (left <= 0) throw err;
+                return new Promise(function (res) {
+                  setTimeout(res, WASM_INIT_BACKOFF_MS);
+                }).then(function () {
+                  return attempt(left - 1);
+                });
+              });
+          }
+          return attempt(WASM_INIT_RETRIES);
+        })();
       window.__pixWasm
         .then(function (mod) {
           // __wbg_init is idempotent once resolved, so this just hands back

--- a/site/src/components/Showcase.astro
+++ b/site/src/components/Showcase.astro
@@ -339,13 +339,35 @@ const countWord = COUNT_WORDS[channels.length] ?? String(channels.length);
       // resolves would instantiate two wasm instances and stomp the single
       // module-global `wasm` (see OfficeBackdrop.astro's `boot()` for the
       // full race + site/CLAUDE.md's VIBING entry).
+      // Bounded retry with backoff so a transient wasm-fetch drop self-heals
+      // instead of stranding the office on the poster until a manual reload — the
+      // retry MUST stay inside the one shared __pixWasm promise (both live-office
+      // consumers await a SINGLE instantiation; a per-consumer retry would
+      // reintroduce the double-instantiate race). Keep in sync with
+      // OfficeBackdrop.astro's boot(), where the full rationale lives.
       window.__pixWasm =
         window.__pixWasm ||
-        import(wasmJsUrl).then(function (m) {
-          return m.default().then(function () {
-            return m;
-          });
-        });
+        (function initSharedWasm() {
+          const WASM_INIT_RETRIES = 2; // extra attempts after the first
+          const WASM_INIT_BACKOFF_MS = 400;
+          function attempt(left) {
+            return import(wasmJsUrl)
+              .then(function (m) {
+                return m.default().then(function () {
+                  return m;
+                });
+              })
+              .catch(function (err) {
+                if (left <= 0) throw err;
+                return new Promise(function (res) {
+                  setTimeout(res, WASM_INIT_BACKOFF_MS);
+                }).then(function () {
+                  return attempt(left - 1);
+                });
+              });
+          }
+          return attempt(WASM_INIT_RETRIES);
+        })();
       window.__pixWasm
         .then(function (mod) {
           // idempotent once resolved — hands back the shared exports/memory

--- a/site/src/components/Showcase.astro
+++ b/site/src/components/Showcase.astro
@@ -339,12 +339,12 @@ const countWord = COUNT_WORDS[channels.length] ?? String(channels.length);
       // resolves would instantiate two wasm instances and stomp the single
       // module-global `wasm` (see OfficeBackdrop.astro's `boot()` for the
       // full race + site/CLAUDE.md's VIBING entry).
-      // Bounded retry with backoff so a transient wasm-fetch drop self-heals
-      // instead of stranding the office on the poster until a manual reload — the
-      // retry MUST stay inside the one shared __pixWasm promise (both live-office
-      // consumers await a SINGLE instantiation; a per-consumer retry would
-      // reintroduce the double-instantiate race). Keep in sync with
-      // OfficeBackdrop.astro's boot(), where the full rationale lives.
+      // Bounded retry with backoff so a transient wasm-binary fetch drop
+      // self-heals instead of stranding the office on the poster until a manual
+      // reload — the retry MUST stay inside the one shared __pixWasm promise (a
+      // per-consumer retry would reintroduce the double-instantiate race). Full
+      // rationale: OfficeBackdrop.astro's boot() + site/CLAUDE.md; retry consts
+      // pinned by config/wasm-init-consts.test.mjs.
       window.__pixWasm =
         window.__pixWasm ||
         (function initSharedWasm() {

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -714,6 +714,43 @@ test('wasm fetch failure keeps the still poster without an uncaught error', asyn
   await context.close();
 });
 
+test('a transient wasm-fetch drop self-heals: the office still goes live via retry', async ({
+  browser,
+}) => {
+  // The boot path memoizes ONE shared init promise on window.__pixWasm; before
+  // the bounded retry (OfficeBackdrop.boot / Showcase.bootCanvas), a single
+  // dropped wasm fetch rejected that promise and stranded the office on the
+  // poster until a manual reload. Abort ONLY the FIRST pixtuoid_web_bg.wasm
+  // request (the big binary — the likeliest drop) and let every retry through:
+  // the office MUST recover and go live without a reload.
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  const errors = watchErrors(page);
+  let wasmHits = 0;
+  let abortedFirst = false;
+  await page.route('**/pixtuoid_web_bg.wasm', (route) => {
+    wasmHits += 1;
+    if (wasmHits === 1) {
+      abortedFirst = true;
+      return route.abort();
+    }
+    return route.continue();
+  });
+  await page.addInitScript(() => sessionStorage.setItem('pix-booted', '1'));
+  await page.goto('./');
+  // Retry recovers: poster → live canvas comes up despite the first-fetch abort.
+  await expect(page.locator('.backdrop.is-live')).toBeAttached({ timeout: 20_000 });
+  await expect(page.locator('[data-sl-onair]')).toHaveText('● LIVE', { timeout: 10_000 });
+  // Prove the recovery went through the retry, not a lucky single fetch: the
+  // first request was aborted and at least one re-fetch followed.
+  expect(abortedFirst).toBe(true);
+  expect(wasmHits).toBeGreaterThan(1);
+  // The one aborted request logs a resource error; the retried rejection must
+  // stay handled — nothing uncaught beyond that line.
+  expect(errors().filter((e) => !e.includes('Failed to load resource'))).toEqual([]);
+  await context.close();
+});
+
 test('key vocabulary: digits ride globally, typing surfaces stay guarded, t keeps its gate', async ({
   page,
 }) => {


### PR DESCRIPTION
## Problem

`pixtuoid.dev` occasionally loads with the office **stuck on the still poster** — the live wasm office never comes up — and a reload fixes it. Diagnosed as a **transient wasm-fetch failure that couldn't self-heal**:

- The hero backdrop and the Showcase VIBING channel share **one** `window.__pixWasm` init promise (needed — the glue's `__wbg_init` memoizes only the *resolved* instance, not the in-flight promise, so independent inits would double-instantiate and stomp the module-global).
- That promise was memoized **even when it rejected**, and the boot `.catch` **never retried** — so a single dropped ~874KB fetch (flaky link, or a brief glue/wasm cache-desync during a Pages deploy: `max-age=600`, unhashed filenames) stranded the office on the poster until a manual reload.

The live deploy is healthy on every systemic axis (CSP `wasm-unsafe-eval` present, `application/wasm` MIME, gzip, live sha256 == committed manifest), so this is a resilience gap, not a broken build.

## Fix

Retry the import+instantiate **2× with 400ms backoff, inside the one shared `__pixWasm` promise** (a per-consumer retry would reintroduce the double-instantiate race). Only once the retries exhaust does it reject → poster, the deliberate no-JS/no-wasm/reduced-motion fallback, unchanged. Duplicated across the two `is:inline` consumers (`OfficeBackdrop.boot` / `Showcase.bootCanvas`) — separate script scopes, no shared const, pinned by a cross-ref comment.

## Test

New Playwright case: abort the **first** `pixtuoid_web_bg.wasm` fetch, let retries through, assert the office still goes `● LIVE` (`abortedFirst && wasmHits > 1`). **Red-checked** — it fails without the fix (office never attaches `.backdrop.is-live`).

## Gates

- `just site-check` — tsc + 38 unit + eslint + build ✓
- `just site-e2e` — 77 Playwright tests ✓ (incl. goes-live, failure-poster, VIBING second-consumer, new retry)
- `just preflight` — full Rust gate green (pre-push hook, 2527 tests) ✓

Two-lens review in progress; disposition will follow in-thread before this is merge-ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fyBXdKR1YzwmfLzm3Pc9H
