### PR TITLE
refactor(paint): one floor-shadow authority (floor_shadow_ellipses)

### DIFF
--- a/crates/pixtuoid-scene/src/pixel_painter/mod.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/mod.rs
@@ -416,6 +416,106 @@ fn ceiling_pool_regions(layout: &Layout) -> impl Iterator<Item = Ellipse> + '_ {
     desks.chain(pantry).chain(corridor)
 }
 
+/// THE authority for the soft floor shadows, in PAINT ORDER (the shadow twin of
+/// [`ceiling_pool_regions`]) — one place for every piece's floor-contact ellipse
+/// so the ~120-line inline block became a short loop and the per-piece extents
+/// aren't anonymous inline literals scattered through `paint_frame`. Painted
+/// BEFORE the y-sorted entity pass so every entity sits on its own shadow. Order
+/// is preserved verbatim so the blended overlaps stay byte-identical.
+///
+/// The per-piece `half_w`/`half_h` are owner-tuned taste literals and the
+/// couch/printer/island special-cases are irreducible — this HOUSES them in one
+/// spot, it does not normalize them (the island/plant/lamp south offsets DO
+/// derive from the shared `center_pin_south_offset`, so those move with a retune;
+/// the generic/printer/couch `+2`/`+1` offsets stay literal by design).
+fn floor_shadow_ellipses(layout: &Layout) -> impl Iterator<Item = Ellipse> + '_ {
+    use crate::layout::{furniture_def, Furniture, WaypointKind};
+
+    let desks = layout
+        .home_desks
+        .iter()
+        .map(|desk| desk_shadow_ellipse(*desk));
+    // Generic waypoint blob. Couch/Printer/Island are handled with fitted
+    // shadows below, so skip them here: a per-seat couch shadow (3 seats) would
+    // overlap-darken; the printer's 4px sprite souths at +1 not the generic +2;
+    // the island STANDS are empty floor beside the body (which carries its own
+    // shadow) so a blob at each stand paints phantom shadows.
+    let generic = layout
+        .waypoints
+        .iter()
+        .filter(|w| {
+            !matches!(
+                w.kind,
+                WaypointKind::Couch | WaypointKind::Printer | WaypointKind::Island
+            )
+        })
+        .map(|wp| {
+            // Fit the ellipse to the sprite width — a flat 7 half-width doubles a
+            // narrow shelf's shadow; `.min(7)` caps a future wide piece.
+            let vis_w = furniture_def(wp.kind.furniture()).visual.w;
+            let half_w = if vis_w > 0 { (vis_w / 2 + 1).min(7) } else { 7 };
+            Ellipse {
+                cx: wp.pos.x,
+                cy: wp.pos.y + 2,
+                half_w,
+                half_h: 2,
+            }
+        });
+    // One fitted shadow under the island BODY (its stands are skipped above):
+    // south edge = the visual south row, width tracks the sprite.
+    let island = layout.pantry.and_then(|p| p.kitchen_island).map(|island| {
+        let vis = furniture_def(Furniture::KitchenIsland).visual;
+        Ellipse {
+            cx: island.x,
+            cy: island.y + center_pin_south_offset(vis.h),
+            half_w: vis.w / 2 + 1,
+            half_h: 2,
+        }
+    });
+    // Flush against the printer's sprite south (pos.y+1), one per printer.
+    let printers = layout
+        .waypoints
+        .iter()
+        .filter(|w| w.kind == WaypointKind::Printer)
+        .map(|wp| Ellipse {
+            cx: wp.pos.x,
+            cy: wp.pos.y + 1,
+            half_w: 5,
+            half_h: 1,
+        });
+    let couch = layout.couch_sprite_center.map(|center| Ellipse {
+        cx: center.x,
+        cy: center.y + 2,
+        half_w: 7,
+        half_h: 2,
+    });
+    // Under the sprite's south row — same offset the z-anchor uses, off the same
+    // height (a fixed +3 only suited the taller Ficus/Tall, floating the others).
+    let plants = layout
+        .plants
+        .iter()
+        .map(|&PlantItem { kind, pos }| Ellipse {
+            cx: pos.x,
+            cy: pos.y + center_pin_south_offset(furniture_def(kind.furniture()).visual.h),
+            half_w: 3,
+            half_h: 1,
+        });
+    let lamp = layout.floor_lamp.map(|lamp| Ellipse {
+        cx: lamp.x,
+        cy: lamp.y + floor_lamp_south_offset(), // flush with the lamp base (sprite south)
+        half_w: 2,
+        half_h: 1,
+    });
+
+    desks
+        .chain(generic)
+        .chain(island)
+        .chain(printers)
+        .chain(couch)
+        .chain(plants)
+        .chain(lamp)
+}
+
 /// The PAINT half of the frame: blit the world the sim already advanced.
 /// Reads the [`SimFrame`] immutably; every positional/lifecycle decision was
 /// made in `sim_step` — this pass only resolves presentation (theme colors,
