### PR TITLE
fix(site): whole-site correctness-audit fixes (14 findings + regression tests)

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -60,6 +60,14 @@ for (const c of showcase) {
   if (c.status === 'soon') continue;
   const demo = /** @param {string} f */ (f) =>
     existsSync(fileURLToPath(new URL(`./public/demos/${f}`, import.meta.url)));
+  // Channel-level variantsRef is RETIRED (#468 deleted its theme_<id>.png /
+  // weather_<id>.png stills). A stray one on ANY kind would resolve those dead
+  // stills → broken <img>s, so reject it before the per-kind checks — variant-set
+  // channels use inline `variants`, live channels use per-group variantGroups (audit C11).
+  if (c.variantsRef)
+    throw new Error(
+      `astro.config: showcase.json "${c.id}" has a channel-level variantsRef, retired in #468 — variant-set channels use inline "variants", live channels use variantGroups`
+    );
   if (c.kind === 'clip') {
     if (!c.asset)
       throw new Error(
@@ -77,15 +85,8 @@ for (const c of showcase) {
         `astro.config: showcase.json live clip "${c.id}" needs numeric "w"/"h" (intrinsic video dims, for CLS)`
       );
   } else if (c.kind === 'variant-set') {
-    // variantsRef synthesized theme_<id>.png / weather_<id>.png stills that were
-    // retired in #468 — a variant-set channel using it would build clean yet
-    // render broken <img>s (the old guard only string-checked the ref, never the
-    // resolved stills). Only `live` channels' variantGroups reference a manifest
-    // now; variant-set channels must supply inline `variants` (audit C11).
-    if (c.variantsRef)
-      throw new Error(
-        `astro.config: showcase.json variant-set "${c.id}" uses variantsRef, whose stills were retired in #468 — supply inline "variants" instead`
-      );
+    // (channel-level variantsRef already rejected above, audit C11 — variant-set
+    // channels supply inline `variants`.)
     if (!(c.variants && c.variants.length))
       throw new Error(`astro.config: showcase.json variant-set "${c.id}" has no "variants"`);
     for (const v of c.variants)

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -77,26 +77,32 @@ for (const c of showcase) {
         `astro.config: showcase.json live clip "${c.id}" needs numeric "w"/"h" (intrinsic video dims, for CLS)`
       );
   } else if (c.kind === 'variant-set') {
-    if (c.variantsRef) {
-      if (c.variantsRef !== 'themes' && c.variantsRef !== 'weather')
-        throw new Error(
-          `astro.config: showcase.json "${c.id}" has unknown variantsRef "${c.variantsRef}" (expected "themes" or "weather")`
-        );
-    } else if (!(c.variants && c.variants.length)) {
+    // variantsRef synthesized theme_<id>.png / weather_<id>.png stills that were
+    // retired in #468 — a variant-set channel using it would build clean yet
+    // render broken <img>s (the old guard only string-checked the ref, never the
+    // resolved stills). Only `live` channels' variantGroups reference a manifest
+    // now; variant-set channels must supply inline `variants` (audit C11).
+    if (c.variantsRef)
       throw new Error(
-        `astro.config: showcase.json variant-set "${c.id}" has neither variantsRef nor variants`
+        `astro.config: showcase.json variant-set "${c.id}" uses variantsRef, whose stills were retired in #468 — supply inline "variants" instead`
       );
-    }
-    for (const v of c.variants ?? [])
+    if (!(c.variants && c.variants.length))
+      throw new Error(`astro.config: showcase.json variant-set "${c.id}" has no "variants"`);
+    for (const v of c.variants)
       if (!demo(v.src))
         throw new Error(
           `astro.config: showcase.json "${c.id}" variant "${v.id}" missing public/demos/${v.src}`
         );
   } else if (c.kind === 'live') {
     // A `live` channel is rendered by the wasm office canvas, not static demo
-    // assets — no asset/w/h required. Only the fallback poster (used when wasm
-    // never loads) and each chip group's manifest ref need validating.
-    if (c.poster && !demo(c.poster))
+    // assets — no asset/w/h required. The fallback poster IS required (it's the
+    // no-JS/no-wasm/reduced-motion image); the old guard only validated it when
+    // present, so a live channel omitting it shipped a blank stage (audit C14).
+    if (!c.poster)
+      throw new Error(
+        `astro.config: showcase.json live channel "${c.id}" needs a "poster" — the no-JS/no-wasm/reduced-motion fallback image`
+      );
+    if (!demo(c.poster))
       throw new Error(
         `astro.config: showcase.json live channel "${c.id}" missing public/demos/${c.poster}`
       );

--- a/site/src/components/MonitorWall.astro
+++ b/site/src/components/MonitorWall.astro
@@ -5,10 +5,17 @@ const { channels, activeId } = Astro.props as {
   channels: EnrichedShowcaseChannel[];
   activeId: string;
 };
+// A `live` channel (vibing) carries variantGroups, not top-level variants, so
+// enriched `c.variants` is [] and the variant-set arm would deref undefined.src
+// → TypeError at build. It renders from its poster instead (audit C8; this
+// component is the currently-unmounted MonitorWall fallback, so the drift was
+// inert, but it breaks the build the moment it's re-mounted).
 const thumb = (c: EnrichedShowcaseChannel) =>
   c.kind === 'clip'
     ? `demos/${c.asset}-poster.png`
-    : `demos/${(c.variants.find((v: ShowcaseVariant) => v.featured) ?? c.variants[0]).src}`;
+    : c.kind === 'live'
+      ? `demos/${c.poster}`
+      : `demos/${(c.variants.find((v: ShowcaseVariant) => v.featured) ?? c.variants[0]).src}`;
 ---
 
 <div class="wall" role="group" aria-label="Demos">

--- a/site/src/components/MonitorWall.astro
+++ b/site/src/components/MonitorWall.astro
@@ -9,7 +9,8 @@ const { channels, activeId } = Astro.props as {
 // enriched `c.variants` is [] and the variant-set arm would deref undefined.src
 // → TypeError at build. It renders from its poster instead (audit C8; this
 // component is the currently-unmounted MonitorWall fallback, so the drift was
-// inert, but it breaks the build the moment it's re-mounted).
+// inert, but it breaks the build the moment it's re-mounted). `c.poster` is
+// build-guaranteed for a live channel by the astro.config poster check (audit C14).
 const thumb = (c: EnrichedShowcaseChannel) =>
   c.kind === 'clip'
     ? `demos/${c.asset}-poster.png`

--- a/site/src/components/OfficeBackdrop.astro
+++ b/site/src/components/OfficeBackdrop.astro
@@ -619,6 +619,7 @@ import { asset, DIM_RESTING } from '../consts';
     }
 
     function paint(nowMs) {
+      if (!img) return; // sizeBuffer bailed on a <1px viewport → no buffer to write (audit C17)
       office.step(nowMs, bufW, BUF_H);
       // Re-read ptr/len EVERY frame (resize reallocates; memory.grow
       // invalidates views) and copy into the reusable ImageData.
@@ -919,9 +920,12 @@ import { asset, DIM_RESTING } from '../consts';
         if ('audioSession' in navigator) navigator.audioSession.type = 'playback';
         audioCtx = new (window.AudioContext || window.webkitAudioContext)();
       } catch (e) {
-        audioBooting = false;
-        audioUnavailable = true;
-        return; // no WebAudio → the ♩ simply does nothing
+        // WebAudio unavailable (Tor / hardened Firefox / enterprise lockdown):
+        // tear down AND HIDE the ♩ via the same path as the createBuffer failure.
+        // A bare flag-set left the button visible, so the click handler flipped
+        // it to a silent "playing" state and persisted AUDIO_PREF=1 (audit C5).
+        audioDisable();
+        return;
       }
       office.audio_begin();
       audioPumpWarmup();
@@ -944,6 +948,7 @@ import { asset, DIM_RESTING } from '../consts';
       audioBtn.addEventListener('click', function () {
         if (audioUnavailable) return; // WebAudio failed earlier — ♩ is a no-op
         if (!audioReady && !audioBooting) audioStart(); // first click: gesture-gated boot
+        if (audioUnavailable) return; // audioStart just failed (ctor threw) → don't flip to a silent "playing" (audit C5)
         setAudioPlaying(!audioPlaying);
       });
     }

--- a/site/src/components/PantryFaq.astro
+++ b/site/src/components/PantryFaq.astro
@@ -70,6 +70,8 @@ import { asset } from '../consts';
     // pantry reveals would blank the whole FAQ. The CSS gates the pop on
     // `:not(.is-paused)`, so a paused (or not-yet-revealed) bubble rests at its
     // base opacity:1 — pause stops motion without ever hiding content (audit C9).
+    // (Trade-off: un-pausing after reveal restarts the pop — a brief replay, never
+    // a permanent hide; strictly better than the freeze-at-opacity:0 it replaces.)
     document.addEventListener('pix:paused', function (e) {
       scene.classList.toggle('is-paused', !!(e.detail && e.detail.paused));
     });

--- a/site/src/components/PantryFaq.astro
+++ b/site/src/components/PantryFaq.astro
@@ -63,14 +63,15 @@ import { asset } from '../consts';
   // (consumer only; #office-pause stays the one dispatcher). Reduced motion
   // never animates (CSS-gated below), so there's nothing to pause there.
   (function () {
-    const chat = document.querySelector('[data-pantry-chat]');
-    if (!chat) return;
-    const animated = chat.querySelectorAll('.pantry__bubble, .pantry__cite');
+    const scene = document.querySelector('.pantry__scene');
+    if (!scene) return;
+    // Toggle a class, NOT inline animationPlayState: freezing the pop at t=0
+    // paints its backwards-fill from-keyframe (opacity:0), so pausing BEFORE the
+    // pantry reveals would blank the whole FAQ. The CSS gates the pop on
+    // `:not(.is-paused)`, so a paused (or not-yet-revealed) bubble rests at its
+    // base opacity:1 — pause stops motion without ever hiding content (audit C9).
     document.addEventListener('pix:paused', function (e) {
-      const paused = !!(e.detail && e.detail.paused);
-      animated.forEach(function (b) {
-        b.style.animationPlayState = paused ? 'paused' : 'running';
-      });
+      scene.classList.toggle('is-paused', !!(e.detail && e.detail.paused));
     });
   })();
 </script>
@@ -147,8 +148,11 @@ import { asset } from '../consts';
      pre-delay opacity 0 without leaving a permanently-hidden element behind
      (the animation ends back at the base style, which is already opacity 1). */
   @media (prefers-reduced-motion: no-preference) {
-    .pantry__scene.in .pantry__bubble,
-    .pantry__scene.in .pantry__cite {
+    /* :not(.is-paused) — the office-pause consumer toggles .is-paused on the
+       scene; without the animation the bubble rests at base opacity:1 (visible)
+       rather than the backwards-fill's opacity:0 (audit C9). */
+    .pantry__scene.in:not(.is-paused) .pantry__bubble,
+    .pantry__scene.in:not(.is-paused) .pantry__cite {
       animation: pantry-pop 0.3s ease backwards;
       animation-delay: calc(var(--turn) * 1.6s + 0.3s);
     }

--- a/site/src/components/Showcase.astro
+++ b/site/src/components/Showcase.astro
@@ -555,7 +555,11 @@ const countWord = COUNT_WORDS[channels.length] ?? String(channels.length);
           img.alt = c.dataset.alt;
           if (title) title.textContent = c.dataset.title;
           if (c.dataset.accent) st.style.setProperty('--accent', c.dataset.accent);
-          if (st.dataset.retint) retintPage(c.dataset.accent, c.dataset.accent2);
+          // also guard on c.dataset.accent (like the VIBING handler) so an
+          // accent-less chip never stamps the string "undefined" onto --coral
+          // and invalidates every var(--coral) on the page (audit C13).
+          if (st.dataset.retint && c.dataset.accent)
+            retintPage(c.dataset.accent, c.dataset.accent2);
           st.classList.remove('retint-pulse');
           void st.offsetWidth;
           st.classList.add('retint-pulse');
@@ -584,7 +588,10 @@ const countWord = COUNT_WORDS[channels.length] ?? String(channels.length);
     function fromHash() {
       const h = location.hash;
       const id = h.indexOf('#showcase-') === 0 ? h.slice('#showcase-'.length) : null;
-      if (!id) return;
+      // channel ids are plain slugs; reject anything else so a crafted hash
+      // (e.g. `#showcase-a"]`) can't build an invalid selector — querySelector
+      // would throw a SyntaxError that also skips the listener wiring (audit C12).
+      if (!id || !/^[\w-]+$/.test(id)) return;
       const exists = studio.querySelector('[data-stage="' + id + '"]');
       if (!exists) return;
       tune(id, true);
@@ -593,8 +600,10 @@ const countWord = COUNT_WORDS[channels.length] ?? String(channels.length);
       const sec = document.getElementById('showcase');
       if (sec) sec.scrollIntoView({ behavior: mq.matches ? 'auto' : 'smooth', block: 'start' });
     }
-    fromHash();
+    // wire the listener BEFORE the initial call so a throw in fromHash can never
+    // leave hashchange unbound (defensive; audit C12).
     window.addEventListener('hashchange', fromHash);
+    fromHash();
   })();
 </script>
 
@@ -620,13 +629,6 @@ const countWord = COUNT_WORDS[channels.length] ?? String(channels.length);
   .dial__ch {
     text-align: left;
   }
-  @media (pointer: coarse) {
-    /* lift the row pitch toward the 44px thumb target — 0.55rem left adjacent
-       demos ~41px centre-to-centre (mis-tap range). */
-    .dial__ch {
-      padding-block: 0.7rem;
-    }
-  }
   .dial__ch {
     background: none;
     border: 0;
@@ -638,6 +640,15 @@ const countWord = COUNT_WORDS[channels.length] ?? String(channels.length);
     color: var(--office-ink);
     cursor: pointer;
     transition: color 0.18s ease;
+  }
+  @media (pointer: coarse) {
+    /* lift the row pitch toward the 44px thumb target (~41px centre-to-centre,
+       mis-tap range). MUST sit AFTER the base `padding: .3rem .2rem` shorthand
+       above — equal specificity, so source order decides; placed before it the
+       shorthand's padding-block clobbered this even on touch (audit C2). */
+    .dial__ch {
+      padding-block: 0.7rem;
+    }
   }
   .dial__ch:hover,
   .dial__ch:focus-visible {

--- a/site/src/components/Statusline.astro
+++ b/site/src/components/Statusline.astro
@@ -17,6 +17,7 @@ import {
   FLOOR_SPY_ROOT_MARGIN,
   BOTTOM_CLAMP_EPSILON_PX,
   REPO,
+  asset,
 } from '../consts';
 import { GH_FETCH_TIMEOUT_MS } from '../../config/gh-stars.mjs';
 
@@ -207,7 +208,7 @@ const FEED_ROTATE_MS = 6000; // one line every 6s
     }
     <a
       class="sl__copy"
-      href="#install"
+      href={doc ? `${asset('')}#install` : '#install'}
       data-sl-install-link
       aria-label="Jump to the install section"
     >
@@ -802,9 +803,12 @@ const FEED_ROTATE_MS = 6000; // one line every 6s
     }
     if (installLink) {
       installLink.addEventListener('click', function (e) {
-        e.preventDefault();
         const sec = document.getElementById('install');
+        // Doc/404 pages have no #install here — DON'T preventDefault; let the
+        // href (now the cross-page `/#install`) carry the visitor to the index
+        // install section instead of eating the click and doing nothing (audit C7).
         if (!sec) return;
+        e.preventDefault();
         sec.scrollIntoView({ behavior: mq.matches ? 'auto' : 'smooth', block: 'start' });
         sec.setAttribute('tabindex', '-1');
         sec.focus({ preventScroll: true });

--- a/site/src/components/SupportedTools.astro
+++ b/site/src/components/SupportedTools.astro
@@ -258,7 +258,10 @@ const legendStates = (['yes', 'experimental', 'planned', 'no'] as OsState[]).fil
   .tools tbody th a:hover {
     opacity: 0.8;
   }
-  .tools__cell {
+  /* td-qualified (0,2,1) so `text-align: center` beats the base `.tools td
+     { text-align: left }` (0,1,1) — bare `.tools__cell` (0,1,0) lost the type
+     selector and the LED discs hugged the left of each OS column (audit C4). */
+  .tools td.tools__cell {
     text-align: center;
     font-size: 1.05rem;
   }
@@ -288,7 +291,11 @@ const legendStates = (['yes', 'experimental', 'planned', 'no'] as OsState[]).fil
     /* the neon: the app's real per-CLI hue, glowing on the dark screen */
     text-shadow: 0 0 8px color-mix(in srgb, var(--badge, var(--led)) 55%, transparent);
   }
-  .tools__board td.tools__how {
+  /* `.tools ` prefix lifts this to (0,3,1) so `opacity: 1` beats the base
+     `.tools td.tools__how { opacity: .7 }` below (both were (0,2,1); the base
+     came later and won on order → the board's How column rendered double-dimmed
+     chip-dim×0.7 ≈ sub-AA) (audit C3). */
+  .tools .tools__board td.tools__how {
     color: var(--chip-dim);
     opacity: 1;
   }

--- a/site/src/consts.ts
+++ b/site/src/consts.ts
@@ -164,8 +164,7 @@ export interface ShowcaseChannel {
   // config/vibing-parity.test.mjs.
   w?: number;
   h?: number;
-  variantsRef?: 'themes' | 'weather'; // variant-set backed by an existing manifest
-  variants?: ShowcaseVariant[]; // …or inline variants
+  variants?: ShowcaseVariant[]; // variant-set channels: INLINE variants (channel-level variantsRef was retired with the #468 stills; a live channel's manifest refs live on its variantGroups)
   retint?: boolean; // chips retint the page (themes only)
   variantGroups?: VariantGroup[]; // live channel: multiple independently-labeled chip groups
   timeSlider?: boolean; // live channel: exposes a time-of-day scrub control
@@ -182,8 +181,8 @@ export interface ShowcaseChannel {
 
 // Single source of truth for the Studio Wall → site/src/showcase.json.
 // themes.json / weather.json stay untouched (their README-sync + just gen-media
-// loops + Rust enum guard tests are unaffected); variant-set channels reference
-// them via variantsRef and resolve here.
+// loops + Rust enum guard tests are unaffected); a live channel's variantGroups
+// reference them via a per-group variantsRef and resolve in showcaseGroups.
 // The manifest's kind/status/default/asset invariants are enforced at build time by the showcase guard in astro.config.mjs.
 export const SHOWCASE: ShowcaseChannel[] = showcaseData as unknown as ShowcaseChannel[];
 
@@ -231,13 +230,11 @@ export interface EnrichedShowcaseChannel extends ShowcaseChannel {
   featureDesc: string; // joined features.json row's desc — the dial accordion body, and the caption fallback
 }
 
-// The manifest resolution a `variantsRef` maps to — the SINGLE place both
-// showcaseVariants (channel-level) and showcaseGroups (live-channel, one per
-// group) read THEMES/WEATHERS, so the two callers can never disagree on shape.
-// `src` below is dead weight for a live-channel consumer (showcaseGroups) —
-// ChannelStage's live-chip branch renders only id/name/accent and never reads
-// it (those theme_<id>.png/weather_<id>.png stills are gone, #468); it's kept
-// because variant-set channels' chip branch still `data-src`-swaps with it.
+// The manifest a live channel's per-group `variantsRef` maps to — showcaseGroups
+// is the ONLY caller (channel-level variantsRef was retired, #468). `src` below
+// is dead weight — ChannelStage's live-chip branch renders only id/name/accent
+// and never reads it (those theme_<id>.png/weather_<id>.png stills are gone) —
+// kept only so the ShowcaseVariant shape stays uniform.
 function variantsForRef(ref: 'themes' | 'weather'): ShowcaseVariant[] {
   if (ref === 'themes')
     return THEMES.map((t) => ({
@@ -258,13 +255,11 @@ function variantsForRef(ref: 'themes' | 'weather'): ShowcaseVariant[] {
 }
 
 export function showcaseVariants(c: ShowcaseChannel): ShowcaseVariant[] {
-  // A channel may carry a manifest-backed `variantsRef` AND extra inline
-  // `variants`, appended after it (variant-set channels only) — no current
-  // channel exercises the append, but the shape supports it.
-  const inline = c.variants ?? [];
-  if (c.variantsRef === 'themes' || c.variantsRef === 'weather')
-    return [...variantsForRef(c.variantsRef), ...inline];
-  return inline;
+  // variant-set channels supply INLINE variants only. Channel-level `variantsRef`
+  // resolved the theme_<id>.png/weather_<id>.png stills #468 deleted, so it was
+  // retired (the astro.config guard rejects a stray one); a live channel's
+  // manifest refs live on its variantGroups (showcaseGroups).
+  return c.variants ?? [];
 }
 
 export function showcaseGroups(c: ShowcaseChannel): EnrichedVariantGroup[] {

--- a/site/src/env.d.ts
+++ b/site/src/env.d.ts
@@ -1,4 +1,5 @@
-// Injected at build time from the workspace Cargo.toml (see astro.config.mjs).
+// Injected at build time: the latest release TAG, or the workspace Cargo.toml
+// version as the tag-less fallback (config/released-version.mjs via astro.config.mjs).
 declare const __PIXTUOID_VERSION__: string;
 // Build-time GitHub star count ("342"), or null when the API was unreachable
 // at build (offline builds must not fail) — consumers omit the count then.

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -48,7 +48,7 @@ const ogImage = new URL(asset('demos/hero-poster.png'), SITE).href;
 // Per-page canonical/og:url — Astro.url.pathname includes the configured base in
 // the static build, so /config no longer self-declares the homepage as canonical.
 const canonical = new URL(Astro.url.pathname, SITE).href;
-const version = __PIXTUOID_VERSION__; // from the workspace Cargo.toml at build
+const version = __PIXTUOID_VERSION__; // the latest release TAG (Cargo.toml is only the tag-less fallback — config/released-version.mjs)
 
 // Escape `<` so no string value can break out of the <script> block (a `</script`
 // or `<!--` in serialized JSON would otherwise close it). Defense-in-depth: every

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -17,8 +17,8 @@ import { asset, REPO, CRATES, floorById, floorName, SITE_ORIGIN } from '../const
 const amenities = floorById('amenities');
 
 // Homepage structured data: a free cross-platform developer tool. Search
-// engines use this for a rich result; the version is single-sourced from the
-// workspace Cargo.toml at build (same define as everywhere else).
+// engines use this for a rich result; the version is the latest release TAG
+// (Cargo.toml is the tag-less fallback), same __PIXTUOID_VERSION__ define as everywhere else.
 const SITE = Astro.site ?? new URL(SITE_ORIGIN);
 const softwareJsonLd = {
   '@context': 'https://schema.org',

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -250,8 +250,15 @@ a {
   text-underline-offset: 2px;
 }
 /* :not(.btn) keeps this repaint off button-anchors — unscoped it outranks
-   .btn-primary's white label and rendered the CTA coral-on-coral. */
-:root[data-theme='night'] a:not(.btn) {
+   .btn-primary's white label and rendered the CTA coral-on-coral. The theme
+   selector is wrapped in :where() so this night shift carries ZERO extra
+   specificity — the whole selector is (0,1,1). It recolors bare content links
+   (base `a`, (0,0,1)) but must NOT outrank a component's own (0,2,0)+ anchor
+   colour (hero ghost, nav logo, docs pager, plaque) — the old (0,3,1) form
+   flipped those coral AT REST in night only, breaking Hero's documented
+   AA-at-rest-over-office invariant and killing the docs-pager night hover cue
+   (audit C1; day/dracula were already correct). */
+:where(:root[data-theme='night']) a:not(.btn) {
   color: var(--coral);
 }
 

--- a/site/tests/e2e/docs-lobby.spec.ts
+++ b/site/tests/e2e/docs-lobby.spec.ts
@@ -122,9 +122,7 @@ test('pantry FAQ: bubbles pop in sequence, join pix:paused, reduced-motion is st
     document.dispatchEvent(new CustomEvent('pix:paused', { detail: { paused: true } }))
   );
   await expect(page.locator('.pantry__scene')).toHaveClass(/\bis-paused\b/);
-  await expect
-    .poll(() => first.evaluate((el) => getComputedStyle(el).animationName))
-    .toBe('none');
+  await expect.poll(() => first.evaluate((el) => getComputedStyle(el).animationName)).toBe('none');
   await expect(first).toBeVisible();
   // reduced-motion: static, no animation, fully visible
   const ctx = await browser.newContext({ reducedMotion: 'reduce' });

--- a/site/tests/e2e/docs-lobby.spec.ts
+++ b/site/tests/e2e/docs-lobby.spec.ts
@@ -114,13 +114,18 @@ test('pantry FAQ: bubbles pop in sequence, join pix:paused, reduced-motion is st
   await expect
     .poll(() => first.evaluate((el) => getComputedStyle(el).opacity), { timeout: 10_000 })
     .toBe('1');
-  // bubbles are pix:paused CONSUMERS (spec §7: bubbles join the set)
+  // bubbles are pix:paused CONSUMERS (spec §7): pausing toggles .is-paused on the
+  // scene, which drops the pop animation so a bubble rests at its base opacity:1
+  // — never frozen at the backwards-fill opacity:0 (audit C9). (Was an inline
+  // animationPlayState toggle, which blanked a paused-before-reveal FAQ.)
   await page.evaluate(() =>
     document.dispatchEvent(new CustomEvent('pix:paused', { detail: { paused: true } }))
   );
+  await expect(page.locator('.pantry__scene')).toHaveClass(/\bis-paused\b/);
   await expect
-    .poll(() => first.evaluate((el) => (el as HTMLElement).style.animationPlayState))
-    .toBe('paused');
+    .poll(() => first.evaluate((el) => getComputedStyle(el).animationName))
+    .toBe('none');
+  await expect(first).toBeVisible();
   // reduced-motion: static, no animation, fully visible
   const ctx = await browser.newContext({ reducedMotion: 'reduce' });
   const m = await ctx.newPage();

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -2324,3 +2324,102 @@ test('proof split: narrow + reduced motion shows the tall poster, not a blank bo
   await expect.poll(() => tall.evaluate((v) => (v as HTMLVideoElement).paused)).toBe(true);
   await context.close();
 });
+
+// ── Correctness-audit regressions ──────────────────────────────────────────
+// Each pins a fix from the whole-site correctness audit; all were UNTESTED and
+// several were dead-declaration cascade traps (a later/higher-specificity rule
+// silently swallowing an intended one). See the audit-fix PR body for C-ids.
+
+async function resolvedCoral(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const probe = document.createElement('span');
+    probe.style.color = 'var(--coral)';
+    document.body.appendChild(probe);
+    const c = getComputedStyle(probe).color;
+    probe.remove();
+    return c;
+  });
+}
+
+test('audit C1: night theme does not repaint chrome anchors coral (a:not(.btn) is :where()-scoped)', async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    sessionStorage.setItem('pix-booted', '1');
+    localStorage.setItem('pix-theme', 'night');
+  });
+  await page.goto('./');
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'night');
+  // Pre-fix the global `:root[data-theme='night'] a:not(.btn)` rule (0,3,1)
+  // outranked these anchors' own (0,2,0) colours → all rendered coral AT REST,
+  // breaking Hero's documented AA-at-rest-over-office invariant. Each must keep
+  // its own colour (hero ghost/nav logo = --fg; plaque = --chip-bright).
+  const coral = await resolvedCoral(page);
+  for (const sel of ['.hero__ghost', '.nav__logo', '.tools__plaque-link']) {
+    const color = await page
+      .locator(sel)
+      .first()
+      .evaluate((e) => getComputedStyle(e).color);
+    expect(color, `${sel} must not be the a:not(.btn) coral in night`).not.toBe(coral);
+  }
+});
+
+test('audit C1 (docs): the /config pager link is not coral in night', async ({ page }) => {
+  await page.addInitScript(() => localStorage.setItem('pix-theme', 'night'));
+  await page.goto('/config/');
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'night');
+  const coral = await resolvedCoral(page);
+  const color = await page
+    .locator('.docs__pager-link')
+    .first()
+    .evaluate((e) => getComputedStyle(e).color);
+  expect(color).not.toBe(coral);
+});
+
+test('audit C3/C4: tools board How column is un-dimmed (opacity 1) and OS cells centre', async ({
+  page,
+}) => {
+  await gotoLive(page);
+  const how = await page
+    .locator('.tools__board td.tools__how')
+    .first()
+    .evaluate((e) => getComputedStyle(e).opacity);
+  expect(how, 'tools__how must be opacity 1 on the board, not the base 0.7 (audit C3)').toBe('1');
+  const align = await page
+    .locator('.tools__cell')
+    .first()
+    .evaluate((e) => getComputedStyle(e).textAlign);
+  expect(align, 'tools__cell must centre its LED (audit C4)').toBe('center');
+});
+
+test('audit C9: pausing the office before the pantry reveals keeps the FAQ visible', async ({
+  page,
+}) => {
+  await gotoLive(page);
+  // pause while the pantry is off-screen, THEN reveal it — the pre-fix inline
+  // animationPlayState froze the pop at its opacity:0 backwards-fill → blank FAQ.
+  await page.evaluate(() =>
+    document.dispatchEvent(new CustomEvent('pix:paused', { detail: { paused: true } }))
+  );
+  await page.evaluate(() =>
+    document
+      .querySelector('.pantry__scene')!
+      .scrollIntoView({ block: 'center', behavior: 'instant' })
+  );
+  const bubble = page.locator('.pantry__bubble').first();
+  await expect(bubble).toBeVisible();
+  await expect
+    .poll(() => bubble.evaluate((e) => parseFloat(getComputedStyle(e).opacity)))
+    .toBeGreaterThan(0.5);
+});
+
+test('audit C7: the doc-page install chip links cross-page, not a dead same-page fragment', async ({
+  page,
+}) => {
+  await page.goto('/config/');
+  const href = await page.locator('[data-sl-install-link]').first().getAttribute('href');
+  // on a doc page there is no local #install — the chip must carry a cross-page
+  // href to the index install section, not the inert same-page '#install'.
+  expect(href).not.toBe('#install');
+  expect(href).toContain('#install');
+});

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -2423,3 +2423,32 @@ test('audit C7: the doc-page install chip links cross-page, not a dead same-page
   expect(href).not.toBe('#install');
   expect(href).toContain('#install');
 });
+
+test('audit C5: ♩ hides and never persists a silent "playing" when the AudioContext constructor throws', async ({
+  page,
+}) => {
+  // WebAudio disabled (Tor / hardened Firefox / enterprise) → `new AudioContext()`
+  // THROWS. Headless Chromium's ctor SUCCEEDS (only createBuffer throws, which the
+  // existing ♩ test covers), so force the ctor-throw path directly. Pre-fix the
+  // ctor-catch only set a flag, leaving the ♩ visible for the click to flip to a
+  // silent "playing" state and persist pix:audio=1 — stuck-silent every visit.
+  const errors = watchErrors(page);
+  await page.addInitScript(() => {
+    const Throwing = function () {
+      throw new Error('WebAudio disabled');
+    } as unknown as typeof AudioContext;
+    window.AudioContext = Throwing;
+    (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext =
+      Throwing;
+  });
+  await gotoLive(page);
+  const btn = page.locator('#office-audio');
+  await expect(btn).toBeVisible({ timeout: 15_000 });
+  await btn.click();
+  // audioDisable(): hides the button, stays not-pressed, and the choice is NEVER
+  // persisted as playing (so a later visit's restore path can't re-flip it silent-on).
+  await expect(btn).toBeHidden();
+  await expect(btn).toHaveAttribute('aria-pressed', 'false');
+  expect(await page.evaluate(() => localStorage.getItem('pix:audio'))).not.toBe('1');
+  expect(errors()).toEqual([]); // caught, not an uncaught page error
+});


### PR DESCRIPTION
Fixes from a whole-`site/` correctness audit (7 parallel finders → adversarial verification workflow, each finding refuted-by-default). 17 candidates → 14 fixed, 1 refuted, 2 deferred. Empirically verified (Playwright computed-style probes) + 6 e2e regression tests; `verify` + 83 e2e green.

## Cascade / dead-declaration (the recurring class — a later/higher-specificity rule swallowing an intended one)
- **C1** `:root[data-theme='night'] a:not(.btn){color:var(--coral)}` (0,3,1) outranked hero-ghost/nav-logo/docs-pager/plaque's own (0,2,0) colours → **coral AT REST in night only**, breaking Hero's documented AA-at-rest-over-office invariant. Wrapped the theme selector in `:where()` → (0,1,1): still recolours bare content links, can't beat a component's own anchor colour. *(measured: night anchors back to ink; day/dracula unchanged)*
- **C2** `.dial__ch{padding:.3rem .2rem}` shorthand sat after `@media(pointer:coarse){padding-block:.7rem}` at equal specificity → mobile 44px touch-target lift dead. Reordered.
- **C3** `.tools__board td.tools__how{opacity:1}` tied+lost to `.tools td.tools__how{opacity:.7}` → board How column double-dimmed (~3:1 sub-AA). `.tools` prefix wins.
- **C4** `.tools__cell{text-align:center}` (0,1,0) lost to `.tools td` (0,1,1). td-qualified.

## JS logic
- **C5** WebAudio-disabled (`new AudioContext()` throws) left the ♩ stuck "playing-but-silent" + persisted the pref. Route the ctor-catch through `audioDisable()` + re-check after `audioStart()`.
- **C7** doc/404-page install chip `preventDefault()`'d then returned on the absent `#install` (inert). Cross-page href + only preventDefault when a local `#install` exists.
- **C9** pausing before the pantry reveals froze the pop at its `opacity:0` backwards-fill → blank FAQ. Class gate (`.is-paused` + `:not(.is-paused)`) → rests at opacity:1.
- **C12** raw URL hash built a `querySelector` → uncaught `SyntaxError` (+ skipped listener wiring). Slug-validate + wire the listener first.
- **C13** OSD retint fired `retintPage(undefined)` unguarded (vs VIBING) → `--coral: undefined`. Aligned the guard.

## Guard/hardening
- **C8** MonitorWall `thumb()` had no `kind:'live'` arm → build TypeError (inert unmounted fallback). Added a poster arm.
- **C11** variant-set `variantsRef` guard passed vacuously (stills retired #468) → throw. **C14** live-channel poster made required.
- **C15** 3 stale "version from Cargo.toml" comments → tag-first. **C17** `paint()` null-`img` guard for a <1px viewport.

## Refuted / deferred (kept for coverage)
- **C6** `paint()` no try/catch — REFUTED: deterministic scripted timeline (no untrusted input) **and** the "no recovery" premise is false (visibilitychange/resize re-arm the loop).
- **C10** VIBING no-self-recover — matches the documented bounded-retry design; "fixing" it would hammer retries during an outage. NIT.
- **C16** hung-fetch cover — real but rare (hung ≠ reject) + delicate boot interaction; deferred.

## Tests
5 new e2e (C1 night-anchors ×2, C3/C4 tools, C7 doc chip, C9 pantry-visible) + updated the existing docs-lobby pantry test for the C9 class mechanism. All were previously **untested**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fyBXdKR1YzwmfLzm3Pc9H