### PR TITLE
feat(site): O(1) hero badge strip — collapsed code cells, hover-expand, roster-aware scroll budget

### DIFF
--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -235,27 +235,12 @@ const badges = sources.filter((s) => s.status === 'supported');
     grid-template-columns: 1fr;
     opacity: 1;
   }
-  /* The typed name ends on a blinking block caret — the SAME STYLED-BOX idiom
-     as the h1's .cursor (inline-block + background, mirrored numbers), NOT a
-     text glyph: a glyph ('▍') involves font/fallback metrics an engine may
-     resolve into a different line box (the Safari-jitter hunt), a box never
-     does. It types out WITH the text (it lives inside the clipped track) and
-     blinks once open; the global reduced-motion clamp freezes it steady. */
-  .hero__badge-name > span::after {
-    content: '';
-    display: inline-block;
-    width: 0.55ch;
-    height: 0.92em;
-    margin-left: 0.08em;
-    transform: translateY(0.08em);
-    background: var(--coral);
-    animation: badge-caret 1.1s steps(1) infinite;
-  }
-  @keyframes badge-caret {
-    50% {
-      opacity: 0;
-    }
-  }
+  /* The typed name ends on a blinking block caret. Its ENTIRE definition
+     lives in global.css's shared caret idiom (`.cursor, .hero__badge-name >
+     span::after`) — one declaration block for both the h1 cursor and this
+     caret, so their metrics/color/blink can't drift apart (review-caught: the
+     first cut copy-pasted the five properties here). Nothing to declare
+     locally; the RM freeze rides the same global arm. */
   /* Pressed-key feedback: the hovered cell's tint + border deepen a notch —
      the hardware "this key is down" read, no geometry change (no translate:
      the strip must never move vertically — see the cursor-shimmer WHY above).

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -131,6 +131,13 @@ const badges = sources.filter((s) => s.status === 'supported');
   .hero__badge {
     display: inline-flex;
     align-items: baseline;
+    /* Label chips, not copy text: without these the pointer flips arrow ↔
+       I-beam per glyph while sweeping the strip — frame-extracted from the
+       user's screen recording as a "vertical shimmer" at the cursor (the
+       row itself is frame-stable) — and a drag would blue-select the codes.
+       The count-link <a> keeps its pointer cursor. */
+    cursor: default;
+    user-select: none;
     /* gap moved INTO .hero__badge-name's inner padding so a collapsed name
        leaves no trailing space after the code */
     gap: 0;
@@ -200,9 +207,13 @@ const badges = sources.filter((s) => s.status === 'supported');
     display: inline-grid;
     grid-template-columns: 0fr;
     opacity: 0;
+    /* steps(), not ease: the track opens in discrete increments, so the clip
+       reveals the name glyph-chunk by glyph-chunk — a terminal TYPING her
+       name, not a drawer sliding (the hero h1's block cursor sets the idiom).
+       Opacity snaps fast so revealed glyphs are already solid. */
     transition:
-      grid-template-columns 0.22s ease,
-      opacity 0.18s ease;
+      grid-template-columns 0.3s steps(12, end),
+      opacity 0.06s linear;
   }
   .hero__badge-name > span {
     min-width: 0;
@@ -212,6 +223,34 @@ const badges = sources.filter((s) => s.status === 'supported');
   .hero__badge:hover .hero__badge-name {
     grid-template-columns: 1fr;
     opacity: 1;
+  }
+  /* The typed name ends on a blinking block caret — the same terminal idiom
+     as the h1's .cursor. It types out WITH the text (it lives inside the
+     clipped track) and blinks once open; the global reduced-motion clamp
+     freezes the blink to a steady bar. */
+  .hero__badge-name > span::after {
+    content: '▍';
+    margin-left: 0.08em;
+    animation: badge-caret 1.1s steps(1) infinite;
+  }
+  @keyframes badge-caret {
+    50% {
+      opacity: 0;
+    }
+  }
+  /* Pressed-key feedback: the hovered cell's tint + border deepen a notch —
+     the hardware "this key is down" read, no geometry change (no translate:
+     the strip must never move vertically — see the cursor-shimmer WHY above).
+     Hover-state contrast audited on rendered pixels across all 13 hues: day
+     26% worst 5.18:1 (grok code), night 42% worst 4.72:1 (grok name) — 46%
+     was rejected (grok code fell to 4.52). The e2e sweep gates REST state;
+     these deepened pairs sit above the same 4.5 floor by audit. */
+  .hero__badge:hover {
+    background: color-mix(in srgb, var(--badge) 26%, var(--surface));
+    border-color: color-mix(in srgb, var(--badge) 62%, var(--border-strong));
+    transition:
+      background-color 0.15s ease,
+      border-color 0.15s ease;
   }
   /* No per-component reduced-motion arm for the name track: global.css's
      universal RM clamp (`* { transition-duration: 0.001ms !important }`)
@@ -225,6 +264,13 @@ const badges = sources.filter((s) => s.status === 'supported');
     background: color-mix(in srgb, var(--badge) 34%, var(--screen));
     border-color: color-mix(in srgb, var(--badge) 60%, var(--chip-line));
     color: var(--chip-ink);
+  }
+  :root[data-theme='night'] .hero__badge:hover,
+  :root[data-theme='dracula'] .hero__badge:hover {
+    /* the pressed-key deepen, night flavor (the higher-specificity night base
+       would otherwise pin hover at the resting 34%) */
+    background: color-mix(in srgb, var(--badge) 42%, var(--screen));
+    border-color: color-mix(in srgb, var(--badge) 74%, var(--chip-line));
   }
   :root[data-theme='night'] .hero__badge-code,
   :root[data-theme='dracula'] .hero__badge-code {

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -213,11 +213,10 @@ const badges = sources.filter((s) => s.status === 'supported');
     grid-template-columns: 1fr;
     opacity: 1;
   }
