### PR TITLE
fix(audio): fold the volume-persist flush into AudioController::drop (#752)

### DIFF
--- a/crates/pixtuoid/CLAUDE.md
+++ b/crates/pixtuoid/CLAUDE.md
@@ -277,8 +277,8 @@ src/
 │                       a release synth build since run_loop is blind to the closed channel mid-build). Each
 │                       painter holds ONE controller (TUI a run_tui local; floating a FloatingApp field),
 │                       built AFTER that painter's fallible `?` boot steps — so no thread predates its
-│                       Drop-owner and the compiler runs the teardown on EVERY exit (q/Ctrl-C/terminate/error/`?`/
-│                       panic-unwind), no hand-wired call to forget. Drop FLUSHES a pending debounced volume
+│                       Drop-owner and the compiler runs the teardown on EVERY exit (q/Ctrl-C/terminate/error/`?`;
+│                       a release `panic=abort` is the one exit it skips), no hand-wired call to forget. Drop FLUSHES a pending debounced volume
 │                       BEFORE the join, so a nudge-then-Ctrl-C persists too (#752, was `q`-branch-only). The join is bounded because
 │                       CoreAudio device-close can itself block. The mute/volume TRANSITION is
 │                       ONE authority — `audio::apply_audio_action(&mut AudioUi, action, paused, spawn)`

--- a/crates/pixtuoid/CLAUDE.md
+++ b/crates/pixtuoid/CLAUDE.md
@@ -277,13 +277,15 @@ src/
 │                       a release synth build since run_loop is blind to the closed channel mid-build). Each
 │                       painter holds ONE controller (TUI a run_tui local; floating a FloatingApp field),
 │                       built AFTER that painter's fallible `?` boot steps — so no thread predates its
-│                       Drop-owner and the compiler runs the join on EVERY exit (q/Ctrl-C/terminate/error/`?`/
-│                       panic-unwind), no hand-wired shutdown call to forget. The join is bounded because
+│                       Drop-owner and the compiler runs the teardown on EVERY exit (q/Ctrl-C/terminate/error/`?`/
+│                       panic-unwind), no hand-wired call to forget. Drop FLUSHES a pending debounced volume
+│                       BEFORE the join, so a nudge-then-Ctrl-C persists too (#752, was `q`-branch-only). The join is bounded because
 │                       CoreAudio device-close can itself block. The mute/volume TRANSITION is
 │                       ONE authority — `audio::apply_audio_action(&mut AudioUi, action, paused, spawn)`
 │                       (audio/mod.rs, unit-tested); the PERSIST protocol around it (mute-save-now, volume
 │                       debounce→flash-expiry, exit-flush) is a SECOND authority BOTH painters OWN —
-│                       `audio::AudioController` (new/apply/tick/flush_on_exit/set_paused/volume_flash/handle;
+│                       `audio::AudioController` (new/apply/tick/set_paused/volume_flash/handle, exit-flush now
+│                       folded into Drop;
 │                       `now` injected → the debounce/flash is unit-tested). The TUI keeps ONE controller (was
 │                       5 loop locals + a deleted `run_audio_action`); floating keeps one (was its own
 │                       volume_flash/volume_dirty/flush_volume). BOTH painters now render the shared

--- a/crates/pixtuoid/src/audio/mod.rs
+++ b/crates/pixtuoid/src/audio/mod.rs
@@ -265,7 +265,9 @@ impl AudioController {
 /// PERSIST a pending debounced volume, THEN stop the device thread. Each painter
 /// holds exactly ONE controller (TUI a `run_tui` local; floating a `FloatingApp`
 /// field), so this fires once on EVERY exit — the compiler guarantees it runs
-/// where a hand-wired call could be forgotten on some `?`/panic path.
+/// where a hand-wired call could be forgotten on some `?`/early-return path.
+/// (Release is `panic="abort"`, so a panic — a crash — is the one exit that
+/// skips Drop; losing a sub-second unsaved volume nudge there is acceptable.)
 ///
 /// Ordering is persist-before-stop, and both run unconditionally: before #752
 /// the volume flush sat on the TUI `q` branch only, so Ctrl-C / terminate / error
@@ -423,6 +425,23 @@ mod controller_tests {
         assert!(
             std::fs::read_to_string(&path).unwrap().contains("volume"),
             "AudioController::drop must persist a pending nudge (the #752 Ctrl-C fix)"
+        );
+    }
+
+    #[test]
+    fn a_clean_drop_does_not_rewrite_the_config() {
+        // Drop now does config I/O on EVERY exit — the ONLY guard against a
+        // needless rewrite (+ `.bak` churn) on every quit is `volume_dirty`. Pin
+        // it: an un-nudged controller's drop must leave the config byte-identical
+        // (a mutant flipping the guard to `if true` would else survive).
+        let (c, _dir) = ctl(false, 0.50);
+        let path = c.config_path.clone();
+        let before = std::fs::read_to_string(&path).unwrap();
+        drop(c); // no nudge → flush_on_exit is a no-op
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            before,
+            "an un-dirtied drop must not touch the user's config"
         );
     }
 }

--- a/crates/pixtuoid/src/audio/mod.rs
+++ b/crates/pixtuoid/src/audio/mod.rs
@@ -232,8 +232,9 @@ impl AudioController {
         }
     }
 
