### PR TITLE
refactor(layout): one plant-obstacle census behind repels_plants

### DIFF
--- a/crates/pixtuoid-scene/src/layout/compute.rs
+++ b/crates/pixtuoid-scene/src/layout/compute.rs
@@ -365,7 +365,9 @@ pub(super) fn compute_with_seed(
         lounge_west_clear,
     );
 
-    // Plants scatter through the cubicle corridor edges + pantry.
+    // Plants scatter at the cubicle corridor edges + the meeting-room corners
+    // (plus the two gated Ficus below) — NOT the pantry (see the connectivity
+    // note below: pantry plants would seal the only bridge to the cubicle area).
     // Scatter plants avoid the cubicle TOP strip by DEFAULT (the wall-to-
     // couch gap is just 7 px) — the only top-strip greenery is the two
     // gated Ficus pushes below (roomy bands only). No plants in the meeting room interior
@@ -512,34 +514,24 @@ pub(super) fn compute_with_seed(
     // aisle before giving up — the corner appliances share the plants'
     // authored corners at most sizes, and yield-by-deletion stripped the
     // office's greenery (both lenses' catch on the first cut).
-    // Fixed singletons the clearance predicate must also see: the fish tank
-    // is NOT a waypoint, so the elevator Ficus interpenetrated it at buf
-    // widths ~88-123 (lens render catch). Lamp/couch verified clear by the
-    // same census; the side table's 1px adjacency to the lounge Ficus is the
-    // owner-ratified mock look — deliberately NOT repelled.
-    // ...and the meeting trio bodies: sofa/table are neither waypoints (their
-    // SEATS are, footprint-less) nor singletons, so a room plant could merge
-    // into the sofa (pinned by scatter_plants_keep_obstacle_clearance_...).
-    let centered = |pos: Point, v: Size| {
-        (
-            super::placement::anchored_top_left(super::placement::Anchor::Center, pos, v.w, v.h),
-            v,
-        )
-    };
-    let singleton_rects: Vec<(Point, Size)> = fish_tank
-        .map(|t| centered(t, furniture_def(Furniture::FishTank).visual))
-        .into_iter()
-        .chain(meeting_rooms.iter().flat_map(|room| {
-            room.trio.iter().flat_map(|trio| {
-                let sofa_v = furniture_def(Furniture::MeetingSofaBody).visual;
-                [
-                    centered(trio.sofas[0], sofa_v),
-                    centered(trio.sofas[1], sofa_v),
-                    centered(trio.table, furniture_def(Furniture::MeetingTable).visual),
-                ]
-            })
-        }))
-        .collect();
+    // Fixed NON-waypoint singletons the clearance predicate must also see —
+    // derived by `plant_obstacle_rects` (THE ONE census, shared with the
+    // placement-sweep backstop) filtering every singleton by `repels_plants`.
+    // History: the fish tank isn't a waypoint, so the elevator Ficus once
+    // interpenetrated it (~88-123px); later a room plant merged into a meeting
+    // sofa/table — both were census-by-OMISSION bugs the per-kind flag + typed
+    // input now guard against (the flag is exhaustive; a new singleton FIELD is
+    // surfaced by the pieces() no-`..` sweep). The lounge lamp + side table are passed but declared
+    // `repels_plants = false` (the owner-ratified 1px Ficus hug); the pantry
+    // island is `true` (a solid body — today plant-free by the pantry's
+    // connectivity rule, so its inclusion is a no-op).
+    let singleton_rects = plant_obstacle_rects(
+        fish_tank,
+        floor_lamp,
+        lounge_side_table,
+        kitchen_island,
+        &meeting_rooms,
+    );
     let mut plants: Vec<PlantItem> = plant_candidates
         .into_iter()
         .filter_map(|p| settle_plant(p, &home_desks, &waypoints, &singleton_rects, &cubicle_band))
@@ -860,6 +852,50 @@ fn place_lounge_vignette(
         side_table,
         fish_tank,
     }
+}
+
+/// THE non-waypoint obstacle census a scatter plant must clear — the single
+/// derivation shared by the production settle path (`compute_with_seed`) and the
+/// placement-sweep clearance backstop, so the two can't drift (they used to hand-
+/// re-derive it, and each omission shipped an interpenetration bug). Takes EVERY
+/// non-waypoint singleton EXPLICITLY and includes each IFF its kind
+/// [`repels_plants`]: the KIND stance is compiler-forced (the exhaustive match),
+/// while wiring a NEW singleton into this arg list is a deliberate edit surfaced
+/// by `placement_sweep::pieces`'s no-`..` destructure (the FIELD backstop), not a
+/// compile error here. Waypoint obstacles are handled by `first_blocking_waypoint`.
+pub(super) fn plant_obstacle_rects(
+    fish_tank: Option<Point>,
+    floor_lamp: Option<Point>,
+    lounge_side_table: Option<Point>,
+    kitchen_island: Option<Point>,
+    meeting_rooms: &[MeetingRoom],
+) -> Vec<(Point, Size)> {
+    let boxed = |kind: Furniture, pos: Point| -> Option<(Point, Size)> {
+        repels_plants(kind).then(|| {
+            let v = furniture_def(kind).visual;
+            (anchored_top_left(Anchor::Center, pos, v.w, v.h), v)
+        })
+    };
+    [
+        (Furniture::FishTank, fish_tank),
+        (Furniture::FloorLamp, floor_lamp),
+        (Furniture::LoungeSideTable, lounge_side_table),
+        (Furniture::KitchenIsland, kitchen_island),
+    ]
+    .into_iter()
+    .filter_map(|(kind, pos)| pos.and_then(|p| boxed(kind, p)))
+    .chain(meeting_rooms.iter().flat_map(|room| {
+        room.trio.iter().flat_map(|trio| {
+            [
+                (Furniture::MeetingSofaBody, trio.sofas[0]),
+                (Furniture::MeetingSofaBody, trio.sofas[1]),
+                (Furniture::MeetingTable, trio.table),
+            ]
+            .into_iter()
+            .filter_map(|(kind, pos)| boxed(kind, pos))
+        })
+    }))
+    .collect()
 }
 
 /// Settle a scatter-plant candidate: keep its authored spot when clear, else

