### PR TITLE
polish(site): footer Coffee gets the nav's brighten-on-hover (+ drop the !important)

### DIFF
--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -69,7 +69,6 @@ import { REPO, CRATES, SPONSOR, asset } from '../consts';
     font-weight: 400;
     font-synthesis: none;
     font-size: 1.1rem;
-    color: var(--chip-bright);
     text-decoration: none;
   }
   .footer__mark {
@@ -112,17 +111,26 @@ import { REPO, CRATES, SPONSOR, asset } from '../consts';
   .footer__line a:hover {
     color: #fff;
   }
-  /* support CTA — same coral accent + brighten-on-hover mechanism as Nav's
-     coffee (#686). The compound selector outranks `.footer__line a`(:hover), so
-     the old `!important` hack is gone. Rest is already full --coral (light on
-     the dark chip), so the brighten mixes toward white — on the dark chip more
-     light only GAINS contrast (AA-safe), and mixing FROM var(--coral) keeps the
-     hover riding a gallery retint accent instead of clashing with it. */
+  /* support CTA — the same brighten-on-hover IDEA as Nav's coffee (#686), but via
+     a colour-mix toward white rather than Nav's deep→full token swap (footer
+     coffee already rests at full --coral). The compound selector outranks
+     `.footer__line a`(:hover), so the old `!important` hack is gone. Rest --coral
+     is light on the dark chip, so mixing toward white only GAINS contrast
+     (AA-safe), and mixing FROM var(--coral) keeps the hover riding a gallery
+     retint accent. Keep this rest rule AFTER `.footer__line a:hover`: on a
+     pre-color-mix engine the hover value drops and the two tie at equal
+     specificity, so source order is what holds the fallback at coral (no #fff flash). */
   .footer__line a.footer__coffee {
     color: var(--coral);
   }
   .footer__line a.footer__coffee:hover {
     color: color-mix(in srgb, var(--coral) 72%, #fff);
+  }
+  /* the brand mark wants the brighter --chip-bright (its `.footer__logo` rule
+     declared it, but `.footer__line a` swallowed it — the same specificity trap
+     the coffee `!important` papered over; fixed with the compound selector). */
+  .footer__line a.footer__logo {
+    color: var(--chip-bright);
   }
   /* shown only when the local clock holds night — toggled by the Base script */
   .footer__clock {

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -106,12 +106,23 @@ import { REPO, CRATES, SPONSOR, asset } from '../consts';
   .footer__line a {
     color: var(--chip-ink);
     text-decoration: none;
+    /* ease the hover like the nav row does — same shared 0.18s colour nudge */
+    transition: color 0.18s ease;
   }
   .footer__line a:hover {
     color: #fff;
   }
-  .footer__coffee {
-    color: var(--coral) !important;
+  /* support CTA — same coral accent + brighten-on-hover mechanism as Nav's
+     coffee (#686). The compound selector outranks `.footer__line a`(:hover), so
+     the old `!important` hack is gone. Rest is already full --coral (light on
+     the dark chip), so the brighten mixes toward white — on the dark chip more
+     light only GAINS contrast (AA-safe), and mixing FROM var(--coral) keeps the
+     hover riding a gallery retint accent instead of clashing with it. */
+  .footer__line a.footer__coffee {
+    color: var(--coral);
+  }
+  .footer__line a.footer__coffee:hover {
+    color: color-mix(in srgb, var(--coral) 72%, #fff);
   }
   /* shown only when the local clock holds night — toggled by the Base script */
   .footer__clock {


### PR DESCRIPTION
Closes the F2 deferral from #686's two-lens review: the footer ☕ Coffee link was the one coffee CTA with **no hover response**.

## Why it was inert
`.footer__coffee { color: var(--coral) !important }` — the `!important` existed only to outrank `.footer__line a`'s specificity, but it also swallowed the row's `.footer__line a:hover { color: #fff }`, so the sponsor link never reacted to hover.

## Fix
- Replace the hack with the **nav coffee's** compound-selector pattern: `.footer__line a.footer__coffee` cleanly outranks the row rules — no `!important`.
- Give it the same **brighten-on-hover** mechanism as #686: rest is already full `--coral`, so hover mixes 28% white into it (`color-mix(in srgb, var(--coral) 72%, #fff)`). On the dark footer chip more light only **gains** contrast (rest was measured 5.9–6.8:1 in #676; hover ≥ that), and mixing *from* `var(--coral)` keeps the hover riding a gallery-retint accent instead of clashing.
- The footer row's links pick up the shared `transition: color 0.18s ease` (same as the nav row).

## Verified
`format:check` · `lint` · `check` (astro-check 0 errors) · `build` · `check:docs` all green. Built dist confirmed `.footer__coffee{color:var(--coral)}` + `:hover{color:color-mix(…)}`, **zero** `!important` on the coffee link. Rendered rest vs hover (night): rest `#e3845f` → hover lightens; sibling GitHub link still hovers to `#fff`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fyBXdKR1YzwmfLzm3Pc9H