### PR TITLE
fix(raycast): patch two advisories across three vulnerable instances

### DIFF
--- a/integrations/raycast/package-lock.json
+++ b/integrations/raycast/package-lock.json
@@ -1676,9 +1676,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -2150,9 +2150,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -2381,9 +2381,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Lockfile only — `package.json` untouched, 9 lines changed, no incidental churn.

| package | bump | scope |
|---|---|---|
| brace-expansion | 5.0.6 → 5.0.7 (patch) | **runtime** |
| brace-expansion | 2.1.1 → 2.1.2 (patch) | **runtime** |
| js-yaml | 4.2.0 → 4.3.0 (minor) | dev |

Two advisories, three instances. **GHSA-3jxr-9vmj-r5cp** (high — DoS via exponential-time brace expansion) covers both brace-expansion copies through separate ranges; **GHSA-52cp-r559-cp3m** (high — quadratic CPU from YAML merge-key chains) covers js-yaml. The js-yaml bump is minor, not patch: 4.3.0 is its first patched version.

**Two of the three are runtime-reachable** — the lockfile marks brace-expansion 5.0.7 `dev: false` (`minimatch@10` is reached from `@raycast/api` → `@oclif/core`, a production dependency). Only js-yaml is dev-only.

Dependabot opened no PR and its update job failed because all three are transitive — absent from `package.json`, so there's no manifest edit to propose, only a lockfile bump.

`npm audit` now reports 0 vulnerabilities; `npm ci` / `tsc` / `eslint` stay green.

**site/ carries the same brace-expansion advisory but is deliberately out of scope** — `npm audit fix` there also pulls astro 7.0.9 → 7.1.3 and a major @antfu/install-pkg bump, too much blast radius for a security patch, and it collides with the open astro PR. Tracked in #734.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2exCpj7ampnCeaF9y7vuF