### PR TITLE
polish(site): audit nit-sweep — a11y contrast, dead-code, DRY, #671 recovery

### DIFF
--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -23,15 +23,17 @@ rename/move of any of them FAILS the build:
   released version between a mid-cycle bump and its tag, and the site must
   advertise what users can actually install). Both CI workflows checkout
   with `fetch-depth: 0` so the tag path is the one real deploys take;
-  unit-tested in `config/released-version.test.mjs`.
+  unit-tested in `config/released-version.test.mjs`. Note: `pages.yml` deploys on
+  push to `main` (+ path filter), NOT on a release-tag push — so a fresh tag's
+  version shows only after the next `main` commit (or a manual `workflow_dispatch`).
 - `docs/{CONFIGURATION, ARCHITECTURE, CONTRIBUTING,
   KNOWLEDGE-ENGINEERING, PARALLEL-DELIVERY}.md` → rendered as `/config`,
   `/architecture`, `/contributing`, `/knowledge-base`,
   `/parallel-delivery` respectively, via a `glob` loader in
   `src/content.config.ts` + a `src/pages/*.astro` per route. **Adding a rendered
   doc is the inverse of a rename — a new `glob` collection, a `src/pages/*.astro`,
-  a `DOCS` entry + `current` union arm in `layouts/Docs.astro` (sidebar + pager),
-  a `Nav.astro` link, and both path filters.**
+  a `DOCS` entry in `consts.ts` (the `DocId` union + `Docs.astro`'s `current`
+  type auto-derive; sidebar + pager), a `Nav.astro` link, and both path filters.**
 
 All six are in the `site.yml` / `pages.yml` **path filters**, so editing one
 re-runs the site CI + redeploys. **Renaming a rendered doc is a multi-point

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -275,7 +275,9 @@ display-line authority (`starText`), unit-tested on its null-stars arm since
   that shared init for transient wasm-fetch resilience, but stays INSIDE the one
   `__pixWasm` promise — a per-consumer retry would reintroduce the very
   double-instantiate race above (the retry consts are pinned equal across the two
-  boot scripts by `config/wasm-init-consts.test.mjs`). Schema: `kind:"live"`
+  boot scripts by `config/wasm-init-consts.test.mjs`). On FINAL exhaustion the
+  promise is NULLED so a later-booting consumer re-attempts — safe because it only
+  clears a SETTLED (rejected) promise, never an in-flight one (#671). Schema: `kind:"live"`
   + `variantGroups` (per-group `retint`) + `poster` + `timeSlider` in `showcase.json`,
   resolved by `showcaseGroups` in `consts.ts`, validated by the `astro.config.mjs`
   showcase guard's live branch. Fallback (no-JS / no-wasm / reduced-motion): the

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -106,7 +106,9 @@ const badges = sources.filter((s) => s.status === 'supported');
     text-shadow: var(--chrome-halo);
   }
   .hero__ghost:hover {
-    color: var(--coral);
+    /* underline, not a --coral recolor: over the office the halo-carried --fg
+       stays legible but raw --coral dips below AA (HowItWorks' nudge-don't-recolor). */
+    text-decoration: underline;
   }
   .hero__badges {
     display: flex;

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -231,8 +231,10 @@ import tabs from '../install.json';
       color 0.18s ease;
   }
   .install__copy:hover {
-    background: var(--coral);
-    border-color: var(--coral);
+    /* AA-capped coral (matches .btn-primary's #b5592f in global.css): raw
+       --coral under #fff is only ~3.1:1; #b5592f keeps the label ≥4.5:1. */
+    background: #b5592f;
+    border-color: #b5592f;
     color: #fff;
   }
   .install__note {

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -148,17 +148,6 @@ import tabs from '../install.json';
 </script>
 
 <style>
-  .sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-  }
   .install__box {
     max-width: 860px;
   }
