### PR TITLE
fix(release): install ALSA headers in the tag-time check job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,17 +49,8 @@ jobs:
       - uses: extractions/setup-just@v4
       - name: Validate tag commit is on main
         # A release tag pushed at an arbitrary (unreviewed) commit must not
-        # build + publish (#215). Pre-release tester tags (v*-winrc.N / -rc.N)
+        # build + publish (#215). Pre-release tester tags (v*-win.N / -rc.N)
         # are deliberately exempt — they exist to test commits BEFORE merge.
-        #
-        # The suffix MUST contain one of Homebrew's UNSTABLE_VERSION_KEYWORDS
-        # (alpha beta bpo dev experimental prerelease preview rc — see
-        # Library/Homebrew/livecheck/livecheck.rb). homebrew-core autobumps us
-        # off `git ls-remote --tags`, and anything the keyword filter misses
-        # parses as a NEWER version: the old `-win.N` name contained no keyword,
-        # so a tester tag on an UNREVIEWED commit could have been auto-bumped
-        # into homebrew-core and bottled on six platforms. `-rc` was safe only
-        # by accident of its spelling. Keep `rc` in any new channel name (#731).
         if: ${{ !contains(github.ref_name, '-') }}
         run: |
           git fetch origin main --quiet
@@ -69,7 +60,7 @@ jobs:
           fi
       - name: Validate tag matches Cargo.toml version
         run: |
-          # Pre-release suffixes (-winrc.1, -rc.1) validate against the base version —
+          # Pre-release suffixes (-win.1, -rc.1) validate against the base version —
           # the suffix is release-channel metadata, not a Cargo version.
           TAG_VERSION="${GITHUB_REF_NAME#v}"
           TAG_VERSION="${TAG_VERSION%%-*}"
@@ -282,7 +273,7 @@ jobs:
     # GH release (needs: [build, deb]) never ships. Matches the `release` job's gate.
     needs: [check, build, deb]
     # Never publish a pre-release to crates.io — the publish is irreversible;
