### PR TITLE
fix: make four quality oracles capable of failing, and fix what the first real readings found

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -26,3 +26,15 @@ path = "junit.xml"
 [[profile.default.overrides]]
 filter = 'test(_exits_zero_without_blocking) | test(_within_watchdog_bound)'
 threads-required = "num-cpus"
+
+# The connection-gate pair spawns a real `run --headless` and polls a wall-clock
+# BUDGET for it to reach a state (a sprite rendered, or the gate's drop line).
+# Same load-sensitivity class as the shim bounds above, one level up: the budget
+# is generous and both arms normally break out inside a second, but under a
+# saturated machine the child is starved and the budget expires — observed, both
+# arms red at 20s while a quiet run finishes in 0.98s. Exclusivity is nearly free
+# here precisely BECAUSE they exit on a positive signal rather than waiting out a
+# fixed timeout; raising the budget instead would only lengthen the failure path.
+[[profile.default.overrides]]
+filter = 'test(connected_codex_rollout_becomes_a_sprite) | test(disconnected_codex_rollout_is_dropped_by_the_gate)'
+threads-required = "num-cpus"

--- a/crates/pixtuoid-core/tests/CLAUDE.md
+++ b/crates/pixtuoid-core/tests/CLAUDE.md
@@ -36,6 +36,9 @@ tests/
 │   ├── liveness.rs           proof-of-life emission, negative vouch, instant exit (pid death), probe-failure no-ops
 │   ├── unclaim.rs            child-end un-claim: turn-N+1 re-register + in-flight multi-turn revival
 │   ├── sources.rs            Source::run glue (codex / antigravity / claude-code / copilot / omp bind+spawn)
+│   │                         + the ONE fixture→Reducer fold: a committed rollout driven through the real
+│   │                         reducer, asserting the ActivityState progression (conformance snapshots stop
+│   │                         at decoded events and never construct a Reducer, so no other test observes one)
 │   └── attach.rs             the mid-attach scenario suite (attach shows exactly the live set)
 ├── transport/main.rs         #[cfg(unix)] mod socket;  #[cfg(windows)] mod pipe;
 ├── render/main.rs            mod {blit, format}  +  render/fixtures/ (sprites)

--- a/crates/pixtuoid-core/tests/watcher/sources.rs
+++ b/crates/pixtuoid-core/tests/watcher/sources.rs
@@ -461,12 +461,9 @@ async fn omp_ended_transcript_is_gated_at_first_sight_and_a_live_one_seeds() {
 // never observes an `ActivityState`, so nothing in the suite has ever checked
 // that a real Codex rollout drives the state machine anywhere.
 //
-// That coverage existed only in `scripts/replay-fixture.sh`, a MANUAL script
-// whose success branch was `if ! grep -q ...; then echo; fi` — the `if` takes
-// its status from the `echo`, so it exited 0 unconditionally. It was also
-// reading the developer's real config, where an unconnected `codex` made the
-// driver drop every event. It therefore reported success for five weeks while
-// producing no agent at all. A script nobody can fail is not coverage.
+// That coverage lived only in a MANUAL script that was structurally incapable
+// of failing, so it reported success while producing no agent at all. A check
+// nobody can fail is not coverage; this is why the assertion belongs in a test.
 #[tokio::test]
 async fn codex_permission_flow_fixture_drives_the_reducer_through_waiting() {
     use pixtuoid_core::state::ActivityState;
@@ -517,8 +514,12 @@ async fn codex_permission_flow_fixture_drives_the_reducer_through_waiting() {
                 }
             }
             // A quiet gap once the whole file has been folded: the fixture is
-            // finite, so this is the normal exit, not a timeout failure.
-            Ok(None) | Err(_) if !states.is_empty() => break,
+            // finite, so this is the normal exit, not a timeout failure. A
+            // CLOSED channel ends the loop unconditionally — guarding it on
+            // `states` would spin at full CPU until the deadline on the very
+            // path where nothing more can arrive.
+            Ok(None) => break,
+            Err(_) if !states.is_empty() => break,
             _ => {}
         }
     }
@@ -536,23 +537,44 @@ async fn codex_permission_flow_fixture_drives_the_reducer_through_waiting() {
         "label derives from the session_meta cwd basename"
     );
 
+    // ORDER, not mere presence. Two `any()` checks would also pass for a reducer
+    // that parked the agent on the permission prompt BEFORE the tool ran, or one
+    // that left it Waiting after the fixture's task_complete — neither of which
+    // is the permission flow this scenario is named for.
+    let idx = |want: &str| {
+        states.iter().position(|s| {
+            matches!(
+                (s, want),
+                (ActivityState::Idle, "idle")
+                    | (ActivityState::Active { .. }, "active")
+                    | (ActivityState::Waiting { .. }, "waiting")
+            )
+        })
+    };
+    let (first_active, first_waiting) = (idx("active"), idx("waiting"));
     assert!(
         matches!(states.first(), Some(ActivityState::Idle)),
         "registration lands Idle, got {states:?}"
     );
     assert!(
-        states
-            .iter()
-            .any(|s| matches!(s, ActivityState::Active { .. })),
+        first_active.is_some(),
         "the fixture's function_call must drive Active, got {states:?}"
     );
     // THE point of this scenario: an escalation-requiring exec_command parks the
     // agent on a permission prompt. This is the only state in the progression a
     // decoder-level test can't reach — it is a reducer decision.
     assert!(
-        states
-            .iter()
-            .any(|s| matches!(s, ActivityState::Waiting { .. })),
+        first_waiting.is_some(),
         "the escalated exec_command must drive Waiting(permission), got {states:?}"
+    );
+    assert!(
+        first_active < first_waiting,
+        "Active must precede Waiting — the tool runs, THEN the gate parks it: {states:?}"
+    );
+    // The terminal state: the fixture ends on task_complete, so the permission
+    // gate must have been resolved rather than left latched.
+    assert!(
+        !matches!(states.last(), Some(ActivityState::Waiting { .. })),
+        "the agent must not still be Waiting after task_complete, got {states:?}"
     );
 }

--- a/crates/pixtuoid-core/tests/watcher/sources.rs
+++ b/crates/pixtuoid-core/tests/watcher/sources.rs
@@ -454,3 +454,105 @@ async fn omp_ended_transcript_is_gated_at_first_sight_and_a_live_one_seeds() {
         handle.abort();
     }
 }
+
+// The COMMITTED permission-flow fixture, folded through the REAL `Reducer` —
+// the assertion `codex_source_run_emits_events_from_rollout` above cannot make.
+// That test stops at "an ActivityStart arrived" over two inline JSON lines; it
+// never observes an `ActivityState`, so nothing in the suite has ever checked
+// that a real Codex rollout drives the state machine anywhere.
+//
+// That coverage existed only in `scripts/replay-fixture.sh`, a MANUAL script
+// whose success branch was `if ! grep -q ...; then echo; fi` — the `if` takes
+// its status from the `echo`, so it exited 0 unconditionally. It was also
+// reading the developer's real config, where an unconnected `codex` made the
+// driver drop every event. It therefore reported success for five weeks while
+// producing no agent at all. A script nobody can fail is not coverage.
+#[tokio::test]
+async fn codex_permission_flow_fixture_drives_the_reducer_through_waiting() {
+    use pixtuoid_core::state::ActivityState;
+    use pixtuoid_core::{Reducer, SceneState};
+
+    fast_watch();
+    let dir = TempDir::new().unwrap();
+    let sessions_root = dir.path().to_path_buf();
+
+    // `codex_id_from_path` keys on the filename's trailing UUID, so the replay
+    // name (not the fixture's own) is what identifies the session.
+    let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/sources/fixtures/codex/permission-flow")
+        .join("rollout-2026-01-01T00-00-00-01000000-0000-7000-8000-000000000001.jsonl");
+    let body = std::fs::read_to_string(&fixture).expect("committed permission-flow fixture");
+    let transcript = sessions_root
+        .join("rollout-2026-01-01T00-00-00-0a0a0a0a-0b0b-0c0c-0d0d-0e0e0e0e0e0e.jsonl");
+
+    let (tx, mut rx) = mpsc::channel::<(Transport, AgentEvent)>(64);
+    let src = CodexSource {
+        sessions_root,
+        child_end_unclaims: None,
+    };
+    let handle = tokio::spawn(async move { Box::new(src).run(tx).await });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Written in one shot: first sight reads the whole file from the top, so the
+    // events arrive in file order without a per-line sleep to make this flaky.
+    tokio::fs::write(&transcript, &body).await.unwrap();
+
+    // `SceneState::uniform` — NOT `default()`, whose all-zero floor_capacities
+    // make `total_capacity()` 0 so `register_slot` refuses every SessionStart
+    // and the scene stays silently empty.
+    let mut scene = SceneState::uniform(8);
+    let mut reducer = Reducer::new();
+    let mut states: Vec<ActivityState> = Vec::new();
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    while tokio::time::Instant::now() < deadline {
+        match tokio::time::timeout(Duration::from_millis(300), rx.recv()).await {
+            Ok(Some((transport, ev))) => {
+                reducer.apply(&mut scene, ev, std::time::SystemTime::now(), transport);
+                if let Some(slot) = scene.agents.values().next() {
+                    // Distinct-consecutive, mirroring what the replay printed.
+                    if states.last() != Some(&slot.state) {
+                        states.push(slot.state.clone());
+                    }
+                }
+            }
+            // A quiet gap once the whole file has been folded: the fixture is
+            // finite, so this is the normal exit, not a timeout failure.
+            Ok(None) | Err(_) if !states.is_empty() => break,
+            _ => {}
+        }
+    }
+    handle.abort();
+
+    let slot = scene
+        .agents
+        .values()
+        .next()
+        .expect("the rollout must register exactly one cx· agent");
+    assert_eq!(scene.agents.len(), 1, "one rollout is one agent");
+    assert_eq!(
+        &*slot.label.text(),
+        "cx·demo-project",
+        "label derives from the session_meta cwd basename"
+    );
+
+    assert!(
+        matches!(states.first(), Some(ActivityState::Idle)),
+        "registration lands Idle, got {states:?}"
+    );
+    assert!(
+        states
+            .iter()
+            .any(|s| matches!(s, ActivityState::Active { .. })),
+        "the fixture's function_call must drive Active, got {states:?}"
+    );
+    // THE point of this scenario: an escalation-requiring exec_command parks the
+    // agent on a permission prompt. This is the only state in the progression a
+    // decoder-level test can't reach — it is a reducer decision.
+    assert!(
+        states
+            .iter()
+            .any(|s| matches!(s, ActivityState::Waiting { .. })),
+        "the escalated exec_command must drive Waiting(permission), got {states:?}"
+    );
+}

