### PR TITLE
refactor(site): share the wasm-Office driver across the two hero consumers (#721)

### DIFF
--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -366,6 +366,10 @@ would make browsers *ignore* `'unsafe-inline'`. Consequences to not "fix":
 - **`script-src` carries no `'unsafe-inline'`** — every inline script is
   whitelisted by content hash, recomputed on each build. Adding/editing an
   `is:inline` script needs NO manual CSP step.
+- **A hand-written `public/*.js` module loaded by URL** (`audio-worker.js` via
+  `new Worker`, `office-driver.js` via `import()`) rides `script-src 'self'` as
+  an EXTERNAL resource — it is not hashed and needs no CSP step; only its
+  runtime-loading `is:inline` caller is (auto-)rehashed when its content changes.
 - **`style-src` keeps `'unsafe-inline'` and must stay hash-free**: Shiki
   spans, the build-time mermaid SVG, and the few `style={}` attributes are
   inline style ATTRIBUTES, which hashes cannot express (one present hash

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -305,10 +305,17 @@ display-line authority (`starText`), unit-tested on its null-stars arm since
   stomp the single module-global `wasm`. A bounded retry (2×, 400ms backoff) wraps
   that shared init for transient wasm-fetch resilience, but stays INSIDE the one
   `__pixWasm` promise — a per-consumer retry would reintroduce the very
-  double-instantiate race above (the retry consts are pinned equal across the two
-  boot scripts by `config/wasm-init-consts.test.mjs`). On FINAL exhaustion the
-  promise is NULLED so a later-booting consumer re-attempts — safe because it only
-  clears a SETTLED (rejected) promise, never an in-flight one (#671). Schema: `kind:"live"`
+  double-instantiate race above. Since #721 that shared init AND the frame-memory
+  contract (`new Uint8ClampedArray(wasm.memory.buffer, office.frame_ptr(),
+  office.frame_len())`, re-read per frame) live ONCE in the runtime-loaded
+  **`public/office-driver.js`** module (`sharedWasm` / `officeFrameView`), which both
+  is:inline consumers dynamic-`import()` at boot (the audio-worker.js precedent — a
+  bundled `src/` import can't reach an is:inline script); the divergent blit stays
+  per-consumer (OfficeBackdrop's reveal-roll sits between the view read and the
+  `putImageData`). `config/wasm-init-consts.test.mjs` now pins that single source (the
+  consts live in office-driver.js and neither consumer re-inlines them). On FINAL
+  exhaustion the promise is NULLED so a later-booting consumer re-attempts — safe
+  because it only clears a SETTLED (rejected) promise, never an in-flight one (#671). Schema: `kind:"live"`
   + `variantGroups` (per-group `retint`) + `poster` + `timeSlider` in `showcase.json`,
   resolved by `showcaseGroups` in `consts.ts`, validated by the `astro.config.mjs`
   showcase guard's live branch. Fallback (no-JS / no-wasm / reduced-motion): the

--- a/site/config/wasm-init-consts.test.mjs
+++ b/site/config/wasm-init-consts.test.mjs
@@ -1,32 +1,34 @@
-// The bounded wasm-init retry lives in TWO is:inline scripts that share no JS
-// module scope — OfficeBackdrop's boot() and Showcase's bootCanvas() — so its
-// consts are duplicated by necessity (an is:inline script can't `import` a
-// shared const at runtime). Only ONE copy ever executes per page (the
-// `window.__pixWasm ||` short-circuit picks whichever consumer boots first), so
-// a drift is runtime-inert — but a one-sided retune would silently make the
-// retry budget depend on which consumer booted first. Pin the two copies equal
-// so the "keep in sync" comment is a fact, not a hope (the repo magic-number
-// convention: duplicated cross-boundary consts are pinned by a test, not a
-// comment alone).
+// The bounded wasm-init retry was once a byte-identical copy in TWO is:inline
+// scripts (OfficeBackdrop's boot() + Showcase's bootCanvas()), and this test
+// pinned the two copies equal. Since #721 the retry lives ONCE in the shared
+// public/office-driver.js module both consumers dynamic-import, so drift is
+// structurally impossible — the test now guards the single source: the consts
+// live in office-driver.js AND neither component re-inlines a copy (which would
+// silently reintroduce the drift class). Keeps the "one source" a fact, not a
+// hope (the repo convention: a cross-boundary invariant is pinned by a test).
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 const read = (rel) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)), 'utf8');
-const FILES = ['../src/components/OfficeBackdrop.astro', '../src/components/Showcase.astro'];
+const DRIVER = read('../public/office-driver.js');
+const CONSUMERS = ['../src/components/OfficeBackdrop.astro', '../src/components/Showcase.astro'];
 
 for (const name of ['WASM_INIT_RETRIES', 'WASM_INIT_BACKOFF_MS']) {
-  test(`${name} is identical across both wasm-init boot scripts`, () => {
-    const values = FILES.map((rel) => {
-      const m = read(rel).match(new RegExp(`const ${name} = (\\d+)`));
-      assert.ok(m, `${rel} must declare ${name}`);
-      return m[1];
-    });
-    assert.equal(
-      values[0],
-      values[1],
-      `${name} drifted between OfficeBackdrop.astro and Showcase.astro`
+  test(`${name} is declared once, in office-driver.js`, () => {
+    assert.ok(
+      new RegExp(`const ${name} = \\d+`).test(DRIVER),
+      `office-driver.js must declare ${name}`
     );
+  });
+
+  test(`${name} is not re-inlined in either live-office consumer`, () => {
+    for (const rel of CONSUMERS) {
+      assert.ok(
+        !read(rel).includes(name),
+        `${rel} re-inlined ${name} — it must ride the shared office-driver.js`
+      );
+    }
   });
 }

--- a/site/config/wasm-init-consts.test.mjs
+++ b/site/config/wasm-init-consts.test.mjs
@@ -24,9 +24,12 @@ for (const name of ['WASM_INIT_RETRIES', 'WASM_INIT_BACKOFF_MS']) {
   });
 
   test(`${name} is not re-inlined in either live-office consumer`, () => {
+    // Match a DECLARATION (`const NAME =`), not a bare mention — a comment
+    // cross-referencing the const by name must not spuriously red this in
+    // a codebase this comment-dense.
     for (const rel of CONSUMERS) {
       assert.ok(
-        !read(rel).includes(name),
+        !new RegExp(`const ${name}\\s*=`).test(read(rel)),
         `${rel} re-inlined ${name} — it must ride the shared office-driver.js`
       );
     }

--- a/site/knip.jsonc
+++ b/site/knip.jsonc
@@ -24,6 +24,9 @@
     // `new Worker(asset('audio-worker.js'))` from OfficeBackdrop.astro's
     // is:inline script — no static import for knip to trace.
     "public/audio-worker.js",
+    // The #721 shared wasm-Office driver: dynamic-`import()`ed at runtime from
+    // both live-office consumers' is:inline scripts — no static import to trace.
+    "public/office-driver.js",
     // The channel dial's documented FALLBACK: if the bare mono dial tests
     // weak on scannability, MonitorWall returns with one import + one grid
     // rule (OPEN FLOOR spec, Showcase section). Deliberately unimported.

--- a/site/public/office-driver.js
+++ b/site/public/office-driver.js
@@ -1,0 +1,61 @@
+// The shared wasm-`Office` driver for the two live-office hero consumers —
+// OfficeBackdrop's page-wide backdrop and Showcase's VIBING channel (#721).
+// Both are `is:inline` scripts (CSP-hashed), which the bundler doesn't process,
+// so they can't static-import a shared `src/` module — they dynamic-`import()`
+// this public ES module at boot instead (precedent: audio-worker.js, #705).
+// This single-sources the ONE wasm-init promise + the frame-memory contract
+// that were byte-identical copies across the two components.
+//
+// Both consumers boot the office OFF the render-critical path (OfficeBackdrop
+// via load→requestIdleCallback, Showcase via IntersectionObserver in-view), so
+// the extra same-origin import hop is not above-fold-critical; a transient
+// failure to fetch this module degrades to the poster through the caller's
+// existing `.catch`, exactly like a wasm-binary fetch failure.
+'use strict';
+
+const WASM_INIT_RETRIES = 2; // extra attempts after the first
+const WASM_INIT_BACKOFF_MS = 400;
+
+// The ONE memoized wasm-glue init both live-office consumers share. The
+// generated glue's `__wbg_init` memoizes only the RESOLVED instance, not an
+// in-flight promise, so two independent boots racing before either resolves
+// would instantiate two wasm instances and stomp the module-global `wasm`,
+// leaving whichever Office built against the loser reading the wrong linear
+// memory forever — so the promise is memoized on `window.__pixWasm` and every
+// consumer awaits the same instantiation. The bounded retry (a transient
+// ~874KB binary-fetch drop self-heals rather than stranding the office on the
+// poster) MUST stay INSIDE this one shared promise: a per-consumer retry would
+// reintroduce the double-instantiate race. On final exhaustion the promise
+// rejects (the deliberate no-wasm poster fallback); the caller nulls
+// `window.__pixWasm` in its own `.catch` so a later-booting consumer can retry
+// after a recovered outage (#671). Full rationale: site/CLAUDE.md VIBING entry.
+export function sharedWasm(wasmJsUrl) {
+  if (window.__pixWasm) return window.__pixWasm;
+  function attempt(left) {
+    return import(wasmJsUrl)
+      .then(function (m) {
+        return m.default().then(function () {
+          return m;
+        });
+      })
+      .catch(function (err) {
+        if (left <= 0) throw err;
+        return new Promise(function (res) {
+          setTimeout(res, WASM_INIT_BACKOFF_MS);
+        }).then(function () {
+          return attempt(left - 1);
+        });
+      });
+  }
+  window.__pixWasm = attempt(WASM_INIT_RETRIES);
+  return window.__pixWasm;
+}
+
+// The frame-memory contract: a fresh view over the office's RGBA frame buffer.
+// Re-read ptr AND len on EVERY frame — a resize / `memory.grow` reallocates and
+// invalidates any retained view (the frame_ptr contract). The caller checks
+// `view.length` against its ImageData before blitting (a resize can land
+// between this read and the paint).
+export function officeFrameView(office, wasm) {
+  return new Uint8ClampedArray(wasm.memory.buffer, office.frame_ptr(), office.frame_len());
+}

--- a/site/src/components/OfficeBackdrop.astro
+++ b/site/src/components/OfficeBackdrop.astro
@@ -389,6 +389,7 @@ import { asset, DIM_RESTING } from '../consts';
   define:vars={{
     wasmJsUrl: asset('wasm/pixtuoid_web.js'),
     audioWorkerUrl: asset('audio-worker.js'),
+    officeDriverUrl: asset('office-driver.js'),
   }}
 >
   (function () {
@@ -455,6 +456,7 @@ import { asset, DIM_RESTING } from '../consts';
 
     let office = null;
     let wasm = null;
+    let officeDriver = null; // { sharedWasm, officeFrameView } from office-driver.js (#721)
     let ctx2d = null;
     let img = null;
     let bufW = 0;
@@ -627,13 +629,10 @@ import { asset, DIM_RESTING } from '../consts';
     function paint(nowMs) {
       if (!img) return; // sizeBuffer bailed on a <1px viewport → no buffer to write (audit C17)
       office.step(nowMs, bufW, BUF_H);
-      // Re-read ptr/len EVERY frame (resize reallocates; memory.grow
-      // invalidates views) and copy into the reusable ImageData.
-      const view = new Uint8ClampedArray(
-        wasm.memory.buffer,
-        office.frame_ptr(),
-        office.frame_len()
-      );
+      // The frame-memory view (re-read ptr/len every frame — resize/memory.grow
+      // moves them) is single-sourced in office-driver.js. paint only runs
+      // after boot set officeDriver alongside office/wasm, so it's non-null here.
+      const view = officeDriver.officeFrameView(office, wasm);
       if (view.length !== img.data.length) return;
       // First good frame = engine is up: release the boot splash's Level-2 gate.
       markEngineResolved();
@@ -1206,41 +1205,18 @@ import { asset, DIM_RESTING } from '../consts';
       // Office built against the losing instance reading the wrong linear
       // memory forever. Memoize ONE shared init promise on `window` so every
       // consumer awaits the same instantiation (site/CLAUDE.md VIBING entry).
-      // A transient drop on the ~874KB wasm-binary fetch (a flaky link) used to
-      // strand the office on the poster until a manual reload — the rejected
-      // init promise was memoized on window and never retried. Retry
-      // import+instantiate a bounded number of times with backoff so a
-      // recoverable blip self-heals; on exhaustion the promise rejects → poster
-      // (the deliberate no-wasm fallback). Scope: this re-fetches the binary; a
-      // first-load GLUE-import() failure is import-map-cached and not covered.
-      // The retry MUST stay INSIDE this one shared promise — a per-consumer
-      // retry would reintroduce the double-instantiate race __pixWasm closes
-      // (site/CLAUDE.md, VIBING entry). Retry consts mirror Showcase.astro's
-      // bootCanvas(), pinned by config/wasm-init-consts.test.mjs.
-      window.__pixWasm =
-        window.__pixWasm ||
-        (function initSharedWasm() {
-          const WASM_INIT_RETRIES = 2; // extra attempts after the first
-          const WASM_INIT_BACKOFF_MS = 400;
-          function attempt(left) {
-            return import(wasmJsUrl)
-              .then(function (m) {
-                return m.default().then(function () {
-                  return m;
-                });
-              })
-              .catch(function (err) {
-                if (left <= 0) throw err;
-                return new Promise(function (res) {
-                  setTimeout(res, WASM_INIT_BACKOFF_MS);
-                }).then(function () {
-                  return attempt(left - 1);
-                });
-              });
-          }
-          return attempt(WASM_INIT_RETRIES);
-        })();
-      window.__pixWasm
+      // The init retry + the frame-memory contract are single-sourced in the
+      // shared office-driver.js module (#721 — was a byte-identical copy in
+      // Showcase.astro). Dynamic-import it (this is an is:inline script the
+      // bundler doesn't process, so no static import), then drive the ONE
+      // shared __pixWasm promise through drv.sharedWasm. A failed driver fetch
+      // falls through to the same poster .catch below — graceful, like a wasm
+      // fetch failure.
+      import(officeDriverUrl)
+        .then(function (drv) {
+          officeDriver = drv; // paint() reads drv.officeFrameView off this
+          return drv.sharedWasm(wasmJsUrl);
+        })
         .then(function (mod) {
           // __wbg_init is idempotent once resolved, so this just hands back
           // the already-instantiated exports (no second fetch/instantiate).

--- a/site/src/components/Showcase.astro
+++ b/site/src/components/Showcase.astro
@@ -142,7 +142,13 @@ const countWord = COUNT_WORDS[channels.length] ?? String(channels.length);
   </div>
 </section>
 
-<script is:inline define:vars={{ wasmJsUrl: asset('wasm/pixtuoid_web.js') }}>
+<script
+  is:inline
+  define:vars={{
+    wasmJsUrl: asset('wasm/pixtuoid_web.js'),
+    officeDriverUrl: asset('office-driver.js'),
+  }}
+>
   (function () {
     const studio = document.getElementById('studio');
     if (!studio) return;
@@ -266,6 +272,7 @@ const countWord = COUNT_WORDS[channels.length] ?? String(channels.length);
     const VIBING_SEED = 11; // fixed u32 — distinct from OfficeBackdrop's page office (seed 0)
     let vWasm = null;
     let vOffice = null;
+    let vDriver = null; // { sharedWasm, officeFrameView } from office-driver.js (#721)
     let vCtx = null;
     let vImg = null;
     let vRaf = 0;
@@ -308,12 +315,9 @@ const countWord = COUNT_WORDS[channels.length] ?? String(channels.length);
     function vPaint() {
       const now = anchorForHour(scrubHour) + (Date.now() - vStart);
       vOffice.step(now, vibingCanvas.width, vibingCanvas.height);
-      // re-read ptr/len every frame — a resize/memory.grow moves them
-      const view = new Uint8ClampedArray(
-        vWasm.memory.buffer,
-        vOffice.frame_ptr(),
-        vOffice.frame_len()
-      );
+      // frame-memory view (re-read every frame) single-sourced in
+      // office-driver.js; vPaint only runs after bootCanvas set vDriver.
+      const view = vDriver.officeFrameView(vOffice, vWasm);
       if (view.length !== vImg.data.length) return;
       vImg.data.set(view);
       vCtx.putImageData(vImg, 0, 0);
@@ -339,36 +343,17 @@ const countWord = COUNT_WORDS[channels.length] ?? String(channels.length);
       // resolves would instantiate two wasm instances and stomp the single
       // module-global `wasm` (see OfficeBackdrop.astro's `boot()` for the
       // full race + site/CLAUDE.md's VIBING entry).
-      // Bounded retry with backoff so a transient wasm-binary fetch drop
-      // self-heals instead of stranding the office on the poster until a manual
-      // reload — the retry MUST stay inside the one shared __pixWasm promise (a
-      // per-consumer retry would reintroduce the double-instantiate race). Full
-      // rationale: OfficeBackdrop.astro's boot() + site/CLAUDE.md; retry consts
-      // pinned by config/wasm-init-consts.test.mjs.
-      window.__pixWasm =
-        window.__pixWasm ||
-        (function initSharedWasm() {
-          const WASM_INIT_RETRIES = 2; // extra attempts after the first
-          const WASM_INIT_BACKOFF_MS = 400;
-          function attempt(left) {
-            return import(wasmJsUrl)
-              .then(function (m) {
-                return m.default().then(function () {
-                  return m;
-                });
-              })
-              .catch(function (err) {
-                if (left <= 0) throw err;
-                return new Promise(function (res) {
-                  setTimeout(res, WASM_INIT_BACKOFF_MS);
-                }).then(function () {
-                  return attempt(left - 1);
-                });
-              });
-          }
-          return attempt(WASM_INIT_RETRIES);
-        })();
-      window.__pixWasm
+      // The init retry + the frame-memory contract are single-sourced in the
+      // shared office-driver.js module (#721 — was a byte-identical copy in
+      // OfficeBackdrop.astro). Dynamic-import it (is:inline, so no static
+      // import), then drive the ONE shared __pixWasm promise through
+      // drv.sharedWasm. A failed driver fetch falls through to the poster
+      // .catch below, like a wasm fetch failure.
+      import(officeDriverUrl)
+        .then(function (drv) {
+          vDriver = drv; // vPaint() reads drv.officeFrameView off this
+          return drv.sharedWasm(wasmJsUrl);
+        })
         .then(function (mod) {
           // idempotent once resolved — hands back the shared exports/memory
           return mod.default().then(function (w) {


### PR DESCRIPTION
Closes #721. The `initSharedWasm` IIFE was **byte-identical** (verified line-for-line) across `OfficeBackdrop.astro` and `Showcase.astro`, and the frame-memory view (`new Uint8ClampedArray(wasm.memory.buffer, office.frame_ptr(), office.frame_len())` + length guard) was duplicated but — unlike the retry consts — **not structurally pinned**.

**Extraction** (per the issue's sketch): a runtime-loaded `public/office-driver.js` ES module (the `audio-worker.js` #705 precedent — is:inline scripts can't static-import a bundled `src/` module) exporting:
- `sharedWasm(wasmJsUrl)` — the ONE memoized `__pixWasm` bounded-retry init.
- `officeFrameView(office, wasm)` — the re-read-per-frame view (the frame contract in one place).

Both consumers dynamic-`import()` it at boot and drive through it. **OfficeBackdrop keeps its own reveal-roll blit** (it sits between the view read and `putImageData`), so only the *contract* is single-sourced, not the divergent blit.

**Verification lane** (the issue names this correctly — a blit mistake is a user-facing broken hero `tsc`/`eslint` can't catch): `just site-e2e` **89/89**, exercising both heroes' full boot→paint through the shared driver. `just site-check` green.

Notes: both consumers already boot the office **off the critical path** (OfficeBackdrop `load`→`requestIdleCallback`, Showcase IntersectionObserver), so the extra same-origin import hop isn't above-fold-critical; a failed driver fetch degrades to the poster through each caller's existing `.catch`. `wasm-init-consts.test.mjs` repurposed from *pin-two-copies-equal* → *guard-the-single-source* (consts in office-driver.js, neither consumer re-inlines). knip ignores the runtime-loaded module; `site/CLAUDE.md` VIBING entry reconciled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136n4TuNi2PC1hAiMYQPxHh