--- a/crates/pixtuoid-scene/src/layout/decor.rs
+++ b/crates/pixtuoid-scene/src/layout/decor.rs
@@ -397,6 +397,59 @@ impl Furniture {
     ];
 }
 
+/// Whether a scatter plant must keep clearance from this furniture kind when it
+/// appears as a NON-waypoint singleton — the plant-obstacle census's per-kind
+/// authority (`plant_obstacle_rects` filters every singleton by it). Was curated
+/// by OMISSION inline in `compute_with_seed`, which let the fish tank (then the
+/// meeting-trio bodies) ship with no repulsion → plants interpenetrated them. An
+/// EXHAUSTIVE match, no `_`: a new [`Furniture`] kind can't compile until it
+/// declares a stance — the KIND axis. (Threading a new non-waypoint SINGLETON
+/// into `plant_obstacle_rects`'s arg list is NOT compiler-forced; `pieces()`'s
+/// no-`..` sweep is the backstop that surfaces the new field so the author wires
+/// it in. Waypoint furniture repels plants via `first_blocking_waypoint`, so its
+/// stance here is moot and `false`.)
+pub(crate) const fn repels_plants(kind: Furniture) -> bool {
+    match kind {
+        // Solid non-waypoint singleton BODIES a scatter plant routes around.
+        // The kitchen island is one by nature even though the pantry is
+        // deliberately plant-free today (compute.rs): declaring it honestly
+        // means "if a plant ever reaches the pantry, it avoids the island" is
+        // one flag, already correct.
+        Furniture::FishTank
+        | Furniture::MeetingSofaBody
+        | Furniture::MeetingTable
+        | Furniture::KitchenIsland => true,
+        // The lounge lamp + side table ARE non-waypoint singletons too, but the
+        // owner-ratified mock has the lounge Ficus hug them (1px) — deliberately
+        // NOT repelled.
+        Furniture::FloorLamp | Furniture::LoungeSideTable => false,
+        // Everything else is never a non-waypoint singleton in the plant census:
+        // waypoint furniture (repelled via `first_blocking_waypoint`), the plants
+        // themselves, wall/pod decor, and the footprint-less seat/stand slots.
+        Furniture::Couch
+        | Furniture::Pantry
+        | Furniture::PhoneBooth
+        | Furniture::StandingDesk
+        | Furniture::VendingMachine
+        | Furniture::Printer
+        | Furniture::MeetingSofa
+        | Furniture::MeetingChair
+        | Furniture::PlantFicus
+        | Furniture::PlantTall
+        | Furniture::PlantFlower
+        | Furniture::PlantSucculent
+        | Furniture::Whiteboard
+        | Furniture::Tv
+        | Furniture::Bookshelf
+        | Furniture::BulletinBoard
+        | Furniture::ExitSign
+        | Furniture::MeetingScreen
+        | Furniture::IslandStand
+        | Furniture::SnackShelf
+        | Furniture::Desk => false,
+    }
+}
+
 /// THE furniture table — one row per [`Furniture`] kind, the **single** source
 /// of truth for ground shape (`footprint`) AND sprite size (`visual`) plus
 /// occupancy / dwell / approach. Every geometric dependent (walkable mask,
