### PR TITLE
docs: add the step-3 design gate to the arc loop (best-practice + adversarial + deepening)

### DIFF
--- a/.claude/skills/add-source/SKILL.md
+++ b/.claude/skills/add-source/SKILL.md
@@ -35,13 +35,12 @@ the runtime wiring + `Source` impl, and ships a `hook.custom` decoder + an
 These are the ones with a failing test attached — do NOT stop before them:
 
 - **`site/src/sources.json` row** — a manifest bridge test fails until it exists;
-  then `just gen-readme` to sync the README. (CLAUDE.md step 5.)
+  then `just gen-readme` to sync the README.
 - **Per-source badge hue** — a `Theme::source` (`SourceColors`) field in EVERY
   theme file + a `dashboard_line` match arm; two guard tests fail otherwise.
-  (CLAUDE.md step 7.)
 - **`pub fn <cli>_home()`** if the CLI has a custom config root — one fn honoring
   its `*_HOME` precedence, called from BOTH the watcher's `default_paths()` AND the
-  installer's `default_config_path()` so they can't disagree. (CLAUDE.md step 6.)
+  installer's `default_config_path()` so they can't disagree.
 - **A captured fixture** under `tests/sources/fixtures/<name>/<scenario>/`
   exercising the **SessionStart hook** — the conformance test forces one, and its
   one-AgentId assertion guards against the reason-field ghost.

--- a/.github/prompts/impl-plan.prompt.md
+++ b/.github/prompts/impl-plan.prompt.md
@@ -18,6 +18,13 @@ right-size the process; don't 700-line-plan a 300-line change.
 
 Every section gets an answer; "n/a" counts only with a reason.
 