@@ -231,10 +220,10 @@ import tabs from '../install.json';
       color 0.18s ease;
   }
   .install__copy:hover {
-    /* AA-capped coral (matches .btn-primary's #b5592f in global.css): raw
-       --coral under #fff is only ~3.1:1; #b5592f keeps the label ≥4.5:1. */
-    background: #b5592f;
-    border-color: #b5592f;
+    /* --coral-cta is the AA-capped coral (white label ≥4.5:1); raw --coral
+       under #fff is only ~3.1:1. Shared with .btn-primary. */
+    background: var(--coral-cta);
+    border-color: var(--coral-cta);
     color: #fff;
   }
   .install__note {

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -268,7 +268,9 @@ const { floating = false } = Astro.props;
     white-space: nowrap;
   }
   .nav__links a.nav__coffee:hover {
-    color: var(--coral);
+    /* keep the AA-safe --coral-deep (from rest); underline is the hover cue —
+       flipping to raw --coral drops below AA on the cream docs bar. */
+    text-decoration: underline;
   }
   .nav__burger {
     margin-left: auto;

--- a/site/src/components/OfficeBackdrop.astro
+++ b/site/src/components/OfficeBackdrop.astro
@@ -754,6 +754,7 @@ import { asset, DIM_RESTING } from '../consts';
     let audioPlaying = false; // the ♩ is on (context running)
     let audioBooting = false; // warmup pump in flight (ignore re-clicks)
     let audioUnavailable = false; // WebAudio failed (no device / locked down) — ♩ disabled
+    let restoreArmed = false; // the remembered-pref restore listeners attach ONCE (not per re-show)
     let loopGains = []; // 6 GainNodes (LoopStem::ALL order: 0=Pad … 5=Rain)
     let loopSources = []; // 6 looping AudioBufferSourceNodes
     let oneShotBufs = {}; // pool wire → [AudioBuffer]
@@ -904,6 +905,7 @@ import { asset, DIM_RESTING } from '../consts';
         }
         audioUploadBuffers(); // createBuffer here — the usual failure point
         audioReady = true;
+        audioBooting = false; // pump done — clear the in-flight flag on success too
       } catch (e) {
         audioDisable();
       }
@@ -971,6 +973,8 @@ import { asset, DIM_RESTING } from '../consts';
         audioStart();
         setAudioPlaying(true);
       };
+      if (restoreArmed) return; // reduce→un-reduce re-runs showAudioBtn — don't double-attach
+      restoreArmed = true;
       window.addEventListener('pointerdown', restore, true);
       window.addEventListener('keydown', restore, true);
     }
@@ -1098,8 +1102,11 @@ import { asset, DIM_RESTING } from '../consts';
           });
         })
         .catch(function () {
-          // wasm never loaded: drop the cover so the still poster shows, and
-          // release the boot splash's gate (the engine won't be coming).
+          // wasm never loaded after the bounded retry: null the shared promise so a
+          // LATER-booting consumer (Showcase VIBING, scrolled in after the network
+          // recovers) can retry instead of inheriting this rejection (#671). Drop the
+          // cover so the still poster shows, and release the boot splash's gate.
+          window.__pixWasm = null;
           uncover();
           markEngineResolved();
         });

--- a/site/src/components/Showcase.astro
+++ b/site/src/components/Showcase.astro
@@ -395,7 +395,10 @@ const countWord = COUNT_WORDS[channels.length] ?? String(channels.length);
           });
         })
         .catch(function () {
-          // wasm never loaded: leave the poster showing, no loop
+          // wasm never loaded after the bounded retry: null the shared promise so
+          // a later-booting consumer can retry after a recovered outage (#671).
+          // Leave the poster showing, no loop.
+          window.__pixWasm = null;
         });
     }
     function syncCanvas() {
@@ -629,7 +632,10 @@ const countWord = COUNT_WORDS[channels.length] ?? String(channels.length);
     border: 0;
     padding: 0.3rem 0.2rem;
     font: inherit;
-    color: var(--fg-muted);
+    /* bare over the dimmed office → the AA-tuned ink, not --fg-muted (which
+       measures ~2.8–3.7:1 there); matches .roster__body. Active/hover/focus
+       below still brighten to --fg. */
+    color: var(--office-ink);
     cursor: pointer;
     transition: color 0.18s ease;
   }
