### PR TITLE
refactor(scene): single-source desk-shadow cy + ceiling-pool geometry

### DIFF
--- a/crates/pixtuoid-scene/src/pixel_painter/mod.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/mod.rs
@@ -364,6 +364,58 @@ pub fn render_to_rgb_buffer(ctx: &mut PixelCtx<'_>) -> PixelPassResult {
     }
 }
 
+/// The soft floor shadow under one home desk. `cy` sits on the desk's z-sort
+/// row — `desk.y + visual.h` — the SAME `visual.h` `enqueue_desk_cubicles` keys
+/// the desk sprite on, read from the one authority (`desk_furniture_def`) rather
+/// than re-hardcoded, so a `DESK_H` retune moves the shadow WITH the sprite's
+/// south base instead of leaving it behind. The half-extents stay inline: a
+/// shadow's width/depth is a per-piece taste value with no source to derive from.
+fn desk_shadow_ellipse(desk: Point) -> Ellipse {
+    Ellipse {
+        cx: desk.x + DESK_W / 2,
+        cy: desk.y + crate::layout::desk_furniture_def().visual.h,
+        half_w: DESK_W / 2 + 1,
+        half_h: 3,
+    }
+}
+
+/// The ceiling-fluorescent light pools, in paint order: one narrow tube per
+/// desk, then a wider fixture over the pantry and the corridor. THE authority
+/// for where the pools sit + how wide each glows, so the paint pass is a short
+/// loop and the per-region ellipse extents aren't anonymous inline literals. The
+/// floor-lamp halo is deliberately NOT here — it is a different painter
+/// (`paint_floor_lamp_halo`) with its own strength + south-offset anchor; the
+/// paint order (pools THEN lamp halo) is load-bearing for byte-identity.
+fn ceiling_pool_regions(layout: &Layout) -> impl Iterator<Item = Ellipse> + '_ {
+    // Half-extents (a fluorescent tube's lit footprint) per pool kind.
+    const DESK_POOL_HALF: (u16, u16) = (10, 5);
+    const PANTRY_POOL_HALF: (u16, u16) = (12, 6);
+    const CORRIDOR_POOL_HALF: (u16, u16) = (14, 5);
+    // The desk tube hangs one row-pair NORTH of the desk origin (above the
+    // monitor, not on the surface); saturating so a top-row desk can't underflow.
+    const DESK_POOL_CY_LIFT: u16 = 2;
+
+    let desks = layout.home_desks.iter().map(|desk| Ellipse {
+        cx: desk.x + DESK_W / 2,
+        cy: desk.y.saturating_sub(DESK_POOL_CY_LIFT),
+        half_w: DESK_POOL_HALF.0,
+        half_h: DESK_POOL_HALF.1,
+    });
+    let pantry = layout.pantry.map(|p| p.bounds).map(|pr| Ellipse {
+        cx: pr.x + pr.width / 2,
+        cy: pr.y + pr.height / 2,
+        half_w: PANTRY_POOL_HALF.0,
+        half_h: PANTRY_POOL_HALF.1,
+    });
+    let corridor = layout.corridor.map(|c| Ellipse {
+        cx: c.x + c.width / 2,
+        cy: c.y + c.height / 2,
+        half_w: CORRIDOR_POOL_HALF.0,
+        half_h: CORRIDOR_POOL_HALF.1,
+    });
+    desks.chain(pantry).chain(corridor)
+}
+
 /// The PAINT half of the frame: blit the world the sim already advanced.
 /// Reads the [`SimFrame`] immutably; every positional/lifecycle decision was
 /// made in `sim_step` — this pass only resolves presentation (theme colors,
@@ -438,46 +490,11 @@ fn paint_frame(
         look.spill_strength * DAYLIGHT_FLOOR_LIFT,
     );
     let pool_strength = (0.15 + 0.30 * look.darkness) * indoor_scale;
