### PR TITLE
docs: extend English-only comment standard to the doc layer (2 CJK owner-quotes)

### DIFF
--- a/.claude/skills/procedural-lofi/SKILL.md
+++ b/.claude/skills/procedural-lofi/SKILL.md
@@ -220,4 +220,4 @@ every taste axis is a data table or named const with ONE home:
 
 Mix LANES stay instrument-blind (StemLevels/mixer/players never learn about voices) — a
 lane is a busy-ness ROLE, an instrument is a timbre WITHIN it. That split is what keeps
-"融入一些别的乐器" a minutes-scale edit instead of an arc.
+"blend in another instrument" a minutes-scale edit instead of an arc.

--- a/crates/pixtuoid-scene/CLAUDE.md
+++ b/crates/pixtuoid-scene/CLAUDE.md
@@ -73,8 +73,8 @@ src/                (the pixtuoid-scene crate root; default pack at ../sprites/d
 │                   the binary's audio/ gateway is the consumer, WebAudio can ride the same model later.
 │                   Since Phase 2 (musical stems) every StemLevels lane is AUDIBLE — the binary
 │                   synthesizes the frozen lofi compositions at startup and loops all six beds.
-│                   ALL-GENERATIVE SOUNDTRACK (owner decision 2026-07-20 — "所有的音乐都自动
-│                   生成"): TrackId {GenDay(seed), GenNight(seed)} + pure select_track(is_day,
+│                   ALL-GENERATIVE SOUNDTRACK (owner decision — all music is generated at
+│                   runtime): TrackId {GenDay(seed), GenNight(seed)} + pure select_track(is_day,
 │                   precip, track_epoch) ride AudioFrame — night hours (the SAME
 │                   pixel_painter::hour_is_day sun window the lighting renders) or any rain pick
 │                   the night MOOD; the compose seed is the audio::track_epoch block


### PR DESCRIPTION
Follow-up to #719 (which scoped to *code* comments). A hidden-inclusive sweep (`rg --hidden`, since `.github`/`.claude` are skipped by default) of every committed `.md` found exactly **two** CJK owner-quotes left in the doc layer:

- `crates/pixtuoid-scene/CLAUDE.md` — the ALL-GENERATIVE SOUNDTRACK tree entry's `"所有的音乐都自动生成"` → `"all music is generated at runtime"` (also dropped the bare decision-date, matching #719's final consistency pass).
- `.claude/skills/procedural-lofi/SKILL.md` — `"融入一些别的乐器"` → `"blend in another instrument"`.

After this, **zero CJK remains in any committed doc**. `docs/superpowers/` is git-ignored (local design records) and the `~/.claude` memory layer is outside the repo, so both are out of scope. No code touched — docs-only, no cargo/site gate surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136n4TuNi2PC1hAiMYQPxHh