### PR TITLE
refactor(runtime): collapse the duplicated pipeline spine into runtime::pipeline (#714)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -6,7 +6,7 @@
 test_tool = "nextest"
 
 exclude_globs = [
-    # Untestable painter / async + winit glue — these five are the painter files
+    # Untestable painter / async + winit glue — these six are the painter files
     # codecov.yml ALSO ignores; no headless test can kill their mutants, so every
     # one "survives" = noise. The two ignore lists OVERLAP, not subset: codecov
     # also ignores crash/logging/sources_cli (pure helpers stay unit-tested —
@@ -15,6 +15,7 @@ exclude_globs = [
     "crates/pixtuoid/src/main.rs",
     "crates/pixtuoid/src/tui/mod.rs",
     "crates/pixtuoid/src/runtime/driver.rs",
+    "crates/pixtuoid/src/runtime/pipeline.rs",
     "crates/pixtuoid/src/floating/mod.rs",
     "crates/pixtuoid/src/floating/window.rs",
     # Timing / FFI liveness probes: their tests assert wall-clock + OS behavior and

--- a/codecov.yml
+++ b/codecov.yml
@@ -69,6 +69,7 @@ ignore:
   - "crates/pixtuoid/src/sources_cli.rs"        # println presenters over the real config path (was main.rs; covered by the cli_json e2e binary run)
   - "crates/pixtuoid/src/tui/mod.rs"            # crossterm event loop + terminal lifecycle: reads/writes the real TTY
   - "crates/pixtuoid/src/runtime/driver.rs"     # async glue: tokio runtime + block_on + ctrl_c + socket bind (#103)
+  - "crates/pixtuoid/src/runtime/pipeline.rs"   # the shared source→reducer spine (#714): same channel/spawn glue class as driver.rs
   - "crates/pixtuoid/src/floating/mod.rs"       # floating run(): tokio runtime + winit EventLoop glue (the floating twin of driver.rs)
   - "crates/pixtuoid/src/floating/window.rs"    # winit ApplicationHandler: creates the real OS window + softbuffer surface
   # The testable floating logic IS counted: offscreen.rs (render seam) + geometry.rs (window/monitor rect math) + input.rs (the pure audio key-map).

--- a/crates/pixtuoid/CLAUDE.md
+++ b/crates/pixtuoid/CLAUDE.md
@@ -195,9 +195,10 @@ src/
 │                       floating::run. boot_caps / socket_path / ConnectedSources stay CALLER-side (the
 │                       documented divergences: TUI measures the terminal, floating its window pixels;
 │                       both need socket/connected after boot). Needs an ambient tokio context
-│                       (run_async's block_on / floating's rt.enter). `_source_handles` must stay BOUND
-│                       at the call site — dropping the Pipeline kills the source tasks.
-│                       codecov-excluded like driver.rs)
+│                       (run_async's block_on / floating's rt.enter) — the RUNTIME is what keeps the
+│                       spawned tasks alive (a dropped tokio JoinHandle DETACHES, never stops);
+│                       `_source_handles` is an inert anchor for future abort/join.
+│                       codecov-excluded + mutants-excluded like driver.rs)
 ├── init_pack.rs        extracts the embedded skeleton pack to a target dir for `init-pack`
 ├── validate.rs         the `validate-pack` presenter; pack.name/version are UNTRUSTED TOML strings (can
 │                       embed ESC/OSC via \u escapes), so every printed line routes through

--- a/crates/pixtuoid/CLAUDE.md
+++ b/crates/pixtuoid/CLAUDE.md
@@ -186,7 +186,18 @@ src/
 │                       — handed to the HookRouter (hook-tee PRODUCER) + ClaudeCodeSource & CodexSource & GrokSource (watcher
 │                       CONSUMERS). Daemon presence (OpenClaw) rides a source-tagged sibling channel into
 │                       SceneState::daemons; reducer_task's presence/sweep arms are registry-driven
-│                       (daemon_sources()) so N daemons need no driver edit)
+│                       (daemon_sources()) so N daemons need no driver edit),
+│                       pipeline.rs (#714 — `spawn_pipeline(socket_path, roots…, connected, boot_caps)
+│                       -> Pipeline {scene_rx, health_rx, floor_caps, _source_handles}`: the ONE
+│                       source→reducer spine BOTH painters boot through — presence chan + exit watch →
+│                       build_source_set → event/scene/health chans → floor-caps atomics → reducer_task
+│                       + SourceManager::spawn_with_health; was hand-mirrored across run_async and
+│                       floating::run. boot_caps / socket_path / ConnectedSources stay CALLER-side (the
+│                       documented divergences: TUI measures the terminal, floating its window pixels;
+│                       both need socket/connected after boot). Needs an ambient tokio context
+│                       (run_async's block_on / floating's rt.enter). `_source_handles` must stay BOUND
+│                       at the call site — dropping the Pipeline kills the source tasks.
+│                       codecov-excluded like driver.rs)
 ├── init_pack.rs        extracts the embedded skeleton pack to a target dir for `init-pack`
 ├── validate.rs         the `validate-pack` presenter; pack.name/version are UNTRUSTED TOML strings (can
 │                       embed ESC/OSC via \u escapes), so every printed line routes through
@@ -366,8 +377,9 @@ src/
 │                         that detects "nothing changed".)
 ├── floating/           `pixtuoid floating` — the frameless, always-on-top DESKTOP WINDOW (winit + softbuffer,
 │                       binary-only; pixtuoid-core stays window-free, invariant #1). ALL floating-only source
-│                       lives here: mod.rs (run: reuses the SAME pipeline as the TUI — build_source_set [the
-│                       ONE source-construction site] + reducer_task, both relaxed to pub(crate) — spawned on
+│                       lives here: mod.rs (run: boots the SAME `runtime::pipeline::spawn_pipeline` spine
+│                       as the TUI (#714 — the old hand-mirrored wiring is gone; only window boot_caps,
+│                       socket resolution and ConnectedSources stay local) — spawned on
 │                       a bg runtime, NEVER block_on [winit owns the main thread]; an EventLoopProxy bridges
 │                       scene changes → redraw), offscreen.rs (OfficeRenderer — owns one
 │                       pixtuoid_scene::floor::FloorSession, the scene-owned painter session over the shared

--- a/crates/pixtuoid/src/floating/mod.rs
+++ b/crates/pixtuoid/src/floating/mod.rs
@@ -1,10 +1,9 @@
 //! `pixtuoid floating` — the frameless, always-on-top desktop window that renders the
 //! live office (every agent across every connected CLI) without opening the TUI.
 //!
-//! A binary-only front-end on the shared engine: it runs the SAME
-//! `source → reducer → SceneState` pipeline the TUI uses (reusing
-//! `runtime::driver::build_source_set` — the ONE source-construction site — and
-//! `reducer_task`), but presents each frame as a full-resolution
+//! A binary-only front-end on the shared engine: it boots the SAME
+//! `runtime::pipeline::spawn_pipeline` spine the TUI uses (source → reducer →
+//! SceneState; #714), but presents each frame as a full-resolution
 //! [`offscreen::OfficeRenderer`] `RgbBuffer` blitted into a `winit` +
 //! `softbuffer` window instead of half-block terminal cells. `pixtuoid-core` stays
 //! window-free (invariant #1) — all windowing lives here.
@@ -78,8 +77,8 @@ pub fn run(cfg: RunConfig) -> Result<()> {
     // (window::sync_floor_caps) agree — reusing the TUI's footer-subtracting,
     // scale-ignorant boot_capacities_for over-seeds and can strand a boot-race agent.
     let boot_caps = offscreen::boot_capacities_for_window(floating_cfg.width, floating_cfg.height);
-    // `_source_handles` must stay BOUND until `run` returns — dropping it
-    // drops the source tasks.
+    // The source tasks live on `rt` (kept alive to the end of `run`);
+    // `_source_handles` is an inert anchor (see Pipeline's doc).
     let crate::runtime::pipeline::Pipeline {
         scene_rx,
         health_rx,

--- a/crates/pixtuoid/src/floating/mod.rs
+++ b/crates/pixtuoid/src/floating/mod.rs
@@ -14,20 +14,11 @@ mod input;
 pub mod offscreen;
 mod window;
 
-use std::sync::atomic::AtomicUsize;
-use std::sync::Arc;
-
 use anyhow::{Context, Result};
 use pixtuoid_core::source::claude_code::ClaudeCodeSource;
-use pixtuoid_core::source::daemon;
-use pixtuoid_core::source::manager::SourceManager;
-use pixtuoid_core::state::{SceneState, MAX_FLOORS};
-use pixtuoid_core::{AgentEvent, Transport};
-use tokio::sync::{mpsc, watch};
 use winit::event_loop::EventLoop;
 
 use crate::config;
-use crate::runtime::driver::{build_source_set, reducer_task};
 use crate::runtime::{ConnectedSources, RunConfig};
 use window::{FloatingApp, FloatingEvent};
 
@@ -76,43 +67,31 @@ pub fn run(cfg: RunConfig) -> Result<()> {
     // (presence watch, source manager) have a runtime context. We never `block_on` here.
     let _guard = rt.enter();
 
-    // --- the live pipeline (mirrors runtime::driver::run_async; build_source_set is the
-    //     shared ONE source-construction site, reused not duplicated) ---
+    // --- the live pipeline: the SAME runtime::pipeline spine the TUI boots
+    //     (#714 — was a hand-mirrored copy of run_async's wiring). The
+    //     rt.enter() guard above provides the ambient runtime its spawns land
+    //     on; only the genuinely floating-specific pieces stay here. ---
     let connected = ConnectedSources::new(connected);
     let socket_path = socket.unwrap_or_else(ClaudeCodeSource::default_socket_path);
-    let (presence_tx, presence_rx) = mpsc::unbounded_channel();
-    let presence_exit_watch = daemon::spawn_presence_exit_watch(presence_tx.clone());
-    let sources = build_source_set(
-        socket_path,
-        projects_root,
-        codex_sessions_root,
-        Some(presence_tx),
-    );
-    let (tx, rx) =
-        mpsc::channel::<(Transport, AgentEvent)>(pixtuoid_core::source::EVENT_CHANNEL_CAPACITY);
     // Boot capacity from the WINDOW at the SAME geometry the window renders (office
     // buffer = window / office_scale, no footer) so the boot seed and the first redraw
     // (window::sync_floor_caps) agree — reusing the TUI's footer-subtracting,
     // scale-ignorant boot_capacities_for over-seeds and can strand a boot-race agent.
     let boot_caps = offscreen::boot_capacities_for_window(floating_cfg.width, floating_cfg.height);
-    let (scene_tx, scene_rx) = watch::channel(Arc::new(SceneState::new(boot_caps)));
-    let floor_caps: Arc<[AtomicUsize; MAX_FLOORS]> =
-        Arc::new(std::array::from_fn(|i| AtomicUsize::new(boot_caps[i])));
-    rt.spawn(reducer_task(
-        rx,
-        scene_tx,
-        Arc::clone(&floor_caps),
-        connected.clone(),
-        presence_rx,
-        presence_exit_watch,
-    ));
-    let (health_tx, health_rx) = watch::channel(Vec::new());
-    let mut manager = SourceManager::new();
-    for src in sources {
-        manager = manager.with_source(src);
-    }
-    // Held until `run` returns — dropping the handles would drop the source tasks.
-    let _source_handles = manager.spawn_with_health(tx, health_tx);
+    // `_source_handles` must stay BOUND until `run` returns — dropping it
+    // drops the source tasks.
+    let crate::runtime::pipeline::Pipeline {
+        scene_rx,
+        health_rx,
+        floor_caps,
+        _source_handles,
+    } = crate::runtime::pipeline::spawn_pipeline(
+        socket_path,
+        projects_root,
+        codex_sessions_root,
+        connected,
+        boot_caps,
+    );
 
     // --- the window event loop (main thread) ---
     let mut builder = EventLoop::<FloatingEvent>::with_user_event();

--- a/crates/pixtuoid/src/runtime/driver.rs
+++ b/crates/pixtuoid/src/runtime/driver.rs
@@ -90,8 +90,8 @@ async fn run_async(cfg: RunConfig) -> Result<()> {
     };
     // The shared spine (#714): presence channel + exit watch, the source set,
     // event/scene/health channels, floor-caps atomics, reducer + source task
-    // spawns — ONE authority with `floating::run`. `_source_handles` must stay
-    // BOUND to the end of this fn (dropping it drops the source tasks).
+    // spawns — ONE authority with `floating::run`. The tasks live on this
+    // fn's runtime; `_source_handles` is an inert anchor (see Pipeline's doc).
     let super::pipeline::Pipeline {
         scene_rx,
         health_rx,

--- a/crates/pixtuoid/src/runtime/driver.rs
+++ b/crates/pixtuoid/src/runtime/driver.rs
@@ -25,13 +25,12 @@ use pixtuoid_core::source::daemon::{self, PresenceMsg};
 use pixtuoid_core::source::grok::GrokSource;
 use pixtuoid_core::source::hook::HookRouter;
 use pixtuoid_core::source::jsonl::ChildEndUnclaims;
-use pixtuoid_core::source::manager::SourceManager;
 use pixtuoid_core::source::omp::OmpSource;
 use pixtuoid_core::source::registry;
 use pixtuoid_core::source::DynSource;
 use pixtuoid_core::state::MAX_FLOORS;
-use pixtuoid_core::{AgentEvent, Reducer, SceneState, TaggedReceiver, Transport};
-use tokio::sync::{mpsc, watch};
+use pixtuoid_core::{AgentEvent, Reducer, SceneState, TaggedReceiver};
+use tokio::sync::watch;
 
 use super::{
     boot_capacities_for, cap_boot_capacities, summarize, ConnectedSources, RunConfig, SceneRx,
@@ -76,31 +75,9 @@ async fn run_async(cfg: RunConfig) -> Result<()> {
     // The live, shared connected-source set: the reducer-task gate reads it, the
     // Sources panel mutates it. Seeded from the resolved boot flags.
     let connected = ConnectedSources::new(connected);
-    // The runtime source set, built in ONE place (`build_source_set`): the
-    // `HookRouter` (the shared-socket owner — every source's hooks ride it) plus
-    // the transcript-bearing watchers (CC / Antigravity / Codex / Copilot / omp).
-    // The hook-only sources (Reasonix / CodeWhale / opencode / Cursor / Hermes) and the daemon
-    // (OpenClaw) have no watchable JSONL — their payloads ride the router's socket,
-    // attributed per-payload by `_pixtuoid_source` — so they have no entry here.
     // Resolve the bound socket (Unix) / pipe (Windows) the HookRouter binds; the
     // Sources panel shows the same path (explicit --socket override, else default).
     let socket_path = socket.unwrap_or_else(ClaudeCodeSource::default_socket_path);
-    // Daemon-presence SIDE channel (invariant #2: NOT the AgentEvent channel). The
-    // HookRouter demux decodes daemon payloads into source-tagged presence deltas
-    // sent here; the shared exit watch drains gateway-pid deaths into the SAME
-    // channel as `(source, PidExited)`; the reducer task merges both into
-    // SceneState::daemons.
-    let (presence_tx, presence_rx) = tokio::sync::mpsc::unbounded_channel::<PresenceMsg>();
-    let presence_exit_watch = daemon::spawn_presence_exit_watch(presence_tx.clone());
-    let sources = build_source_set(
-        socket_path.clone(),
-        projects_root,
-        codex_sessions_root,
-        Some(presence_tx),
-    );
-
-    let (tx, rx) =
-        mpsc::channel::<(Transport, AgentEvent)>(pixtuoid_core::source::EVENT_CHANNEL_CAPACITY);
     let boot_caps: [usize; MAX_FLOORS] = match (desk_cap, headless) {
         // Headless: no terminal to measure. Honor the cap as-is, else the fallback.
         (Some(cap), true) => [cap; MAX_FLOORS],
@@ -111,31 +88,22 @@ async fn run_async(cfg: RunConfig) -> Result<()> {
         // an over-seed strands agents on non-existent desks until the terminal grows.
         (cap, false) => cap_boot_capacities(compute_boot_capacities(), cap),
     };
-    let (scene_tx, scene_rx) = watch::channel(Arc::new(SceneState::new(boot_caps)));
-
-    let floor_caps: Arc<[AtomicUsize; MAX_FLOORS]> =
-        Arc::new(std::array::from_fn(|i| AtomicUsize::new(boot_caps[i])));
-
-    tokio::spawn(reducer_task(
-        rx,
-        scene_tx,
-        Arc::clone(&floor_caps),
+    // The shared spine (#714): presence channel + exit watch, the source set,
+    // event/scene/health channels, floor-caps atomics, reducer + source task
+    // spawns — ONE authority with `floating::run`. `_source_handles` must stay
+    // BOUND to the end of this fn (dropping it drops the source tasks).
+    let super::pipeline::Pipeline {
+        scene_rx,
+        health_rx,
+        floor_caps,
+        _source_handles,
+    } = super::pipeline::spawn_pipeline(
+        socket_path.clone(),
+        projects_root,
+        codex_sessions_root,
         connected.clone(),
-        presence_rx,
-        presence_exit_watch,
-    ));
-
-    // Source-health side channel (#157): a fatal source exit must reach the
-    // TUI footer — in default TUI mode tracing only reaches the log file, and
-    // the office silently freezing is the worst failure class. Deliberately
-    // NOT an AgentEvent: the one event channel carries agent activity (its
-    // Transport tag drives hook-wins dedup), not source lifecycle.
-    let (health_tx, health_rx) = tokio::sync::watch::channel(Vec::new());
-    let mut manager = SourceManager::new();
-    for src in sources {
-        manager = manager.with_source(src);
-    }
-    let _source_handles = manager.spawn_with_health(tx, health_tx);
+        boot_caps,
+    );
 
     if headless {
         headless_loop(scene_rx, health_rx).await
@@ -431,6 +399,7 @@ fn compute_boot_capacities() -> [usize; MAX_FLOORS] {
 mod tests {
     use super::*;
     use pixtuoid_core::source::manager::SourceDeath;
+    use pixtuoid_core::Transport;
 
     type HealthPair = (
         watch::Sender<Vec<SourceDeath>>,

--- a/crates/pixtuoid/src/runtime/mod.rs
+++ b/crates/pixtuoid/src/runtime/mod.rs
@@ -5,6 +5,7 @@
 //! (issue #103).
 
 pub(crate) mod driver;
+pub(crate) mod pipeline;
 
 pub use driver::run;
 

--- a/crates/pixtuoid/src/runtime/pipeline.rs
+++ b/crates/pixtuoid/src/runtime/pipeline.rs
@@ -38,10 +38,12 @@ use tokio::task::JoinHandle;
 use super::driver::{build_source_set, reducer_task};
 use super::ConnectedSources;
 
-/// The live pipeline's caller-facing handles. `_source_handles` keeps the
-/// source tasks alive — destructure it into a `_source_handles` BINDING held
-/// for the painter's whole scope (both callers do), never into `..`/`_`,
-/// which would drop the tasks at the call site.
+/// The live pipeline's caller-facing handles. The spawned source tasks are
+/// kept alive by the caller's tokio RUNTIME (floating's `rt`, `run_async`'s
+/// `block_on`), not by `_source_handles` — dropping a tokio `JoinHandle`
+/// DETACHES the task, it doesn't stop it (this fn itself discards the
+/// reducer's handle). The field is a harmless anchor that also lets a future
+/// caller `.abort()`/join the sources.
 pub(crate) struct Pipeline {
     pub(crate) scene_rx: watch::Receiver<Arc<SceneState>>,
     pub(crate) health_rx: watch::Receiver<Vec<SourceDeath>>,

--- a/crates/pixtuoid/src/runtime/pipeline.rs
+++ b/crates/pixtuoid/src/runtime/pipeline.rs
@@ -1,0 +1,107 @@
+//! The ONE source→reducer pipeline spine both painters boot through (#714).
+//!
+//! `run_async` (TUI) and `floating::run` used to hand-mirror this glue line
+//! for line — a new channel or spawn had to be added to both files (the
+//! presence channel + exit watch historically were). The MECHANISM was
+//! already shared (`build_source_set`, `reducer_task`); this module owns the
+//! wiring between them. What deliberately STAYS caller-side, because the two
+//! painters genuinely diverge there:
+//! - **`boot_caps`**: the TUI measures the terminal (footer-subtracting,
+//!   cap-clamped, headless arms); floating measures its window pixels — a
+//!   documented sharp edge (reusing the TUI math over-seeds and strands
+//!   agents on non-existent desks), so the pipeline takes the seed as a
+//!   PARAMETER and must never compute it.
+//! - **socket resolution + `ConnectedSources`**: both values outlive the
+//!   boot (the Sources panel displays the path and mutates the live set), so
+//!   the callers own them and hand in a clone.
+//!
+//! Requires an ambient tokio runtime context — `run_async` executes inside
+//! `block_on`, floating holds an `rt.enter()` guard — so the `tokio::spawn`s
+//! here land on the caller's runtime either way.
+//!
+//! Like its two callers this is codecov-excluded async glue (#103): the win
+//! is ONE authority for the wiring, not new test surface — behavior stays
+//! pinned through the reducer/watcher/transport suites that drive the
+//! spawned halves.
+
+use std::path::PathBuf;
+use std::sync::atomic::AtomicUsize;
+use std::sync::Arc;
+
+use pixtuoid_core::source::daemon;
+use pixtuoid_core::source::manager::{SourceDeath, SourceManager};
+use pixtuoid_core::state::MAX_FLOORS;
+use pixtuoid_core::{AgentEvent, SceneState, Transport};
+use tokio::sync::{mpsc, watch};
+use tokio::task::JoinHandle;
+
+use super::driver::{build_source_set, reducer_task};
+use super::ConnectedSources;
+
+/// The live pipeline's caller-facing handles. `_source_handles` keeps the
+/// source tasks alive — destructure it into a `_source_handles` BINDING held
+/// for the painter's whole scope (both callers do), never into `..`/`_`,
+/// which would drop the tasks at the call site.
+pub(crate) struct Pipeline {
+    pub(crate) scene_rx: watch::Receiver<Arc<SceneState>>,
+    pub(crate) health_rx: watch::Receiver<Vec<SourceDeath>>,
+    pub(crate) floor_caps: Arc<[AtomicUsize; MAX_FLOORS]>,
+    pub(crate) _source_handles: Vec<JoinHandle<()>>,
+}
+
+/// Wire and spawn the whole live pipeline: presence channel + exit watch →
+/// [`build_source_set`] → event/scene/health channels → boot-seeded
+/// floor-caps atomics → [`reducer_task`] → `SourceManager::spawn_with_health`.
+pub(crate) fn spawn_pipeline(
+    socket_path: PathBuf,
+    projects_root: Option<PathBuf>,
+    codex_sessions_root: Option<PathBuf>,
+    connected: ConnectedSources,
+    boot_caps: [usize; MAX_FLOORS],
+) -> Pipeline {
+    // Daemon-presence SIDE channel (invariant #2: NOT the AgentEvent channel).
+    // The HookRouter demux decodes daemon payloads into source-tagged presence
+    // deltas sent here; the shared exit watch drains gateway-pid deaths into
+    // the SAME channel as `(source, PidExited)`; the reducer task merges both
+    // into SceneState::daemons.
+    let (presence_tx, presence_rx) = mpsc::unbounded_channel();
+    let presence_exit_watch = daemon::spawn_presence_exit_watch(presence_tx.clone());
+    let sources = build_source_set(
+        socket_path,
+        projects_root,
+        codex_sessions_root,
+        Some(presence_tx),
+    );
+
+    let (tx, rx) =
+        mpsc::channel::<(Transport, AgentEvent)>(pixtuoid_core::source::EVENT_CHANNEL_CAPACITY);
+    let (scene_tx, scene_rx) = watch::channel(Arc::new(SceneState::new(boot_caps)));
+    let floor_caps: Arc<[AtomicUsize; MAX_FLOORS]> =
+        Arc::new(std::array::from_fn(|i| AtomicUsize::new(boot_caps[i])));
+    tokio::spawn(reducer_task(
+        rx,
+        scene_tx,
+        Arc::clone(&floor_caps),
+        connected,
+        presence_rx,
+        presence_exit_watch,
+    ));
+
+    // Source-health side channel (#157): a fatal source exit must reach the
+    // painter's footer. Deliberately NOT an AgentEvent — the one event channel
+    // carries agent activity (its Transport tag drives hook-wins dedup), not
+    // source lifecycle.
+    let (health_tx, health_rx) = watch::channel(Vec::new());
+    let mut manager = SourceManager::new();
+    for src in sources {
+        manager = manager.with_source(src);
+    }
+    let _source_handles = manager.spawn_with_health(tx, health_tx);
+
+    Pipeline {
+        scene_rx,
+        health_rx,
+        floor_caps,
+        _source_handles,
+    }
+}


### PR DESCRIPTION
Closes #714. The per-line diff the issue demanded, done first: nine identical steps across the two `run` bodies, three real divergences (boot_caps derivation, socket resolution, `ConnectedSources`) — the nine move into `runtime::pipeline::spawn_pipeline(...) -> Pipeline`, the three stay caller-side exactly as the issue's sketch prescribed (boot_caps as a PARAMETER preserves the documented TUI-terminal vs floating-window-pixels sharp edge).

Key mechanics:
- Ambient-runtime spawns: `run_async` executes inside `block_on`; floating already holds `rt.enter()` — its explicit `rt.spawn` was equivalent and is deleted.
- `Pipeline._source_handles` must stay BOUND at the call site (dropping it kills the source tasks) — documented on the struct; both callers destructure into a held `_source_handles` binding, preserving today's exact lifetime.
- `build_source_set` / `reducer_task` stay in driver.rs with their tests and doc identity; the pipeline composes them.
- codecov: pipeline.rs added to the same #103 exclusion class as its callers.

Verification (the issue notes the module inherits no test-teeth, so dogfood is the gate): preflight green (2628 tests, incl. the driver wiring tests); **headless dogfood** against live `~/.claude/projects` — the new spine rendered this very session and its subagents as sprites and shut down cleanly on SIGINT; **floating dogfood** — window boots through the same spine, zero errors/panics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136n4TuNi2PC1hAiMYQPxHh