-    /// Flush any pending volume on shutdown (a nudge-then-quit).
-    pub(crate) fn flush_on_exit(&mut self) {
+    /// Flush any pending debounced volume on exit (a nudge-then-quit). Called
+    /// from `Drop` now — the ONE exit path — not per painter.
+    fn flush_on_exit(&mut self) {
         if self.volume_dirty {
             self.save_volume();
         }
@@ -260,17 +261,25 @@ impl AudioController {
     }
 }
 
-/// RAII teardown: stop the device thread when the controller drops. Each painter
+/// RAII teardown — the ONE exit verb for BOTH halves of the audio protocol:
+/// PERSIST a pending debounced volume, THEN stop the device thread. Each painter
 /// holds exactly ONE controller (TUI a `run_tui` local; floating a `FloatingApp`
 /// field), so this fires once on EVERY exit — the compiler guarantees it runs
-/// where a hand-wired `shutdown()` call could be forgotten on some `?`/panic
-/// path. `AudioHandle::shutdown` drops the sole sender (closing the device
-/// thread's channel) and JOINS the thread so its `RodioSink` Drop — the OS
-/// device close — completes before the process exits; idempotent + a no-op for a
-/// muted session that never spawned. See the `AudioHandle::shutdown` docs for
-/// why the join (not just the drop) is load-bearing on macOS CoreAudio.
+/// where a hand-wired call could be forgotten on some `?`/panic path.
+///
+/// Ordering is persist-before-stop, and both run unconditionally: before #752
+/// the volume flush sat on the TUI `q` branch only, so Ctrl-C / terminate / error
+/// lost a nudge that landed inside the debounce window — moving it here fixes that
+/// (Drop already ran on every exit for the device stop). `flush_on_exit` is a
+/// no-op unless a nudge is pending; both halves are panic-free (save + join log,
+/// never unwrap), safe to run during unwind. `AudioHandle::shutdown` drops the
+/// sole sender (closing the device thread's channel) and JOINS the thread so its
+/// `RodioSink` Drop — the OS device close — completes before the process exits;
+/// idempotent + a no-op for a muted session that never spawned. See the
+/// `AudioHandle::shutdown` docs for why the join is load-bearing on macOS CoreAudio.
 impl Drop for AudioController {
     fn drop(&mut self) {
+        self.flush_on_exit();
         self.ui.handle.shutdown();
     }
 }
@@ -394,6 +403,26 @@ mod controller_tests {
                 .unwrap()
                 .contains("volume"),
             "a nudge-then-quit persists on exit"
+        );
+    }
+
+    #[test]
+    fn drop_persists_a_pending_nudge_even_without_the_q_path() {
+        // #752 Ctrl-C bug: the flush used to run only on the TUI `q` branch, so
+        // an external terminate (Ctrl-C / signal / error) lost a debounced volume
+        // nudge. Now `AudioController::drop` flushes on EVERY exit — modelled by
+        // dropping a dirtied controller WITHOUT the q path or an explicit flush.
+        let (mut c, _dir) = ctl(false, 0.50);
+        let path = c.config_path.clone();
+        c.apply(AudioAction::Volume(false), false, Instant::now(), |_, _| {});
+        assert!(
+            !std::fs::read_to_string(&path).unwrap().contains("volume"),
+            "not yet persisted — still inside the debounce window"
+        );
+        drop(c); // the ONLY exit signal: no `q`, no explicit flush_on_exit()
+        assert!(
+            std::fs::read_to_string(&path).unwrap().contains("volume"),
+            "AudioController::drop must persist a pending nudge (the #752 Ctrl-C fix)"
         );
     }
 }