@@ -1071,6 +1124,40 @@ mod tests {
     const S: (i32, i32) = (0, 1);
     const E: (i32, i32) = (1, 0);
     const W: (i32, i32) = (-1, 0);
+
+    #[test]
+    fn repels_plants_is_exactly_the_solid_non_waypoint_bodies() {
+        // The plant census's per-kind policy. Pin the WHOLE set off Furniture::ALL
+        // so a new kind wrongly set `true` is caught (the exhaustive match already
+        // catches a new kind left undeclared).
+        for k in [
+            Furniture::FishTank,
+            Furniture::MeetingSofaBody,
+            Furniture::MeetingTable,
+            Furniture::KitchenIsland,
+        ] {
+            assert!(
+                repels_plants(k),
+                "{k:?} is a solid body — must repel plants"
+            );
+        }
+        // The owner-ratified 1px Ficus hug: the lounge lamp + side table are
+        // non-waypoint singletons too, but must NEVER repel (a silent flip to
+        // `true` would shove the lounge Ficus off its authored spot).
+        assert!(
+            !repels_plants(Furniture::FloorLamp),
+            "lamp keeps the Ficus hug"
+        );
+        assert!(
+            !repels_plants(Furniture::LoungeSideTable),
+            "side table keeps the Ficus hug"
+        );
+        assert_eq!(
+            Furniture::ALL.iter().filter(|&&k| repels_plants(k)).count(),
+            4,
+            "exactly four kinds repel — a new `true` must be deliberate"
+        );
+    }
 
     fn allowed(sides: ApproachSides, facing: Facing) -> Vec<(i32, i32)> {
         [N, S, E, W]

--- a/crates/pixtuoid-scene/src/layout/mod.rs
+++ b/crates/pixtuoid-scene/src/layout/mod.rs
@@ -32,12 +32,12 @@ mod rooms;
 // scene crate's own synthetic-mask unit tests. No external caller.
 pub(crate) use approach::{approach_point, stand_point};
 pub use compute::PANTRY_COUNTER_LARGE_W;
-pub(crate) use decor::DESK_GROUND_H;
 pub use decor::{
     desk_furniture_def, desk_walk_anchor, furniture_def, seated_foot_cell, ApproachSides,
     DwellWindow, Facing, Furniture, FurnitureDef, PlantKind, PodDecor, WallDecor, WaypointKind,
     DESK_APPROACH, SEAT_RENDER_Y_OFF, WALKING_Y_OFF,
 };
+pub(crate) use decor::{repels_plants, DESK_GROUND_H};
 pub use placement::{anchored_top_left, z_sort_row, Anchor};
 pub use reach::ReachSet;
 pub use rooms::{MeetingRoom, MeetingTrio, PantryRoom};

--- a/crates/pixtuoid-scene/src/layout/placement_sweep.rs
+++ b/crates/pixtuoid-scene/src/layout/placement_sweep.rs
@@ -990,6 +990,33 @@ fn the_sweep_reaches_every_floor_variant() {
 }
 
 #[test]
+fn plant_obstacle_census_honors_repels_plants() {
+    // The ONE census (`compute::plant_obstacle_rects`) includes a singleton IFF
+    // its kind `repels_plants`: the fish tank + kitchen island (solid bodies) are
+    // IN; the lounge lamp + side table (the owner-ratified Ficus hug) are OUT.
+    // Positions are arbitrary — only presence/absence in the census matters.
+    let p = |x: u16, y: u16| Point { x, y };
+    let rects = super::compute::plant_obstacle_rects(
+        Some(p(10, 10)), // fish tank      -> repels -> in
+        Some(p(50, 50)), // floor lamp     -> NOT    -> out
+        Some(p(60, 60)), // side table     -> NOT    -> out
+        Some(p(80, 40)), // kitchen island -> repels -> in
+        &[],             // no meeting rooms
+    );
+    assert_eq!(
+        rects.len(),
+        2,
+        "fish tank + island repel; lamp + side table are the declared Ficus-hug exclusions"
+    );
+    // with none of the repelling singletons present, the census is empty
+    assert!(
+        super::compute::plant_obstacle_rects(None, Some(p(1, 1)), Some(p(2, 2)), None, &[])
+            .is_empty(),
+        "only repels_plants singletons enter the census"
+    );
+}
+
+#[test]
 fn scatter_plants_keep_obstacle_clearance_and_survive_by_sliding() {
     // Yield-by-DELETION was
     // structurally universal (the corner appliances share the plants'
@@ -1014,8 +1041,9 @@ fn scatter_plants_keep_obstacle_clearance_and_survive_by_sliding() {
     };
     // Does the plant box come within PLANT_OBSTACLE_CLEARANCE_PX of the obstacle
     // box (obs_pos, obs_v)? Inflate the obstacle box by the clearance on every side
-    // and test overlap — the shared predicate the three obstacle families (fish
-    // tank / meeting-trio bodies / obstacle waypoints) each need.
+    // and test overlap. The center-anchored predicate the WAYPOINT family needs;
+    // the fixed non-waypoint singletons instead ride the SAME `plant_obstacle_rects`
+    // census the production path uses (TL rects → `overlaps_within_clearance`).
     let within_clearance = |plant_box: (Point, Size), obs_pos: Point, obs_v: Size| {
         let m = PLANT_OBSTACLE_CLEARANCE_PX;
         let (otl, osz) = visual_tl(obs_pos, obs_v);
@@ -1036,38 +1064,27 @@ fn scatter_plants_keep_obstacle_clearance_and_survive_by_sliding() {
         for p in &l.plants {
             let pv = furniture_def(p.kind.furniture()).visual;
             let plant_box = visual_tl(p.pos, pv);
-            if let Some(t) = l.fish_tank {
-                let tv = furniture_def(Furniture::FishTank).visual;
-                if within_clearance(plant_box, t, tv) {
+            // The fixed non-waypoint singletons — the SAME `plant_obstacle_rects`
+            // census the production settle path uses (fish tank / meeting-trio
+            // bodies / kitchen island, filtered by `repels_plants`), no longer a
+            // hand-re-derived second copy that shipped each interpenetration bug.
+            // A census miss here IS a plant interpenetration.
+            for (otl, osz) in super::compute::plant_obstacle_rects(
+                l.fish_tank,
+                l.floor_lamp,
+                l.lounge_side_table,
+                l.pantry.and_then(|pr| pr.kitchen_island),
+                &l.meeting_rooms,
+            ) {
+                if super::placement::overlaps_within_clearance(
+                    plant_box,
+                    (otl, osz),
+                    PLANT_OBSTACLE_CLEARANCE_PX,
+                ) {
                     v.push(format!(
-                        "{w}x{h} seed {seed}: plant {:?}@{:?} within clearance of the fish tank @{:?}",
-                        p.kind, p.pos, t
+                        "{w}x{h} seed {seed}: plant {:?}@{:?} within clearance of a repels-plants singleton @{:?}",
+                        p.kind, p.pos, otl
                     ));
-                }
-            }
-            // Meeting trio bodies are neither waypoints nor singletons — a
-            // census that misses them lets a room plant merge into the sofa
-            // (visible at ~110x45).
-            for room in &l.meeting_rooms {
-                let Some(trio) = &room.trio else { continue };
-                let bodies = [
-                    (
-                        trio.sofas[0],
-                        furniture_def(Furniture::MeetingSofaBody).visual,
-                    ),
-                    (
-                        trio.sofas[1],
-                        furniture_def(Furniture::MeetingSofaBody).visual,
-                    ),
-                    (trio.table, furniture_def(Furniture::MeetingTable).visual),
-                ];
-                for (bpos, bv) in bodies {
-                    if within_clearance(plant_box, bpos, bv) {
-                        v.push(format!(
-                            "{w}x{h} seed {seed}: plant {:?}@{:?} within clearance of a trio body @{:?}",
-                            p.kind, p.pos, bpos
-                        ));
-                    }
                 }
             }
             for wp in &l.waypoints {


### PR DESCRIPTION
## What

The scatter-plant obstacle **census** (the non-waypoint singleton boxes a plant must keep clearance from) was an inline hand-list in `compute_with_seed` **and** a hand-re-derived second copy in the placement sweep — both curated by **omission**, which shipped two interpenetration bugs (the fish tank, then the meeting-trio bodies). This replaces both with **one derivation driven by a per-kind property**:

- **`decor.rs`**: an exhaustive `repels_plants(kind) -> bool` (no `_`, so a new `Furniture` kind can't compile until it declares a stance — the KIND axis). A standalone fn, **not** a `FurnitureDef` field: same completeness teeth with no 11-row churn and no pub-struct semver change.
- **`compute.rs`**: one `plant_obstacle_rects(...)` taking every non-waypoint singleton and including each **iff** `repels_plants`. The lounge lamp + side table are now a **declared `false`** (the owner-ratified Ficus hug), not a silent omission. Fish-tank + trio rects are byte-identical to the old inline list.
- **`placement_sweep.rs`**: the clearance backstop consumes the **same** derivation — the hand-re-derived second census is gone.

## Notable
- The kitchen island is now honestly `repels_plants=true`; verified a **visual no-op** — `gen-check` is pixel-identical (plants never scatter into the pantry, so the island is never within clearance of one).
- Fixed a stale `+ pantry` comment that contradicted "No pantry plants".
- `just gen-wasm` regenerated (scene change).

## Gates
- `just preflight` green (2590 tests)
- `just gen-check` pixel-identical
- Two-lens review: 3 low doc-accuracy findings → all fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Efqga1oH86ye6eKeB9Gzab