+0. **Design gate cleared** (arc-loop step 3) — before the sections below, the
+   plan states the approach passed the gate: the idiomatic way is confirmed
+   against real docs/source (not memory); the design survived an adversarial
+   pass; the deepening lens ran (deletion test — does this *deepen* a module or
+   add another shallow one = AI-slop?). Name any big-radius refactor the
+   deepening warrants — a slop-reducing refactor is in-scope here, not deferred
+   by default.
 1. **Data shapes** — for every NEW field, config key, map, or collection:
    name its identity/key-space. If it overlaps an existing structure's
    identity (two collections keyed by the same id; an attribute map

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,21 +195,35 @@ repo-committed and won't exist on a fresh checkout or in a non-Claude tool.
 2. **Grill the design** — decide the open questions ONE at a time, each with a
    recommended answer, before writing code. (A big arc introducing new
    seams/vocabulary grills against the domain docs first.)
-3. **Spec** — synthesize the grilled decisions into `docs/superpowers/specs/`
+3. **Design gate (before build; NOT the step-8 merge review)** — the grilled
+   approach clears three design-time lenses so slop dies in design, not review:
+   **best-practice search** (confirm the *idiomatic* way against real
+   docs/source online — never memory: the dep's own API/features, the standard
+   pattern); **adversarial design review** (red-team the design itself — simplest
+   shape? failure mode? — BEFORE code exists); **deepening lens** (the deletion
+   test — would deleting this concentrate complexity or just move it? — plus the
+   deep-vs-shallow check: does the change *deepen* a module or add another
+   shallow one = AI-slop?). Cut slop in small, verified steps; a big-radius
+   refactor is fine when the deepening earns it. (`codebase-design` /
+   `improve-codebase-architecture` drive the deepening lens; this repo keeps its
+   domain record + decisions-not-to-relitigate in nested `CLAUDE.md` + "Known
+   sharp edges", NOT a `CONTEXT.md`/`docs/adr/` — map onto those, don't scaffold
+   competing docs.)
+4. **Spec** — synthesize the grilled decisions into `docs/superpowers/specs/`
    (LOCAL, git-ignored — the working design record, not the tracker). Also
    plan against [`.github/prompts/impl-plan.prompt.md`](.github/prompts/impl-plan.prompt.md).
-4. **Mock gate (taste/visual work only)** — ratify the AFTER visual BEFORE any
+5. **Mock gate (taste/visual work only)** — ratify the AFTER visual BEFORE any
    code (the `beautify-decoration` skill's "The visual-iteration loop").
-5. **Build** — TDD (see Conventions): failing test → minimal impl → commit.
-6. **Self-review** — a standards+spec pass before pushing. Not the merge gate.
-7. **Merge gate (non-negotiable)** — the **two-lens review** (2+ differentiated
+6. **Build** — TDD (see Conventions): failing test → minimal impl → commit.
+7. **Self-review** — a standards+spec pass before pushing. Not the merge gate.
+8. **Merge gate (non-negotiable)** — the **two-lens review** (2+ differentiated
    lenses on the diff) + green CI + the online review bot's `Findings: 0` at
    HEAD, checked atomically. (If the bot errors or posts no findings comment at
    HEAD — it can fail on a very large diff — the gate is unsatisfiable as
    written; the `two-lens-review` skill's step 6 owns the fallback.)
    See "Things NOT to do" and the running order under "Where to look". **A human
    merges.**
-8. **Wrap** — retro; record durable lessons.
+9. **Wrap** — retro; record durable lessons.
 
 **Skills.** Repo skills live in [`.claude/skills/`](.claude/skills/) (committed,
 so they travel with the repo): `two-lens-review` (the merge gate),
@@ -221,7 +235,9 @@ run the loop above as prose.
 
 **Bootstrap on a fresh machine / other tool.** `git clone` gives you the repo
 skills + all `just` gates immediately. The day-to-day *loop* skills
-(`grilling`, `to-spec`, `tdd`, `code-review`, `diagnosing-bugs`) are a
+(`grilling`, `to-spec`, `tdd`, `code-review`, `diagnosing-bugs`, plus
+`research`/`grill-with-docs` and `improve-codebase-architecture`/`codebase-design`
+for the step-3 design gate) are a
 PERSONAL, non-committed layer — install [mattpocock/skills](https://github.com/mattpocock/skills)
 if you want the Claude Code implementations; otherwise this section IS the loop.
 Do NOT run its `setup-matt-pocock-skills` here — it scaffolds a `CONTEXT.md` +


### PR DESCRIPTION
## What

Codifies a standing, session-portable **design gate** so every session and tool (via the `AGENTS.md` symlink) runs it *before* build — not just ad hoc. Inserts a new **arc-loop step 3** between *Grill* and *Spec* (renumbering Spec→4 … Wrap→9), fusing three design-time lenses so AI-slop dies in design rather than at review:

- **best-practice search** — confirm the idiomatic approach against real docs/source online, never memory (the exact discipline that caught the rodio `open_default_sink` / `tracing`-feature fallback regression in #746);
- **adversarial design review** — red-team the design itself *before* code exists;
- **deepening lens** — the deletion test + deep-vs-shallow check (does this *deepen* a module or add another shallow one = slop?), driven by the `codebase-design` / `improve-codebase-architecture` vocabulary. Cut slop in small verified steps; big-radius refactors are in-scope when earned.

## Integration

The deepening lens deliberately maps onto this repo's nested `CLAUDE.md` + "Known sharp edges" instead of the arch skill's `CONTEXT.md`/`docs/adr/` — which the Bootstrap note already rejects as a competing doc convention.

## Also

- Names the gate's personal-skill implementations in the Bootstrap paragraph.
- Adds a "0. Design gate cleared" lead-in to `impl-plan.prompt.md` so non-trivial changes assert it where they plan.

## Verification

Docs-only. `just links` (offline link+anchor check) passes; `AGENTS.md` is a symlink to `CLAUDE.md` so the change propagates; arc-loop step numbers have no hard cross-refs elsewhere (verified before renumbering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2exCpj7ampnCeaF9y7vuF