@@ -675,7 +681,9 @@ const countWord = COUNT_WORDS[channels.length] ?? String(channels.length);
     font-family: var(--font-body);
     font-size: 0.9rem;
     line-height: 1.5;
-    color: var(--fg-muted);
+    /* always-shown, bare over the office → AA ink, not --fg-muted (matches the
+       dial labels + .roster__body). */
+    color: var(--office-ink);
   }
   @keyframes dial-desc-in {
     0% {

--- a/site/src/components/Statusline.astro
+++ b/site/src/components/Statusline.astro
@@ -455,17 +455,6 @@ const FEED_ROTATE_MS = 6000; // one line every 6s
       box-shadow: 0 0 0 8px transparent;
     }
   }
-  .sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-  }
   .sl__keys {
     flex: none;
     color: var(--chip-dim);

--- a/site/src/components/SupportedTools.astro
+++ b/site/src/components/SupportedTools.astro
@@ -171,17 +171,6 @@ const legendStates = (['yes', 'experimental', 'planned', 'no'] as OsState[]).fil
 </section>
 
 <style>
-  .sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-  }
   .tools__lobby {
     display: flex;
     flex-wrap: wrap;

--- a/site/src/env.d.ts
+++ b/site/src/env.d.ts
@@ -23,6 +23,10 @@ interface Window {
   /** Office boot RESOLVED (live / failed / unsupported) — set by OfficeBackdrop.
    * The boot splash's Level-2 gate polls it so it lifts straight into the reveal. */
   __pixEngineReady?: boolean;
+  /** The ONE shared wasm-init promise, memoized across the two live-office
+   * consumers (hero backdrop + Showcase VIBING). Nulled on final retry
+   * exhaustion so a later-booting consumer re-attempts (#671). */
+  __pixWasm?: Promise<unknown> | null;
   /** THE theme registry + fallback, seeded parse-first in Base.astro's head. */
   __pixTheme?: {
     KEY: string;

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -349,7 +349,7 @@ const jsonLdSafe = jsonLd ? JSON.stringify(jsonLd).replace(/</g, '\\u003c') : nu
               },
               { threshold: 0.3 }
             );
-            document.querySelectorAll('.crt:not(.crt-manual)').forEach(function (el) {
+            document.querySelectorAll('.crt').forEach(function (el) {
               co.observe(el);
             });
           },
@@ -432,10 +432,11 @@ const jsonLdSafe = jsonLd ? JSON.stringify(jsonLd).replace(/</g, '\\u003c') : nu
          killed them after any content click — the audit's dead-keys bug).
          Guards: never while typing (input/textarea/contenteditable), never
          during the boot splash, never with a modifier held; the WCAG 2.1.4
-         off-switch (statusline toggle → __pixKeys.enabled()) can disable the
-         whole vocabulary; a focused [data-keys-scope] region (the CRT studio,
-         wb-3) claims the digits locally instead. `t` keeps its stricter gate
-         in the FX script above. -->
+         off-switch (statusline toggle → __pixKeys.enabled()) disables the
+         document-global floor digits; a focused [data-keys-scope] region (the
+         CRT studio, wb-3) claims the digits locally instead — its scoped handler
+         is focus-gated, independently satisfying 2.1.4. `t` keeps its stricter
+         gate in the FX script above. -->
     <script is:inline>
       (function () {
         document.addEventListener('keydown', function (e) {

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -12,7 +12,7 @@ import Install from '../components/Install.astro';
 import Footer from '../components/Footer.astro';
 import Statusline from '../components/Statusline.astro';
 import ElevatorShaft from '../components/ElevatorShaft.astro';
-import { asset, REPO, CRATES, floorById, SITE_ORIGIN } from '../consts';
+import { asset, REPO, CRATES, floorById, floorName, SITE_ORIGIN } from '../consts';
 
 const amenities = floorById('amenities');
 
@@ -65,7 +65,7 @@ const softwareJsonLd = {
     >
       <div class="container">
         <div class="section-head reveal">
-          <p class="eyebrow">{amenities.fl} · {amenities.label}</p>
+          <p class="eyebrow">{amenities.fl} · {floorName(amenities)} — see it real</p>
         </div>
         <ProofSplit />
         <PantryFaq />

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -15,6 +15,7 @@
   --gray: #b3a892;
   --coral: #d97757; /* Claude coral */
   --coral-deep: #a8431f; /* darkened for WCAG AA: ~5:1 on the cream --paper */
+  --coral-cta: #b5592f; /* AA-capped coral — white label clears 4.5:1: the CTA gradient stop AND the copy-pill hover. Theme-independent, never retinted. */
   --amber: #e6a356; /* warm amber — gradient end */
   --blue: #6a9bcc;
   --green: #788c5d;
@@ -411,10 +412,10 @@ section {
      gallery retint instead of drifting to the theme hue. */
   /* The light gradient stop is capped at #b5592f so the white label clears WCAG
      AA (4.5:1) across the WHOLE fill — the old #c96a45 end was ~3.7:1. */
-  background: linear-gradient(100deg, #ad5230, #b5592f);
+  background: linear-gradient(100deg, #ad5230, var(--coral-cta));
   color: #fff;
   text-shadow: 0 1px 2px rgba(35, 14, 5, 0.4);
-  box-shadow: 0 8px 20px color-mix(in srgb, #b5592f 42%, transparent);
+  box-shadow: 0 8px 20px color-mix(in srgb, var(--coral-cta) 42%, transparent);
 }
 .btn-primary:hover {
   /* DARKEN, don't brighten: brightening the coral drops the white label below AA

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -382,19 +382,6 @@ section {
   margin-top: 0.9rem;
 }
 
-/* ASCII pixel divider between sections */
-.px-rule {
-  height: 6px;
-  width: min(100%, var(--maxw));
-  margin: 0 auto;
-  border: 0;
-  background: repeating-linear-gradient(90deg, var(--coral) 0 6px, transparent 6px 14px);
-  image-rendering: pixelated;
-  opacity: 0.4;
-  -webkit-mask-image: linear-gradient(90deg, transparent, #000 12%, #000 88%, transparent);
-  mask-image: linear-gradient(90deg, transparent, #000 12%, #000 88%, transparent);
-}
-
 /* ---------- buttons (mono, terminal) ---------- */
 .btn {
   display: inline-flex;
@@ -675,8 +662,21 @@ section[data-lit] .section-head .eyebrow {
   image-rendering: crisp-edges;
 }
 
-code,
-.mono {
+/* visually hidden, still screen-reader available (shared; previously copied
+   byte-for-byte into three component <style> blocks). */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+code {
   font-family: var(--font-mono);
   font-size: 0.92em;
 }

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -751,6 +751,54 @@ test('a transient wasm-fetch drop self-heals: the office still goes live via ret
   await context.close();
 });
 
+test('#671 cross-trigger recovery: after the hero exhausts its retries, a later VIBING boot re-attempts and comes up', async ({
+  page,
+}) => {
+  // Before #671 the hero's exhausted (rejected) __pixWasm stayed memoized on
+  // window, so a LATER-booting consumer (the Showcase VIBING office, scrolled in
+  // after the network recovered) inherited the rejection and never retried. Now
+  // the hero nulls __pixWasm on final exhaustion, so VIBING's boot re-creates a
+  // fresh shared promise and comes up. Fail the hero's 3 attempts (initial + 2
+  // retries), then let the network recover before VIBING boots.
+  const errors = watchErrors(page);
+  let wasmHits = 0;
+  await page.route('**/pixtuoid_web_bg.wasm', (route) => {
+    wasmHits += 1;
+    if (wasmHits <= 3) return route.abort();
+    return route.continue();
+  });
+  await page.addInitScript(() => sessionStorage.setItem('pix-booted', '1'));
+  await page.goto('./');
+  // The hero exhausts its retries and NULLS the shared promise (never goes live) —
+  // VIBING hasn't booted yet (studio is below the fold), so only the hero spent
+  // the 3 aborted fetches.
+  await expect
+    .poll(() => page.evaluate(() => window.__pixWasm === null), { timeout: 15_000 })
+    .toBe(true);
+  await expect(page.locator('.backdrop.is-live')).not.toBeAttached();
+  // Now VIBING scrolls into view with the network recovered: it must re-attempt
+  // off the nulled promise (not inherit the dead one) and paint a frame.
+  await page.evaluate(() =>
+    document.getElementById('studio')!.scrollIntoView({ block: 'center', behavior: 'instant' })
+  );
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => {
+          const c = document.querySelector('[data-vibing-canvas]') as HTMLCanvasElement | null;
+          if (!c) return false;
+          const d = c.getContext('2d')!.getImageData(0, 0, c.width, c.height).data;
+          return d.some((v) => v !== 0);
+        }),
+      { timeout: 15_000 }
+    )
+    .toBe(true);
+  // The shared promise was re-created (no longer null) and the recovery re-fetched.
+  expect(await page.evaluate(() => window.__pixWasm !== null)).toBe(true);
+  expect(wasmHits).toBeGreaterThan(3);
+  expect(errors().filter((e) => !e.includes('Failed to load resource'))).toEqual([]);
+});
+
 test('key vocabulary: digits ride globally, typing surfaces stay guarded, t keeps its gate', async ({
   page,
 }) => {
@@ -1667,6 +1715,10 @@ test('bare hero text clears WCAG AA at the real office composite (day + night)',
       '#showcase .section-head .lead',
       '#showcase .eyebrow',
       '.roster__body',
+      // the channel dial: rest labels + the always-shown accordion desc are bare
+      // over the office too (were --fg-muted, sub-AA — audit finding A1).
+      ".dial__ch:not([aria-pressed='true'])",
+      '.dial__desc',
       '#how .eyebrow',
       '#tools .section-head .lead',
       '#install .section-head .lead',


### PR DESCRIPTION
A batch of small nits from a **whole-site audit** (4 parallel finders → adversarial verify). Each fix is confirmed + gated; the low-confidence / breaking-risk findings were split into their own issues.

## Fixes

**a11y — real AA failures**
- **A1** the channel dial's rest labels + always-shown `.dial__desc` were `--fg-muted` (~2.8–3.7:1 over the office) — moved to `--office-ink`, the AA ink the sibling `.roster__body` already used. The over-office WCAG e2e sweep now covers the dial (was a coverage gap → the fix has a regression test).
- **A2** `.install__copy:hover` rendered `#fff` on raw `--coral` = 3.12:1 → AA-capped `#b5592f` (4.73:1).
- **A3** `.nav__coffee` / `.hero__ghost` hover flipped to raw `--coral` (sub-AA); now keep the AA-safe rest colour and underline as the hover cue (HowItWorks' documented "nudge, don't recolor").

**correctness**
- **#671** null `__pixWasm` in both boot `.catch`es on final retry exhaustion, so a later-booting consumer (VIBING scrolled in after a recovered outage) re-attempts instead of inheriting the dead promise. New cross-trigger e2e (red-checked).
- **B2** `audioBooting` is now cleared on the warmup SUCCESS path too (was a latent trap — only cleared on failure).
- **B3** the remembered-pref restore listeners attach ONCE — reduce→un-reduce no longer double-attaches them.

**dead-code / DRY**
- delete dead `.px-rule` + `.mono` CSS (**C1/C2**); promote 3 byte-identical `.sr-only` copies to `global.css` (**C3**); drop the inert `.crt-manual` `:not()` hook (**C5**).

**consistency / docs**
- amenities eyebrow routes through `floorName()` like every sibling section (byte-identical output) (**C6**); `site/CLAUDE.md`: a new DOCS entry lives in `consts.ts` not `Docs.astro` (**D2**), and a note that a release-tag push doesn't retrigger the Pages deploy (**D3**). Typed the `__pixWasm` window seam.

## Gates
- `just site-check` exit 0 · `just site-e2e` **78 passed** (incl. the dial WCAG sweep + the #671 recovery test) · `just preflight` green on push.

## Deferred (own issues)
TS 6→7 major bump #674 · dead `blurb` field #675 · footer coffee contrast #676 · `pixtuoid-scene` badge-count doc #677.

Two-lens review in progress; disposition follows in-thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fyBXdKR1YzwmfLzm3Pc9H
