### PR TITLE
fix(scripts): openclaw-e2e mid-attach step tested a state it never reached (closes #725)

### DIFF
--- a/scripts/openclaw-live-e2e.sh
+++ b/scripts/openclaw-live-e2e.sh
@@ -39,6 +39,9 @@ done
 # shellcheck disable=SC2329  # invoked indirectly via `trap cleanup EXIT` below
 cleanup() {
     [ -n "$PIXPID" ] && kill "$PIXPID" 2>/dev/null
+    # The #318 step's background `sleep` (set later, so guard under `set -u`):
+    # a Ctrl-C before step [12] kills it would otherwise leak a 10-min sleep.
+    [ -n "${SPID:-}" ] && kill "$SPID" 2>/dev/null
     rm -f "$SOCK" "$OUT"
     rm -rf "$PROJ" "$CFGDIR"
 }
@@ -134,10 +137,16 @@ expect idle idle-healed
 # session_start here would adopt nothing (its PidSeen hits a Some) and killing
 # its pid would be a no-op — the exact false-premise bug that made [11] fail.
 #
-# The real #318 case is a RECONNECT after an abrupt down (openclaw.rs models the
-# same path): gateway_stop takes the mascot Down, enter_down clears current_pid,
-# and the reconnect is learned only from a plain _pid-carrying event — never a
-# fresh gateway_start. So drive that: down, then re-adopt via PidSeen.
+# The real #318 trigger is a MID-ATTACH — pixtuoid attaches to an
+# already-running gateway, never sees gateway_start, and adopts the pid off the
+# first plain event into a fresh current_pid=None entry. That literal shape
+# can't be reproduced in one process here, since [5]'s gateway_start already
+# created the entry with an armed pid. So reach the SAME None state the honest
+# way: gateway_stop takes the mascot Down and enter_down clears current_pid,
+# then the reconnect's plain _pid event re-adopts via PidSeen — the identical
+# adoption path (pinned by the pid_seen_re_adopts_after_an_abrupt_down unit
+# test). gateway_stop is a clean shutdown, used here only as the deterministic
+# route to current_pid=None; the mechanism under test is the None-only adoption.
 echo "[10] gateway_stop -> down (clears current_pid so the rung can re-arm)"
 send '{"type":"gateway_stop"}'
 expect down down-before-reattach
@@ -145,12 +154,16 @@ expect down down-before-reattach
 sleep 600 &
 SPID=$!
 echo "[11] session_start carrying _pid=$SPID (reconnect, no gateway_start) -> idle"
-# The explicit _pid is KEPT by the shim (an inbound value wins over getppid),
-# so this is the real live pid, adopted by PidSeen because current_pid is None.
+# The explicit _pid is KEPT by the shim (an inbound value wins over getppid), so
+# this is the real live pid. The `idle` here does NOT itself prove adoption — it
+# comes from the SessionStarted resurrect; the adoption is proved only by [12]
+# below (kill the adopted pid, get an instant down). Keep both steps.
 send "{\"type\":\"session_start\",\"sessionId\":\"mid1\",\"_pid\":$SPID}"
 expect idle idle-midattach
 
 echo "[12] kill $SPID -> down (instant abrupt-down off the RE-adopted pid, #318)"
+# THE assertion that gates #318: this reds unless PidSeen actually adopted $SPID
+# at [11] (verified by mutation — disabling the adoption fails exactly here).
 kill "$SPID" 2>/dev/null
 expect down down-abrupt
 

--- a/scripts/openclaw-live-e2e.sh
+++ b/scripts/openclaw-live-e2e.sh
@@ -126,18 +126,31 @@ send '{"type":"agent_end","runId":"r3","success":true}'
 expect idle idle-healed
 
 # ---- #318 mid-attach pid adoption + instant abrupt-down ----
-# The daemon is up with current_pid=None (no gateway_start carried a _pid). A
-# NON-gateway_start event carrying a REAL live _pid must adopt it (PidSeen), so
-# killing that pid takes the daemon down via the PresenceExitWatch — the proof
-# the mid-attach pid binding works (a non-adopted pid's death would be a no-op,
-# leaving the daemon idle and failing step [11]).
+# `PidSeen` adoption is None-ONLY (apply_presence): it bootstraps current_pid
+# only when the daemon has none, so GatewayUp never gets clobbered. That means
+# the mid-attach scenario has to REACH current_pid=None first, and the shim
+# stamps _pid=getppid() onto every event that lacks one — so the gateway_start
+# at [5] already armed current_pid to the shim's parent. Sending a bare
+# session_start here would adopt nothing (its PidSeen hits a Some) and killing
+# its pid would be a no-op — the exact false-premise bug that made [11] fail.
+#
+# The real #318 case is a RECONNECT after an abrupt down (openclaw.rs models the
+# same path): gateway_stop takes the mascot Down, enter_down clears current_pid,
+# and the reconnect is learned only from a plain _pid-carrying event — never a
+# fresh gateway_start. So drive that: down, then re-adopt via PidSeen.
+echo "[10] gateway_stop -> down (clears current_pid so the rung can re-arm)"
+send '{"type":"gateway_stop"}'
+expect down down-before-reattach
+
 sleep 600 &
 SPID=$!
-echo "[10] session_start carrying _pid=$SPID -> idle (PidSeen adopts the live pid)"
+echo "[11] session_start carrying _pid=$SPID (reconnect, no gateway_start) -> idle"
+# The explicit _pid is KEPT by the shim (an inbound value wins over getppid),
+# so this is the real live pid, adopted by PidSeen because current_pid is None.
 send "{\"type\":\"session_start\",\"sessionId\":\"mid1\",\"_pid\":$SPID}"
 expect idle idle-midattach
 
-echo "[11] kill $SPID -> down (instant abrupt-down off the adopted pid, #318)"
+echo "[12] kill $SPID -> down (instant abrupt-down off the RE-adopted pid, #318)"
 kill "$SPID" 2>/dev/null
 expect down down-abrupt
 


### PR DESCRIPTION
The #318 mid-attach step of `scripts/openclaw-live-e2e.sh` failed on its first-ever execution (#725, surfaced when the script was wired into `just openclaw-e2e` in #727).

## Root cause — the test, not the product

`#318` works. The script asserted a precondition it had already defeated:

- `PidSeen` pid-adoption is **None-only** by design (`apply_presence`, `source/daemon.rs`): it bootstraps `current_pid` only when the daemon has none, so it can never clobber a live pid armed by `GatewayUp`.
- The shim stamps `_pid = getppid()` onto every event that lacks one, and an inbound `_pid` is kept (`pixtuoid-hook/src/main.rs`).
- So the `gateway_start` at step [5] already armed `current_pid` to the shim's parent. Step [10]'s `session_start` carrying `_pid=$SPID` hit a `Some`, adopted nothing, and killing `$SPID` was a no-op — the mascot correctly stayed `idle`.

The script's own comment claimed *"the daemon is up with current_pid=None"*; that was never true after step [5].

## Fix

Drive the scenario `#318` actually models (the same path documented in `source/openclaw.rs`): a reconnect after an abrupt down. `gateway_stop` takes the mascot Down, which clears `current_pid` via `enter_down`; the reconnect is then learned only from a plain `_pid`-carrying event, and `PidSeen` re-adopts because `current_pid` is None. The explicit `_pid` is kept by the shim, so it is the real live pid.

## Verified both ways — not by reading

- **Corrected script:** all 12 steps PASS, timeline ends `idle → down (gateway_stop) → idle (reconnect) → down (abrupt kill off the re-adopted pid)`.
- **Mutation:** disabling `PidSeen` adoption in the product reds the script at exactly `down-abrupt`. So the step now genuinely proves `#318` instead of passing vacuously — it could not catch a regression before, which was the issue's own stated concern.

No production code changed — this is a test-harness fix. The unit tests that already pin the product behaviour (`pid_seen_adopts_when_current_pid_is_none`, `pid_seen_never_clobbers_a_known_pid`, `pid_seen_re_adopts_after_an_abrupt_down_so_the_second_cycle_arms`) are unchanged and green.

Closes #725.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FysCoSsr1D1HiLsmsgpuGw