### PR TITLE
refactor(audio): fold the mute/volume persist protocol into one AudioController

### DIFF
--- a/crates/pixtuoid/CLAUDE.md
+++ b/crates/pixtuoid/CLAUDE.md
@@ -250,9 +250,14 @@ src/
 │                       buffers) — run_tui swaps the fresh handle into the renderer; floating boot-spawns
 │                       iff !muted AND has the SAME m/+/- runtime keys. The mute/volume TRANSITION is
 │                       ONE authority — `audio::apply_audio_action(&mut AudioUi, action, paused, spawn)`
-│                       (audio/mod.rs, unit-tested) — that BOTH painters run: the TUI's ToggleAudioMute/
-│                       AdjustVolume arms (via run_audio_action, marshalling the loop locals) and floating's
-│                       key handler. Only the KEY→action decode is painter-specific: crossterm dispatch in
+│                       (audio/mod.rs, unit-tested); the PERSIST protocol around it (mute-save-now, volume
+│                       debounce→flash-expiry, exit-flush) is a SECOND authority BOTH painters OWN —
+│                       `audio::AudioController` (new/apply/tick/flush_on_exit/set_paused/volume_flash/handle;
+│                       `now` injected → the debounce/flash is unit-tested). The TUI keeps ONE controller (was
+│                       5 loop locals + a deleted `run_audio_action`); floating keeps one (was its own
+│                       volume_flash/volume_dirty/flush_volume). Flash is VOLUME-only on both now — a mute
+│                       toggle relies on the footer's `♩` indicator (TUI); floating shows no transient until a
+│                       footer lands (AudioController is that footer's `♩` source). Only the KEY→action decode is painter-specific: crossterm dispatch in
 │                       tui/mod.rs, winit in floating/input.rs (the pure key-map, `m`/`+`=/`-`_, lowercase
 │                       m only; winit's repeat flag swallows a held m — the TUI's crossterm path lacks it).
 │                       window.rs stays thin winit glue; lazy spawn + persistence identical; feedback = a

--- a/crates/pixtuoid/src/audio/mod.rs
+++ b/crates/pixtuoid/src/audio/mod.rs
@@ -131,6 +131,189 @@ pub(crate) fn apply_audio_action(
     persist
 }
 
+/// Owns the whole mute/volume PERSIST protocol both painters used to duplicate:
+/// the pure [`apply_audio_action`] transition PLUS its side effects — mute saves
+/// NOW, a volume nudge marks dirty + arms the `♩ N%` readout, the debounced
+/// volume save fires once that window elapses (a held `+`/`-` writes once, not
+/// per repeat), and a flush on shutdown. The TUI keeps ONE of these instead of
+/// five loop locals + `run_audio_action`; floating keeps one instead of its own
+/// duplicated `volume_flash`/`volume_dirty`/`flush_volume`. `now` is injected so
+/// the debounce is unit-testable without a clock.
+pub(crate) struct AudioController {
+    ui: AudioUi,
+    config_path: std::path::PathBuf,
+    /// A volume nudge awaits its debounced `save_audio_volume`.
+    volume_dirty: bool,
+    /// When the transient `♩ N%` readout was armed (volume nudges only). Doubles
+    /// as the debounce clock: the volume save lands once this window elapses.
+    flash_at: Option<std::time::Instant>,
+}
+
+impl AudioController {
+    pub(crate) fn new(ui: AudioUi, config_path: std::path::PathBuf) -> Self {
+        Self {
+            ui,
+            config_path,
+            volume_dirty: false,
+            flash_at: None,
+        }
+    }
+
+    /// Run one gesture: the shared transition, then persist — mute NOW, volume
+    /// debounced (dirty + readout armed). A lazy spawn may mint a new handle;
+    /// read it back via [`Self::handle`].
+    pub(crate) fn apply(
+        &mut self,
+        action: AudioAction,
+        paused: bool,
+        now: std::time::Instant,
+        spawn: impl FnOnce(f32) -> AudioHandle,
+    ) {
+        let persist = apply_audio_action(&mut self.ui, action, paused, spawn);
+        if persist.muted {
+            // persist like a theme commit: next launch boots as the user left it
+            if let Err(e) = crate::config::save_audio_muted(&self.config_path, self.ui.muted) {
+                tracing::warn!("failed to persist audio mute: {e}");
+            }
+        }
+        if persist.volume_nudged {
+            self.volume_dirty = true;
+            self.flash_at = Some(now);
+        }
+    }
+
+    /// The transient readout window is still fresh.
+    fn flashing(&self, now: std::time::Instant) -> bool {
+        self.flash_at
+            .is_some_and(|t| now.duration_since(t).as_millis() < VOLUME_FLASH_MS)
+    }
+
+    /// The `♩ N%` volume readout, `Some` iff the window is fresh (volume nudges
+    /// only — mute state is shown by the persistent footer indicator, not this).
+    pub(crate) fn volume_flash(&self, now: std::time::Instant) -> Option<u8> {
+        self.flashing(now)
+            .then(|| (self.ui.volume * 100.0).round() as u8)
+    }
+
+    /// Per frame: flush the debounced volume save once the readout window has
+    /// elapsed.
+    pub(crate) fn tick(&mut self, now: std::time::Instant) {
+        if self.volume_dirty && !self.flashing(now) {
+            self.save_volume();
+        }
+    }
+
+    /// Flush any pending volume on shutdown (a nudge-then-quit).
+    pub(crate) fn flush_on_exit(&mut self) {
+        if self.volume_dirty {
+            self.save_volume();
+        }
+    }
+
+    fn save_volume(&mut self) {
+        self.volume_dirty = false;
+        if let Err(e) = crate::config::save_audio_volume(&self.config_path, self.ui.volume) {
+            tracing::warn!("failed to persist audio volume: {e}");
+        }
+    }
+
+    /// Re-apply the effective mute when the external pause toggles (a frozen
+    /// office must not keep clacking; unpause restores the user's own m-state).
+    pub(crate) fn set_paused(&mut self, paused: bool) {
+        self.ui.handle.set_muted(paused || self.ui.muted);
+    }
+
+    pub(crate) fn muted(&self) -> bool {
+        self.ui.muted
+    }
+
+    pub(crate) fn volume(&self) -> f32 {
+        self.ui.volume
+    }
+
+    /// The live audio handle — the renderer/window feeds frames to it. Re-sync
+    /// the consumer after [`Self::apply`], which may have lazily spawned a new one.
+    pub(crate) fn handle(&self) -> &AudioHandle {
+        &self.ui.handle
+    }
+}
+
+#[cfg(test)]
+mod controller_tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    fn ctl(muted: bool, volume: f32) -> (AudioController, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "theme = \"normal\"\n").unwrap();
+        let ui = AudioUi {
+            handle: AudioHandle::disabled(),
+            muted,
+            volume,
+        };
+        (AudioController::new(ui, path), dir)
+    }
+
+    #[test]
+    fn mute_persists_immediately_and_does_not_arm_the_volume_flash() {
+        let (mut c, _d) = ctl(false, 0.4);
+        let t0 = Instant::now();
+        c.apply(AudioAction::ToggleMute, false, t0, |_| {
+            AudioHandle::disabled()
+        });
+        assert!(
+            std::fs::read_to_string(&c.config_path)
+                .unwrap()
+                .contains("muted = true"),
+            "mute toggled on AND persists NOW (like a theme commit)"
+        );
+        assert_eq!(c.volume_flash(t0), None, "mute does not flash ♩ N%");
+    }
+
+    #[test]
+    fn volume_flashes_now_and_debounces_the_save_until_the_window_elapses() {
+        let (mut c, _d) = ctl(false, 0.50);
+        let t0 = Instant::now();
+        let saved = |c: &AudioController| std::fs::read_to_string(&c.config_path).unwrap();
+        c.apply(AudioAction::Volume(true), false, t0, |_| {
+            AudioHandle::disabled()
+        });
+        assert_eq!(c.volume_flash(t0), Some(55), "readout armed immediately");
+        assert!(
+            !saved(&c).contains("volume"),
+            "volume NOT persisted mid-flash (debounced, not per-repeat)"
+        );
+        c.tick(t0 + Duration::from_millis(500));
+        assert!(
+            !saved(&c).contains("volume"),
+            "still within the window → no flush"
+        );
+        let after = t0 + Duration::from_millis(VOLUME_FLASH_MS as u64 + 50);
+        c.tick(after);
+        assert!(
+            saved(&c).contains("volume"),
+            "window elapsed → debounced save flushes"
+        );
+        assert_eq!(c.volume_flash(after), None, "readout expired");
+    }
+
+    #[test]
+    fn flush_on_exit_writes_a_pending_nudge() {
+        let (mut c, _d) = ctl(false, 0.50);
+        c.apply(AudioAction::Volume(false), false, Instant::now(), |_| {
+            AudioHandle::disabled()
+        });
+        c.flush_on_exit();
+        assert!(
+            std::fs::read_to_string(&c.config_path)
+                .unwrap()
+                .contains("volume"),
+            "a nudge-then-quit persists on exit"
+        );
+    }
+}
+
 #[cfg(test)]
 mod controls_tests {
     use super::*;

--- a/crates/pixtuoid/src/floating/window.rs
+++ b/crates/pixtuoid/src/floating/window.rs
@@ -53,18 +53,13 @@ pub(crate) struct FloatingApp {
     /// The configured office pets — one is selected per floor (v1 shows floor 0's).
     pets: Vec<pixtuoid_scene::pet::Pet>,
     renderer: OfficeRenderer,
-    /// Runtime audio state the m/+/- keys drive (#633 close-out) — the same
-    /// handle/muted/volume trio the TUI loop keeps as locals. The renderer
-    /// holds its own handle clone (installed by `set_audio_ui` + on every
-    /// lazy spawn).
-    audio: crate::audio::AudioUi,
-    /// A fresh m/+/- press shows the `♩` readout overlay for
-    /// `crate::audio::VOLUME_FLASH_MS` — the window has no footer, so this
-    /// transient is the keys' only visual feedback.
-    volume_flash: Option<Instant>,
-    /// The debounced volume persist (TUI parity): save once when the nudge
-    /// burst's flash expires, plus a final flush on close.
-    volume_dirty: bool,
+    /// The whole mute/volume persist protocol (#633 close-out) — the SAME
+    /// `AudioController` the TUI owns (was `audio`/`volume_flash`/`volume_dirty`
+    /// duplicated here). The renderer holds its own handle clone, re-synced by
+    /// `set_audio_ui` + after every lazy spawn. Flash is VOLUME-only now (was
+    /// every-gesture): a mute toggle shows no transient overlay until a footer
+    /// lands to display it — the accepted TUI-parity tradeoff.
+    audio_ctl: crate::audio::AudioController,
     scene_rx: watch::Receiver<Arc<SceneState>>,
     floor_caps: Arc<[AtomicUsize; MAX_FLOORS]>,
     /// The buffer size the capacity atomics were last synced for — capacity only changes
@@ -99,6 +94,14 @@ impl FloatingApp {
         scene_rx: watch::Receiver<Arc<SceneState>>,
         floor_caps: Arc<[AtomicUsize; MAX_FLOORS]>,
     ) -> Self {
+        let audio_ctl = crate::audio::AudioController::new(
+            crate::audio::AudioUi {
+                handle: crate::audio::AudioHandle::disabled(),
+                muted: true,
+                volume: 1.0,
+            },
+            config_path.clone(),
+        );
         Self {
             cfg,
             theme,
@@ -106,13 +109,7 @@ impl FloatingApp {
             config_path,
             pets,
             renderer: OfficeRenderer::new(),
-            audio: crate::audio::AudioUi {
-                handle: crate::audio::AudioHandle::disabled(),
-                muted: true,
-                volume: 1.0,
-            },
-            volume_flash: None,
-            volume_dirty: false,
+            audio_ctl,
             scene_rx,
             floor_caps,
             last_caps_size: None,
@@ -156,17 +153,13 @@ impl FloatingApp {
         let (Some(nw), Some(nh)) = (NonZeroU32::new(win_w), NonZeroU32::new(win_h)) else {
             return; // a 0-area window: nothing to draw
         };
-        // The transient ♩ readout + its expiry-driven debounced volume persist
-        // (TUI parity) — resolved BEFORE the surface borrow below.
-        let flashing = self
-            .volume_flash
-            .is_some_and(|t| t.elapsed().as_millis() < crate::audio::VOLUME_FLASH_MS);
-        if !flashing {
-            self.volume_flash = None;
-            self.flush_volume();
-        }
-        let flash_text = flashing
-            .then(|| super::offscreen::volume_flash_text(self.audio.muted, self.audio.volume));
+        // The transient ♩ readout + its expiry-driven debounced volume persist,
+        // both owned by the controller — resolved BEFORE the surface borrow below.
+        let audio_now = Instant::now();
+        self.audio_ctl.tick(audio_now);
+        let flash_text = self.audio_ctl.volume_flash(audio_now).map(|_pct| {
+            super::offscreen::volume_flash_text(self.audio_ctl.muted(), self.audio_ctl.volume())
+        });
         // Office buffer = window / SCALE (kept ~OFFICE_TARGET_H tall → chunky sprites).
         // The ONE projection helper, shared with the boot seed so the two can't drift.
         let (scale, buf_w, buf_h) = super::offscreen::window_buffer_geometry(win_w, win_h);
@@ -364,7 +357,7 @@ impl ApplicationHandler<FloatingEvent> for FloatingApp {
     ) {
         match event {
             WindowEvent::CloseRequested => {
-                self.flush_volume();
+                self.audio_ctl.flush_on_exit();
                 self.persist_geometry();
                 event_loop.exit();
             }
@@ -380,26 +373,14 @@ impl ApplicationHandler<FloatingEvent> for FloatingApp {
                 ..
             } if event.state == ElementState::Pressed => {
                 if let Some(action) = super::input::audio_action(&event.logical_key, event.repeat) {
-                    let persist = crate::audio::apply_audio_action(
-                        &mut self.audio,
-                        action,
-                        false, // floating has no [p]ause; effective mute == muted
-                        crate::audio::spawn,
-                    );
+                    // floating has no [p]ause; effective mute == muted. The
+                    // controller persists mute NOW + debounces the volume + arms
+                    // the (volume-only) readout.
+                    self.audio_ctl
+                        .apply(action, false, Instant::now(), crate::audio::spawn);
                     // a lazy spawn mints a NEW handle — reinstall so the
                     // renderer's frame feed reaches the live thread
-                    self.renderer.set_audio(self.audio.handle.clone());
-                    if persist.muted {
-                        if let Err(e) =
-                            config::save_audio_muted(&self.config_path, self.audio.muted)
-                        {
-                            tracing::warn!("pixtuoid floating: could not persist audio mute: {e}");
-                        }
-                    }
-                    if persist.volume_nudged {
-                        self.volume_dirty = true;
-                    }
-                    self.volume_flash = Some(Instant::now());
+                    self.renderer.set_audio(self.audio_ctl.handle().clone());
                     if let Some(window) = &self.window {
                         window.request_redraw();
                     }
@@ -474,19 +455,7 @@ impl FloatingApp {
     /// clone (the per-frame feed), the app keeps the handle/muted/volume trio
     /// the m/+/- keys drive.
     pub(crate) fn set_audio_ui(&mut self, audio: crate::audio::AudioUi) {
-        self.renderer.set_audio(audio.handle.clone());
-        self.audio = audio;
-    }
-
-    /// The debounced volume's flush — fired when a nudge burst's flash
-    /// expires (from `redraw`) and on the close path, the TUI quit-flush
-    /// twin. A no-op unless a nudge is pending.
-    fn flush_volume(&mut self) {
-        if self.volume_dirty {
-            self.volume_dirty = false;
-            if let Err(e) = config::save_audio_volume(&self.config_path, self.audio.volume) {
-                tracing::warn!("pixtuoid floating: could not persist audio volume: {e}");
-            }
-        }
+        self.audio_ctl = crate::audio::AudioController::new(audio, self.config_path.clone());
+        self.renderer.set_audio(self.audio_ctl.handle().clone());
     }
 }

--- a/crates/pixtuoid/src/tui/mod.rs
+++ b/crates/pixtuoid/src/tui/mod.rs
@@ -260,46 +260,6 @@ fn should_dispatch_key(kind: KeyEventKind) -> bool {
     kind == KeyEventKind::Press
 }
 
-/// The `m`/`+`/`-` dispatch, marshalling the loop's audio locals through the
-/// SHARED `crate::audio::apply_audio_action` (the ONE mute/volume transition
-/// both painters run — floating's key handler is the twin caller). The side
-/// effects the pure transition returns are applied here: reinstall the handle
-/// (a lazy spawn mints a new one), persist mute immediately, flash + mark the
-/// volume dirty on a nudge (the debounced persist lands on flash expiry / quit).
-#[allow(clippy::too_many_arguments)] // the loop's flat audio locals, threaded once from two arms
-fn run_audio_action<B: ratatui::backend::Backend<Error: Send + Sync + 'static>>(
-    action: crate::audio::AudioAction,
-    audio: &mut crate::audio::AudioHandle,
-    audio_muted: &mut bool,
-    audio_volume: &mut f32,
-    paused: bool,
-    renderer: &mut TuiRenderer<B>,
-    config_path: &std::path::Path,
-    volume_flash: &mut Option<Instant>,
-    volume_dirty: &mut bool,
-) {
-    let mut ui = crate::audio::AudioUi {
-        handle: audio.clone(),
-        muted: *audio_muted,
-        volume: *audio_volume,
-    };
-    let persist = crate::audio::apply_audio_action(&mut ui, action, paused, crate::audio::spawn);
-    *audio = ui.handle;
-    *audio_muted = ui.muted;
-    *audio_volume = ui.volume;
-    renderer.set_audio(audio.clone());
-    if persist.muted {
-        // persist like the theme commit: next launch boots as the user left it
-        if let Err(e) = crate::config::save_audio_muted(config_path, *audio_muted) {
-            tracing::warn!("failed to persist audio mute: {e}");
-        }
-    }
-    if persist.volume_nudged {
-        *volume_flash = Some(Instant::now());
-        *volume_dirty = true; // the debounced write; see the volume_flash comment
-    }
-}
-
 /// What pressing `t` on a Sources-panel row does.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ToggleIntent {
@@ -590,22 +550,23 @@ pub(crate) async fn run_tui(session: TuiSession) -> Result<()> {
         audio,
         audio_cfg,
     } = session;
-    let mut audio = audio;
     let pack = embedded_pack::load_sprite_pack(pack_dir)?;
     let term = setup_terminal()?;
     let mut renderer = TuiRenderer::new(term, theme, pets);
-    renderer.set_audio(audio.clone());
-    // the persisted m-state: the office boots exactly as the user left it
-    let mut audio_muted = audio_cfg.muted;
-    let mut audio_volume = audio_cfg.volume;
-    // transient +/- readout: the footer shows "♩ N%" for a beat after a nudge.
-    // The same window DEBOUNCES the persist: +/- is a repeatable key (unlike
-    // every other inline config write, which is a one-shot confirm — the
-    // accepted-stall class), so a held key must not fire a ConfigLock round
-    // per repeat event. The write lands once, when the flash expires (and on
-    // quit, for a nudge-then-exit).
-    let mut volume_flash: Option<std::time::Instant> = None;
-    let mut volume_dirty = false;
+    // Audio persistence — mute/volume debounce, the `♩ N%` readout, exit-flush —
+    // is ONE owned `AudioController` now (was five loop locals + `run_audio_action`).
+    // The office boots exactly as the user left it. Debounce: `+`/`-` is a
+    // repeatable key, so the volume write lands ONCE when the flash window expires
+    // (and on quit), never per repeat event.
+    let mut audio_ctl = crate::audio::AudioController::new(
+        crate::audio::AudioUi {
+            handle: audio,
+            muted: audio_cfg.muted,
+            volume: audio_cfg.volume,
+        },
+        config_path.clone(),
+    );
+    renderer.set_audio(audio_ctl.handle().clone());
     // First-run onboarding "move-in" overlay (TOP of the modal precedence chain).
     // The roster is built only on first run; if no agent CLIs are detected there's
     // nothing to connect, so it stays closed and the office shows normally.
@@ -696,18 +657,12 @@ pub(crate) async fn run_tui(session: TuiSession) -> Result<()> {
             // the drift-scan-fed footer warning) — see UiState::build_frames.
             ui.build_frames(now, &snapshot, &health)
                 .apply_to(&mut renderer, now);
-            // transient +/- readout: ~1s after a nudge the footer appends the
-            // percent to the ♩ glyph (the lowfi volume-timer pattern)
-            let flashing = volume_flash
-                .is_some_and(|t| t.elapsed().as_millis() < crate::audio::VOLUME_FLASH_MS);
-            renderer.set_volume_flash(flashing.then(|| (audio_volume * 100.0).round() as u8));
-            if volume_dirty && !flashing {
-                // the debounced volume persist: once, when the nudge burst ends
-                volume_dirty = false;
-                if let Err(e) = crate::config::save_audio_volume(&config_path, audio_volume) {
-                    tracing::warn!("failed to persist audio volume: {e}");
-                }
-            }
+            // transient +/- readout (~1s after a nudge, appended to the ♩ glyph)
+            // + the debounced volume persist when the window expires — both owned
+            // by the controller.
+            let audio_now = std::time::Instant::now();
+            audio_ctl.tick(audio_now);
+            renderer.set_volume_flash(audio_ctl.volume_flash(audio_now));
             renderer.render(&snapshot, &pack, now)?;
 
             // Auto-compute per-floor desk capacity from the current
@@ -757,7 +712,7 @@ pub(crate) async fn run_tui(session: TuiSession) -> Result<()> {
                                 // pause holds the SOUND too (the frozen office
                                 // must not keep clacking); unpause restores the
                                 // user's own m-key state rather than clobbering it
-                                audio.set_muted(ui.paused() || audio_muted);
+                                audio_ctl.set_paused(ui.paused());
                             }
                             KeyAction::ToggleHelp => ui.toggle_help(),
                             KeyAction::CloseHelp => ui.close_help(),
@@ -782,30 +737,23 @@ pub(crate) async fn run_tui(session: TuiSession) -> Result<()> {
                                 renderer.navigate_floor(target, now);
                             }
                             KeyAction::ToggleAudioMute => {
-                                run_audio_action(
+                                audio_ctl.apply(
                                     crate::audio::AudioAction::ToggleMute,
-                                    &mut audio,
-                                    &mut audio_muted,
-                                    &mut audio_volume,
                                     ui.paused(),
-                                    &mut renderer,
-                                    &config_path,
-                                    &mut volume_flash,
-                                    &mut volume_dirty,
+                                    std::time::Instant::now(),
+                                    crate::audio::spawn,
                                 );
+                                // a lazy spawn mints a new handle — re-sync the feed
+                                renderer.set_audio(audio_ctl.handle().clone());
                             }
                             KeyAction::AdjustVolume(up) => {
-                                run_audio_action(
+                                audio_ctl.apply(
                                     crate::audio::AudioAction::Volume(up),
-                                    &mut audio,
-                                    &mut audio_muted,
-                                    &mut audio_volume,
                                     ui.paused(),
-                                    &mut renderer,
-                                    &config_path,
-                                    &mut volume_flash,
-                                    &mut volume_dirty,
+                                    std::time::Instant::now(),
+                                    crate::audio::spawn,
                                 );
+                                renderer.set_audio(audio_ctl.handle().clone());
                             }
                             KeyAction::ToggleWalkableDebug => {
                                 let on = renderer.debug_walkable();
@@ -1110,11 +1058,7 @@ pub(crate) async fn run_tui(session: TuiSession) -> Result<()> {
                     renderer.set_theme(theme::ALL_THEMES[ui.saved_theme_idx]);
                 }
                 // a nudge-then-quit inside the debounce window still persists
-                if volume_dirty {
-                    if let Err(e) = crate::config::save_audio_volume(&config_path, audio_volume) {
-                        tracing::warn!("failed to persist audio volume: {e}");
-                    }
-                }
+                audio_ctl.flush_on_exit();
                 break;
             }
             // The frame-pacing sleep doubles as the signal-listen window (the


### PR DESCRIPTION
## What

The mute/volume persist protocol — mute-save-now, volume-debounce, the `♩ N%` flash timer, exit-flush — was duplicated across the TUI event-loop locals (`run_audio_action` + 5 loop-locals) and the floating window's own fields (`flush_volume` + audio/volume_flash/volume_dirty).

## Change

`audio::AudioController` owns the whole protocol behind one `now`-injected interface (`new`/`apply`/`tick`/`flush_on_exit`/`set_paused`/`volume_flash`/`muted`/`volume`/`handle`). Both painters migrate onto it:
- TUI: 5 loop-locals + `run_audio_action` → one controller
- floating: the audio/volume_flash/volume_dirty fields + `flush_volume` → one controller

The previously-untestable loop code becomes 3 unit tests. Flash is volume-only now; floating drops its mute overlay until a **footer** lands — which is the deliberate setup for the next arc (`footer → floating`), where `AudioController` is the footer's `♩` state source.

## Gates
- `just preflight` green (fmt · clippy `-D warnings` · hack · 2580 tests)
- Two-lens review (correctness + design/blast-radius, adversarial verify): only finding was one stale nested-CLAUDE.md line, fixed in-branch

One of three independent deepening candidates from the `/improve-codebase-architecture` scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015tagWGvC3zAApcXaP3bWYN