### PR TITLE
refactor(core): fold fd-probe id-derivation to one seam authority

### DIFF
--- a/crates/pixtuoid-core/src/source/codex/native.rs
+++ b/crates/pixtuoid-core/src/source/codex/native.rs
@@ -28,19 +28,19 @@ fn codex_session_ended(_tail: &[u8]) -> bool {
 /// whole session (upstream `RolloutRecorder` owns the handle), so an open
 /// rollout fd IS the first-party liveness signal: pid → open fd → rollout
 /// path → UUID. The mechanics (canonicalize, under-root filter, #223 failure
-/// semantics, #252 pid bind) live in `ProbeSnapshot::from_open_fds`; only
-/// `codex_accept` — the per-source rollout recognition + id derivation
-/// (invariant #3) — is ours.
+/// semantics, #252 pid bind, the id-space fold via `walk::id_path`) live in
+/// `ProbeSnapshot::from_open_fds`; only the RECOGNIZER (`is_rollout_filename`)
+/// and the id deriver (`codex_id_from_path`) are ours (invariant #3).
 pub fn live_codex_rollout_ids(sessions_root: &Path) -> Option<ProbeSnapshot> {
-    ProbeSnapshot::from_open_fds(sessions_root, &["codex"], codex_accept)
-}
-
-/// The per-source ACCEPT half (invariant #3 — per-source format knowledge
-/// stays per-source): a held-open path vouches iff it is a `rollout-*.jsonl`,
-/// and its id is the rollout UUID via `codex_id_from_path` (the watcher's
-/// `IdDeriver`, so probe ids and gate ids can't drift).
-fn codex_accept(path: &Path) -> Option<String> {
-    is_rollout_filename(path).then(|| codex_id_from_path(path))
+    // A held-open path vouches iff it is a `rollout-*.jsonl`; its id is the
+    // rollout UUID via `codex_id_from_path` — the SAME fn `with_id_deriver`
+    // installs, so probe ids and gate ids can't drift (UUIDs are fold-invariant).
+    ProbeSnapshot::from_open_fds(
+        sessions_root,
+        &["codex"],
+        is_rollout_filename,
+        codex_id_from_path,
+    )
 }
 
 fn is_rollout_filename(path: &Path) -> bool {
@@ -152,7 +152,12 @@ mod tests {
     const UUID: &str = "019e7762-9ded-7e33-be41-946ecf105bf4";
 
     fn snap_of(root: &Path, paths: Vec<PathBuf>) -> ProbeSnapshot {
-        ProbeSnapshot::from_open_fd_pairs(root, paths.into_iter().map(|p| (42, p)), codex_accept)
+        ProbeSnapshot::from_open_fd_pairs(
+            root,
+            paths.into_iter().map(|p| (42, p)),
+            is_rollout_filename,
+            codex_id_from_path,
+        )
     }
 
     #[test]
@@ -186,7 +191,8 @@ mod tests {
             let got = ProbeSnapshot::from_open_fd_pairs(
                 root,
                 pids.into_iter().map(|p| (p, path.clone())),
-                codex_accept,
+                is_rollout_filename,
+                codex_id_from_path,
             );
             assert_eq!(
                 got.ids().cloned().collect::<Vec<_>>(),

--- a/crates/pixtuoid-core/src/source/jsonl/liveness.rs
+++ b/crates/pixtuoid-core/src/source/jsonl/liveness.rs
@@ -55,12 +55,13 @@ impl ProbeSnapshot {
 
     /// Build a snapshot from the regular files that live `comm_names`-named
     /// processes hold open under `root` — THE producer-side skeleton the
-    /// open-FD liveness sources (Codex, omp) share. `accept` is the ONLY
-    /// per-source knowledge (invariant #3): it decides whether a held-open
-    /// path is one of this source's transcripts and, if so, returns its
-    /// session id in the watcher's `IdDeriver` id-space (so probe ids join the
-    /// first-sight gate directly). Everything mechanical lives here so a NEW
-    /// fd-probe source can't re-derive it wrong: the #223 canonicalize-or-
+    /// open-FD liveness sources (Codex, omp) share. The per-source knowledge
+    /// (invariant #3) is TWO pure fns: `recognize` decides whether a held-open
+    /// path is one of this source's transcripts, and `id_derive` (the watcher's
+    /// own `IdDeriver`) derives its session id — applied to `walk::id_path(path)`
+    /// HERE, so the probe id-space is folded identically to the walk seam (a NEW
+    /// fd-probe source can't forget the fold; omp used to inline it, Codex omit
+    /// it). Everything else mechanical lives here too: the #223 canonicalize-or-
     /// `Some(empty)` failure semantics, the under-root filter, the #252 bind.
     ///
     /// `None` ONLY when the proc-table enumeration itself fails
@@ -71,7 +72,8 @@ impl ProbeSnapshot {
     pub(crate) fn from_open_fds(
         root: &Path,
         comm_names: &[&str],
-        accept: impl Fn(&Path) -> Option<String>,
+        recognize: impl Fn(&Path) -> bool,
+        id_derive: super::IdDeriver,
     ) -> Option<Self> {
         // Canonicalize once per call: kernel-reported fd paths are fully
         // resolved (/tmp → /private/tmp on macOS), so the under-root compare
@@ -92,24 +94,33 @@ impl ProbeSnapshot {
                 .into_iter()
                 .map(move |path| (pid, path))
         });
-        Some(Self::from_open_fd_pairs(&canonical, pairs, accept))
+        Some(Self::from_open_fd_pairs(
+            &canonical, pairs, recognize, id_derive,
+        ))
     }
 
     /// The PURE join half of [`from_open_fds`] (unit-testable without FFI —
     /// drive it with synthetic `(pid, path)` pairs): keep each pair whose path
-    /// is under `root` and `accept`ed, binding id → owning pid via
-    /// [`bind_pid`] (the #252 tiebreak).
+    /// is under `root` and `recognize`d, derive its id via `id_derive` over the
+    /// folded `walk::id_path(path)`, and bind id → owning pid via [`bind_pid`]
+    /// (the #252 tiebreak).
     pub(crate) fn from_open_fd_pairs(
         root: &Path,
         pairs: impl Iterator<Item = (i32, PathBuf)>,
-        accept: impl Fn(&Path) -> Option<String>,
+        recognize: impl Fn(&Path) -> bool,
+        id_derive: super::IdDeriver,
     ) -> Self {
         let mut snap = Self::default();
         for (pid, path) in pairs {
             if !path.starts_with(root) {
                 continue;
             }
-            if let Some(id) = accept(&path) {
+            if recognize(&path) {
+                // The fold lives at the seam (`walk::id_path`), NOT inside each
+                // source's deriver — so the probe id-space matches the walk
+                // seam's and a new fd-probe source can't forget it (omp's
+                // case-carrying stems need it; CC/Codex UUIDs are fold-invariant).
+                let id = (id_derive)(&super::walk::id_path(&path));
                 debug!(
                     "fd probe: pid {pid} holds {} open (id {id})",
                     path.display()

--- a/crates/pixtuoid-core/src/source/jsonl/tests.rs
+++ b/crates/pixtuoid-core/src/source/jsonl/tests.rs
@@ -45,22 +45,22 @@ fn bind_pid_keeps_the_larger_pid_in_both_orders() {
 }
 
 #[test]
-fn from_open_fd_pairs_filters_under_root_then_applies_accept() {
-    // The shared producer-side join: keep only under-root, accepted paths,
-    // bound to the owning pid. `accept` here is a trivial "any .jsonl, id =
-    // file stem" so the test pins the MECHANICS (under-root filter + #252
-    // bind), not any source's format.
+fn from_open_fd_pairs_filters_under_root_then_recognizes_and_derives() {
+    // The shared producer-side join: keep only under-root, RECOGNIZED paths,
+    // bound to the owning pid. `recognize` = any .jsonl; `id_derive` = file stem
+    // (the fold via `walk::id_path` is identity on Unix) — so the test pins the
+    // MECHANICS (under-root filter + #252 bind), not any source's format.
     let root = std::path::Path::new("/root");
-    let accept = |p: &std::path::Path| {
-        (p.extension().and_then(|e| e.to_str()) == Some("jsonl"))
-            .then(|| p.file_stem().unwrap().to_string_lossy().into_owned())
-    };
+    let recognize = |p: &std::path::Path| p.extension().and_then(|e| e.to_str()) == Some("jsonl");
+    fn stem_id(p: &std::path::Path) -> String {
+        p.file_stem().unwrap().to_string_lossy().into_owned()
+    }
     let pairs = [
-        (7, std::path::PathBuf::from("/root/a/keep.jsonl")), // under root, accepted
+        (7, std::path::PathBuf::from("/root/a/keep.jsonl")), // under root, recognized
         (9, std::path::PathBuf::from("/elsewhere/keep.jsonl")), // outside root
         (11, std::path::PathBuf::from("/root/a/skip.txt")),  // under root, rejected
     ];
-    let got = ProbeSnapshot::from_open_fd_pairs(root, pairs.into_iter(), accept);
+    let got = ProbeSnapshot::from_open_fd_pairs(root, pairs.into_iter(), recognize, stem_id);
     assert_eq!(
         got.ids().cloned().collect::<Vec<_>>(),
         vec!["keep".to_string()]

--- a/crates/pixtuoid-core/src/source/jsonl/walk.rs
+++ b/crates/pixtuoid-core/src/source/jsonl/walk.rs
@@ -38,7 +38,7 @@ pub(super) const MAX_PENDING_BYTES: u64 = 1 << 20;
 /// case-carrying stem chains (`…T…Z_<uuid>/Alpha`) are why the fold must
 /// live HERE at the seam, not inside each deriver — a pure deriver keeps the
 /// fixture-fed conformance goldens platform-invariant. Identity on Unix.
-fn id_path(path: &Path) -> std::path::PathBuf {
+pub(super) fn id_path(path: &Path) -> std::path::PathBuf {
     std::path::PathBuf::from(crate::id::normalize_path_key(&path.to_string_lossy()))
 }
 

--- a/crates/pixtuoid-core/src/source/omp/native.rs
+++ b/crates/pixtuoid-core/src/source/omp/native.rs
@@ -89,7 +89,8 @@ impl Source for OmpSource {
 /// pass — an intermittent resurrection at worst, reaped again once the fd
 /// closes (the negative-vouch ladder). The mechanics (canonicalize, under-root
 /// filter, #223 failure semantics, #252 pid bind) live in
-/// `ProbeSnapshot::from_open_fds`; only `omp_accept` is ours.
+/// `ProbeSnapshot::from_open_fds`; only the RECOGNIZER (`omp_recognize`) and the
+/// id deriver (`omp_id_from_path`) are ours.
 ///
 /// Module-private on purpose: the sole consumer is `OmpSource::run` — omp has
 /// no focus point-query (registry: `FocusChannel::Unsupported`), so unlike
@@ -97,22 +98,25 @@ impl Source for OmpSource {
 /// to justify a public path (CONTRIBUTING pitfall 5: pub evades dead-code
 /// lints).
 fn live_omp_session_ids(sessions_root: &Path) -> Option<ProbeSnapshot> {
-    ProbeSnapshot::from_open_fds(sessions_root, &["bun", "omp"], omp_accept)
+    // A held-open `.jsonl` under the root vouches; its id is the stem-chain key
+    // via `omp_id_from_path` — the SAME fn `with_id_deriver` installs, over the
+    // folded `walk::id_path` (root transcripts AND nested task children both key
+    // on the chain, so a live child vouches for the child id specifically). omp's
+    // case-carrying stems are WHY the fold lives at the SEAM (`from_open_fds`),
+    // not inlined here as it used to be — so the goldens stay platform-invariant.
+    ProbeSnapshot::from_open_fds(
+        sessions_root,
+        &["bun", "omp"],
+        omp_recognize,
+        omp_id_from_path,
+    )
 }
 
-/// The per-source ACCEPT half (invariant #3): a held-open `.jsonl` under the
-/// root vouches; its id is the stem-chain key via `omp_id_from_path` (root
-/// transcripts AND nested task children both key on the chain, so a live child
-/// file vouches for the child id specifically). The path is folded through
-/// `normalize_path_key` first — the watcher's id-space is folded at the seam
-/// (walk.rs `id_path`), so probe ids must fold identically or they miss the
-/// first-sight gate on Windows (the CC probe folds the same way).
-fn omp_accept(path: &Path) -> Option<String> {
-    (path.extension().and_then(|e| e.to_str()) == Some("jsonl")).then(|| {
-        omp_id_from_path(Path::new(&crate::id::normalize_path_key(
-            &path.to_string_lossy(),
-        )))
-    })
+/// The per-source RECOGNIZER (invariant #3): a held-open `.jsonl` under the root
+/// vouches. The id-space fold (`normalize_path_key` via `walk::id_path`) is
+/// applied by `from_open_fds`, not here.
+fn omp_recognize(path: &Path) -> bool {
+    path.extension().and_then(|e| e.to_str()) == Some("jsonl")
 }
 
 /// Attach the probe ONLY for omp's first-party layout: the standard
@@ -204,7 +208,12 @@ mod tests {
     const STEM: &str = "2026-07-10T18-32-27-539Z_019f4d4d-6c93-7000-af7b-59b47b0e8111";
 
     fn snap_of(root: &Path, paths: Vec<PathBuf>) -> ProbeSnapshot {
-        ProbeSnapshot::from_open_fd_pairs(root, paths.into_iter().map(|p| (42, p)), omp_accept)
+        ProbeSnapshot::from_open_fd_pairs(
+            root,
+            paths.into_iter().map(|p| (42, p)),
+            omp_recognize,
+            omp_id_from_path,
+        )
     }
 
     #[test]
@@ -245,7 +254,8 @@ mod tests {
             let got = ProbeSnapshot::from_open_fd_pairs(
                 root,
                 pids.into_iter().map(|p| (p, path.clone())),
-                omp_accept,
+                omp_recognize,
+                omp_id_from_path,
             );
             assert_eq!(
                 got.ids().cloned().collect::<Vec<_>>(),


### PR DESCRIPTION
## What

The open-FD liveness probe seam (`ProbeSnapshot::from_open_fds` / `from_open_fd_pairs`) took `accept: Fn(&Path) -> Option<String>`, where each source both **recognized** its transcript AND **derived** the session id. That duplicated the id-space fold (`id::normalize_path_key`, applied via `walk::id_path`): omp inlined it, Codex omitted it entirely (rollout UUIDs are fold-invariant, so it happened not to matter). Two copies of one fold is a latent drift bug — a new fd-probe source could forget it and key its probe ids off the walk seam's.

## Change

Split the seam into a pure `recognize: Fn(&Path) -> bool` plus the watcher's own `IdDeriver`, and apply the fold **once** inside the probe as `(id_derive)(&walk::id_path(path))` — the exact form the walk first-sight seam already uses (`walk.rs:248/358/472`). `walk::id_path` becomes `pub(super)` so the probe and walk seams share the one fold authority; probe-ids == gate-ids by construction. Per-source knowledge shrinks to the bool recognizer (`is_rollout_filename` / `omp_recognize`), honoring invariant #3.

Behavior-identical (fold is identity on Unix / for UUIDs). Renamed test `from_open_fd_pairs_..._recognizes_and_derives` pins the mechanics.

## Gates
- `just preflight` green (fmt · clippy `-D warnings` · hack · 2580 tests)
- Two-lens review (correctness + design/blast-radius, adversarial verify): **0 findings**

One of three independent deepening candidates from the `/improve-codebase-architecture` scan (core-only, no interaction with the other two).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015tagWGvC3zAApcXaP3bWYN