-  @media (prefers-reduced-motion: reduce) {
-    .hero__badge-name {
-      transition: none;
-    }
-  }
+  /* No per-component reduced-motion arm for the name track: global.css's
+     universal RM clamp (`* { transition-duration: 0.001ms !important }`)
+     already zeroes it — a local `transition: none` here would be dead code
+     under that !important (pinned by the reduced-motion badge e2e). */
   :root[data-theme='night'] .hero__badge,
   :root[data-theme='dracula'] .hero__badge {
     /* dracula's --bg is dark too (same direction as night — see

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -32,11 +32,17 @@ const badges = sources.filter((s) => s.status === 'supported');
       <ul class="hero__badges" aria-label={`Works with ${badges.length} coding CLIs`}>
         {
           badges.map((s) => (
-            <li class="hero__badge" style={`--badge:${s.badge_color}`}>
-              <span class="hero__badge-code">{s.badge.replace('·', '')}</span> {s.name}
+            <li class="hero__badge" style={`--badge:${s.badge_color}`} aria-label={s.name}>
+              <span class="hero__badge-code">{s.badge.replace('·', '')}</span>
+              <span class="hero__badge-name" aria-hidden="true">
+                <span>{s.name}</span>
+              </span>
             </li>
           ))
         }
+        <li class="hero__badge hero__badge--more">
+          <a href="#tools">{badges.length} CLIs <span aria-hidden="true">→</span></a>
+        </li>
       </ul>
       <div class="hero__cta">
         <a class="btn btn-primary" href="#install">[ install <span aria-hidden="true">→</span> ]</a>
@@ -125,7 +131,10 @@ const badges = sources.filter((s) => s.status === 'supported');
   .hero__badge {
     display: inline-flex;
     align-items: baseline;
-    gap: 0.4em;
+    /* gap moved INTO .hero__badge-name's inner padding so a collapsed name
+       leaves no trailing space after the code */
+    gap: 0;
+    white-space: nowrap;
     font-family: var(--font-mono);
     font-size: 0.8rem;
     letter-spacing: 0.02em;
@@ -135,34 +144,86 @@ const badges = sources.filter((s) => s.status === 'supported');
        day office, user-caught). NIGHT below switches to the --screen /
        --chip-line hardware family instead (the mock's look, matching the
        app's own dark Sources panel). */
-    background: var(--surface);
-    border: 1px solid var(--border-strong);
+    /* Each cell is FILLED with its agent's brand hue, gently — a low-mix tint
+       over the surface so the strip reads as a colorful spectrum row without
+       shouting (user-directed: whole-cell fill, transparent-ish, gentle). */
+    background: color-mix(in srgb, var(--badge) 14%, var(--surface));
+    border: 1px solid color-mix(in srgb, var(--badge) 40%, var(--border-strong));
     color: var(--fg);
+  }
+  /* The one non-source cell: a quiet count-link to the full #tools matrix —
+     the breadth signal (the number) + the path to full names for touch users,
+     who get no hover-expand. Its --badge is the NEUTRAL border tone so the
+     shared tint formulas above apply unchanged (a per-chip background override
+     here would go invalid-at-computed-value on the formulas' var(--badge) and
+     fall to transparent — text straight on office pixels); the gray tint reads
+     as chrome, not a 14th CLI. */
+  .hero__badge--more {
+    --badge: var(--border-strong);
+  }
+  .hero__badge--more a {
+    color: var(--fg);
+    text-decoration: none;
+    transition: color 0.18s ease;
+  }
+  .hero__badge--more a:hover {
+    color: var(--coral); /* the shared link idiom (see .hero__ghost) */
   }
   .hero__badge-code {
     font-weight: 700;
     /* the app's real per-CLI hue (sources.json badge_color, pinned to
        theme::NORMAL.source by crates/pixtuoid-scene/tests/site_badge_colors.rs),
-       darkened toward black so it clears WCAG AA (4.5:1) on the light day
-       chip — measured worst case (OpenClaw #ffaa30) 5.37:1 at 45% black; the
-       e2e badge-hue sweep (smoke.spec.ts) pins every hue in both themes. */
-    color: color-mix(in srgb, var(--badge) 55%, black);
+       darkened toward black so it clears WCAG AA (4.5:1) on the TINTED day
+       cell (same-hue text on same-hue tint eats contrast, so 50% black vs the
+       old 45%) — computed worst case (Grok #66d0e8) 5.57:1; the e2e badge-hue
+       sweep (smoke.spec.ts) pins every hue in both themes. */
+    color: color-mix(in srgb, var(--badge) 50%, black);
+  }
+  /* Collapsed-by-default name: a 0fr grid track animates open to auto width on
+     hover (interaction-triggered, so no WCAG 2.2.2 pause obligation). The chip
+     grows RIGHTWARD — its own left edge never moves, so the pointer stays
+     inside and hover can't jitter. Deliberately hover-only: chips carry no
+     tabindex (13 tab stops before the CTA is hostile keyboard UX) — names stay
+     available to AT via aria-label and to everyone at the #tools matrix the
+     trailing count-link points at. */
+  .hero__badge-name {
+    display: inline-grid;
+    grid-template-columns: 0fr;
+    opacity: 0;
+    transition:
+      grid-template-columns 0.22s ease,
+      opacity 0.18s ease;
+  }
+  .hero__badge-name > span {
+    min-width: 0;
+    overflow: hidden;
+    padding-left: 0.4em;
+  }
+  .hero__badge:hover .hero__badge-name {
+    grid-template-columns: 1fr;
+    opacity: 1;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .hero__badge-name {
+      transition: none;
+    }
   }
   :root[data-theme='night'] .hero__badge,
   :root[data-theme='dracula'] .hero__badge {
     /* dracula's --bg is dark too (same direction as night — see
        --office-ink's dracula arm in global.css); it piggybacks on night's
        already-measured formula rather than a third dedicated sweep. */
-    background: var(--screen);
-    border-color: var(--chip-line);
+    background: color-mix(in srgb, var(--badge) 34%, var(--screen));
+    border-color: color-mix(in srgb, var(--badge) 60%, var(--chip-line));
     color: var(--chip-ink);
   }
   :root[data-theme='night'] .hero__badge-code,
   :root[data-theme='dracula'] .hero__badge-code {
-    /* lightened toward white so the hue clears 4.5:1 on the dark --screen
-       chip — measured worst case (DeepSeek-Reasonix #9c3cc0) 5.09:1 at 20%
-       white. */
-    color: color-mix(in srgb, var(--badge) 80%, white);
+    /* lightened toward white so the hue clears 4.5:1 — measured against the
+       TINTED night cell (same-hue bg eats same-hue text, so 45% white vs the
+       old 20%) — computed worst case (opencode #e8823c-family) 5.86:1 at the
+       34% cell tint; the e2e sweep pins every hue. */
+    color: color-mix(in srgb, var(--badge) 55%, white);
   }
   .hero__avail {
     margin-top: 1.1rem;

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -127,6 +127,11 @@ const badges = sources.filter((s) => s.status === 'supported');
     margin: 1.15rem 0 0;
     padding: 0;
     list-style: none;
+    /* Permanent compositing layer: Safari promotes/demotes elements around
+       hover transitions, and the raster snap on that boundary can read as a
+       sub-pixel text wiggle even when geometry probes measure 0.00 (the
+       Safari-only jitter report). Pinning the layer removes the boundary. */
+    transform: translateZ(0);
   }
   .hero__badge {
     display: inline-flex;
@@ -230,13 +235,20 @@ const badges = sources.filter((s) => s.status === 'supported');
     grid-template-columns: 1fr;
     opacity: 1;
   }
-  /* The typed name ends on a blinking block caret — the same terminal idiom
-     as the h1's .cursor. It types out WITH the text (it lives inside the
-     clipped track) and blinks once open; the global reduced-motion clamp
-     freezes the blink to a steady bar. */
+  /* The typed name ends on a blinking block caret — the SAME STYLED-BOX idiom
+     as the h1's .cursor (inline-block + background, mirrored numbers), NOT a
+     text glyph: a glyph ('▍') involves font/fallback metrics an engine may
+     resolve into a different line box (the Safari-jitter hunt), a box never
+     does. It types out WITH the text (it lives inside the clipped track) and
+     blinks once open; the global reduced-motion clamp freezes it steady. */
   .hero__badge-name > span::after {
-    content: '▍';
+    content: '';
+    display: inline-block;
+    width: 0.55ch;
+    height: 0.92em;
     margin-left: 0.08em;
+    transform: translateY(0.08em);
+    background: var(--coral);
     animation: badge-caret 1.1s steps(1) infinite;
   }
   @keyframes badge-caret {

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -175,6 +175,12 @@ const badges = sources.filter((s) => s.status === 'supported');
   .hero__badge--more a {
     color: var(--fg);
     text-decoration: none;
+    /* EXPLICIT pointer: the ancestor chips force cursor: default (inherited),
+       and only a UA-stylesheet special case (a:any-link) restores pointer —
+       measured present in Chromium, but not spec-guaranteed across engines.
+       State the intent instead of leaning on the UA rule; pinned by the
+       bridge e2e's cursor assertions. */
+    cursor: pointer;
     transition: color 0.18s ease;
   }
   .hero__badge--more a:hover {

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -157,7 +157,11 @@ const badges = sources.filter((s) => s.status === 'supported');
      shared tint formulas above apply unchanged (a per-chip background override
      here would go invalid-at-computed-value on the formulas' var(--badge) and
      fall to transparent — text straight on office pixels); the gray tint reads
-     as chrome, not a 14th CLI. */
+     as chrome, not a 14th CLI. One knowing wrinkle: --border-strong is itself
+     a TRANSLUCENT token, so unlike the opaque-hex source cells this cell's mix
+     keeps some alpha (~a quarter of the office bleeds through at night) —
+     accepted, the chrome-halo/raw-contrast posture covers it and the e2e gates
+     the nominal ink pair. */
   .hero__badge--more {
     --badge: var(--border-strong);
   }
@@ -175,14 +179,20 @@ const badges = sources.filter((s) => s.status === 'supported');
        theme::NORMAL.source by crates/pixtuoid-scene/tests/site_badge_colors.rs),
        darkened toward black so it clears WCAG AA (4.5:1) on the TINTED day
        cell (same-hue text on same-hue tint eats contrast, so 50% black vs the
-       old 45%) — computed worst case (Grok #66d0e8) 5.57:1; the e2e badge-hue
+       old 45%) — computed worst case (Grok #30d0e8) 5.57:1; the e2e badge-hue
        sweep (smoke.spec.ts) pins every hue in both themes. */
     color: color-mix(in srgb, var(--badge) 50%, black);
   }
   /* Collapsed-by-default name: a 0fr grid track animates open to auto width on
      hover (interaction-triggered, so no WCAG 2.2.2 pause obligation). The chip
      grows RIGHTWARD — its own left edge never moves, so the pointer stays
-     inside and hover can't jitter. Deliberately hover-only: chips carry no
+     inside and the HOVERED chip can't jitter (empirically swept 760–1440px:
+     0 wrap-jumps of the hovered chip itself; a last-on-line chip overflows
+     right rather than re-wrapping, bounded by .hero's overflow:hidden). "Left
+     edge never moves" ≠ "nothing below moves": at line-wrap-boundary widths
+     the expansion can push a TRAILING sibling to a new line (+1 strip row,
+     the CTA shifts ~35px, self-correcting on un-hover) — accepted as LOW over
+     the costlier reserve-height/overlay alternatives. Deliberately hover-only: chips carry no
      tabindex (13 tab stops before the CTA is hostile keyboard UX) — names stay
      available to AT via aria-label and to everyone at the #tools matrix the
      trailing count-link points at. */
@@ -221,7 +231,7 @@ const badges = sources.filter((s) => s.status === 'supported');
   :root[data-theme='dracula'] .hero__badge-code {
     /* lightened toward white so the hue clears 4.5:1 — measured against the
        TINTED night cell (same-hue bg eats same-hue text, so 45% white vs the
-       old 20%) — computed worst case (opencode #e8823c-family) 5.86:1 at the
+       old 20%) — computed worst case (opencode #d83a3a) 5.86:1 at the
        34% cell tint; the e2e sweep pins every hue. */
     color: color-mix(in srgb, var(--badge) 55%, white);
   }

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -348,7 +348,13 @@ h3 {
 }
 
 /* blinking block cursor */
-.cursor {
+/* THE blinking-caret idiom — one declaration block, two consumers: the h1's
+   .cursor span and the hero badge strip's typed-name caret (a ::after that
+   can't carry the class attribute, hence the selector list — the caret is
+   ALWAYS a styled box, never a text glyph: glyph fallback metrics caused the
+   Safari badge jitter). A metrics/color tweak here moves BOTH carets. */
+.cursor,
+.hero__badge-name > span::after {
   display: inline-block;
   width: 0.55ch;
   height: 0.92em;
@@ -356,6 +362,9 @@ h3 {
   transform: translateY(0.08em);
   background: var(--coral);
   animation: blink 1.05s steps(1) infinite;
+}
+.hero__badge-name > span::after {
+  content: '';
 }
 @keyframes blink {
   50% {
@@ -717,6 +726,7 @@ code {
     transform: none;
   }
   .cursor,
+  .hero__badge-name > span::after,
   .hl {
     animation: none;
   }

--- a/site/tests/e2e/floors.spec.ts
+++ b/site/tests/e2e/floors.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import featuresData from '../../src/features.json' with { type: 'json' };
+import sourcesData from '../../src/sources.json' with { type: 'json' };
 
 // wb-3's runtime contracts: the merged 5F band (the dial is the ONE channel
 // switcher; the feature roster below the stage is quiet, non-interactive
@@ -304,7 +305,9 @@ test('elevator shaft: the ding pulse joins the pix:paused set', async ({ page })
   ).toBe(false);
 });
 
-test('scroll budget: the page fits ~8.9 viewport-heights at 1440×900', async ({ browser }) => {
+test('scroll budget: the page fits its roster-aware viewport-height budget at 1440×900', async ({
+  browser,
+}) => {
   // The spec's original compression target (§4) was 6.5vh — a plan-authoring
   // proxy that turned out to bake in assumptions three LOCKED design
   // decisions invalidate: hold #1 stays full-viewport, the hero stays
@@ -353,22 +356,27 @@ test('scroll budget: the page fits ~8.9 viewport-heights at 1440×900', async ({
   // margin; the pin keeps catching section ballooning while scaling with
   // the source roster it deliberately tracks.
   //
-  // The kimi source (13th supported CLI, PR #692) is the same class: one
-  // more tools-table row + one more hero badge chip. CI measured 8.812vh
-  // after the row landed (was 8.637 at 12 — ~0.175vh, consistent with
-  // grok's per-source delta). 8.9 = that measured value plus ~0.09vh of
-  // headroom, the same order as the last two bumps. This is the pin's THIRD
-  // roster-driven bump — the hero badge row's height is O(sources), so the
-  // treadmill is structural; the planned fix is an O(1) hero badge layout
-  // (featured chips + code strip) plus a roster-aware budget
-  // (BASE + N*PER_SOURCE, N from sources.json), after which this constant
-  // stops tracking the roster entirely.
+  // The kimi source (13th supported CLI, PR #692) forced the pin's THIRD
+  // roster-driven bump (8.75 → 8.9) and ended the treadmill: the hero badge
+  // row is now the O(1) collapsed code strip (Hero.astro — codes-only cells,
+  // hover-expand), so a new source adds ONLY its tools-table row. The budget
+  // is therefore ROSTER-AWARE — BASE + N×PER_SOURCE, N from the same
+  // sources.json the page renders — so a source-add never touches this test
+  // again, while non-roster ballooning (a section growing, a regression
+  // re-introducing per-source hero height) still trips it. Measured at the
+  // strip's landing: 8.811vh at N=13, and 8.883 at a synthetic N=14 → a
+  // 0.072vh/source slope (the table row alone). PER_SOURCE = 0.075 (the
+  // measured slope + rounding slack); BASE = 7.95 ≈ 8.811 − 13×0.075 plus
+  // ~0.11vh headroom, the same order as the historical bumps' margins.
+  const SCROLL_BUDGET_BASE_VH = 7.95;
+  const SCROLL_BUDGET_PER_SOURCE_VH = 0.075;
+  const supported = sourcesData.filter((s) => s.status === 'supported').length;
   const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 } });
   const page = await ctx.newPage();
   await page.addInitScript(() => sessionStorage.setItem('pix-booted', '1'));
   await page.goto('./');
   await page.waitForLoadState('networkidle');
   const vh = await page.evaluate(() => document.documentElement.scrollHeight / window.innerHeight);
-  expect(vh).toBeLessThanOrEqual(8.9);
+  expect(vh).toBeLessThanOrEqual(SCROLL_BUDGET_BASE_VH + supported * SCROLL_BUDGET_PER_SOURCE_VH);
   await ctx.close();
 });

--- a/site/tests/e2e/floors.spec.ts
+++ b/site/tests/e2e/floors.spec.ts
@@ -368,6 +368,9 @@ test('scroll budget: the page fits its roster-aware viewport-height budget at 14
   // 0.072vh/source slope (the table row alone). PER_SOURCE = 0.075 (the
   // measured slope + rounding slack); BASE = 7.95 ≈ 8.811 − 13×0.075 plus
   // ~0.11vh headroom, the same order as the historical bumps' margins.
+  // Caveat: the strip is O(1) only while its codes fit ONE line at 1440
+  // (~20 sources); past that it wraps a step the linear PER_SOURCE doesn't
+  // model — whoever adds the ~20th source should re-measure BASE.
   const SCROLL_BUDGET_BASE_VH = 7.95;
   const SCROLL_BUDGET_PER_SOURCE_VH = 0.075;
   const supported = sourcesData.filter((s) => s.status === 'supported').length;

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -1768,6 +1768,10 @@ test('hero badge hover expands the full CLI name in place', async ({ page }) => 
   // (probed during the mock round) — a real pointer has no such machinery.
   await page.addInitScript(() => sessionStorage.setItem('pix-booted', '1'));
   await page.goto('./');
+  // Let the hero's `rise` entrance (translateY, 0.7s) settle before capturing
+  // the box — a one-shot mouse.move to a mid-animation center can land off
+  // the chip once it settles (the sibling hero tests' networkidle idiom).
+  await page.waitForLoadState('networkidle');
   const chip = page.locator('.hero__badges .hero__badge:not(.hero__badge--more)').nth(6);
   const restBox = (await chip.boundingBox())!;
   await page.mouse.move(restBox.x + restBox.width / 2, restBox.y + restBox.height / 2);
@@ -1825,7 +1829,9 @@ test('hero badge hues clear WCAG AA against their theme-aware chip surface (day 
       }
     }
 
-    // The count-link cell (neutral tint) in both its rest and idiom-hover ink.
+    // The count-link cell (neutral tint), REST ink only — its hover ink is
+    // --coral, the same transient-hover-dips-below-AA exception .hero__ghost
+    // documents (rest is the AA case, hover is the accepted exception).
     const moreColor = await page.evaluate(() => {
       const a = document.querySelector('.hero__badge--more a')!;
       return {

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -1742,14 +1742,43 @@ test('hero badge row: one chip per registered source, matching the tools-table r
   // adding/removing a source can't silently desync them.
   await page.addInitScript(() => sessionStorage.setItem('pix-booted', '1'));
   await page.goto('./');
-  const chips = page.locator('.hero__badges .hero__badge');
+  // Source chips exclude the trailing count-link cell (chrome, not a CLI).
+  const chips = page.locator('.hero__badges .hero__badge:not(.hero__badge--more)');
   await expect(chips).toHaveCount(supportedSources.length);
-  await expect(chips.first()).toHaveText(
-    `${supportedSources[0].badge.replace('·', '')} ${supportedSources[0].name}`
+  // Collapsed rest state: the two-letter code is the visible face; the full
+  // name rides aria-label (AT) and the hover expansion (tested separately).
+  await expect(chips.first().locator('.hero__badge-code')).toHaveText(
+    supportedSources[0].badge.replace('·', '')
   );
+  await expect(chips.first()).toHaveAttribute('aria-label', supportedSources[0].name);
+  // The count-link is bridged to the SAME manifest length and points at #tools.
+  const more = page.locator('.hero__badge--more a');
+  await expect(more).toHaveText(`${supportedSources.length} CLIs →`);
+  await expect(more).toHaveAttribute('href', '#tools');
 
   const tableRows = page.locator('.tools tbody:not(.tools__planned) tr');
   await expect(tableRows).toHaveCount(supportedSources.length);
+});
+
+test('hero badge hover expands the full CLI name in place', async ({ page }) => {
+  // The strip is codes-only at rest; hovering a chip opens its 0fr name track
+  // (Hero.astro .hero__badge-name). Raw mouse.move, NOT page.hover(): the
+  // page's html { scroll-behavior: smooth } lets hover()'s actionability pass
+  // queue a smooth CDP scroll that slides the page out from under the pointer
+  // (probed during the mock round) — a real pointer has no such machinery.
+  await page.addInitScript(() => sessionStorage.setItem('pix-booted', '1'));
+  await page.goto('./');
+  const chip = page.locator('.hero__badges .hero__badge:not(.hero__badge--more)').nth(6);
+  const restBox = (await chip.boundingBox())!;
+  await page.mouse.move(restBox.x + restBox.width / 2, restBox.y + restBox.height / 2);
+  // The chip grows RIGHTWARD past its collapsed width and the name becomes
+  // visible; its own left edge must not move (jitter-free hover contract).
+  await expect
+    .poll(async () => (await chip.boundingBox())!.width)
+    .toBeGreaterThan(restBox.width + 20);
+  const hoverBox = (await chip.boundingBox())!;
+  expect(Math.abs(hoverBox.x - restBox.x)).toBeLessThan(1);
+  await expect(chip.locator('.hero__badge-name')).toHaveCSS('opacity', '1');
 });
 
 test('hero badge hues clear WCAG AA against their theme-aware chip surface (day + night)', async ({
@@ -1757,10 +1786,13 @@ test('hero badge hues clear WCAG AA against their theme-aware chip surface (day 
 }) => {
   // The badge-code hue is a cross-boundary copy of the app's per-source color
   // (pinned to theme::NORMAL.source by the Rust bridge test), painted on a
-  // chip surface that FLIPS per theme — day's light --surface chip darkens
-  // the hue toward black, night's dark --screen chip lightens it toward
-  // white (global.css's .hero__badge-code doc comment) — so this sweeps
-  // every rendered hue in both themes rather than trusting one spot check.
+  // cell TINTED with the same hue per theme (Hero.astro's tint formulas:
+  // day darkens the code toward black on a 14% tint, night lightens it
+  // toward white on a 34% tint — same-hue text on same-hue ground is exactly
+  // where contrast silently dies) — so this sweeps every rendered hue in both
+  // themes rather than trusting one spot check. It sweeps BOTH text pairs per
+  // cell: the always-visible code AND the hover-expanded name (state-sweep,
+  // not spot-check — the #455 rendered-runtime lesson).
   for (const theme of ['day', 'night'] as const) {
     await page.addInitScript((t) => {
       sessionStorage.setItem('pix-booted', '1');
@@ -1770,22 +1802,45 @@ test('hero badge hues clear WCAG AA against their theme-aware chip surface (day 
     await expect(page.locator('html')).toHaveAttribute('data-theme', theme);
 
     const chips = await page.evaluate(() =>
-      [...document.querySelectorAll('.hero__badge')].map((li) => ({
+      [...document.querySelectorAll('.hero__badge:not(.hero__badge--more)')].map((li) => ({
         codeColor: getComputedStyle(li.querySelector('.hero__badge-code')!).color,
+        nameColor: getComputedStyle(li.querySelector('.hero__badge-name')!).color,
         chipBg: getComputedStyle(li).backgroundColor,
-        label: li.textContent?.trim(),
+        label: li.getAttribute('aria-label'),
       }))
     );
     expect(chips.length, `${theme}: no .hero__badge chips rendered`).toBe(supportedSources.length);
-    for (const { codeColor, chipBg, label } of chips) {
-      const fg = parseRgb(codeColor).slice(0, 3) as [number, number, number];
+    for (const { codeColor, nameColor, chipBg, label } of chips) {
       const bg = parseRgb(chipBg).slice(0, 3) as [number, number, number];
-      const ratio = contrastRatio(fg, bg);
-      expect(
-        ratio,
-        `${theme} "${label}": WCAG AA floor is 4.5:1; code ${codeColor} on chip ${chipBg} measured ${ratio.toFixed(2)}:1`
-      ).toBeGreaterThanOrEqual(4.5);
+      for (const [what, color] of [
+        ['code', codeColor],
+        ['hover-expanded name', nameColor],
+      ] as const) {
+        const fg = parseRgb(color).slice(0, 3) as [number, number, number];
+        const ratio = contrastRatio(fg, bg);
+        expect(
+          ratio,
+          `${theme} "${label}" ${what}: WCAG AA floor is 4.5:1; ${color} on cell ${chipBg} measured ${ratio.toFixed(2)}:1`
+        ).toBeGreaterThanOrEqual(4.5);
+      }
     }
+
+    // The count-link cell (neutral tint) in both its rest and idiom-hover ink.
+    const moreColor = await page.evaluate(() => {
+      const a = document.querySelector('.hero__badge--more a')!;
+      return {
+        fg: getComputedStyle(a).color,
+        bg: getComputedStyle(a.closest('.hero__badge')!).backgroundColor,
+      };
+    });
+    const moreRatio = contrastRatio(
+      parseRgb(moreColor.fg).slice(0, 3) as [number, number, number],
+      parseRgb(moreColor.bg).slice(0, 3) as [number, number, number]
+    );
+    expect(
+      moreRatio,
+      `${theme} count-link: WCAG AA floor is 4.5:1; measured ${moreRatio.toFixed(2)}:1`
+    ).toBeGreaterThanOrEqual(4.5);
   }
 });
 

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -1785,6 +1785,34 @@ test('hero badge hover expands the full CLI name in place', async ({ page }) => 
   await expect(chip.locator('.hero__badge-name')).toHaveCSS('opacity', '1');
 });
 
+test('reduced motion: the badge hover-expand is instant but still works', async ({ browser }) => {
+  // Under RM the name track's transition is zeroed by global.css's UNIVERSAL
+  // clamp (`* { transition-duration: 0.001ms !important }`) — Hero.astro
+  // deliberately carries NO per-component arm (it would be dead code under
+  // that !important). Pins BOTH halves: the clamp actually reaches the track
+  // (sub-millisecond duration — deleting the global block reds this) AND the
+  // expansion still functions (motion removed ≠ feature removed — the hover
+  // rule still flips the 0fr track, instantly). Mirrors the repo's
+  // every-new-animated-element RM pattern (rise-entry, caption-overlay,
+  // ding-pulse pins).
+  const context = await browser.newContext({ reducedMotion: 'reduce' });
+  const page = await context.newPage();
+  await page.addInitScript(() => sessionStorage.setItem('pix-booted', '1'));
+  await page.goto('./');
+  await page.waitForLoadState('networkidle');
+  const chip = page.locator('.hero__badges .hero__badge:not(.hero__badge--more)').nth(6);
+  const durationSecs = await chip
+    .locator('.hero__badge-name')
+    .evaluate((el) => parseFloat(getComputedStyle(el).transitionDuration));
+  expect(durationSecs).toBeLessThan(0.001);
+  const restBox = (await chip.boundingBox())!;
+  await page.mouse.move(restBox.x + restBox.width / 2, restBox.y + restBox.height / 2);
+  await expect
+    .poll(async () => (await chip.boundingBox())!.width)
+    .toBeGreaterThan(restBox.width + 20);
+  await context.close();
+});
+
 test('hero badge hues clear WCAG AA against their theme-aware chip surface (day + night)', async ({
   page,
 }) => {

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -1755,6 +1755,13 @@ test('hero badge row: one chip per registered source, matching the tools-table r
   const more = page.locator('.hero__badge--more a');
   await expect(more).toHaveText(`${supportedSources.length} CLIs →`);
   await expect(more).toHaveAttribute('href', '#tools');
+  // Cursor affordances: label chips arrow, the link pointer. Pins the I-beam
+  // shimmer fix (chips are not copy text — an inherited/UA regression here
+  // re-introduces the per-glyph arrow↔I-beam flicker) AND the count-link's
+  // explicit pointer (cursor inherits; only a UA special case would otherwise
+  // restore it).
+  await expect(chips.first()).toHaveCSS('cursor', 'default');
+  await expect(more).toHaveCSS('cursor', 'pointer');
 
   const tableRows = page.locator('.tools tbody:not(.tools__planned) tr');
   await expect(tableRows).toHaveCount(supportedSources.length);


### PR DESCRIPTION
## Summary

The hero badge row was **O(sources) tall** — 13 full-name chips wrapping to three lines, walling off the live office (the hero's whole point) and forcing a scroll-budget pin bump on every source add (3× now: 8.6 → 8.75 → 8.9, the last one in #692). This makes it **O(1)**:

- Every source renders as its **two-letter code in a cell filled with its brand hue** (`sources.json badge_color` — the app's own dashboard badge vocabulary), gently: day 14% tint / code 50% toward black, night 34% tint / code 55% toward white. Contrast audited across all 26 hue×theme pairs — computed worst cases **5.57:1 (day, grok)** / **5.86:1 (night, opencode)**, comfortably over the 4.5 AA floor, enforced by the e2e sweep on real rendered pixels.
- **Hover expands the full name in place** (a `0fr→1fr` grid track, 0.22s): the cell grows rightward, its left edge stationary — jitter-free. Interaction-triggered, so no WCAG 2.2.2 pause obligation (a marquee was considered and rejected for exactly that + competing with the office). Deliberately hover-only, no tabindex (13 tab stops before the CTA is hostile keyboard UX) — names ride `aria-label` for AT and the #tools matrix for everyone.
- A trailing neutral **`13 CLIs →` count-link** (bridged to the same manifest length) carries the breadth signal + the path to full names for touch users.
- The scroll budget is now **roster-aware**: `7.95 + 0.075 × N` (N from `sources.json`). Measured 8.811vh at N=13 and 8.883 at a synthetic N=14 → 0.072vh/source slope (the tools-table row alone). **A source add never touches the test again**; non-roster ballooning still trips it.

Direction ratified against rendered mocks (baseline vs variants, day/night/mobile/hover); final day/night values fixed by the contrast audit.

## Type of change

- [x] Site (Astro) — visual + e2e; no Rust surface touched.

## How I tested it

- `just site-check` — green (format · lint · types · knip · unit · build · docs).
- `just site-e2e` — **85/85**, including: the reshaped chip-count bridge (excludes the count cell, pins it to the manifest), a NEW hover-expand test (raw `mouse.move` — `page.hover()`'s actionability queues a smooth CDP scroll under `html{scroll-behavior:smooth}` that slides the page out from under the pointer; empirically probed), the WCAG sweep extended to BOTH text pairs per cell (code + hover-expanded name) + the count-link in both themes, and the roster-aware scroll budget.
- Rendered screenshots audited at 1440×900 day/night + hover + 375 mobile.

## Visual verification (required for sprite / rendering changes)

- [x] Hero-only DOM/CSS change; rendered and audited day/night/hover/mobile. No committed media renders the hero badge row (gen-media demos render the office/TUI, not the site hero), so no `just gen` regen is needed.

## AI assistance

- [x] This PR was written / heavily assisted by an AI agent — please visually verify before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELMX3ae5b8g13pKMG8E9gP