-    # tester pre-release tags (v*-winrc.N etc.) build artifacts only.
+    # tester pre-release tags (v*-win.N etc.) build artifacts only.
     if: ${{ !contains(github.ref_name, '-') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -340,7 +331,7 @@ jobs:
     needs: [check, build, deb]
     # Never publish a pre-release to npm — like crates.io, an npm publish is
     # effectively irreversible (no unpublish after 72h). Pre-release tags
-    # (v*-winrc.N / -rc) build artifacts only. Consumes the SAME build artifacts
+    # (v*-win.N / -rc) build artifacts only. Consumes the SAME build artifacts
     # as the release job — npm is a third downstream consumer of the one build
     # matrix, not a parallel build.
     if: ${{ !contains(github.ref_name, '-') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,13 @@ jobs:
         with:
           # Full history for the tag-on-main ancestry check below.
           fetch-depth: 0
+      # rodio/cpal (the default-on `audio` feature) needs ALSA headers to BUILD
+      # on Linux (#633) — alsa-sys's build script PANICS when pkg-config can't
+      # find them. ci.yml installs this in every Linux job; this workflow had
+      # none, so `just clippy` below would have failed on the FIRST tag after
+      # #633 — in the one gate that only ever runs at tag time.
+      - name: Install ALSA headers
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
@@ -42,8 +49,17 @@ jobs:
       - uses: extractions/setup-just@v4
       - name: Validate tag commit is on main
         # A release tag pushed at an arbitrary (unreviewed) commit must not
-        # build + publish (#215). Pre-release tester tags (v*-win.N / -rc.N)
+        # build + publish (#215). Pre-release tester tags (v*-winrc.N / -rc.N)
         # are deliberately exempt — they exist to test commits BEFORE merge.
+        #
+        # The suffix MUST contain one of Homebrew's UNSTABLE_VERSION_KEYWORDS
+        # (alpha beta bpo dev experimental prerelease preview rc — see
+        # Library/Homebrew/livecheck/livecheck.rb). homebrew-core autobumps us
+        # off `git ls-remote --tags`, and anything the keyword filter misses
+        # parses as a NEWER version: the old `-win.N` name contained no keyword,
+        # so a tester tag on an UNREVIEWED commit could have been auto-bumped
+        # into homebrew-core and bottled on six platforms. `-rc` was safe only
+        # by accident of its spelling. Keep `rc` in any new channel name (#731).
         if: ${{ !contains(github.ref_name, '-') }}
         run: |
           git fetch origin main --quiet
@@ -53,7 +69,7 @@ jobs:
           fi
       - name: Validate tag matches Cargo.toml version
         run: |
-          # Pre-release suffixes (-win.1, -rc.1) validate against the base version —
+          # Pre-release suffixes (-winrc.1, -rc.1) validate against the base version —
           # the suffix is release-channel metadata, not a Cargo version.
           TAG_VERSION="${GITHUB_REF_NAME#v}"
           TAG_VERSION="${TAG_VERSION%%-*}"
@@ -266,7 +282,7 @@ jobs:
     # GH release (needs: [build, deb]) never ships. Matches the `release` job's gate.
     needs: [check, build, deb]
     # Never publish a pre-release to crates.io — the publish is irreversible;
-    # tester pre-release tags (v*-win.N etc.) build artifacts only.
+    # tester pre-release tags (v*-winrc.N etc.) build artifacts only.
     if: ${{ !contains(github.ref_name, '-') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -324,7 +340,7 @@ jobs:
     needs: [check, build, deb]
     # Never publish a pre-release to npm — like crates.io, an npm publish is
     # effectively irreversible (no unpublish after 72h). Pre-release tags
-    # (v*-win.N / -rc) build artifacts only. Consumes the SAME build artifacts
+    # (v*-winrc.N / -rc) build artifacts only. Consumes the SAME build artifacts
     # as the release job — npm is a third downstream consumer of the one build
     # matrix, not a parallel build.
     if: ${{ !contains(github.ref_name, '-') }}


### PR DESCRIPTION
The `check` job in `release.yml` runs `just clippy` + `just test` on ubuntu-latest with DEFAULT features. #633 made `audio` default → `rodio → cpal → alsa-sys`, whose build script **panics** when pkg-config can't find ALSA:

```
Pkg-config failed - usually this is because alsa development headers are not installed.
For Debian/Ubuntu users:  # apt-get install libasound2-dev
```

`ci.yml` installs `libasound2-dev` in eight jobs; `release.yml` installed it in zero. `v0.15.0` predates the audio feature (`git show v0.15.0:Cargo.lock | grep -c alsa` → 0), so the **first tag after #633 is the first to hit it** — in the one gate that only runs when it's already too late to iterate. This is not reachable from a PR (`release.yml` runs only on `v*` tags), so nothing here has ever been exercised.

Fix: one apt step, byte-for-byte the line `ci.yml` already uses.

## History of this PR (two commits)

It originally also renamed the Windows tester tag channel `-win.N` → `-winrc.N`, so its suffix would carry `rc` and be caught by Homebrew's pre-release keyword filter — stopping an unreviewed tester tag from auto-bumping homebrew-core.

**That was reverted after a fact-check.** Homebrew's documented mechanism for excluding pre-release tags is a `livecheck` regex on the *formula*, which excludes every suffix rather than only keyword-matching ones. The keyword list is Homebrew's internal fallback, not a naming contract for upstreams, so a rename here rested on an implementation detail and left the next channel name (or a typo) able to reopen the gap. The correct fix already existed in **#731** (the livecheck regex). Commit `619043e4` reverts the rename; the pre-release/autobump concern is left entirely to #731.

So this PR now closes exactly one gap: the missing ALSA headers.

## Verification

`actionlint` 0 · `just preflight` 0 (pre-push hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2exCpj7ampnCeaF9y7vuF