--- a/crates/pixtuoid/src/floating/window.rs
+++ b/crates/pixtuoid/src/floating/window.rs
@@ -370,7 +370,9 @@ impl ApplicationHandler<FloatingEvent> for FloatingApp {
     ) {
         match event {
             WindowEvent::CloseRequested => {
-                self.audio_ctl.flush_on_exit();
+                // Geometry MUST persist HERE — the window is gone once `run_app`
+                // returns. The audio persist + device stop instead ride
+                // `AudioController::drop` when `app` drops post-`run_app` (#752).
                 self.persist_geometry();
                 event_loop.exit();
             }

--- a/crates/pixtuoid/src/tui/mod.rs
+++ b/crates/pixtuoid/src/tui/mod.rs
@@ -1047,8 +1047,9 @@ pub(crate) async fn run_tui(session: TuiSession) -> Result<()> {
                 if ui.theme_picker.is_some() {
                     renderer.set_theme(theme::ALL_THEMES[ui.saved_theme_idx]);
                 }
-                // a nudge-then-quit inside the debounce window still persists
-                audio_ctl.flush_on_exit();
+                // The debounced-volume flush + device stop both ride
+                // `AudioController::drop` (fires on ALL exits, not just `q`) —
+                // `audio_ctl` drops as this fn returns. See its Drop impl (#752).
                 break;
             }
             // The frame-pacing sleep doubles as the signal-listen window (the


### PR DESCRIPTION
Closes #752.

Deferred from the #746 three-lens review (design lens §3). Unifies the painter
audio exit into ONE verb and fixes a pre-existing persist bug.

## The bug (concern #2)

After #746 made device teardown RAII, the volume flush stayed split: `flush_on_exit()`
ran only on the TUI `q` branch and floating's `CloseRequested`, while
`AudioController::drop` (device stop) ran on **every** exit. So a debounced volume
nudge inside its window was **lost on Ctrl-C / terminate / error**.

## The fix (concern #1 + #2)

`impl Drop` now does **persist THEN stop** — `flush_on_exit()` before `shutdown()`,
both on every exit path. The two explicit `flush_on_exit()` call sites are deleted
(floating keeps `persist_geometry()` in `CloseRequested` — it needs the live window;
only the audio flush moves to Drop). `flush_on_exit` drops to **private** — Drop is
its only caller now.

This completes the "AudioController is the one persist+device exit authority" story
with **less** code than the issue's proposed `close()`: Drop *is* the single verb.
Both halves are panic-free (save + join log, never unwrap), safe during unwind.

## Test

Device-free regression test: a volume-dirtied controller dropped **without** the `q`
path or an explicit flush must persist the nudge. Negative-controlled — red before
the Drop change, on the exact assertion.

Gates: `just preflight` green; clippy `-D warnings` clean; `pixtuoid --lib` 833 passed
incl. the new test. CLAUDE.md audio-teardown note updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2exCpj7ampnCeaF9y7vuF