### PR TITLE
fix(ci): deploy re-renders /architecture — disable the poisoned Astro build cache

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -59,6 +59,16 @@ jobs:
         with:
           path: ./site
           node-version: 26
+          # DISABLE the action's Astro build cache (node_modules/.astro). It is
+          # keyed with a bare `astro-cache-<os>-` restore-key prefix, so a deploy
+          # RESTORES the most recent prior deploy's cache — and a deploy that once
+          # rendered /architecture EMPTY (the pnpm-era Chromium miss below) cached
+          # that empty <Content /> and every later deploy served it back as a
+          # +7ms cache HIT, never re-rendering the ```mermaid block. `cache: false`
+          # forces a fresh, real mermaid render each deploy — poison can't persist.
+          # (site.yml renders fine precisely because it has no cross-run Astro cache.)
+          # A static 7-page build; the lost speedup is milliseconds, correctness isn't.
+          cache: false
           # PIN npm. Without it, v6's detection fell back to pnpm, whose fresh
           # install resolved a DIFFERENT Playwright than the Chromium installed
           # above → rehype-mermaid's inline-SVG render of /architecture failed

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -67,7 +67,9 @@ jobs:
           # +7ms cache HIT, never re-rendering the ```mermaid block. `cache: false`
           # forces a fresh, real mermaid render each deploy — poison can't persist.
           # (site.yml renders fine precisely because it has no cross-run Astro cache.)
-          # A static 7-page build; the lost speedup is milliseconds, correctness isn't.
+          # Cost is a cold content-layer rebuild (incl. the one Chromium mermaid
+          # render) — seconds on a 7-page site, negligible for an infrequent deploy;
+          # correctness isn't negotiable.
           cache: false
           # PIN npm. Without it, v6's detection fell back to pnpm, whose fresh
           # install resolved a DIFFERENT Playwright than the Chromium installed

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -47,10 +47,18 @@ but a Chromium/Playwright *version* mismatch fails DIFFERENTLY: `rehype-mermaid`
 collapses the whole `<Content />` to an empty `<article>` WITHOUT erroring the
 build, so it can silently ship an empty `/architecture` (the deploy's
 `withastro/action` fell back to pnpm → a Playwright unmatched to the installed
-Chromium; #680 pins `package-manager: npm`). Guarded by
-`config/assert-docs-rendered.mjs` (`check:docs`) — run in `verify`/site-check AND
-the deploy's `build-cmd`, asserting every doc page's `<article>` has a body +
-`/architecture` kept its `<svg>` — so a collapsed render reddens, never deploys.
+Chromium; #680 pins `package-manager: npm`). A SECOND, subtler way it ships empty:
+`withastro/action`'s Astro build cache (`cache: true`, `node_modules/.astro`)
+uses a bare `astro-cache-<os>-` restore-key, so a deploy restores the *previous*
+deploy's cache — and once a broken deploy caches an empty `/architecture`, every
+later deploy serves it back as a **+7ms cache HIT** and never re-renders the
+`mermaid` block (no Chromium launch, no error, still empty). `pages.yml` sets
+`cache: false` so each deploy does a fresh real render; poison can't persist
+(#682). `site.yml` renders fine because it has no cross-run Astro cache. Both
+paths are caught by `config/assert-docs-rendered.mjs` (`check:docs`) — run in
+`verify`/site-check AND the deploy's `build-cmd`, asserting every doc page's
+`<article>` has a body + `/architecture` kept its `<svg>` — so a collapsed render
+reddens, never deploys.
 
 **wb-5 (Lobby + Docs):** the five doc routes now mount the Statusline **doc
 variant** (index-only organs — floor lift, PR feed, env readouts, keys hint —


### PR DESCRIPTION
## Problem

The #680 merge's deploy ([run 29671701103](https://github.com/IvanWng97/pixtuoid/actions/runs/29671701103)) **failed at the `check:docs` guard** — `/architecture` still rendered empty. The guard working as designed (it reddened instead of shipping empty), but the underlying render was still broken.

## Root cause (from the deploy log — NOT a Chromium problem)

`withastro/action@v6`'s default **`cache: true`** caches the Astro build cache (`node_modules/.astro`) under a bare `astro-cache-<os>-` restore-key. So each deploy **restores the *previous* deploy's cache**:

```
Cache restored from key: astro-cache-Linux-d346569f…   # d346569f = the prior #679 deploy
…
/architecture/index.html (+7ms)                        # +7ms = a cache HIT, not a real render
```

The #679 (pnpm-era) deploy had cached an **empty** `/architecture` (the Chromium miss #680 diagnosed). Every deploy since served that empty `<Content />` back as a **+7ms cache hit** — never launching Chromium, never re-rendering the ` ```mermaid ` block, no error. So #680's `package-manager: npm` render fix was correct but **never actually ran**.

`site.yml` (the PR gate) renders fine precisely because it has **no cross-run Astro cache** — always a fresh build.

## Fix

`cache: false` on the action → a fresh, real mermaid render every deploy; the poison can't persist. `check:docs` (from #680) still proves the render before upload, so a genuine render failure would redden rather than ship empty.

- `.github/workflows/pages.yml` — add `cache: false`
- `site/CLAUDE.md` — document the cache-poisoning failure mode alongside the existing Chromium-mismatch note.

## Verification

The real proof is the deploy itself (this failure class only reproduces in the action's cross-run cache env; local + `site.yml` always render fresh). Once merged, the `main` deploy does a cold build → real render → `check:docs` passes → `/architecture` goes live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fyBXdKR1YzwmfLzm3Pc9H