### PR TITLE
polish(site): unify link hovers — coffee/ghost brighten to coral, not underline

### DIFF
--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -104,11 +104,13 @@ const badges = sources.filter((s) => s.status === 'supported');
     color: var(--fg);
     text-decoration: none;
     text-shadow: var(--chrome-halo);
+    transition: color 0.18s ease;
   }
   .hero__ghost:hover {
-    /* underline, not a --coral recolor: over the office the halo-carried --fg
-       stays legible but raw --coral dips below AA (HowItWorks' nudge-don't-recolor). */
-    text-decoration: underline;
+    /* brighten to --coral on hover — the shared link idiom (see Nav's coffee).
+       Over the office --coral dips below AA, but only in this transient hover
+       state; the resting halo-carried --fg is AA and is what the sweep gates. */
+    color: var(--coral);
   }
   .hero__badges {
     display: flex;

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -108,8 +108,10 @@ const badges = sources.filter((s) => s.status === 'supported');
   }
   .hero__ghost:hover {
     /* brighten to --coral on hover — the shared link idiom (see Nav's coffee).
-       Over the office --coral dips below AA, but only in this transient hover
-       state; the resting halo-carried --fg is AA and is what the sweep gates. */
+       Over the office --coral dips below AA, but ONLY in this transient hover
+       state — the resting colour is the full --fg, kept legible over the office
+       by the chrome-halo (rest is the AA case, hover is the exception). Deliberate
+       trade-off (was #678's A3 underline); don't "re-fix" it back without that history. */
     color: var(--coral);
   }
   .hero__badges {

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -268,9 +268,12 @@ const { floating = false } = Astro.props;
     white-space: nowrap;
   }
   .nav__links a.nav__coffee:hover {
-    /* keep the AA-safe --coral-deep (from rest); underline is the hover cue —
-       flipping to raw --coral drops below AA on the cream docs bar. */
-    text-decoration: underline;
+    /* brighten to --coral on hover — the SAME muted→full nudge every sibling nav
+       link uses (`.nav__links a:hover`), so the row shares one hover mechanism
+       instead of the coffee link alone underlining. --coral dips below AA on the
+       cream day bar, but only in this transient hover state; the resting
+       --coral-deep is AA and is what the e2e sweep gates (rest colours only). */
+    color: var(--coral);
   }
   .nav__burger {
     margin-left: auto;

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -271,8 +271,10 @@ const { floating = false } = Astro.props;
     /* brighten to --coral on hover — the SAME muted→full nudge every sibling nav
        link uses (`.nav__links a:hover`), so the row shares one hover mechanism
        instead of the coffee link alone underlining. --coral dips below AA on the
-       cream day bar, but only in this transient hover state; the resting
-       --coral-deep is AA and is what the e2e sweep gates (rest colours only). */
+       cream day bar, but ONLY in this transient hover state — the resting
+       --coral-deep is AA-safe by design (global.css: ~5:1 on --paper, and light
+       on the night bar). Deliberate trade-off (was #678's A3 underline); don't
+       "re-fix" it back without reading that history. */
     color: var(--coral);
   }
   .nav__burger {


### PR DESCRIPTION
## What

The nav **Coffee** link and the **hero ghost** links underlined on hover, while every other nav link (**Docs**, **GitHub**) brightens its *colour*. Inconsistent mechanism. This restores the pre-#678 behaviour: both brighten to `--coral` on hover (Coffee: `--coral-deep → --coral`; ghosts: `--fg → --coral`), so the whole row shares **one** hover mechanism (colour brightens), Coffee keeping its warm CTA accent.

Reverts #678's **A3** hover cue (per maintainer request — the underline read as an odd one-off vs Docs/GitHub).

## The a11y trade-off (deliberate)

A3 chose underline because raw `--coral` dips below AA on the cream day bar / over the office. That trade-off is now **accepted on purpose**:
- it's a **transient hover** state — the resting colours (`--coral-deep` / haloed `--fg`) stay AA;
- the e2e over-office/AA sweep gates **rest** colours only (verified — no hover assertion), so CI stays green;
- the code comments record this so a future audit doesn't "re-fix" it back to underline.

## Scope

Unifies the chrome/CTA links (nav Coffee + hero ghosts). Content-area idioms (HowItWorks' "read more →" arrow, the tools-table hover) keep their own affordances — out of scope here.

## Verified
`format:check` · `lint` · `check` (astro-check 0 errors) · `build` · `check:docs` all green; built dist confirmed `nav__coffee:hover{color:var(--coral)}` + `hero__ghost…:hover{color:var(--coral)}`, **zero** `text-decoration:underline` in dist. Rendered the hover states (night) — Coffee brightens, no underline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fyBXdKR1YzwmfLzm3Pc9H