--- a/crates/pixtuoid/src/runtime/driver.rs
+++ b/crates/pixtuoid/src/runtime/driver.rs
@@ -220,6 +220,8 @@ pub(crate) async fn reducer_task(
     // Disabled once the presence channel closes (all senders dropped) so its
     // `recv() -> None` branch can't busy-loop the select.
     let mut presence_open = true;
+    // Sources already announced as gated (see the connection gate below).
+    let mut gate_logged: std::collections::HashSet<String> = std::collections::HashSet::new();
     let initial_caps: [usize; MAX_FLOORS] =
         std::array::from_fn(|i| floor_caps[i].load(Ordering::Relaxed));
     let mut scene = SceneState::new(initial_caps);
@@ -239,7 +241,17 @@ pub(crate) async fn reducer_task(
                 let now = SystemTime::now();
                 // Connection gate: drop a disconnected source's events before
                 // they register/refresh a sprite. No scene change → no send.
-                if event_source(&scene, &ev).is_some_and(|src| !connected.is_connected(src)) {
+                //
+                // Logged ONCE PER SOURCE, because this `continue` sits above the
+                // only `debug!` below: a gated source otherwise emits zero lines
+                // at every log level, so "connected, but no sprite" and "not
+                // connected" are indistinguishable from the outside. That cost a
+                // full replay-harness misdiagnosis. Per-source, never per-event —
+                // a disconnected watcher streams events indefinitely.
+                if let Some(src) = event_source(&scene, &ev).filter(|s| !connected.is_connected(s)) {
+                    if gate_logged.insert(src.to_string()) {
+                        tracing::debug!(source = src, "dropping events: source not connected");
+                    }
                     continue;
                 }
                 tracing::debug!(?transport, ?ev, "event");

--- a/crates/pixtuoid/src/runtime/driver.rs
+++ b/crates/pixtuoid/src/runtime/driver.rs
@@ -220,8 +220,14 @@ pub(crate) async fn reducer_task(
     // Disabled once the presence channel closes (all senders dropped) so its
     // `recv() -> None` branch can't busy-loop the select.
     let mut presence_open = true;
-    // Sources already announced as gated (see the connection gate below).
-    let mut gate_logged: std::collections::HashSet<String> = std::collections::HashSet::new();
+    // Registered sources already announced as gated (see the connection gate).
+    // Bounded by the registry, NOT by the wire: `_pixtuoid_source` arrives
+    // verbatim from socket JSON with no registry check and no length cap, and an
+    // unknown name is a supported, tested decode path — so keying this on the
+    // raw string would let a long-lived `run` accumulate one entry per distinct
+    // name seen. An unregistered source is a DRIFT story, not a connection-gate
+    // one, and `source/drift.rs` already owns it.
+    let mut gate_logged: std::collections::HashSet<&'static str> = std::collections::HashSet::new();
     let initial_caps: [usize; MAX_FLOORS] =
         std::array::from_fn(|i| floor_caps[i].load(Ordering::Relaxed));
     let mut scene = SceneState::new(initial_caps);
@@ -242,15 +248,20 @@ pub(crate) async fn reducer_task(
                 // Connection gate: drop a disconnected source's events before
                 // they register/refresh a sprite. No scene change → no send.
                 //
-                // Logged ONCE PER SOURCE, because this `continue` sits above the
-                // only `debug!` below: a gated source otherwise emits zero lines
-                // at every log level, so "connected, but no sprite" and "not
-                // connected" are indistinguishable from the outside. That cost a
-                // full replay-harness misdiagnosis. Per-source, never per-event —
-                // a disconnected watcher streams events indefinitely.
+                // Announced once per registered source, because this `continue`
+                // sits above the only `debug!` below: without it a gated source
+                // emits zero lines at every log level, making "connected but no
+                // sprite" indistinguishable from "not connected" — the two
+                // hypotheses a reader most needs to separate. Per-source, never
+                // per-event: a disconnected watcher streams indefinitely.
                 if let Some(src) = event_source(&scene, &ev).filter(|s| !connected.is_connected(s)) {
-                    if gate_logged.insert(src.to_string()) {
-                        tracing::debug!(source = src, "dropping events: source not connected");
+                    if let Some(known) = registry::descriptor_for(src) {
+                        if gate_logged.insert(known.name) {
+                            tracing::debug!(
+                                source = known.name,
+                                "dropping events: source not connected"
+                            );
+                        }
                     }
                     continue;
                 }

--- a/crates/pixtuoid/tests/cli_json.rs
+++ b/crates/pixtuoid/tests/cli_json.rs
@@ -1,7 +1,22 @@
-//! End-to-end golden for the `sources --json` CLI contract (the shape the Raycast
-//! extension parses). Runs the REAL `pixtuoid` binary — exercising clap parse →
-//! `sources::status` → the JSON presenter → stdout — which the in-process
-//! `source_status_*` unit tests (struct shape + committed schema) never cover.
+//! Process-level contracts of the REAL `pixtuoid` binary — anything that only
+//! holds once clap, config resolution, and the runtime are wired together, which
+//! no in-process test can reach.
+//!
+//! SCOPE NOTE: this file began as the `sources --json` golden alone and was
+//! widened deliberately. The second contract here is the CONNECTION GATE, which
+//! is process-level by nature: it is the composition of `resolve_connected`
+//! (config) with `reducer_task`'s per-event drop (runtime), and each half is
+//! individually correct while the composition silently ate every Codex event for
+//! five weeks. Keep new tests here to that bar — a contract that needs the real
+//! process — rather than letting this become a general binary-test dumping
+//! ground.
+//!
+//! 1. `sources --json` — the shape the Raycast extension parses. Exercises clap
+//!    parse → `sources::status` → the JSON presenter → stdout, which the
+//!    in-process `source_status_*` unit tests (struct shape + committed schema)
+//!    never cover.
+//! 2. The connection gate end-to-end — a real rollout dripped into a real
+//!    `run --headless` appears as a sprite iff its source is connected.
 //!
 //! Determinism: each source's `connected`/`cli_present` is a function of whether
 //! it is target-bearing (probed absent in an empty HOME → disconnected) or
@@ -91,5 +106,122 @@ fn a_failing_connect_emits_the_outcome_rows_and_exits_nonzero() {
     assert_eq!(
         rows[0]["outcome"], "failed",
         "a blocked install surfaces as `failed`, never a clean success: {rows:?}"
+    );
+}
+
+// ── the connection gate, end to end ─────────────────────────────────────────
+
+/// Run a headless pixtuoid against an isolated everything, drip a real Codex
+/// rollout into its sessions root, and return whatever it printed.
+///
+/// `sources_toml` is the `[sources]` body — the ONLY difference between the two
+/// arms below, so any behaviour difference is attributable to it alone.
+fn headless_replay(sources_toml: &str, settle: std::time::Duration) -> String {
+    use std::io::Write;
+
+    let home = tempfile::tempdir().expect("home");
+    let cfg = tempfile::tempdir().expect("config");
+    let sessions = tempfile::tempdir().expect("sessions");
+    let projects = tempfile::tempdir().expect("projects");
+    let out = tempfile::NamedTempFile::new().expect("stdout file");
+
+    std::fs::create_dir_all(cfg.path().join("pixtuoid")).unwrap();
+    std::fs::write(
+        cfg.path().join("pixtuoid/config.toml"),
+        format!("[sources]\n{sources_toml}"),
+    )
+    .unwrap();
+
+    // Isolate the SOCKET too, and not merely for hygiene: on the default socket
+    // a real CC session's hook traffic on the developer's machine lands in this
+    // run's scene, and the negative arm would see a sprite unrelated to Codex.
+    let sock = home.path().join("hook.sock");
+
+    let mut child = std::process::Command::new(env!("CARGO_BIN_EXE_pixtuoid"))
+        .args(["run", "--headless"])
+        .arg("--codex-sessions-root")
+        .arg(sessions.path())
+        .arg("--projects-root")
+        .arg(projects.path())
+        .args(["--log-level", "error"])
+        .env_clear()
+        .env("HOME", home.path())
+        .env("PATH", "/usr/bin:/bin")
+        .env("XDG_CONFIG_HOME", cfg.path())
+        .env("PIXTUOID_SOCKET", &sock)
+        .stdout(out.reopen().expect("stdout handle"))
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn pixtuoid run --headless");
+
+    // Let the watcher bind before the first write, so the rollout arrives as an
+    // append rather than being present at first sight — the path the replay
+    // harness exercises, and the one that broke.
+    std::thread::sleep(std::time::Duration::from_millis(800));
+
+    let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../pixtuoid-core/tests/sources/fixtures/codex/permission-flow")
+        .join("rollout-2026-01-01T00-00-00-01000000-0000-7000-8000-000000000001.jsonl");
+    let body = std::fs::read_to_string(&fixture).expect("committed permission-flow fixture");
+    let mut f = std::fs::File::create(
+        sessions
+            .path()
+            .join("rollout-2026-01-01T00-00-00-0a0a0a0a-0b0b-0c0c-0d0d-0e0e0e0e0e0e.jsonl"),
+    )
+    .unwrap();
+    f.write_all(body.as_bytes()).unwrap();
+    f.sync_all().unwrap();
+    drop(f);
+
+    // Poll rather than sleeping the whole budget: the positive arm settles well
+    // under a second, so only the negative arm pays the full wait.
+    let deadline = std::time::Instant::now() + settle;
+    let mut seen = String::new();
+    while std::time::Instant::now() < deadline {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        seen = std::fs::read_to_string(out.path()).unwrap_or_default();
+        if seen.contains("cx·") {
+            break;
+        }
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+    seen
+}
+
+/// A connected source's rollout becomes a sprite. This is the assertion the
+/// manual `scripts/replay-fixture.sh` was the only carrier for — and it exited 0
+/// unconditionally (`if ! grep -q ...; then echo; fi` takes the `if` from the
+/// `echo`), so it reported success for five weeks while producing no agent.
+#[test]
+fn connected_codex_rollout_becomes_a_sprite() {
+    let out = headless_replay("codex = true\n", std::time::Duration::from_secs(20));
+    assert!(
+        out.contains("cx·"),
+        "a connected Codex rollout must render a cx· sprite; headless printed:\n{out}"
+    );
+}
+
+/// The same rollout with the flag absent renders NOTHING — `resolve_connected`
+/// treats a missing key as disconnected (0.12.0 dropped the install-state
+/// inference) and `reducer_task` drops the events before the reducer.
+///
+/// This half is why the replay harness broke: it read the developer's real
+/// config, where `codex` is simply not in `[sources]`, so it silently exercised
+/// THIS arm while asserting the one above.
+#[test]
+fn disconnected_codex_rollout_renders_nothing() {
+    // No early-exit path here, so this arm pays the full budget — kept small
+    // deliberately; the positive arm is what proves the wait is long enough for
+    // a sprite to appear at all.
+    let out = headless_replay("claude-code = true\n", std::time::Duration::from_secs(6));
+    assert!(
+        !out.contains("cx·"),
+        "a DISCONNECTED Codex rollout must render no sprite; headless printed:\n{out}"
+    );
+    assert!(
+        out.contains("agents=[]"),
+        "the headless summary should still be running and reporting an empty scene:\n{out}"
     );
 }

--- a/crates/pixtuoid/tests/cli_json.rs
+++ b/crates/pixtuoid/tests/cli_json.rs
@@ -5,11 +5,11 @@
 //! SCOPE NOTE: this file began as the `sources --json` golden alone and was
 //! widened deliberately. The second contract here is the CONNECTION GATE, which
 //! is process-level by nature: it is the composition of `resolve_connected`
-//! (config) with `reducer_task`'s per-event drop (runtime), and each half is
-//! individually correct while the composition silently ate every Codex event for
-//! five weeks. Keep new tests here to that bar — a contract that needs the real
-//! process — rather than letting this become a general binary-test dumping
-//! ground.
+//! (config) with `reducer_task`'s per-event drop (runtime). Each half is
+//! individually correct and the composition still silently ate every Codex
+//! event, which no in-process test could observe. Keep new tests to that bar —
+//! a contract that genuinely needs the real process — rather than letting this
+//! become a general binary-test dumping ground.
 //!
 //! 1. `sources --json` — the shape the Raycast extension parses. Exercises clap
 //!    parse → `sources::status` → the JSON presenter → stdout, which the
@@ -111,19 +111,62 @@ fn a_failing_connect_emits_the_outcome_rows_and_exits_nonzero() {
 
 // ── the connection gate, end to end ─────────────────────────────────────────
 
-/// Run a headless pixtuoid against an isolated everything, drip a real Codex
-/// rollout into its sessions root, and return whatever it printed.
+/// The gate's own announcement, from `runtime/driver.rs`'s reducer_task. Paired
+/// by this literal because an integration test cannot see a `pub(crate)` const
+/// and the message is not worth widening the API for; the negative arm below is
+/// what fails if the two drift apart.
+const GATE_DROP_MSG: &str = "dropping events: source not connected";
+
+/// Everything a caller needs to tell "the gate kept the scene empty" apart from
+/// "the replay never happened" — an assertion of ABSENCE is only evidence when
+/// the thing that should have produced presence demonstrably reached the code.
+struct Replay {
+    /// The child's stdout: the `agents=[…]` summary lines.
+    out: String,
+    /// The child's stderr, captured to its OWN file. Headless routes tracing to
+    /// stderr, so this carries the gate's announcement; and discarding it would
+    /// make a binary that died at startup indistinguishable from one that ran
+    /// and rendered nothing. It must not share `out`'s file: two handles on one
+    /// `NamedTempFile` keep independent offsets and overwrite each other.
+    err: String,
+    /// Whether the fixture is readable under the WATCHED sessions root.
+    fixture_landed: bool,
+}
+
+/// `Child::drop` neither kills nor waits, so any panic between spawn and the
+/// explicit kill would orphan a `run --headless` loop — which exits only on
+/// Ctrl-C — reparented to init and writing to an already-deleted temp file.
+struct Reaped(std::process::Child);
+
+impl Drop for Reaped {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// Run a headless pixtuoid against an isolated everything and drip a real Codex
+/// rollout into its sessions root.
 ///
-/// `sources_toml` is the `[sources]` body — the ONLY difference between the two
-/// arms below, so any behaviour difference is attributable to it alone.
-fn headless_replay(sources_toml: &str, settle: std::time::Duration) -> String {
+/// `sources_toml` is the `[sources]` body and the ONLY difference between the
+/// two arms below, so any behavioural difference is attributable to it alone —
+/// which is why the log level is fixed here rather than varied per arm.
+fn headless_replay(sources_toml: &str, budget: std::time::Duration) -> Replay {
     use std::io::Write;
+
+    // Read the fixture BEFORE spawning: it has no dependency on the child, and
+    // read-then-spawn keeps the panic off the far side of the kill.
+    let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../pixtuoid-core/tests/sources/fixtures/codex/permission-flow")
+        .join("rollout-2026-01-01T00-00-00-01000000-0000-7000-8000-000000000001.jsonl");
+    let body = std::fs::read_to_string(&fixture).expect("committed permission-flow fixture");
 
     let home = tempfile::tempdir().expect("home");
     let cfg = tempfile::tempdir().expect("config");
     let sessions = tempfile::tempdir().expect("sessions");
     let projects = tempfile::tempdir().expect("projects");
     let out = tempfile::NamedTempFile::new().expect("stdout file");
+    let err = tempfile::NamedTempFile::new().expect("stderr file");
 
     std::fs::create_dir_all(cfg.path().join("pixtuoid")).unwrap();
     std::fs::write(
@@ -133,95 +176,131 @@ fn headless_replay(sources_toml: &str, settle: std::time::Duration) -> String {
     .unwrap();
 
     // Isolate the SOCKET too, and not merely for hygiene: on the default socket
-    // a real CC session's hook traffic on the developer's machine lands in this
+    // a live CC session's hook traffic on the developer's machine lands in this
     // run's scene, and the negative arm would see a sprite unrelated to Codex.
     let sock = home.path().join("hook.sock");
 
-    let mut child = std::process::Command::new(env!("CARGO_BIN_EXE_pixtuoid"))
+    // `debug` is required, not incidental: the gate's announcement is the only
+    // observable proof of WHY a scene stayed empty, and headless floors nothing
+    // (unlike TUI mode, which caps at warn).
+    let child = std::process::Command::new(env!("CARGO_BIN_EXE_pixtuoid"))
         .args(["run", "--headless"])
         .arg("--codex-sessions-root")
         .arg(sessions.path())
         .arg("--projects-root")
         .arg(projects.path())
-        .args(["--log-level", "error"])
+        .args(["--log-level", "debug"])
         .env_clear()
         .env("HOME", home.path())
         .env("PATH", "/usr/bin:/bin")
         .env("XDG_CONFIG_HOME", cfg.path())
         .env("PIXTUOID_SOCKET", &sock)
         .stdout(out.reopen().expect("stdout handle"))
-        .stderr(std::process::Stdio::null())
+        .stderr(err.reopen().expect("stderr handle"))
         .spawn()
         .expect("spawn pixtuoid run --headless");
+    let mut child = Reaped(child);
 
-    // Let the watcher bind before the first write, so the rollout arrives as an
-    // append rather than being present at first sight — the path the replay
-    // harness exercises, and the one that broke.
-    std::thread::sleep(std::time::Duration::from_millis(800));
+    // Give the watcher a moment to bind. Deliberately short: the rollout is
+    // picked up whether it arrives as an append or is already present at first
+    // sight, so this is startup slack, not a path selector.
+    std::thread::sleep(std::time::Duration::from_millis(200));
 
-    let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../pixtuoid-core/tests/sources/fixtures/codex/permission-flow")
-        .join("rollout-2026-01-01T00-00-00-01000000-0000-7000-8000-000000000001.jsonl");
-    let body = std::fs::read_to_string(&fixture).expect("committed permission-flow fixture");
-    let mut f = std::fs::File::create(
-        sessions
-            .path()
-            .join("rollout-2026-01-01T00-00-00-0a0a0a0a-0b0b-0c0c-0d0d-0e0e0e0e0e0e.jsonl"),
-    )
-    .unwrap();
+    let landed = sessions
+        .path()
+        .join("rollout-2026-01-01T00-00-00-0a0a0a0a-0b0b-0c0c-0d0d-0e0e0e0e0e0e.jsonl");
+    let mut f = std::fs::File::create(&landed).unwrap();
     f.write_all(body.as_bytes()).unwrap();
     f.sync_all().unwrap();
     drop(f);
 
-    // Poll rather than sleeping the whole budget: the positive arm settles well
-    // under a second, so only the negative arm pays the full wait.
-    let deadline = std::time::Instant::now() + settle;
-    let mut seen = String::new();
+    // Poll until the run has DECIDED — a sprite rendered, or the gate announced
+    // the drop. Both arms therefore exit on a POSITIVE signal and share one
+    // budget; neither waits out a fixed timeout to conclude an absence.
+    // `if let Ok` rather than `unwrap_or_default`: a torn read mid-write must
+    // not blank an already-good buffer ("·" is two bytes).
+    let deadline = std::time::Instant::now() + budget;
+    let (mut seen_out, mut seen_err) = (String::new(), String::new());
     while std::time::Instant::now() < deadline {
         std::thread::sleep(std::time::Duration::from_millis(100));
-        seen = std::fs::read_to_string(out.path()).unwrap_or_default();
-        if seen.contains("cx·") {
+        if let Ok(s) = std::fs::read_to_string(out.path()) {
+            seen_out = s;
+        }
+        if let Ok(s) = std::fs::read_to_string(err.path()) {
+            seen_err = s;
+        }
+        // Each arm waits for ALL the evidence it will assert, not just its
+        // first signal: the gate announces the drop before the summary loop has
+        // printed its first line, so breaking on the announcement alone returns
+        // an empty stdout and reds the very assertion it was meant to satisfy.
+        let rendered = seen_out.contains("cx·");
+        let gated = seen_err.contains(GATE_DROP_MSG) && seen_out.contains("agents=[");
+        if rendered || gated {
             break;
         }
     }
 
-    let _ = child.kill();
-    let _ = child.wait();
-    seen
+    let _ = child.0.kill();
+    let _ = child.0.wait();
+    Replay {
+        out: seen_out,
+        err: seen_err,
+        fixture_landed: landed.metadata().is_ok_and(|m| m.len() > 0),
+    }
 }
 
-/// A connected source's rollout becomes a sprite. This is the assertion the
-/// manual `scripts/replay-fixture.sh` was the only carrier for — and it exited 0
-/// unconditionally (`if ! grep -q ...; then echo; fi` takes the `if` from the
-/// `echo`), so it reported success for five weeks while producing no agent.
+/// A connected source's rollout becomes a sprite — the assertion whose only
+/// carrier used to be a manual script that could not fail.
 #[test]
 fn connected_codex_rollout_becomes_a_sprite() {
-    let out = headless_replay("codex = true\n", std::time::Duration::from_secs(20));
+    let r = headless_replay("codex = true\n", std::time::Duration::from_secs(20));
     assert!(
-        out.contains("cx·"),
-        "a connected Codex rollout must render a cx· sprite; headless printed:\n{out}"
+        r.fixture_landed,
+        "the fixture must reach the watched sessions root\nstderr:\n{}",
+        r.err
+    );
+    assert!(
+        r.out.contains("cx·"),
+        "a connected Codex rollout must render a cx· sprite\nstdout:\n{}\nstderr:\n{}",
+        r.out,
+        r.err
+    );
+    assert!(
+        !r.err.contains(GATE_DROP_MSG),
+        "a CONNECTED source must not be announced as gated\nstderr:\n{}",
+        r.err
     );
 }
 
-/// The same rollout with the flag absent renders NOTHING — `resolve_connected`
-/// treats a missing key as disconnected (0.12.0 dropped the install-state
-/// inference) and `reducer_task` drops the events before the reducer.
+/// The same rollout with the flag absent renders nothing — and, crucially, for
+/// the RIGHT reason. `resolve_connected` treats a missing key as disconnected
+/// (0.12.0 dropped the install-state inference) and reducer_task drops the
+/// events ahead of the reducer.
 ///
-/// This half is why the replay harness broke: it read the developer's real
-/// config, where `codex` is simply not in `[sources]`, so it silently exercised
-/// THIS arm while asserting the one above.
+/// Asserting only the absence would be satisfied by any breakage that stopped
+/// the rollout reaching the watcher at all, so the gate's own announcement is
+/// what this pins; the fixture-landed check closes the remaining gap.
 #[test]
-fn disconnected_codex_rollout_renders_nothing() {
-    // No early-exit path here, so this arm pays the full budget — kept small
-    // deliberately; the positive arm is what proves the wait is long enough for
-    // a sprite to appear at all.
-    let out = headless_replay("claude-code = true\n", std::time::Duration::from_secs(6));
+fn disconnected_codex_rollout_is_dropped_by_the_gate() {
+    let r = headless_replay("claude-code = true\n", std::time::Duration::from_secs(20));
     assert!(
-        !out.contains("cx·"),
-        "a DISCONNECTED Codex rollout must render no sprite; headless printed:\n{out}"
+        r.fixture_landed,
+        "the fixture must reach the watched sessions root\nstderr:\n{}",
+        r.err
     );
     assert!(
-        out.contains("agents=[]"),
-        "the headless summary should still be running and reporting an empty scene:\n{out}"
+        r.err.contains(GATE_DROP_MSG) && r.err.contains("codex"),
+        "the gate must announce dropping codex's events\nstderr:\n{}",
+        r.err
+    );
+    assert!(
+        !r.out.contains("cx·"),
+        "a DISCONNECTED Codex rollout must render no sprite\nstdout:\n{}",
+        r.out
+    );
+    assert!(
+        r.out.contains("agents=[]"),
+        "the run must still be alive and reporting an empty scene\nstdout:\n{}",
+        r.out
     );
 }

--- a/justfile
+++ b/justfile
@@ -234,12 +234,18 @@ mutants *args:
     base="${MUTANTS_BASE:-origin/main}"
     mkdir -p target
     git diff "$base...HEAD" > target/mutants.diff
-    # A diff with NO Rust changes (dispatched from `main` where HEAD==origin/main,
-    # or a docs/justfile/site-only branch) makes `--in-diff` test ZERO mutants and
-    # exit 0 — a vacuous green reading as "teeth verified" having checked nothing
-    # (cargo-mutants has no --error-on-zero flag). Gate on actual `.rs` changes.
-    if ! git diff --name-only "$base...HEAD" -- '*.rs' | grep -q .; then
-        echo "error: no Rust changes vs $base — no mutants to test. Run from a feature branch with .rs changes, or set MUTANTS_BASE." >&2
+    # Gate on the MUTANT COUNT, not on `.rs` changes. cargo-mutants has no
+    # --error-on-zero and exits 0 having tested nothing when the diff yields no
+    # mutants — a vacuous green reading as "teeth verified". A `.rs`-changes
+    # check is NOT sufficient, which this recipe's first real execution proved:
+    # a diff of test files plus `exclude_globs` entries (driver.rs) passed that
+    # check and still printed "No mutants to filter" and exit 0. `--list`
+    # enumerates without running, so the pre-check is cheap.
+    if ! cargo mutants --in-diff target/mutants.diff --list 2>/dev/null | grep -q .; then
+        echo "error: the diff vs $base yields ZERO mutants — nothing would be tested." >&2
+        echo "  Either there are no .rs changes, or every changed .rs is test code" >&2
+        echo "  or listed in .cargo/mutants.toml exclude_globs." >&2
+        echo "  Run from a branch touching mutable production Rust, or set MUTANTS_BASE." >&2
         exit 1
     fi
     cargo mutants --in-diff target/mutants.diff {{ args }}

--- a/justfile
+++ b/justfile
@@ -495,7 +495,8 @@ gen-wasm: gen-wasm-tools wasm-build
 # Bloat + PAIR gate for the committed wasm artifact. Size: the hero must stay
 # a lazy-load behind the poster, so a silent size regression (a dep pulling in
 # formatting machinery, an accidental debug build) fails loudly — 1 MiB raw ≈
-# ~350-400 KB gzipped; the artifact is ~700 KB today. Pair (#424): the
+# The artifact is ~900 KB (the recipe prints the exact figure and the headroom
+# left against the cap — read it there rather than trusting this line). Pair (#424): the
 # wasm-bindgen JS glue's ABI must match the exact .wasm it was generated with;
 # a one-sided merge resolution or partial regen ships a silent runtime throw,
 # so every committed file must match gen-wasm's sha256 manifest AND every file
@@ -514,6 +515,11 @@ gen-wasm-check:
     CAP=1048576
     SIZE=$(wc -c < "$W" | tr -d ' ')
     test "$SIZE" -le "$CAP" || { echo "$W is $SIZE bytes (> $CAP cap) — investigate the bloat"; exit 1; }
+    # Report the headroom, don't just pass silently. A ratchet you can only read
+    # at the moment it breaks gives no warning that it is about to: the prose
+    # above said "~700 KB today" while the artifact had grown to ~900 KB, and
+    # nothing surfaced the drift because every run was a silent green.
+    echo "wasm $SIZE / $CAP bytes ($((SIZE * 100 / CAP))% of cap, $(((CAP - SIZE) / 1024)) KB headroom)"
     test -f "$M" || { echo "missing $M — run 'just gen-wasm' (the wasm/glue pair manifest)"; exit 1; }
     (cd site/public/wasm && shasum -a 256 --strict -c manifest.sha256 >/dev/null) \
         || { echo "wasm/glue pair MISMATCH vs $M — a partial regen or one-sided merge; run 'just gen-wasm' and commit all of site/public/wasm/"; exit 1; }

--- a/justfile
+++ b/justfile
@@ -267,6 +267,16 @@ fuzz dir:
     cargo build --release --example decoder_fuzz -p pixtuoid-core
     find "$dir" -name '*.jsonl' -print0 | xargs -0 cat | ./target/release/examples/decoder_fuzz
 
+# Hermetic OpenClaw daemon live-e2e: drives the REAL shim with crafted gateway
+# envelopes on an isolated socket and asserts the lobster's
+# idle/busy/degraded/down via the headless `daemons=` line. Zero gateway, zero
+# model calls. Same on-demand local tier as `fuzz` — it needs a release build
+# and an ExitWatch backend (macOS kqueue / Linux pidfd), so it is not a CI gate.
+[group('rust')]
+[doc('Hermetic OpenClaw daemon live-e2e (needs `just build --release`)')]
+openclaw-e2e:
+    scripts/openclaw-live-e2e.sh
+
 # Compile the workspace; extra args are forwarded:
 #   just build                                # debug
 #   just build --release                      # release
@@ -523,6 +533,10 @@ gen-check: gen-readme-check gen-wasm-check
     #!/usr/bin/env sh
     set -eu
     test -x .venv/bin/python3 || { echo "needs the venv: python3 -m venv .venv && .venv/bin/pip install -r requirements-dev.txt"; exit 1; }
+    # The comparator's selftest gates the pixel predicate itself, and runs FIRST:
+    # gen-media.py --check delegates every image comparison to it, so an
+    # always-green comparator would report success for any render at all.
+    .venv/bin/python3 scripts/compare-screenshots.py --selftest
     .venv/bin/python3 scripts/gen-media.py --check
     .venv/bin/python3 scripts/gen-pix-icons.py --check
 

--- a/justfile
+++ b/justfile
@@ -237,11 +237,22 @@ mutants *args:
     # Gate on the MUTANT COUNT, not on `.rs` changes. cargo-mutants has no
     # --error-on-zero and exits 0 having tested nothing when the diff yields no
     # mutants — a vacuous green reading as "teeth verified". A `.rs`-changes
-    # check is NOT sufficient, which this recipe's first real execution proved:
-    # a diff of test files plus `exclude_globs` entries (driver.rs) passed that
-    # check and still printed "No mutants to filter" and exit 0. `--list`
-    # enumerates without running, so the pre-check is cheap.
-    if ! cargo mutants --in-diff target/mutants.diff --list 2>/dev/null | grep -q .; then
+    # check is NOT sufficient: a diff of test files plus `exclude_globs` entries
+    # yields zero mutants and passes it. `--list` enumerates without running
+    # (sub-second), so the pre-check is cheap.
+    #
+    # A FAILING tool and an empty result are reported separately. Folding them
+    # sends the reader to inspect their diff when the real cause is a missing
+    # cargo-mutants or an unparseable .cargo/mutants.toml — misdirection is the
+    # failure class this gate exists to remove, so it must not commit it.
+    if ! listed=$(cargo mutants --in-diff target/mutants.diff --list 2>/dev/null); then
+        echo "error: \`cargo mutants --list\` failed — the mutant count is unknown." >&2
+        echo "  Usually a missing cargo-mutants (\`just setup-tools\`) or an" >&2
+        echo "  unparseable .cargo/mutants.toml. Rerunning with stderr shown:" >&2
+        cargo mutants --in-diff target/mutants.diff --list >/dev/null || true
+        exit 1
+    fi
+    if [ -z "$listed" ]; then
         echo "error: the diff vs $base yields ZERO mutants — nothing would be tested." >&2
         echo "  Either there are no .rs changes, or every changed .rs is test code" >&2
         echo "  or listed in .cargo/mutants.toml exclude_globs." >&2
@@ -516,9 +527,8 @@ gen-wasm-check:
     SIZE=$(wc -c < "$W" | tr -d ' ')
     test "$SIZE" -le "$CAP" || { echo "$W is $SIZE bytes (> $CAP cap) — investigate the bloat"; exit 1; }
     # Report the headroom, don't just pass silently. A ratchet you can only read
-    # at the moment it breaks gives no warning that it is about to: the prose
-    # above said "~700 KB today" while the artifact had grown to ~900 KB, and
-    # nothing surfaced the drift because every run was a silent green.
+    # at the moment it breaks gives no warning that it is about to — and a prose
+    # estimate of the size drifts unnoticed precisely because every run is green.
     echo "wasm $SIZE / $CAP bytes ($((SIZE * 100 / CAP))% of cap, $(((CAP - SIZE) / 1024)) KB headroom)"
     test -f "$M" || { echo "missing $M — run 'just gen-wasm' (the wasm/glue pair manifest)"; exit 1; }
     (cd site/public/wasm && shasum -a 256 --strict -c manifest.sha256 >/dev/null) \
@@ -541,14 +551,10 @@ gen-wasm-check:
 # + a release build of the snapshot example.
 [group('gen')]
 [doc('Fail if any committed README section or rendered image has drifted')]
-gen-check: gen-readme-check gen-wasm-check
+gen-check: compare-selftest gen-readme-check gen-wasm-check
     #!/usr/bin/env sh
     set -eu
     test -x .venv/bin/python3 || { echo "needs the venv: python3 -m venv .venv && .venv/bin/pip install -r requirements-dev.txt"; exit 1; }
-    # The comparator's selftest gates the pixel predicate itself, and runs FIRST:
-    # gen-media.py --check delegates every image comparison to it, so an
-    # always-green comparator would report success for any render at all.
-    .venv/bin/python3 scripts/compare-screenshots.py --selftest
     .venv/bin/python3 scripts/gen-media.py --check
     .venv/bin/python3 scripts/gen-pix-icons.py --check
 
@@ -752,6 +758,22 @@ setup-tools:
     # would otherwise be the only gate). Idempotent. CI re-runs `just preflight`
     # regardless, so a skipped local hook still meets the same checks at merge.
     git config core.hooksPath .githooks
+
+# The pixel comparator is the primitive under `gen-check` and the smoke job, and
+# it had no test of its own — an always-green comparator reports success for any
+# render at all. Its own recipe, matching the other two selftests, because it
+# needs only Pillow while `gen-check` needs the venv plus ffmpeg, node, a release
+# snapshot build and the wasm pair: a developer who cannot run that gate should
+# still be able to run this.
+[group('meta')]
+[doc('Self-test the pixel comparator that gen-check and smoke ride on')]
+compare-selftest:
+    #!/usr/bin/env sh
+    set -eu
+    # Prefer the venv (the same Pillow gen-media.py uses), but do not require it:
+    # any python3 with Pillow answers the question this recipe asks.
+    if [ -x .venv/bin/python3 ]; then py=.venv/bin/python3; else py=python3; fi
+    "$py" scripts/compare-screenshots.py --selftest
 
 # Self-test the upstream-drift watcher — its ONLY test. A regex-parser regression
 # is a silent monitor death (the script returns empty / raises, the weekly job

--- a/scripts/check_upstream_drift.py
+++ b/scripts/check_upstream_drift.py
@@ -578,12 +578,42 @@ def try_fetch(
         return None
 
 
-def read_codex_events() -> set[str]:
-    src = (REPO / "crates/pixtuoid/src/install/codex.rs").read_text()
-    m = re.search(r"const CODEX_EVENTS[^=]*=\s*&\[(.*?)\];", src, re.S)
+def rust_const_str_array(rel_path: str, const_name: str) -> set[str]:
+    """The quoted words of a `const NAME: &[&str] = &[ … ];` array, COMMENTS EXCLUDED.
+
+    Comment-stripping is load-bearing, not tidiness. A bare `"(\\w+)"` scrape over
+    the raw block also captures every quoted word inside an explanatory comment —
+    and this repo's comment convention actively encourages those. It fired for
+    real: a WHY comment added inside CODEX_EVENTS mentioned the SessionEnd
+    payload's `reason const "other"`, the watcher read `other` as a REGISTERED
+    hook event, found no such variant upstream, and reported a phantom
+    "⛔ Breaking drift — decoder will silently drop events" that auto-filed an
+    issue and failed the run. A watcher that cries wolf gets its real alarms
+    ignored, so every event reader shares this one parser.
+    """
+    got = parse_rust_const_str_array((REPO / rel_path).read_text(), const_name)
+    if got is None:
+        raise RuntimeError(f"could not locate {const_name} in {rel_path}")
+    return got
+
+
+def parse_rust_const_str_array(src: str, const_name: str) -> set[str] | None:
+    """The pure half of `rust_const_str_array` — `None` when the const is absent.
+
+    Split out so the comment-blindness above is testable from a synthetic snippet:
+    the shape assertions in the selftest cannot catch it, since a phantom scraped
+    out of a comment is an ordinary-looking word that passes every shape regex.
+    """
+    m = re.search(rf"const {const_name}[^=]*=\s*&\[(.*?)\];", src, re.S)
     if not m:
-        raise RuntimeError("could not locate CODEX_EVENTS in install/codex.rs")
-    return set(re.findall(r'"(\w+)"', m.group(1)))
+        return None
+    body = re.sub(r"/\*.*?\*/", "", m.group(1), flags=re.S)
+    body = re.sub(r"//[^\n]*", "", body)
+    return set(re.findall(r'"(\w+)"', body))
+
+
+def read_codex_events() -> set[str]:
+    return rust_const_str_array("crates/pixtuoid/src/install/codex.rs", "CODEX_EVENTS")
 
 
 def read_codex_rollout_types() -> tuple[set[str], set[str]]:
@@ -606,11 +636,7 @@ def read_codex_rollout_types() -> tuple[set[str], set[str]]:
 
 
 def read_cc_events() -> set[str]:
-    src = (REPO / "crates/pixtuoid/src/install/claude.rs").read_text()
-    m = re.search(r"const EVENTS[^=]*=\s*&\[(.*?)\];", src, re.S)
-    if not m:
-        raise RuntimeError("could not locate EVENTS in install/claude.rs")
-    return set(re.findall(r'"(\w+)"', m.group(1)))
+    return rust_const_str_array("crates/pixtuoid/src/install/claude.rs", "EVENTS")
 
 
 def read_dispatch_names() -> set[str]:
@@ -718,11 +744,7 @@ def upstream_cc_hook_events(text: str) -> set[str] | None:
 
 
 def read_reasonix_events() -> set[str]:
-    src = (REPO / "crates/pixtuoid/src/install/reasonix.rs").read_text()
-    m = re.search(r"const REASONIX_EVENTS[^=]*=\s*&\[(.*?)\];", src, re.S)
-    if not m:
-        raise RuntimeError("could not locate REASONIX_EVENTS in install/reasonix.rs")
-    return set(re.findall(r'"(\w+)"', m.group(1)))
+    return rust_const_str_array("crates/pixtuoid/src/install/reasonix.rs", "REASONIX_EVENTS")
 
 
 def upstream_reasonix_hooks(text: str) -> set[str] | None:
@@ -732,11 +754,7 @@ def upstream_reasonix_hooks(text: str) -> set[str] | None:
 
 
 def read_codewhale_events() -> set[str]:
-    src = (REPO / "crates/pixtuoid/src/install/codewhale.rs").read_text()
-    m = re.search(r"const CODEWHALE_EVENTS[^=]*=\s*&\[(.*?)\];", src, re.S)
-    if not m:
-        raise RuntimeError("could not locate CODEWHALE_EVENTS in install/codewhale.rs")
-    return set(re.findall(r'"(\w+)"', m.group(1)))
+    return rust_const_str_array("crates/pixtuoid/src/install/codewhale.rs", "CODEWHALE_EVENTS")
 
 
 def read_opencode_events() -> set[str]:
@@ -786,11 +804,7 @@ def read_cursor_events() -> set[str]:
     truth (mirrors read_reasonix_events / read_codewhale_events). Reading the
     decoder's `match event` block instead would risk a future camelCase field
     lookup in an arm leaking a phantom event into the drift set."""
-    src = (REPO / "crates/pixtuoid/src/install/cursor.rs").read_text()
-    m = re.search(r"const CURSOR_EVENTS[^=]*=\s*&\[(.*?)\];", src, re.S)
-    if not m:
-        raise RuntimeError("could not locate CURSOR_EVENTS in install/cursor.rs")
-    return set(re.findall(r'"(\w+)"', m.group(1)))
+    return rust_const_str_array("crates/pixtuoid/src/install/cursor.rs", "CURSOR_EVENTS")
 
 
 def read_openclaw_events() -> set[str]:
@@ -799,11 +813,7 @@ def read_openclaw_events() -> set[str]:
     HOOKS array and the decoder arms are pinned to by
     `openclaw_events_plugin_decoder_and_const_agree`, so this is a leak-free
     source of truth (mirrors read_cursor_events / read_codewhale_events)."""
-    src = (REPO / "crates/pixtuoid/src/install/openclaw.rs").read_text()
-    m = re.search(r"const OPENCLAW_EVENTS[^=]*=\s*&\[(.*?)\];", src, re.S)
-    if not m:
-        raise RuntimeError("could not locate OPENCLAW_EVENTS in install/openclaw.rs")
-    return set(re.findall(r'"(\w+)"', m.group(1)))
+    return rust_const_str_array("crates/pixtuoid/src/install/openclaw.rs", "OPENCLAW_EVENTS")
 
 
 def read_hermes_events() -> set[str]:
@@ -811,11 +821,7 @@ def read_hermes_events() -> set[str]:
     `HERMES_EVENTS` const in install/hermes.rs — pinned to the decoder arms by
     `every_registered_hermes_event_decodes` (install/hermes.rs), so this is a
     leak-free source of truth (mirrors read_cursor_events / read_openclaw_events)."""
-    src = (REPO / "crates/pixtuoid/src/install/hermes.rs").read_text()
-    m = re.search(r"const HERMES_EVENTS[^=]*=\s*&\[(.*?)\];", src, re.S)
-    if not m:
-        raise RuntimeError("could not locate HERMES_EVENTS in install/hermes.rs")
-    return set(re.findall(r'"(\w+)"', m.group(1)))
+    return rust_const_str_array("crates/pixtuoid/src/install/hermes.rs", "HERMES_EVENTS")
 
 
 def read_grok_events() -> set[str]:
@@ -823,11 +829,7 @@ def read_grok_events() -> set[str]:
     const in install/grok.rs — pinned to the decoder arms by
     `every_registered_grok_event_decodes`, so this is a leak-free source of
     truth (mirrors read_cursor_events / read_hermes_events)."""
-    src = (REPO / "crates/pixtuoid/src/install/grok.rs").read_text()
-    m = re.search(r"const GROK_EVENTS[^=]*=\s*&\[(.*?)\];", src, re.S)
-    if not m:
-        raise RuntimeError("could not locate GROK_EVENTS in install/grok.rs")
-    return set(re.findall(r'"(\w+)"', m.group(1)))
+    return rust_const_str_array("crates/pixtuoid/src/install/grok.rs", "GROK_EVENTS")
 
 
 def read_kimi_events() -> set[str]:

--- a/scripts/check_upstream_drift.py
+++ b/scripts/check_upstream_drift.py
@@ -597,6 +597,61 @@ def rust_const_str_array(rel_path: str, const_name: str) -> set[str]:
     return got
 
 
+def strip_rust_comments(body: str) -> str:
+    """Remove Rust comments, PRESERVING string literals and honouring nesting.
+
+    A scanner rather than a pair of `re.sub`s, because both regex approaches drop
+    a REAL registered event and so fail SILENTLY OPEN — the watcher stops checking
+    a name and nothing says so, which is worse than the phantom it replaced:
+
+    - blind `//[^\\n]*` eats to end of line from a `//` inside a STRING, taking
+      every later entry on that line with it;
+    - `/\\*.*?\\*/` stops at the first `*/`, so a nested block comment (legal Rust)
+      leaves its tail behind and re-admits words from inside it.
+
+    Neither can fire on today's `\\w+` hook names, so this is robustness for the
+    general parser the docstring below promises, not a live defect.
+    """
+    out: list[str] = []
+    i, n, depth = 0, len(body), 0
+    while i < n:
+        pair = body[i : i + 2]
+        if depth:
+            if pair == "/*":
+                depth += 1
+                i += 2
+            elif pair == "*/":
+                depth -= 1
+                i += 2
+            else:
+                i += 1
+            continue
+        if pair == "/*":
+            depth = 1
+            i += 2
+            continue
+        if pair == "//":
+            nl = body.find("\n", i)
+            i = n if nl < 0 else nl
+            continue
+        if body[i] == '"':
+            j = i + 1
+            while j < n:
+                if body[j] == "\\":
+                    j += 2
+                    continue
+                if body[j] == '"':
+                    j += 1
+                    break
+                j += 1
+            out.append(body[i:j])
+            i = j
+            continue
+        out.append(body[i])
+        i += 1
+    return "".join(out)
+
+
 def parse_rust_const_str_array(src: str, const_name: str) -> set[str] | None:
     """The pure half of `rust_const_str_array` — `None` when the const is absent.
 
@@ -607,9 +662,7 @@ def parse_rust_const_str_array(src: str, const_name: str) -> set[str] | None:
     m = re.search(rf"const {const_name}[^=]*=\s*&\[(.*?)\];", src, re.S)
     if not m:
         return None
-    body = re.sub(r"/\*.*?\*/", "", m.group(1), flags=re.S)
-    body = re.sub(r"//[^\n]*", "", body)
-    return set(re.findall(r'"(\w+)"', body))
+    return set(re.findall(r'"(\w+)"', strip_rust_comments(m.group(1))))
 
 
 def read_codex_events() -> set[str]:
@@ -644,7 +697,10 @@ def read_dispatch_names() -> set[str]:
     m = re.search(r"known_name\s*=\s*([^;]+);", src)
     if not m:
         raise RuntimeError("could not locate the dispatch known_name check in decoder.rs")
-    return set(re.findall(r'"(\w+)"', m.group(1)))
+    # Same comment-blindness class as the array readers: the captured span is an
+    # EXPRESSION, so a trailing `// the legacy "Task" name was dropped` — exactly
+    # the history CLAUDE.md records for this line — would read as a known name.
+    return set(re.findall(r'"(\w+)"', strip_rust_comments(m.group(1))))
 
 
 def upstream_codex_hooks(text: str) -> set[str] | None:
@@ -838,11 +894,7 @@ def read_kimi_events() -> set[str]:
     `every_registered_kimi_event_decodes` test pins to the decode path (the shared
     CC-shaped arms + the source's custom Extend decoder), so this is a leak-free
     source of truth (mirrors read_cursor_events / read_hermes_events)."""
-    src = (REPO / "crates/pixtuoid/src/install/kimi.rs").read_text()
-    m = re.search(r"const KIMI_EVENTS[^=]*=\s*&\[(.*?)\];", src, re.S)
-    if not m:
-        raise RuntimeError("could not locate KIMI_EVENTS in install/kimi.rs")
-    return set(re.findall(r'"(\w+)"', m.group(1)))
+    return rust_const_str_array("crates/pixtuoid/src/install/kimi.rs", "KIMI_EVENTS")
 
 
 def upstream_grok_hooks(text: str) -> set[str] | None:

--- a/scripts/check_upstream_drift.py
+++ b/scripts/check_upstream_drift.py
@@ -652,6 +652,33 @@ def strip_rust_comments(body: str) -> str:
     return "".join(out)
 
 
+def rust_block_after(src: str, anchor_re: str) -> str | None:
+    """The `{ … }` block following the first `anchor_re` match, `None` if absent.
+
+    Scraping a whole FILE for a decoder's arms is the same class as scraping a
+    whole const-array block including its comments: it admits text the decoder
+    does not actually depend on — a `#[cfg(test)] mod tests` constructing the same
+    tuple shape leaks a phantom, and a phantom makes the watcher alarm on a name
+    upstream never had to have. Run the source through `strip_rust_comments`
+    first so a brace inside a comment or string cannot move the bounds.
+    """
+    m = re.search(anchor_re, src)
+    if not m:
+        return None
+    start = src.find("{", m.end())
+    if start < 0:
+        return None
+    depth = 0
+    for i in range(start, len(src)):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : i + 1]
+    return None
+
+
 def parse_rust_const_str_array(src: str, const_name: str) -> set[str] | None:
     """The pure half of `rust_const_str_array` — `None` when the const is absent.
 
@@ -677,8 +704,20 @@ def read_codex_rollout_types() -> tuple[set[str], set[str]]:
     decoders) — so a positive "each depended type still exists upstream" check is
     the only backstop against an upstream rename going dark."""
     src = (REPO / "crates/pixtuoid-core/src/source/codex.rs").read_text()
-    event_msg = set(re.findall(r'\(\s*"event_msg"\s*,\s*"(\w+)"\s*\)', src))
-    response_item = set(re.findall(r'\(\s*"response_item"\s*,\s*"(\w+)"\s*\)', src))
+    # Bounded to the decoder's own match block, NOT the whole file: the file also
+    # carries `#[cfg(test)] mod tests`, and a future test constructing a tuple of
+    # this shape with a type the decoder does not depend on would leak a phantom
+    # into the depended set — the watcher would then alarm on a name upstream
+    # never had to have. Comments are stripped first so a brace inside one cannot
+    # move the block's bounds.
+    block = rust_block_after(strip_rust_comments(src), r"match \(outer, inner\)")
+    if block is None:
+        raise RuntimeError(
+            "could not locate the codex `match (outer, inner)` decode block in "
+            "source/codex.rs — the transcript decoder was refactored; update the parser."
+        )
+    event_msg = set(re.findall(r'\(\s*"event_msg"\s*,\s*"(\w+)"\s*\)', block))
+    response_item = set(re.findall(r'\(\s*"response_item"\s*,\s*"(\w+)"\s*\)', block))
     if not event_msg or not response_item:
         raise RuntimeError(
             "could not locate codex ('event_msg'|'response_item', …) decode arms "

--- a/scripts/check_upstream_drift_selftest.py
+++ b/scripts/check_upstream_drift_selftest.py
@@ -290,6 +290,53 @@ def test_parser_never_drops_a_real_event() -> None:
         check(got == want, f"no real event dropped from `{body}`: {got!r} != {want!r}")
 
 
+def test_block_scrape_is_bounded_to_the_decoder() -> None:
+    """A scrape bounded to one block must not see code that follows it.
+
+    `read_codex_rollout_types` used to scan the WHOLE of source/codex.rs, so a
+    `#[cfg(test)] mod tests` constructing the same tuple shape would leak a type
+    the decoder does not depend on — and a phantom makes the watcher alarm on a
+    name upstream never had to have.
+
+    This exists because the sibling comment-safe parser shipped exactly such a
+    case one commit earlier and this bounding fix did not: the negative control
+    was RUN and then left out of the suite, which is the failure this whole
+    branch is about.
+    """
+    src = """
+fn decode(v: Value) -> Vec<Event> {
+    let out = match (outer, inner) {
+        ("event_msg", "task_started") => vec![start()],
+        ("response_item", "function_call") => { let f = |x| { x }; vec![f(call())] }
+        _ => vec![],
+    };
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    fn planted() { let _ = ("event_msg", "PHANTOM"); }
+}
+"""
+    block = d.rust_block_after(d.strip_rust_comments(src), r"match \(outer, inner\)")
+    check(block is not None, "the anchor's block is found")
+    got = set(re.findall(r'\(\s*"event_msg"\s*,\s*"(\w+)"\s*\)', block or ""))
+    # Nested braces from the closure/vec! must not close the block early, and the
+    # planted test tuple after it must not be visible.
+    check(got == {"task_started"}, f"bounded to the decoder's arms: {got!r}")
+    check(
+        "function_call" in (block or ""),
+        "the nested-brace arm is INSIDE the block (it did not close early)",
+    )
+
+    # A missing anchor is None, so the caller raises loudly rather than silently
+    # scraping nothing — a decoder refactor must break the watcher, not blind it.
+    check(
+        d.rust_block_after("fn unrelated() { }", r"match \(outer, inner\)") is None,
+        "a missing anchor returns None, never an empty block",
+    )
+
+
 def test_every_const_array_reader_uses_the_shared_parser() -> None:
     """No reader may hand-roll the scrape the shared parser exists to own.
 
@@ -319,6 +366,7 @@ def main() -> int:
         test_cc_doc_marker_detection_fires_both_directions,
         test_const_array_parser_ignores_words_quoted_inside_comments,
         test_parser_never_drops_a_real_event,
+        test_block_scrape_is_bounded_to_the_decoder,
         test_every_const_array_reader_uses_the_shared_parser,
     ):
         t()

--- a/scripts/check_upstream_drift_selftest.py
+++ b/scripts/check_upstream_drift_selftest.py
@@ -261,6 +261,56 @@ const DEMO_EVENTS: &[&str] = &[
     )
 
 
+def test_parser_never_drops_a_real_event() -> None:
+    """The failing-OPEN direction, which is the worse one.
+
+    A phantom is loud: the watcher alarms on a name upstream does not have. A
+    DROPPED registration is silent — that name simply stops being checked, and
+    nothing says so. Both regex formulations of this parser had that bug, so
+    each case below is a construct that made one of them swallow a real entry.
+    """
+    cases = [
+        # `//` inside a string literal: a line-comment strip runs to end of line
+        # and takes every later entry with it.
+        ('"SessionStart", "a//b", "SessionEnd"', {"SessionStart", "SessionEnd"}),
+        ('"Alpha", "http://x", "Charlie"', {"Alpha", "Charlie"}),
+        # Nested block comments are legal Rust; a non-greedy `/\\*.*?\\*/` closes
+        # at the FIRST `*/` and re-admits words from the comment's tail.
+        ('"Alpha", /* outer /* inner */ names "Phantom" */ "B"', {"Alpha", "B"}),
+        # A `/*` that only ever appears inside a line comment must not open a
+        # block that swallows the entries after it.
+        ('"Alpha",\n // uses /* as a marker\n "Beta", /* real */', {"Alpha", "Beta"}),
+        # Escaped quotes must not end the string early.
+        (r'"Alpha", "say \"Beta\"", "Gamma"', {"Alpha", "Gamma"}),
+        # A URL in a COMMENT is the benign twin of case 2 — still excluded.
+        ('"Alpha",\n // see https://x "Notification"\n "Beta"', {"Alpha", "Beta"}),
+    ]
+    for body, want in cases:
+        got = d.parse_rust_const_str_array(f"const E: &[&str] = &[{body}];", "E")
+        check(got == want, f"no real event dropped from `{body}`: {got!r} != {want!r}")
+
+
+def test_every_const_array_reader_uses_the_shared_parser() -> None:
+    """No reader may hand-roll the scrape the shared parser exists to own.
+
+    This is the mechanical form of the lesson, not a second copy of it: the
+    original migration was a HAND-LISTED sweep of nine readers and it missed one
+    (`read_kimi_events`), which is the N-1-of-N class this repo's review prompt
+    calls its most-recurrent escape. A checklist cannot enforce itself; this can.
+    """
+    src = (pathlib.Path(__file__).parent / "check_upstream_drift.py").read_text()
+    offenders = [
+        ln.strip()
+        for ln in src.splitlines()
+        if 'findall(r\'"(\\w+)"\'' in ln and "strip_rust_comments" not in ln
+    ]
+    check(
+        not offenders,
+        "every `\"(\\\\w+)\"` scrape must route through strip_rust_comments; "
+        f"unrouted: {offenders!r}",
+    )
+
+
 def main() -> int:
     for t in (
         test_try_fetch_classifies_permanent_vs_transient,
@@ -268,6 +318,8 @@ def main() -> int:
         test_upstream_parsers_extract_from_a_snippet,
         test_cc_doc_marker_detection_fires_both_directions,
         test_const_array_parser_ignores_words_quoted_inside_comments,
+        test_parser_never_drops_a_real_event,
+        test_every_const_array_reader_uses_the_shared_parser,
     ):
         t()
     if FAILS:

--- a/scripts/check_upstream_drift_selftest.py
+++ b/scripts/check_upstream_drift_selftest.py
@@ -232,12 +232,42 @@ def test_cc_doc_marker_detection_fires_both_directions() -> None:
     check(len(got) == 1 and "ultra_effort_exit" in got[0], f"appearance fires: {got!r}")
 
 
+def test_const_array_parser_ignores_words_quoted_inside_comments() -> None:
+    """A quoted word in a comment must NOT be read as a registered event.
+
+    The shape assertions above cannot catch this: a phantom scraped out of a
+    comment is an ordinary-looking word that passes every shape regex. It shipped
+    for real — a WHY comment inside CODEX_EVENTS mentioning the SessionEnd
+    payload's `reason const "other"` made the watcher report a phantom breaking
+    drift, auto-file an issue, and fail the run.
+    """
+    src = '''
+const DEMO_EVENTS: &[&str] = &[
+    "SessionStart",
+    // upstream's payload carries a reason const "other"; the field is
+    // `hook_event_name:"SessionEnd"` — neither is a registered event here
+    /* a block comment naming "PreToolUse" is not a registration either */
+    "SessionEnd",
+];
+'''
+    got = d.parse_rust_const_str_array(src, "DEMO_EVENTS")
+    check(got == {"SessionStart", "SessionEnd"}, f"comments excluded: {got!r}")
+
+    # And an absent const is reported as such, not as an empty set — an empty
+    # set would read as "nothing registered" and silence every check downstream.
+    check(
+        d.parse_rust_const_str_array(src, "NOPE_EVENTS") is None,
+        "a missing const returns None, never an empty set",
+    )
+
+
 def main() -> int:
     for t in (
         test_try_fetch_classifies_permanent_vs_transient,
         test_source_parsers_find_nonempty_well_shaped_sets,
         test_upstream_parsers_extract_from_a_snippet,
         test_cc_doc_marker_detection_fires_both_directions,
+        test_const_array_parser_ignores_words_quoted_inside_comments,
     ):
         t()
     if FAILS:

--- a/scripts/compare-screenshots.py
+++ b/scripts/compare-screenshots.py
@@ -15,6 +15,7 @@ images has an all-zero alpha band, and Pillow >= 10's getbbox() defaults to
 alpha_only=True, which would make ANY two same-size images compare equal.
 """
 
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -139,6 +140,22 @@ def _selftest():
         flat = write("flat.png", "RGB", black, size=(10, 10))
         check("1% diff under a 0.5% threshold must FAIL", compare_images(flat, spot, diff_out, 0.5), 1)
         check("1% diff under a 2% threshold must PASS", compare_images(flat, spot, diff_out, 2.0), 0)
+        # ON the boundary, so `>` vs `>=` is observable. Both cases above sit off
+        # it, which let a flipped operator survive; a threshold is a policy and
+        # its inclusivity is the part worth pinning.
+        check("1% diff exactly AT a 1% threshold must PASS", compare_images(flat, spot, diff_out, 1.0), 0)
+
+        # The consumers do not import this module — gen-media.py and
+        # gen-pix-icons.py subprocess it. Exercise that path too, or argv
+        # handling and the exit-code mapping stay untested however many
+        # in-process checks pass.
+        argv = [sys.executable, str(Path(__file__).resolve())]
+        cli_ok = subprocess.run([*argv, str(rgb_a), str(rgb_a), str(diff_out)], capture_output=True)
+        check("CLI: identical images exit 0", cli_ok.returncode, 0)
+        cli_bad = subprocess.run([*argv, str(rgb_a), str(rgb_b), str(diff_out)], capture_output=True)
+        check("CLI: differing images exit 1", cli_bad.returncode, 1)
+        cli_usage = subprocess.run([*argv, str(rgb_a)], capture_output=True)
+        check("CLI: wrong arity exits 2", cli_usage.returncode, 2)
 
     failed = [(n, got, want) for n, got, want in checks if got != want]
     for name, got, want in failed:

--- a/scripts/compare-screenshots.py
+++ b/scripts/compare-screenshots.py
@@ -16,6 +16,7 @@ alpha_only=True, which would make ANY two same-size images compare equal.
 """
 
 import sys
+import tempfile
 from pathlib import Path
 
 from PIL import Image, ImageChops, UnidentifiedImageError
@@ -85,9 +86,77 @@ def compare_images(ref_path, cand_path, diff_path, threshold_percent=0.0):
     return 0
 
 
+def _selftest():
+    """Assert the comparator can actually FAIL. Returns an exit code.
+
+    Two required gates (`gen-check`, smoke) ride on this predicate, so a
+    silently-always-green comparator would report success for any render. The
+    RGBA case below is the specific always-green mode the module docstring
+    warns about: drop the `.convert("RGB")` and ImageChops.difference leaves an
+    all-zero alpha band that Pillow >= 10's alpha_only=True getbbox() reads as
+    "no difference" — every case here still passes EXCEPT that one.
+    """
+    checks = []
+
+    def check(name, got, want):
+        checks.append((name, got, want))
+
+    black = (0, 0, 0)
+    white = (255, 255, 255)
+
+    with tempfile.TemporaryDirectory() as td:
+        td = Path(td)
+        diff_out = td / "diff.png"
+
+        def write(name, mode, color, size=(8, 8)):
+            p = td / name
+            Image.new(mode, size, color).save(p)
+            return p
+
+        # THE anti-rot check: opaque RGBA, differing only in colour. Without the
+        # RGB conversion this returns 0 and the whole gate is decorative.
+        rgba_a = write("rgba_a.png", "RGBA", black + (255,))
+        rgba_b = write("rgba_b.png", "RGBA", white + (255,))
+        check("differing RGBA images must FAIL", compare_images(rgba_a, rgba_b, diff_out), 1)
+
+        rgb_a = write("rgb_a.png", "RGB", black)
+        rgb_b = write("rgb_b.png", "RGB", white)
+        check("differing RGB images must FAIL", compare_images(rgb_a, rgb_b, diff_out), 1)
+
+        check("identical images must PASS", compare_images(rgb_a, rgb_a, diff_out), 0)
+
+        bigger = write("bigger.png", "RGB", black, size=(16, 16))
+        check("size mismatch must ERROR", compare_images(rgb_a, bigger, diff_out), 2)
+
+        check("missing file must ERROR", compare_images(td / "nope.png", rgb_a, diff_out), 2)
+
+        # A threshold must gate on the measured percentage, not swallow the diff:
+        # one differing pixel in 100 is 1%, so 0.5% fails and 2% passes.
+        spotted = Image.new("RGB", (10, 10), black)
+        spotted.putpixel((0, 0), white)
+        spot = td / "spot.png"
+        spotted.save(spot)
+        flat = write("flat.png", "RGB", black, size=(10, 10))
+        check("1% diff under a 0.5% threshold must FAIL", compare_images(flat, spot, diff_out, 0.5), 1)
+        check("1% diff under a 2% threshold must PASS", compare_images(flat, spot, diff_out, 2.0), 0)
+
+    failed = [(n, got, want) for n, got, want in checks if got != want]
+    for name, got, want in failed:
+        print(f"SELFTEST FAIL: {name} — got exit {got}, want {want}", file=sys.stderr)
+    if failed:
+        print(f"compare-screenshots selftest: {len(failed)}/{len(checks)} checks FAILED", file=sys.stderr)
+        return 1
+    print(f"compare-screenshots selftest: all {len(checks)} checks passed", file=sys.stderr)
+    return 0
+
+
 if __name__ == "__main__":
+    if "--selftest" in sys.argv[1:]:
+        sys.exit(_selftest())
+
     if len(sys.argv) not in (4, 5):
         print("Usage: compare-screenshots.py <reference> <candidate> <diff_out> [threshold_percent]")
+        print("       compare-screenshots.py --selftest")
         sys.exit(2)
 
     threshold = float(sys.argv[4]) if len(sys.argv) == 5 else 0.0

--- a/scripts/replay-fixture.sh
+++ b/scripts/replay-fixture.sh
@@ -46,12 +46,11 @@ cleanup() {
 trap cleanup EXIT
 
 # An ISOLATED config marking Codex connected. `resolve_connected` treats a
-# missing [sources] key as DISCONNECTED (config/mod.rs), and the driver drops
-# every event from a disconnected source BEFORE the reducer and before its only
-# `debug!` — so on a box that never connected Codex in the Sources panel this
-# replay produced zero agents and zero log lines, at any log level. Broken this
-# way since the connection gate landed (#284); openclaw-live-e2e.sh learned the
-# same lesson two days later, this script never got it.
+# missing [sources] key as DISCONNECTED (config/mod.rs) and the driver drops a
+# disconnected source's events ahead of the reducer, so without this a box that
+# never connected Codex in the Sources panel replays into zero agents — and,
+# because the drop sits above the gate's own log line, zero explanation too.
+# openclaw-live-e2e.sh isolates its config for exactly this reason.
 mkdir -p "$cfgdir/pixtuoid"
 printf '[sources]\ncodex = true\n' >"$cfgdir/pixtuoid/config.toml"
 
@@ -81,14 +80,17 @@ sleep 2
 
 echo "=== cx· agent state progression ==="
 grep 'agents=' "$out" || true
-# Headless always prints `agents=[]` (empty scene), so success = at least one
-# NON-empty agents line ever appeared. `agents=\[[^]]` = a char after `[` other than `]`.
+# Success requires a STATE TRANSITION, not merely a registered sprite: junk
+# content still registers `agents=[cx@0:idle]`, so a bare "a non-empty scene
+# appeared" predicate reports PASS for a decoder that has stopped decoding
+# entirely. The bundled permission-flow fixture guarantees both active and
+# waiting, so requiring either keeps the check honest without over-fitting.
 #
-# This EXITS non-zero: two review prompts cite this script as a verification
-# step, so a replay that produced no agent must fail the caller rather than
-# print a note and exit 0.
-if ! grep -qE 'agents=\[[^]]' "$out"; then
-    echo "FAIL: no cx· agent ever appeared — is '$bin' the codex-aware build, and is the fixture a codex rollout?" >&2
+# This EXITS non-zero: the script is cited as a verification step, so a replay
+# that produced nothing must fail its caller rather than print a note and exit 0.
+if ! grep -qE 'agents=\[cx·[^]]*:(active|waiting)' "$out"; then
+    echo "FAIL: the fixture never drove a cx· agent into active/waiting — is '$bin'" >&2
+    echo "  the codex-aware build, and is the fixture a codex rollout?" >&2
     exit 1
 fi
-echo "PASS: the fixture replayed into at least one non-empty scene."
+echo "PASS: the fixture drove a cx· agent through a real state transition."

--- a/scripts/replay-fixture.sh
+++ b/scripts/replay-fixture.sh
@@ -60,6 +60,12 @@ echo "=== cx· agent state progression ==="
 grep 'agents=' "$out" || true
 # Headless always prints `agents=[]` (empty scene), so success = at least one
 # NON-empty agents line ever appeared. `agents=\[[^]]` = a char after `[` other than `]`.
+#
+# This EXITS non-zero: two review prompts cite this script as a verification
+# step, so a replay that produced no agent must fail the caller rather than
+# print a note and exit 0.
 if ! grep -qE 'agents=\[[^]]' "$out"; then
-    echo "(no cx· agent ever appeared — is '$bin' the codex-aware build, and is the fixture a codex rollout?)"
+    echo "FAIL: no cx· agent ever appeared — is '$bin' the codex-aware build, and is the fixture a codex rollout?" >&2
+    exit 1
 fi
+echo "PASS: the fixture replayed into at least one non-empty scene."

--- a/scripts/replay-fixture.sh
+++ b/scripts/replay-fixture.sh
@@ -31,7 +31,14 @@ command -v "$bin" >/dev/null 2>&1 || {
 root="$(mktemp -d)"
 proj="$(mktemp -d)"
 cfgdir="$(mktemp -d)"
-sock="$(mktemp -u)"
+# The socket lives inside a PRIVATE 0700 dir, not as a bare name in the shared
+# temp dir: `mktemp -u` reserves a name without creating anything, leaving a
+# pre-plant/symlink race between name generation and pixtuoid's bind(). Nothing
+# downstream closes it — `ensure_owned_socket_dir` (hook/unix.rs) deliberately
+# does not police an explicit PIXTUOID_SOCKET path. This matches what the sibling
+# Rust harness (cli_json.rs::headless_replay) already does with tempfile::tempdir.
+sockdir="$(mktemp -d)"
+sock="$sockdir/hook.sock"
 out="$(mktemp)"
 hpid=""
 cleanup() {
@@ -39,8 +46,7 @@ cleanup() {
         kill "$hpid" 2>/dev/null || true
         wait "$hpid" 2>/dev/null || true # reap quietly (suppress "Terminated")
     fi
-    rm -rf "$root" "$proj" "$cfgdir" "$out"
-    rm -f "$sock"
+    rm -rf "$root" "$proj" "$cfgdir" "$sockdir" "$out"
     return 0
 }
 trap cleanup EXIT

--- a/scripts/replay-fixture.sh
+++ b/scripts/replay-fixture.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 # replay-fixture.sh — replay a captured Codex rollout fixture into a HERMETIC
-# headless pixtuoid run (via --codex-sessions-root + a temp dir, so ~/.codex is
-# untouched) and print the cx· agent's state progression. Lets you eyeball a
-# source's lifecycle (e.g. permission -> resume) end-to-end without a live CLI.
+# headless pixtuoid run and print the cx· agent's state progression. Lets you
+# eyeball a source's lifecycle (e.g. permission -> resume) end-to-end without a
+# live CLI.
+#
+# "Hermetic" means all FOUR host couplings are isolated — sessions root, projects
+# root, config (XDG_CONFIG_HOME) and the hook socket. The original wording
+# claimed hermetic while only naming ~/.codex, and the two unnamed leaks are
+# exactly what silently broke this script; keep the list explicit.
 #
 # Usage:  scripts/replay-fixture.sh <rollout.jsonl> [delay_secs]
 #   e.g.  scripts/replay-fixture.sh \
@@ -25,6 +30,8 @@ command -v "$bin" >/dev/null 2>&1 || {
 
 root="$(mktemp -d)"
 proj="$(mktemp -d)"
+cfgdir="$(mktemp -d)"
+sock="$(mktemp -u)"
 out="$(mktemp)"
 hpid=""
 cleanup() {
@@ -32,17 +39,33 @@ cleanup() {
         kill "$hpid" 2>/dev/null || true
         wait "$hpid" 2>/dev/null || true # reap quietly (suppress "Terminated")
     fi
-    rm -rf "$root" "$proj" "$out"
+    rm -rf "$root" "$proj" "$cfgdir" "$out"
+    rm -f "$sock"
     return 0
 }
 trap cleanup EXIT
+
+# An ISOLATED config marking Codex connected. `resolve_connected` treats a
+# missing [sources] key as DISCONNECTED (config/mod.rs), and the driver drops
+# every event from a disconnected source BEFORE the reducer and before its only
+# `debug!` — so on a box that never connected Codex in the Sources panel this
+# replay produced zero agents and zero log lines, at any log level. Broken this
+# way since the connection gate landed (#284); openclaw-live-e2e.sh learned the
+# same lesson two days later, this script never got it.
+mkdir -p "$cfgdir/pixtuoid"
+printf '[sources]\ncodex = true\n' >"$cfgdir/pixtuoid/config.toml"
 
 mkdir -p "$root/replay"
 # The filename's trailing UUID is the Codex session key (codex_id_from_path);
 # any canonical UUID works for a replay.
 file="$root/replay/rollout-2026-01-01T00-00-00-0a0a0a0a-0b0b-0c0c-0d0d-0e0e0e0e0e0e.jsonl"
 
-"$bin" run --headless --codex-sessions-root "$root" --projects-root "$proj" \
+# The isolated socket matters for the ASSERTION, not just for hygiene: on the
+# default socket a live CC session's hook traffic lands in this run's scene and
+# satisfies the `agents=\[[^]]` success grep, so a totally broken Codex path
+# would report PASS.
+XDG_CONFIG_HOME="$cfgdir" PIXTUOID_SOCKET="$sock" \
+    "$bin" run --headless --codex-sessions-root "$root" --projects-root "$proj" \
     --log-level error >"$out" 2>&1 &
 hpid=$!
 sleep 2 # let the watcher bind/seed before the first append


### PR DESCRIPTION
Four instruments in this repo could not report a problem. Each was fixed, then RUN — and the first real readings found two live defects.

## The four

| instrument | before | first real reading |
|---|---|---|
| `scripts/replay-fixture.sh` | `if ! grep -q ...; then echo; fi` — the `if` takes its status from the `echo`, so it exited 0 unconditionally under `set -euo pipefail`, while two prompts in `.github/prompts/` cite it as a verification step | **FAIL** → root-caused, fixed |
| `scripts/compare-screenshots.py` | zero self-tests, with `gen-check` and smoke riding on it | 7/7 PASS |
| `scripts/openclaw-live-e2e.sh` | no justfile entry point, no caller — never executed | 10/11 PASS → #725 |
| `just mutants` | gated on `.rs` changes, not on mutant count | **zero mutants, exit 0** → fixed |

## What the readings found

**1. The replay harness leaked the host config (fixed here).** It isolated the sessions root and the projects root but not `XDG_CONFIG_HOME` or the hook socket, so it read the developer’s real `~/.config/pixtuoid/config.toml`. `resolve_connected` treats a missing `[sources]` key as disconnected, and `reducer_task` drops those events before the reducer *and* before its only `debug!` — hence zero agents and zero log lines at any level.

Broken since the connection gate landed (#284, 2026-06-13). `openclaw-live-e2e.sh` learned exactly this lesson two days later and comments it verbatim; it was never fed back here.

The socket isolation is load-bearing for the assertion, not hygiene: on the default socket a live CC session’s hook traffic satisfies the success grep, so the script could report **green for a completely broken Codex path** as easily as red for a correct build.

Verified: before `EXIT=1` with `agents=[]`; after, the full permission flow `idle → active → waiting(permission) → active`, `EXIT=0`.

**2. `just mutants` was a fourth false green (fixed here).** Its own comment names the failure mode — cargo-mutants has no `--error-on-zero` — but gated on the wrong condition. A diff of test files plus `exclude_globs` entries passes an `.rs`-changes check and still yields zero mutants. This recipe’s first ever execution was exactly that shape. Now gated on the mutant count via `--list`, verified both ways: this branch fails with an explanatory message, a diff with real production Rust lists 406 mutants and is admitted.

**3. openclaw step 11 (#318 mid-attach abrupt-down) fails** → filed as #725. Deliberately **not** labelled a regression: the script had never run, so there is no evidence the scenario was ever green.

## Tests

Two regression tests, at the two levels the bug spans:

- `pixtuoid-core/tests/watcher/sources.rs` — the committed permission-flow fixture folded through the real `Reducer`, asserting the progression reaches `Waiting`. The neighbouring `codex_source_run_emits_events_from_rollout` stops at “an ActivityStart arrived” over two inline JSON lines and never observes an `ActivityState`, so nothing in the suite had checked that a real rollout drives the state machine anywhere.
- `pixtuoid/tests/cli_json.rs` — the connection gate end to end, two arms differing only in the `[sources]` body.

Both verified by mutation, since a test that has never failed is what this whole branch is about:

- `require_escalated` → a dummy value reds the lifecycle test
- deleting the connection gate reds the disconnected arm, and only it

`cli_json.rs`’s module doc is widened from “the `sources --json` golden” to process-level contracts, with a scope note on the bar for adding more. Called out because it is a deliberate scope change.

## Product change

One, diagnosability only: the connection gate’s `continue` sits above the only `debug!`, so a gated source is silent at every log level and “connected but no sprite” is indistinguishable from “not connected”. That ambiguity cost five hypotheses to resolve. Now logged once per source — never per event, since a disconnected watcher streams indefinitely.

## One finding refuted

An audit claimed *“a Rust theme change does not trigger the repo’s only WCAG 4.5:1 check”*. The check is real and has teeth (`site/tests/e2e/smoke.spec.ts` measures actual canvas pixels, composites the dimmer, asserts ≥ 4.5:1), it does run in CI, and `site.yml`’s `paths` genuinely omits `crates/**` — but the conclusion does not follow. The only path from the Rust theme to the site is the committed wasm blob under `site/public/wasm/`, which `site/**` already matches. Regenerate the wasm and the check runs against the new pixels; do not regenerate and the site still renders the old ones, so there is nothing to catch. Adding `crates/**` would manufacture a false signal by testing stale pixels. No change made.

## Not done here

`driver.rs` is in `exclude_globs` as untestable async glue, so mutation testing structurally could not have caught the connection-gate bug. The exclusion is correct; the blind spot is real and worth knowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FysCoSsr1D1HiLsmsgpuGw