### PR TITLE
ci(release): serialize releases with a concurrency group

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,14 @@ on:
   push:
     tags: ["v*"]
 
+# One release at a time per tag: a tag re-push / rapid double-tag must not run two
+# publishes concurrently (they'd race creating the GH release + crates.io/npm
+# publish). cancel-in-progress: false — never interrupt an in-flight release
+# (mirrors pages.yml's deploy concurrency).
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 # Least-privilege (#215): jobs inherit read-only; the `release` job alone
 # carries write + attestation scopes (it creates the GH release and attests
 # provenance), and `publish`/`npm` carry id-token for OIDC publishing. A


### PR DESCRIPTION
CI-audit follow-up (#3, the only actionable gap besides the /architecture fix in #680; SHA-pinning was ruled out by the owner, and `@stable` is deliberate with the MSRV floor covering the other end).

`release.yml` had no `concurrency` group, so a tag re-push or a rapid double-tag could run two release jobs at once — racing on creating the GitHub release + the crates.io / npm OIDC publish. Add:

```yaml
concurrency:
  group: release-${{ github.ref }}
  cancel-in-progress: false
```

One publish per tag; `cancel-in-progress: false` never interrupts an in-flight release (mirrors `pages.yml`'s deploy concurrency). Belt-and-suspenders — tag pushes are already owner-only + rare — but it closes the double-publish race for free. actionlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fyBXdKR1YzwmfLzm3Pc9H