-    for desk in &ctx.layout.home_desks {
-        paint_ceiling_pool(
-            ctx.buf,
-            Ellipse {
-                cx: desk.x + DESK_W / 2,
-                cy: desk.y.saturating_sub(2),
-                half_w: 10,
-                half_h: 5,
-            },
-            pool_strength,
-            ctx.theme,
-        );
-    }
-    // Two ceiling fluorescents over the pantry and a third over the
-    // corridor so the floor is lit consistently with the lounge_band gone.
-    if let Some(pr) = ctx.layout.pantry.map(|p| p.bounds) {
-        paint_ceiling_pool(
-            ctx.buf,
-            Ellipse {
-                cx: pr.x + pr.width / 2,
-                cy: pr.y + pr.height / 2,
-                half_w: 12,
-                half_h: 6,
-            },
-            pool_strength,
-            ctx.theme,
-        );
-    }
-    if let Some(corridor) = ctx.layout.corridor {
-        paint_ceiling_pool(
-            ctx.buf,
-            Ellipse {
-                cx: corridor.x + corridor.width / 2,
-                cy: corridor.y + corridor.height / 2,
-                half_w: 14,
-                half_h: 5,
-            },
-            pool_strength,
-            ctx.theme,
-        );
+    // Ceiling fluorescents (one narrow tube per desk + a wider fixture over the
+    // pantry and the corridor) so the floor is lit consistently with the
+    // lounge_band gone — geometry single-sourced in `ceiling_pool_regions`.
+    for pool in ceiling_pool_regions(ctx.layout) {
+        paint_ceiling_pool(ctx.buf, pool, pool_strength, ctx.theme);
     }
     if let Some(lamp) = ctx.layout.floor_lamp {
         paint_floor_lamp_halo(
@@ -557,12 +574,7 @@ fn paint_frame(
     for desk in &ctx.layout.home_desks {
         paint_shadow(
             ctx.buf,
-            Ellipse {
-                cx: desk.x + DESK_W / 2,
-                cy: desk.y + 7,
-                half_w: DESK_W / 2 + 1,
-                half_h: 3,
-            },
+            desk_shadow_ellipse(*desk),
             shadow_strength,
             ctx.theme,
         );

--- a/crates/pixtuoid-scene/src/pixel_painter/mod.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/mod.rs
@@ -368,8 +368,8 @@ pub fn render_to_rgb_buffer(ctx: &mut PixelCtx<'_>) -> PixelPassResult {
 /// row — `desk.y + visual.h` — the SAME `visual.h` `enqueue_desk_cubicles` keys
 /// the desk sprite on, read from the one authority (`desk_furniture_def`) rather
 /// than re-hardcoded, so a `DESK_H` retune moves the shadow WITH the sprite's
-/// south base instead of leaving it behind. The half-extents stay inline: a
-/// shadow's width/depth is a per-piece taste value with no source to derive from.
+/// south base instead of leaving it behind. `half_w` tracks `DESK_W` (the same
+/// authority `cx` uses); only `half_h` is a source-less per-piece taste literal.
 fn desk_shadow_ellipse(desk: Point) -> Ellipse {
     Ellipse {
         cx: desk.x + DESK_W / 2,

--- a/crates/pixtuoid-scene/src/pixel_painter/tests.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/tests.rs
@@ -3434,3 +3434,43 @@ fn waypoint_render_anchor_upright_height_recovers_the_feet_row() {
         );
     }
 }
+
+#[test]
+fn desk_shadow_tracks_the_desk_zsort_row_not_a_hardcoded_offset() {
+    // The shadow's cy must derive from the SAME visual.h the desk sprite z-sorts
+    // on (enqueue_desk_cubicles: desk.y + visual.h), so a DESK_H retune keeps the
+    // shadow pinned under the sprite's south base instead of floating 1px off.
+    let desk = Point { x: 40, y: 30 };
+    let e = desk_shadow_ellipse(desk);
+    assert_eq!(e.cy, desk.y + crate::layout::desk_furniture_def().visual.h);
+    assert_eq!(e.cx, desk.x + DESK_W / 2);
+}
+
+#[test]
+fn ceiling_pool_regions_yields_desks_then_pantry_then_corridor_in_order() {
+    let l =
+        Layout::compute(192, 160, Some(crate::layout::TEST_DEFAULT_DESKS)).expect("192x160 fits");
+    let pools: Vec<_> = ceiling_pool_regions(&l).collect();
+    assert_eq!(
+        pools.len(),
+        l.home_desks.len() + l.pantry.is_some() as usize + l.corridor.is_some() as usize
+    );
+    // The leading run is one pool per desk, centred + lifted 2px north.
+    for (pool, desk) in pools.iter().zip(&l.home_desks) {
+        assert_eq!(pool.cx, desk.x + DESK_W / 2);
+        assert_eq!(pool.cy, desk.y.saturating_sub(2));
+        assert_eq!((pool.half_w, pool.half_h), (10, 5));
+    }
+    // Then the wider pantry fixture (if it fit), centred on its bounds.
+    if let Some(pr) = l.pantry.map(|p| p.bounds) {
+        let p = pools[l.home_desks.len()];
+        assert_eq!((p.cx, p.cy), (pr.x + pr.width / 2, pr.y + pr.height / 2));
+        assert_eq!((p.half_w, p.half_h), (12, 6));
+    }
+    // The corridor fixture is last.
+    if let Some(c) = l.corridor {
+        let p = *pools.last().unwrap();
+        assert_eq!((p.cx, p.cy), (c.x + c.width / 2, c.y + c.height / 2));
+        assert_eq!((p.half_w, p.half_h), (14, 5));
+    }
+}


### PR DESCRIPTION
## What

Two **byte-identical** background-pass cleanups from the
`/improve-codebase-architecture` review (deferred candidates **#10** + **#11**),
both verified against current code.

| # | Concentrates |
|---|--------------|
| **#10** | the desk floor-shadow `cy` hardcoded `desk.y + 7` — a **second copy** of `desk_furniture_def().visual.h` (= `DESK_H+2`) that the desk z-key (`enqueue_desk_cubicles`) already derives. A `DESK_H` retune would move the z-sorted sprite but leave the shadow behind (the magic-number / latent-drift class the `CLAUDE.md` convention forbids). → `desk_shadow_ellipse` reads `visual.h` from the one authority. |
| **#11** | the three inline ceiling-pool ellipse blocks (per-desk + pantry + corridor) → a `ceiling_pool_regions(layout)` iterator, naming the pool half-extents (`10/5`, `12/6`, `14/5`) + the desk cy-lift as consts instead of anonymous inline literals. |

The half-extents stay inline (per-piece taste, no authoritative source); the
floor-lamp halo stays a **separate** painter and the paint order (pools → lamp)
is preserved, so byte-identity holds.

## Why they're safe

Byte-identical by construction: `visual.h == 7` today, and the iterator yields the
same ellipses in the same order. Pinned by the existing
`paint_frame_is_pure_and_byte_identical` guard + **two new teeth** (the shadow cy
tracks the z-key row; the pools yield desks→pantry→corridor at the expected
extents). No pixels change → `gen-check` goldens are unaffected.

## Not done (deliberately)

The full floor-shadow **table** consolidation (`#10`'s broader form) was **dropped**
as *just-moves-shallow* — the couch/printer/generic shadows are hand-tuned per-kind
constants + iteration exceptions with no per-def derivation. Only the desk `cy`,
which has a real authority (the z-sort row), reads from the def. Shadow deliberately
**stays render-side** (not moved onto `FurnitureDef`): its strength is a daylight
function only the painter uses.

## Test

Full `pixtuoid-scene` suite green (642 tests) + the two new teeth. Separate PR from
the `ProbeLadder` liveness refactor (`#2`) on purpose — disjoint crate, disjoint
blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121zsMsaPE6YZgv6UrAXUVE
