### PR TITLE
fix(ci): deploy renders /architecture — pin withastro/action to npm + guard

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -43,22 +43,38 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('site/package-lock.json') }}
-      # withastro/action only runs `astro build`; gate the deploy on lint + types
-      # too, so a build-clean but lint/typecheck-failing commit can't ship. Also
-      # install Chromium here (same runner → cached) so withastro/action's build
-      # can render the /architecture ```mermaid block to an inline SVG.
+      # withastro/action runs `astro build` + uploads the Pages artifact; gate the
+      # deploy on lint + types too (a build-clean but typecheck-failing commit
+      # mustn't ship), and install Chromium here (same runner → global cache) so
+      # the action's build can render /architecture's ```mermaid block to an SVG.
       - name: Validate (lint + types) + Chromium for the diagram
         working-directory: site
         run: npm ci && npm run lint && npm run check && npx playwright install --with-deps chromium
       - uses: withastro/action@v6
-        # the ticker's build-time merged-PR fetch: unauthenticated quota on
-        # shared runner IPs is routinely exhausted -> silent canned-reel
-        # fallback; the ambient token (contents: read) gives real headroom
+        # the ticker's build-time merged-PR fetch: unauthenticated quota on shared
+        # runner IPs is routinely exhausted -> silent canned-reel fallback; the
+        # ambient token (contents: read) gives real headroom
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           path: ./site
           node-version: 26
+          # PIN npm. Without it, v6's detection fell back to pnpm, whose fresh
+          # install resolved a DIFFERENT Playwright than the Chromium installed
+          # above → rehype-mermaid's inline-SVG render of /architecture failed
+          # ("Executable doesn't exist at …/ms-playwright/chromium-XXXX") and
+          # silently shipped an EMPTY page. Forcing npm reuses package-lock.json,
+          # so the build's Playwright matches the cached Chromium and it renders.
+          package-manager: npm
+      # Fail LOUD: a mermaid render failure can collapse the whole ARCHITECTURE.md
+      # <Content /> to an empty article WITHOUT erroring the build. Assert the one
+      # mermaid page rendered its body — the deploy job is `needs: build`, so this
+      # gates it: a broken diagram can never silently ship an empty /architecture.
+      - name: Guard — the mermaid doc rendered its body
+        working-directory: site
+        run: |
+          test -f dist/architecture/index.html || { echo "::error::site/dist/architecture/index.html missing after build"; exit 1; }
+          grep -q 'Data flow' dist/architecture/index.html || { echo "::error::/architecture rendered EMPTY — rehype-mermaid inline-SVG failed (Chromium version mismatch?)"; exit 1; }
   deploy:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -66,15 +66,13 @@ jobs:
           # silently shipped an EMPTY page. Forcing npm reuses package-lock.json,
           # so the build's Playwright matches the cached Chromium and it renders.
           package-manager: npm
-      # Fail LOUD: a mermaid render failure can collapse the whole ARCHITECTURE.md
-      # <Content /> to an empty article WITHOUT erroring the build. Assert the one
-      # mermaid page rendered its body — the deploy job is `needs: build`, so this
-      # gates it: a broken diagram can never silently ship an empty /architecture.
-      - name: Guard — the mermaid doc rendered its body
-        working-directory: site
-        run: |
-          test -f dist/architecture/index.html || { echo "::error::site/dist/architecture/index.html missing after build"; exit 1; }
-          grep -q 'Data flow' dist/architecture/index.html || { echo "::error::/architecture rendered EMPTY — rehype-mermaid inline-SVG failed (Chromium version mismatch?)"; exit 1; }
+          # Build, then assert EVERY doc page rendered a body (and /architecture kept
+          # its mermaid <svg>) IN the action's own context, before it uploads — so a
+          # silent empty-render fails the build and never deploys. rehype-mermaid can
+          # collapse a doc's <Content /> to an empty <article> WITHOUT erroring
+          # `astro build` (it shipped an empty /architecture once). check:docs is the
+          # SAME generic check `verify`/site-check runs — see config/assert-docs-rendered.mjs.
+          build-cmd: npm run build && npm run check:docs
   deploy:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -66,6 +66,9 @@ jobs:
       - run: npm run build
         env:
           GH_STARS_OVERRIDE: 842