@@ -571,123 +671,8 @@ fn paint_frame(
     // function of daylight so noon shadows are crisp and night shadows
     // are subtle.
     let shadow_strength = 0.5 - 0.3 * look.darkness;
-    for desk in &ctx.layout.home_desks {
-        paint_shadow(
-            ctx.buf,
-            desk_shadow_ellipse(*desk),
-            shadow_strength,
-            ctx.theme,
-        );
-    }
-    for wp in &ctx.layout.waypoints {
-        use crate::layout::WaypointKind;
-        // Couch shadow is emitted once below (3 seat waypoints; per-seat
-        // shadows would overlap). Printer is handled just after — its 4px-tall
-        // sprite's south is pos.y+1, so the generic +2 would float 1px below.
-        // Island stands are EMPTY FLOOR cells beside the island (the body
-        // carries its own fitted shadow below) — a generic blob at each stand
-        // painted phantom shadows left/right of the island.
-        if matches!(
-            wp.kind,
-            WaypointKind::Couch | WaypointKind::Printer | WaypointKind::Island
-        ) {
-            continue;
-        }
-        // Fit the ellipse to the piece's actual sprite width — a flat 7
-        // half-width doubles a narrow shelf's shadow. The .min(7) caps a
-        // future wide piece from over-shadowing.
-        let vis_w = crate::layout::furniture_def(wp.kind.furniture()).visual.w;
-        let half_w = if vis_w > 0 { (vis_w / 2 + 1).min(7) } else { 7 };
-        paint_shadow(
-            ctx.buf,
-            Ellipse {
-                cx: wp.pos.x,
-                cy: wp.pos.y + 2,
-                half_w,
-                half_h: 2,
-            },
-            shadow_strength,
-            ctx.theme,
-        );
-    }
-    if let Some(island) = ctx.layout.pantry.and_then(|p| p.kitchen_island) {
-        // One fitted shadow under the island BODY (its stands are skipped
-        // above): south edge = the visual south row, width tracks the sprite.
-        let vis = crate::layout::furniture_def(crate::layout::Furniture::KitchenIsland).visual;
-        paint_shadow(
-            ctx.buf,
-            Ellipse {
-                cx: island.x,
-                cy: island.y + center_pin_south_offset(vis.h),
-                half_w: vis.w / 2 + 1,
-                half_h: 2,
-            },
-            shadow_strength,
-            ctx.theme,
-        );
-    }
-    for wp in ctx
-        .layout
-        .waypoints
-        .iter()
-        .filter(|w| w.kind == crate::layout::WaypointKind::Printer)
-    {
-        // Flush against the printer's sprite south (pos.y+1).
-        paint_shadow(
-            ctx.buf,
-            Ellipse {
-                cx: wp.pos.x,
-                cy: wp.pos.y + 1,
-                half_w: 5,
-                half_h: 1,
-            },
-            shadow_strength,
-            ctx.theme,
-        );
-    }
-    if let Some(center) = ctx.layout.couch_sprite_center {
-        paint_shadow(
-            ctx.buf,
-            Ellipse {
-                cx: center.x,
-                cy: center.y + 2,
-                half_w: 7,
-                half_h: 2,
-            },
-            shadow_strength,
-            ctx.theme,
-        );
-    }
-    for &PlantItem { kind, pos } in &ctx.layout.plants {
-        // Shadow sits under the sprite's south row — same offset the z-anchor
-        // uses, off the same height (Succulent/Flower were floating at a fixed
-        // +3 that only suited the taller Ficus/Tall).
-        let cy = pos.y
-            + center_pin_south_offset(crate::layout::furniture_def(kind.furniture()).visual.h);
-        paint_shadow(
-            ctx.buf,
-            Ellipse {
-                cx: pos.x,
-                cy,
-                half_w: 3,
-                half_h: 1,
-            },
-            shadow_strength,
-            ctx.theme,
-        );
-    }
-    if let Some(lamp) = ctx.layout.floor_lamp {
-        paint_shadow(
-            ctx.buf,
-            Ellipse {
-                cx: lamp.x,
-                cy: lamp.y + floor_lamp_south_offset(), // flush with the lamp base (sprite south)
-                half_w: 2,
-                half_h: 1,
-            },
-            shadow_strength,
-            ctx.theme,
-        );
+    for ell in floor_shadow_ellipses(ctx.layout) {
+        paint_shadow(ctx.buf, ell, shadow_strength, ctx.theme);
     }
 
     // Ceiling halos gate on the sim's `seated_agents` so a tool-glow halo

--- a/crates/pixtuoid-scene/src/pixel_painter/tests.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/tests.rs
@@ -3482,105 +3482,21 @@ fn floor_shadow_ellipses_fit_each_family_in_paint_order() {
         Layout::compute(192, 160, Some(crate::layout::TEST_DEFAULT_DESKS)).expect("192x160 fits");
     // Ellipse is Copy, not PartialEq — compare by field tuple.
     let e = |el: &Ellipse| (el.cx, el.cy, el.half_w, el.half_h);
-    let shadows: Vec<_> = floor_shadow_ellipses(&l).collect();
 
-    // One shadow per family member; the couch/printer/island waypoints are
-    // dropped from the generic run and re-added with their own fitted shadows.
-    let generic = l
-        .waypoints
-        .iter()
-        .filter(|w| {
-            !matches!(
-                w.kind,
-                WaypointKind::Couch | WaypointKind::Printer | WaypointKind::Island
-            )
-        })
-        .count();
-    let printers = l
-        .waypoints
-        .iter()
-        .filter(|w| w.kind == WaypointKind::Printer)
-        .count();
-    assert_eq!(
-        shadows.len(),
-        l.home_desks.len()
-            + generic
-            + l.pantry.and_then(|p| p.kitchen_island).is_some() as usize
-            + printers
-            + l.couch_sprite_center.is_some() as usize
-            + l.plants.len()
-            + l.floor_lamp.is_some() as usize,
-        "one shadow per family member, in paint order"
-    );
-
-    // The leading run is the desk shadows, verbatim (the taste literal half_h=3).
-    for (s, desk) in shadows.iter().zip(&l.home_desks) {
-        assert_eq!(
-            e(s),
-            e(&desk_shadow_ellipse(*desk)),
-            "desk run leads, unchanged"
-        );
+    // Rebuild the expected shadow run family-by-family in the SAME chain order
+    // the authority emits (desks → generic → island → printers → couch → plants
+    // → lamp), then assert the WHOLE ordered vec. Asserting the full sequence —
+    // not per-family `.any()` membership — is what actually guards the
+    // cross-family paint order (blended overlaps depend on it): a reordered
+    // chain, a dropped family, a per-seat couch, or a retuned taste literal each
+    // fail this one assert_eq.
+    let mut expected: Vec<(u16, u16, u16, u16)> = Vec::new();
+    // Desks lead — verbatim, incl. the taste literal half_h=3.
+    for &desk in &l.home_desks {
+        expected.push(e(&desk_shadow_ellipse(desk)));
     }
-    // The lamp's fitted 2×1 blob (flush with the sprite south) is present iff the
-    // lamp is — a distinctive taste literal a retune must not silently drop.
-    if let Some(lamp) = l.floor_lamp {
-        assert!(
-            shadows
-                .iter()
-                .any(|s| e(s) == (lamp.x, lamp.y + floor_lamp_south_offset(), 2, 1)),
-            "lamp shadow present + fitted 2x1"
-        );
-    }
-    // Every plant gets the 3×1 blob under its OWN south row (not a fixed +3).
-    for &PlantItem { kind, pos } in &l.plants {
-        let want = (
-            pos.x,
-            pos.y
-                + center_pin_south_offset(crate::layout::furniture_def(kind.furniture()).visual.h),
-            3,
-            1,
-        );
-        assert!(
-            shadows.iter().any(|s| e(s) == want),
-            "plant {kind:?} shadow present + fitted 3x1"
-        );
-    }
-    // The couch's 7×2 blob — emitted ONCE from couch_sprite_center (not per seat).
-    if let Some(c) = l.couch_sprite_center {
-        assert!(
-            shadows.iter().any(|s| e(s) == (c.x, c.y + 2, 7, 2)),
-            "couch shadow present + fitted 7x2 (once)"
-        );
-    }
-    // Each printer's flush 5×1 blob at the sprite south (pos.y+1, not the generic +2).
-    for wp in l
-        .waypoints
-        .iter()
-        .filter(|w| w.kind == WaypointKind::Printer)
-    {
-        assert!(
-            shadows
-                .iter()
-                .any(|s| e(s) == (wp.pos.x, wp.pos.y + 1, 5, 1)),
-            "printer shadow present + fitted 5x1"
-        );
-    }
-    // The island BODY's blob under its south row, width tracking the sprite.
-    if let Some(island) = l.pantry.and_then(|p| p.kitchen_island) {
-        let vis = crate::layout::furniture_def(crate::layout::Furniture::KitchenIsland).visual;
-        let want = (
-            island.x,
-            island.y + center_pin_south_offset(vis.h),
-            vis.w / 2 + 1,
-            2,
-        );
-        assert!(
-            shadows.iter().any(|s| e(s) == want),
-            "island shadow present + fitted to the sprite"
-        );
-    }
-    // Each generic (non couch/printer/island) waypoint's +2 blob, width fitted to
-    // its sprite and min-capped at 7.
+    // Generic (non couch/printer/island) waypoints — +2 blob, width fitted to the
+    // sprite and min-capped at 7.
     for wp in l.waypoints.iter().filter(|w| {
         !matches!(
             w.kind,
@@ -3589,12 +3505,48 @@ fn floor_shadow_ellipses_fit_each_family_in_paint_order() {
     }) {
         let vis_w = crate::layout::furniture_def(wp.kind.furniture()).visual.w;
         let half_w = if vis_w > 0 { (vis_w / 2 + 1).min(7) } else { 7 };
-        assert!(
-            shadows
-                .iter()
-                .any(|s| e(s) == (wp.pos.x, wp.pos.y + 2, half_w, 2)),
-            "generic waypoint {:?} shadow present + fitted",
-            wp.kind
-        );
+        expected.push((wp.pos.x, wp.pos.y + 2, half_w, 2));
     }
+    // The island BODY's blob under its south row, width tracking the sprite.
+    if let Some(island) = l.pantry.and_then(|p| p.kitchen_island) {
+        let vis = crate::layout::furniture_def(crate::layout::Furniture::KitchenIsland).visual;
+        expected.push((
+            island.x,
+            island.y + center_pin_south_offset(vis.h),
+            vis.w / 2 + 1,
+            2,
+        ));
+    }
+    // Each printer's flush 5×1 blob at the sprite south (pos.y+1, not the generic +2).
+    for wp in l
+        .waypoints
+        .iter()
+        .filter(|w| w.kind == WaypointKind::Printer)
+    {
+        expected.push((wp.pos.x, wp.pos.y + 1, 5, 1));
+    }
+    // The couch's 7×2 blob — emitted ONCE from couch_sprite_center (not per seat).
+    if let Some(c) = l.couch_sprite_center {
+        expected.push((c.x, c.y + 2, 7, 2));
+    }
+    // Every plant's 3×1 blob under its OWN south row (not a fixed +3).
+    for &PlantItem { kind, pos } in &l.plants {
+        expected.push((
+            pos.x,
+            pos.y
+                + center_pin_south_offset(crate::layout::furniture_def(kind.furniture()).visual.h),
+            3,
+            1,
+        ));
+    }
+    // The lamp's fitted 2×1 blob, flush with the sprite south — last in the chain.
+    if let Some(lamp) = l.floor_lamp {
+        expected.push((lamp.x, lamp.y + floor_lamp_south_offset(), 2, 1));
+    }
+
+    let got: Vec<_> = floor_shadow_ellipses(&l).map(|el| e(&el)).collect();
+    assert_eq!(
+        got, expected,
+        "one fitted shadow per family member, emitted in paint order"
+    );
 }

--- a/crates/pixtuoid-scene/src/pixel_painter/tests.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/tests.rs
@@ -3474,3 +3474,127 @@ fn ceiling_pool_regions_yields_desks_then_pantry_then_corridor_in_order() {
         assert_eq!((p.half_w, p.half_h), (14, 5));
     }
 }
+
+#[test]
+fn floor_shadow_ellipses_fit_each_family_in_paint_order() {
+    use crate::layout::WaypointKind;
+    let l =
+        Layout::compute(192, 160, Some(crate::layout::TEST_DEFAULT_DESKS)).expect("192x160 fits");
+    // Ellipse is Copy, not PartialEq — compare by field tuple.
+    let e = |el: &Ellipse| (el.cx, el.cy, el.half_w, el.half_h);
+    let shadows: Vec<_> = floor_shadow_ellipses(&l).collect();
+
+    // One shadow per family member; the couch/printer/island waypoints are
+    // dropped from the generic run and re-added with their own fitted shadows.
+    let generic = l
+        .waypoints
+        .iter()
+        .filter(|w| {
+            !matches!(
+                w.kind,
+                WaypointKind::Couch | WaypointKind::Printer | WaypointKind::Island
+            )
+        })
+        .count();
+    let printers = l
+        .waypoints
+        .iter()
+        .filter(|w| w.kind == WaypointKind::Printer)
+        .count();
+    assert_eq!(
+        shadows.len(),
+        l.home_desks.len()
+            + generic
+            + l.pantry.and_then(|p| p.kitchen_island).is_some() as usize
+            + printers
+            + l.couch_sprite_center.is_some() as usize
+            + l.plants.len()
+            + l.floor_lamp.is_some() as usize,
+        "one shadow per family member, in paint order"
+    );
+
+    // The leading run is the desk shadows, verbatim (the taste literal half_h=3).
+    for (s, desk) in shadows.iter().zip(&l.home_desks) {
+        assert_eq!(
+            e(s),
+            e(&desk_shadow_ellipse(*desk)),
+            "desk run leads, unchanged"
+        );
+    }
+    // The lamp's fitted 2×1 blob (flush with the sprite south) is present iff the
+    // lamp is — a distinctive taste literal a retune must not silently drop.
+    if let Some(lamp) = l.floor_lamp {
+        assert!(
+            shadows
+                .iter()
+                .any(|s| e(s) == (lamp.x, lamp.y + floor_lamp_south_offset(), 2, 1)),
+            "lamp shadow present + fitted 2x1"
+        );
+    }
+    // Every plant gets the 3×1 blob under its OWN south row (not a fixed +3).
+    for &PlantItem { kind, pos } in &l.plants {
+        let want = (
+            pos.x,
+            pos.y
+                + center_pin_south_offset(crate::layout::furniture_def(kind.furniture()).visual.h),
+            3,
+            1,
+        );
+        assert!(
+            shadows.iter().any(|s| e(s) == want),
+            "plant {kind:?} shadow present + fitted 3x1"
+        );
+    }
+    // The couch's 7×2 blob — emitted ONCE from couch_sprite_center (not per seat).
+    if let Some(c) = l.couch_sprite_center {
+        assert!(
+            shadows.iter().any(|s| e(s) == (c.x, c.y + 2, 7, 2)),
+            "couch shadow present + fitted 7x2 (once)"
+        );
+    }
+    // Each printer's flush 5×1 blob at the sprite south (pos.y+1, not the generic +2).
+    for wp in l
+        .waypoints
+        .iter()
+        .filter(|w| w.kind == WaypointKind::Printer)
+    {
+        assert!(
+            shadows
+                .iter()
+                .any(|s| e(s) == (wp.pos.x, wp.pos.y + 1, 5, 1)),
+            "printer shadow present + fitted 5x1"
+        );
+    }
+    // The island BODY's blob under its south row, width tracking the sprite.
+    if let Some(island) = l.pantry.and_then(|p| p.kitchen_island) {
+        let vis = crate::layout::furniture_def(crate::layout::Furniture::KitchenIsland).visual;
+        let want = (
+            island.x,
+            island.y + center_pin_south_offset(vis.h),
+            vis.w / 2 + 1,
+            2,
+        );
+        assert!(
+            shadows.iter().any(|s| e(s) == want),
+            "island shadow present + fitted to the sprite"
+        );
+    }
+    // Each generic (non couch/printer/island) waypoint's +2 blob, width fitted to
+    // its sprite and min-capped at 7.
+    for wp in l.waypoints.iter().filter(|w| {
+        !matches!(
+            w.kind,
+            WaypointKind::Couch | WaypointKind::Printer | WaypointKind::Island
+        )
+    }) {
+        let vis_w = crate::layout::furniture_def(wp.kind.furniture()).visual.w;
+        let half_w = if vis_w > 0 { (vis_w / 2 + 1).min(7) } else { 7 };
+        assert!(
+            shadows
+                .iter()
+                .any(|s| e(s) == (wp.pos.x, wp.pos.y + 2, half_w, 2)),
+            "generic waypoint {:?} shadow present + fitted",
+            wp.kind
+        );
+    }
+}


### PR DESCRIPTION
## What

The soft floor-shadow pass in `paint_frame` was ~120 lines of inline per-piece `paint_shadow(Ellipse{..})` calls across **7 families** (desks, generic waypoints, kitchen-island body, printer, couch, plants, floor lamp) with skip-then-re-add logic. This consolidates them into **one authoritative iterator** `floor_shadow_ellipses(layout) -> impl Iterator<Item = Ellipse>` — the shadow twin of the existing `ceiling_pool_regions` — so `paint_frame` is a 3-line loop.

## Behavior-preserving
Each family's exact ellipse (`cx`/`cy`/`half_w`/`half_h`) **and the paint order** are reproduced verbatim, so blended shadow overlaps stay byte-identical. **`gen-check` is pixel-identical (52/52).** The owner-tuned `half_w`/`half_h` taste literals + the couch/printer/island special-cases are **housed** in the authority, not normalized (island/plant/lamp south offsets derive from the shared `center_pin_south_offset`; the generic/printer/couch `+2`/`+1` stay literal by design).

## Notable
- New `floor_shadow_ellipses_fit_each_family_in_paint_order` test value-pins all 7 families' extents + paint order (mirrors the `ceiling_pool_regions` test).
- **Net −117 lines** in `paint_frame`.
- `just gen-wasm` regenerated (scene change).

## Gates
- `just preflight` green (2589 tests)
- `just gen-check` pixel-identical
- Two-lens review: 0 confirmed findings (4 refuted — gen-check owns rendered taste literals)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Efqga1oH86ye6eKeB9Gzab
