### PR TITLE
fix(site): hero strip first-row top border shaved on iOS — pad the composited layer

### DIFF
--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -124,8 +124,16 @@ const badges = sources.filter((s) => s.status === 'supported');
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
-    margin: 1.15rem 0 0;
-    padding: 0;
+    /* 2px of the old margin moved INSIDE the layer as padding-top (net
+       geometry identical): with padding 0 the first row's 1px chip border
+       sat on the composited layer's exact top edge, and iOS Safari
+       rasterizing the pinned layer at a fractional offset shaved that
+       device-pixel row — the row-1-only "top of the badges is clipped"
+       phone report. Rows 2+ are interior to the layer and were never hit;
+       headless Chromium doesn't reproduce it (different rasterizer). The
+       padding keeps the border off the raster boundary. */
+    margin: calc(1.15rem - 2px) 0 0;
+    padding: 2px 0 0;
     list-style: none;
     /* Permanent compositing layer: Safari promotes/demotes elements around
        hover transitions, and the raster snap on that boundary can read as a

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -124,14 +124,18 @@ const badges = sources.filter((s) => s.status === 'supported');
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
-    /* 2px of the old margin moved INSIDE the layer as padding-top (net
+    /* 2px of the old margin moved INSIDE the element as padding-top (net
        geometry identical): with padding 0 the first row's 1px chip border
-       sat on the composited layer's exact top edge, and iOS Safari
-       rasterizing the pinned layer at a fractional offset shaved that
-       device-pixel row — the row-1-only "top of the badges is clipped"
-       phone report. Rows 2+ are interior to the layer and were never hit;
-       headless Chromium doesn't reproduce it (different rasterizer). The
-       padding keeps the border off the raster boundary. */
+       sat on the element's exact top paint edge, and iOS Safari
+       rasterizing at a fractional offset (composited or not — the rise
+       animation's fill overrides the translateZ below at steady state)
+       shaved that device-pixel row — the row-1-only "top of the badges is
+       clipped ~1px" phone report, confirmed on-device. Rows 2+ are
+       interior and were never hit; headless Chromium doesn't reproduce it
+       (different rasterizer). The padding keeps the border off the paint
+       boundary under every rasterization variant. The calc compensation is
+       LOAD-BEARING, not cosmetic: padding-only would grow the page ~2px
+       and red the ≤7.9vh scroll-budget e2e pin (~1px headroom). */
     margin: calc(1.15rem - 2px) 0 0;
     padding: 2px 0 0;
     list-style: none;


### PR DESCRIPTION
Owner phone report: the hero badge grid's FIRST row loses ~1px off its top edge on iOS Safari (flat shave, rows 2+ fine — user-confirmed shape B, ~1px).

Mechanism: `.hero__badges` is a pinned compositing layer (`translateZ(0)`, the existing Safari hover-jitter fix) with `padding: 0`, so row 1's 1px chip border sits on the layer's exact top raster edge; iOS rasterizing the layer at a fractional offset (measured 421.05px locally) drops the topmost device-pixel row. Interior rows are immune; headless Chromium doesn't reproduce (different rasterizer). Ruled out by pixel-probe + rendered crop at iPhone metrics: geometric clipping (none), overlaying elements (none at ±3px), translucent chip fill (opaque).

Fix: 2px of the strip's top margin moves INSIDE the layer as `padding-top` (margin compensated via `calc` — net geometry identical), so the raster boundary crops padding instead of the border.

Verify on-device after deploy: the first row's top border should render at full weight.

Gates: `just site-check` green, `just site-e2e` 89/89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136n4TuNi2PC1hAiMYQPxHh