### PR TITLE
chore: patch three raycast advisories + make packaging-build cacheable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,8 +326,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-14]
     runs-on: ${{ matrix.os }}
-    # Two release-mode `cargo install`s from a cold cache; `cargo install` uses
-    # its own target dir, so rust-cache only partly covers it.
+    # Two release-mode `cargo install`s. `cargo install` defaults to a TEMP
+    # target dir it deletes on exit, so rust-cache would have nothing to save
+    # and every run would be a cold release build — the env below points it at
+    # the workspace target/ instead, which rust-cache does persist. First run
+    # on a new lockfile is still cold; the ceiling is sized for that.
+    env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7

--- a/integrations/raycast/package-lock.json
+++ b/integrations/raycast/package-lock.json
@@ -1676,9 +1676,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -2150,9 +2150,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -2381,9 +2381,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Two unrelated follow-ups from the #729 merge, kept as separate commits so the security fix is readable on its own.

## 1. Three high-severity advisories in the Raycast extension (`b2247915`)

`npm audit fix --package-lock-only` — three patch bumps, lockfile only, `package.json` untouched:

| package | bump | chain | scope |
|---|---|---|---|
| brace-expansion | 5.0.6 → 5.0.7 | `eslint` → `minimatch@10` | dev |
| brace-expansion | 2.1.1 → 2.1.2 | `@raycast/api` → `@oclif/core` → `ejs` → `jake` → `filelist` → `minimatch@5` | **runtime** |
| js-yaml | 4.2.0 → 4.3.0 | `json-schema-to-typescript` | dev |

All three are ReDoS / quadratic-CPU advisories. Only the middle one sits under a runtime dependency.

**Why Dependabot couldn't do this**: its update job for these failed and opened no PR, because every one is a *transitive* dep absent from `package.json` — there is no manifest edit to propose, only a lockfile bump. That's exactly what this is.

`npm audit` now reports **0 vulnerabilities**. Diff is 9 insertions / 9 deletions — no incidental lockfile churn.

## 2. `packaging-build` was cold-building on every run (`df52e112`)

`cargo install` defaults to a **temporary** target dir it deletes on exit, so `Swatinem/rust-cache` had nothing to persist and both matrix legs did a full cold release build every time — the per-PR cost the #729 review flagged.

Setting `CARGO_TARGET_DIR` to the workspace `target/` puts the artifacts somewhere rust-cache actually saves. Verified locally that `cargo install` honours it: release artifacts land in the named dir and the binary still installs to `--root/bin`.

**The review's suggestion — gate the job to release branches or nightly — was rejected**, for a reason that only shows up when the two follow-ups are considered together: such a job also has to leave branch protection, since a required context that never runs on PRs blocks every PR. And the job exists to fail *before* an irreversible tag rather than in Homebrew's CI after one. Cutting the cost keeps both properties; cutting the coverage keeps neither.

Related: `packaging-build (ubuntu-latest)` and `packaging-build (macos-14)` were added to `main`'s required status checks (18 → 20), so this PR is the first to actually be gated on them — and the first real test of the caching change.

## Verification

`npm ci` 0 · `tsc` 0 · `eslint` 0 errors · `actionlint` 0 · `just preflight` 0 (the pre-push hook). Exit codes captured directly.

Not in scope: the `caveats` regression from the tap retirement (homebrew-core discourages `caveats`, so there is nothing to change), and #731 (needs a tag tarball that doesn't exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2exCpj7ampnCeaF9y7vuF