+      # the empty-render guard runs in the PR-gating CI too — not only `verify` /
+      # the deploy — so a collapsed doc render is caught pre-merge (#680).
+      - run: npm run check:docs
       # e2e smoke suite vs the PRODUCTION build just produced (astro preview,
       # the official Astro testing posture): pins the page's runtime contracts
       # — wasm office goes live, statusline truth-light, digit-key scrollspy,

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -42,7 +42,15 @@ path filters, and the doc itself (the `KNOWLEDGE-BASE → KNOWLEDGE-ENGINEERING`
 rename is the worked example: the *route slug* `/knowledge-base` was kept to
 avoid link rot while the file + display name changed). `ARCHITECTURE.md`'s
 Mermaid diagram becomes an inline SVG at build via `rehype-mermaid`, which is
-**why CI installs Chromium**; break the Mermaid syntax and `astro build` fails.
+**why CI installs Chromium**; break the Mermaid *syntax* and `astro build` fails —
+but a Chromium/Playwright *version* mismatch fails DIFFERENTLY: `rehype-mermaid`
+collapses the whole `<Content />` to an empty `<article>` WITHOUT erroring the
+build, so it can silently ship an empty `/architecture` (the deploy's
+`withastro/action` fell back to pnpm → a Playwright unmatched to the installed
+Chromium; #680 pins `package-manager: npm`). Guarded by
+`config/assert-docs-rendered.mjs` (`check:docs`) — run in `verify`/site-check AND
+the deploy's `build-cmd`, asserting every doc page's `<article>` has a body +
+`/architecture` kept its `<svg>` — so a collapsed render reddens, never deploys.
 
 **wb-5 (Lobby + Docs):** the five doc routes now mount the Statusline **doc
 variant** (index-only organs — floor lift, PR feed, env readouts, keys hint —

--- a/site/README.md
+++ b/site/README.md
@@ -35,7 +35,7 @@ fails loud on a squatted port by design.
 ## Quality gates
 
 ```sh
-npm run verify     # format:check → lint → astro check → knip → build  (== site CI)
+npm run verify     # format:check → lint → check → knip → test:unit → build → check:docs
 # individually:
 npm run format     # prettier --write .
 npm run lint       # eslint .

--- a/site/config/assert-docs-rendered.mjs
+++ b/site/config/assert-docs-rendered.mjs
@@ -1,0 +1,60 @@
+// Assert every rendered doc page actually has a body, and that /architecture kept
+// its mermaid <svg>. Catches the silent rehype-mermaid empty-render class: a
+// headless-Chromium/Playwright version hiccup collapses a doc's <Content /> to an
+// EMPTY <article> WITHOUT failing `astro build` — it shipped an empty /architecture
+// once (the deploy build's pnpm fallback pulled a Playwright that didn't match the
+// installed Chromium). GENERIC on purpose: it globs every page carrying the Docs
+// layout's `<article class="prose">` (config / architecture / contributing /
+// knowledge-base / parallel-delivery + any future doc), so there's no per-page or
+// per-heading string to drift — the exact "hardcoded grep" this replaces.
+//
+// Runs in TWO places off ONE source: `npm run check:docs` in `verify` (site-check,
+// the host build — catches content/mermaid-syntax regressions) AND in pages.yml
+// after the deploy build (catches deploy-ENV failures the host build can't repro).
+//
+// Usage: node config/assert-docs-rendered.mjs [distDir=dist]
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import process from 'node:process';
+
+const dist = process.argv[2] ?? 'dist';
+// Real doc bodies are 8k–19k chars of stripped text; a collapsed render is ~4. A
+// generous floor flags the failure class without coupling to any page's real size.
+const MIN_BODY_CHARS = 500;
+const DOC_ARTICLE = /<article class="prose"[^>]*>([\s\S]*?)<\/article>/;
+
+const failures = [];
+let docPages = 0;
+
+// Doc pages render to dist/<route>/index.html (one level deep). Non-doc dirs
+// (_astro, demos, wasm, …) simply won't carry the prose article and are skipped.
+for (const entry of readdirSync(dist, { withFileTypes: true })) {
+  if (!entry.isDirectory()) continue;
+  const file = join(dist, entry.name, 'index.html');
+  if (!existsSync(file)) continue;
+  const m = readFileSync(file, 'utf8').match(DOC_ARTICLE);
+  if (!m) continue; // not a Docs-layout page
+  docPages += 1;
+  const body = m[1]
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (body.length < MIN_BODY_CHARS) {
+    failures.push(
+      `/${entry.name}: doc body only ${body.length} chars (< ${MIN_BODY_CHARS}) — render collapsed`
+    );
+  }
+  if (entry.name === 'architecture' && !/<svg[\s>]/.test(m[1])) {
+    failures.push('/architecture: no inline <svg> — the mermaid diagram did not render');
+  }
+}
+
+if (docPages === 0) {
+  failures.push(`no doc pages found under ${dist}/ (the 'article.prose' selector drifted?)`);
+}
+
+if (failures.length > 0) {
+  console.error(`✗ doc-render check FAILED (${dist}):\n  ${failures.join('\n  ')}`);
+  process.exit(1);
+}
+console.log(`✓ doc-render check: ${docPages} doc pages have a body; /architecture <svg> present`);

--- a/site/config/assert-docs-rendered.mjs
+++ b/site/config/assert-docs-rendered.mjs
@@ -18,10 +18,12 @@ import { join } from 'node:path';
 import process from 'node:process';
 
 const dist = process.argv[2] ?? 'dist';
-// Real doc bodies are 8k–19k chars of stripped text; a collapsed render is ~4. A
+// Real doc bodies are ~8k–18k chars of stripped text; a collapsed render is ~4. A
 // generous floor flags the failure class without coupling to any page's real size.
 const MIN_BODY_CHARS = 500;
-const DOC_ARTICLE = /<article class="prose"[^>]*>([\s\S]*?)<\/article>/;
+// \bprose\b (not a sole-class match) so a future `class="prose max-w-none"` or an
+// appended Astro scoped class doesn't drop the article → redden every deploy.
+const DOC_ARTICLE = /<article class="[^"]*\bprose\b[^"]*"[^>]*>([\s\S]*?)<\/article>/;
 
 const failures = [];
 let docPages = 0;

--- a/site/config/assert-docs-rendered.mjs
+++ b/site/config/assert-docs-rendered.mjs
@@ -6,57 +6,79 @@
 // installed Chromium). GENERIC on purpose: it globs every page carrying the Docs
 // layout's `<article class="prose">` (config / architecture / contributing /
 // knowledge-base / parallel-delivery + any future doc), so there's no per-page or
-// per-heading string to drift — the exact "hardcoded grep" this replaces.
+// per-heading string to drift.
 //
-// Runs in TWO places off ONE source: `npm run check:docs` in `verify` (site-check,
-// the host build — catches content/mermaid-syntax regressions) AND in pages.yml
-// after the deploy build (catches deploy-ENV failures the host build can't repro).
+// Runs off ONE source in THREE places: `check:docs` in `verify` (local site-check),
+// as a step in site.yml (the PR-gating CI, on the host build — catches content /
+// mermaid-syntax regressions pre-merge), AND in pages.yml's `build-cmd` (catches
+// deploy-ENV failures the host build can't repro).
+//
+// The pure `checkDocPages()` core is unit-tested (assert-docs-rendered.test.mjs,
+// mirroring the config/*.mjs pure-fn + test split); the CLI below is a thin wrapper.
 //
 // Usage: node config/assert-docs-rendered.mjs [distDir=dist]
 import { readFileSync, readdirSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import process from 'node:process';
 
-const dist = process.argv[2] ?? 'dist';
 // Real doc bodies are ~8k–18k chars of stripped text; a collapsed render is ~4. A
 // generous floor flags the failure class without coupling to any page's real size.
-const MIN_BODY_CHARS = 500;
+export const MIN_BODY_CHARS = 500;
 // \bprose\b (not a sole-class match) so a future `class="prose max-w-none"` or an
 // appended Astro scoped class doesn't drop the article → redden every deploy.
 const DOC_ARTICLE = /<article class="[^"]*\bprose\b[^"]*"[^>]*>([\s\S]*?)<\/article>/;
 
-const failures = [];
-let docPages = 0;
-
-// Doc pages render to dist/<route>/index.html (one level deep). Non-doc dirs
-// (_astro, demos, wasm, …) simply won't carry the prose article and are skipped.
-for (const entry of readdirSync(dist, { withFileTypes: true })) {
-  if (!entry.isDirectory()) continue;
-  const file = join(dist, entry.name, 'index.html');
-  if (!existsSync(file)) continue;
-  const m = readFileSync(file, 'utf8').match(DOC_ARTICLE);
-  if (!m) continue; // not a Docs-layout page
-  docPages += 1;
-  const body = m[1]
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
-  if (body.length < MIN_BODY_CHARS) {
-    failures.push(
-      `/${entry.name}: doc body only ${body.length} chars (< ${MIN_BODY_CHARS}) — render collapsed`
-    );
+/**
+ * Pure core (unit-tested): given the doc-page entries `[{ name, html }]`, return the
+ * failures + how many Docs-layout pages were seen. No fs / process — testable
+ * without a real `dist/`.
+ */
+export function checkDocPages(entries) {
+  const failures = [];
+  let docPages = 0;
+  for (const { name, html } of entries) {
+    const m = html.match(DOC_ARTICLE);
+    if (!m) continue; // not a Docs-layout page
+    docPages += 1;
+    const body = m[1]
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+    if (body.length < MIN_BODY_CHARS) {
+      failures.push(
+        `/${name}: doc body only ${body.length} chars (< ${MIN_BODY_CHARS}) — render collapsed`
+      );
+    }
+    if (name === 'architecture' && !/<svg[\s>]/.test(m[1])) {
+      failures.push('/architecture: no inline <svg> — the mermaid diagram did not render');
+    }
   }
-  if (entry.name === 'architecture' && !/<svg[\s>]/.test(m[1])) {
-    failures.push('/architecture: no inline <svg> — the mermaid diagram did not render');
+  if (docPages === 0) {
+    failures.push("no doc pages found (the 'article.prose' selector drifted?)");
   }
+  return { failures, docPages };
 }
 
-if (docPages === 0) {
-  failures.push(`no doc pages found under ${dist}/ (the 'article.prose' selector drifted?)`);
+// Thin CLI wrapper: read dist/<route>/index.html into entries (doc pages are one
+// level deep; non-doc dirs _astro/demos/wasm lack the prose article and drop out),
+// run the core, exit non-zero on any failure so CI / the deploy reddens.
+function main(dist) {
+  const entries = readdirSync(dist, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => ({ name: e.name, file: join(dist, e.name, 'index.html') }))
+    .filter((e) => existsSync(e.file))
+    .map((e) => ({ name: e.name, html: readFileSync(e.file, 'utf8') }));
+  const { failures, docPages } = checkDocPages(entries);
+  if (failures.length > 0) {
+    console.error(`✗ doc-render check FAILED (${dist}):\n  ${failures.join('\n  ')}`);
+    process.exit(1);
+  }
+  console.log(`✓ doc-render check: ${docPages} doc pages have a body; /architecture <svg> present`);
 }
 
-if (failures.length > 0) {
-  console.error(`✗ doc-render check FAILED (${dist}):\n  ${failures.join('\n  ')}`);
-  process.exit(1);
+// Run the CLI only when invoked directly (`node config/assert-docs-rendered.mjs`),
+// so the test can import checkDocPages without triggering the fs read + process.exit.
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main(process.argv[2] ?? 'dist');
 }
-console.log(`✓ doc-render check: ${docPages} doc pages have a body; /architecture <svg> present`);

--- a/site/config/assert-docs-rendered.test.mjs
+++ b/site/config/assert-docs-rendered.test.mjs
@@ -1,0 +1,66 @@
+// Unit tests for the doc-render guard's pure core. The guard is the safety net
+// this PR adds against the silent empty-render class, so its own logic (the
+// regex, the body-size floor, the svg + no-doc-pages branches) must have teeth —
+// mirroring the config/*.mjs pure-fn + node:test convention.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { checkDocPages, MIN_BODY_CHARS } from './assert-docs-rendered.mjs';
+
+const body = (n) => 'x'.repeat(n);
+const doc = (inner) => `<article class="prose" data-astro-cid-x>${inner}</article>`;
+const arch = (inner) => doc(`<svg id="mermaid-0" aria-roledescription="flowchart"></svg>${inner}`);
+
+test('all good: every body present, /architecture has its <svg>', () => {
+  const { failures, docPages } = checkDocPages([
+    { name: 'config', html: doc(body(MIN_BODY_CHARS)) },
+    { name: 'architecture', html: arch(body(MIN_BODY_CHARS)) },
+  ]);
+  assert.equal(docPages, 2);
+  assert.deepEqual(failures, []);
+});
+
+test('a collapsed (empty) doc <article> body fails — the exact bug', () => {
+  const { failures, docPages } = checkDocPages([{ name: 'config', html: doc('') }]);
+  assert.equal(docPages, 1);
+  assert.ok(failures.some((f) => f.includes('/config') && f.includes('render collapsed')));
+});
+
+test('/architecture without an inline <svg> fails (mermaid did not render)', () => {
+  const { failures } = checkDocPages([{ name: 'architecture', html: doc(body(MIN_BODY_CHARS)) }]);
+  assert.ok(failures.some((f) => f.includes('/architecture') && f.includes('no inline <svg>')));
+});
+
+test('no doc pages at all (selector drift) fails loudly, never vacuously passes', () => {
+  const { failures, docPages } = checkDocPages([
+    { name: 'x', html: '<article class="other">hi</article>' },
+  ]);
+  assert.equal(docPages, 0);
+  assert.ok(failures.some((f) => f.includes('no doc pages found')));
+});
+
+test('the article selector tolerates EXTRA classes (\\bprose\\b, not sole-class)', () => {
+  const { failures, docPages } = checkDocPages([
+    {
+      name: 'config',
+      html: `<article class="prose max-w-none astro-abc">${body(MIN_BODY_CHARS)}</article>`,
+    },
+  ]);
+  assert.equal(docPages, 1);
+  assert.deepEqual(failures, []);
+});
+
+test('word boundary: a mere substring like "prosetype" is NOT treated as a doc page', () => {
+  const { docPages } = checkDocPages([
+    { name: 'x', html: `<article class="prosetype">${body(600)}</article>` },
+  ]);
+  assert.equal(docPages, 0);
+});
+
+test('a body exactly at the floor passes; one char under fails (off-by-one guard)', () => {
+  assert.deepEqual(
+    checkDocPages([{ name: 'config', html: doc(body(MIN_BODY_CHARS)) }]).failures,
+    []
+  );
+  const under = checkDocPages([{ name: 'config', html: doc(body(MIN_BODY_CHARS - 1)) }]);
+  assert.ok(under.failures.some((f) => f.includes('render collapsed')));
+});

--- a/site/package.json
+++ b/site/package.json
@@ -17,7 +17,8 @@
     "format:check": "prettier --check .",
     "knip": "knip",
     "test:unit": "node --test \"config/**/*.test.mjs\"",
-    "verify": "npm run format:check && npm run lint && npm run check && npm run knip && npm run test:unit && npm run build",
+    "check:docs": "node config/assert-docs-rendered.mjs dist",
+    "verify": "npm run format:check && npm run lint && npm run check && npm run knip && npm run test:unit && npm run build && npm run check:docs",
     "lighthouse": "lhci autorun",
     "e2e": "playwright test"
   },


### PR DESCRIPTION
## Bug: `/architecture` deploys as an empty page

`https://www.pixtuoid.dev/architecture/` ships an **empty `<article>`** — no headings, prose, or the mermaid diagram — while every other doc route renders fully. (Verified by downloading the deployed Pages artifact: `dist/architecture/index.html`'s article is 4 bytes.) A local build of the exact deployed commit renders it **fully** (48 KB, all headings, the SVG), so source + deps are fine — the **deploy build** is where it breaks.

## Root cause

`ARCHITECTURE.md` is the only doc with a ```mermaid block, rendered to inline SVG at build by `rehype-mermaid` (needs Playwright Chromium). The deploy build log shows `withastro/action@v6`'s package-manager detection **fell back to pnpm** (the repo has no `pnpm-lock.yaml` to match). pnpm's fresh install resolved a *different* Playwright than the Chromium the prior step installed for npm → the classic `Executable doesn't exist at …/ms-playwright/chromium-XXXX` → `rehype-mermaid` failed and collapsed the whole `<Content />` to an empty article **without erroring the build**, so the deploy stayed green. CI (`site.yml`) never caught it because it builds directly on the host (its build renders fine).

## Fix (keep the official Astro action)

Per `withastro/action`'s own `action.yml`, it has a `package-manager` input. Pass **`package-manager: npm`** so it reuses `package-lock.json` → the build's Playwright matches the pre-installed Chromium → the diagram renders. This is the community-standard pattern for rehype-mermaid on Pages (install Chromium → `withastro/action`), which the repo already followed — the only bug was the pnpm drift.

Plus a **fail-loud guard**: assert `dist/architecture/index.html` rendered its body after the build (deploy is `needs: build`), so a broken diagram can never silently ship an empty page again.

## Verification
- ✅ `actionlint` clean; `package-manager` input confirmed from the action's `action.yml`; no stray `pnpm-lock.yaml`.
- ✅ Local build of HEAD renders `/architecture` fully; the guard grep passes on a good build, fails on empty.
- ⚠️ The failure is deploy-env-specific and can't be fully reproduced locally — but this uses the action's sanctioned input, and the guard guarantees the worst case is a **red deploy**, never another silently-empty page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fyBXdKR1YzwmfLzm3Pc9H
