### PR TITLE
perf(test): de-duplicate synth-test synthesis + belt the irreducible one (#736)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -49,7 +49,9 @@ threads-required = "num-cpus"
 # taxes every CI job's wall-clock) — instead raise only the hard KILL. Keep the
 # 60s SLOW marker so its growth stays VISIBLE every run; lift terminate to 5×60=300s
 # so coverage instrumentation (~2×) + CI contention can't false-red it while a real
-# ≥1.5× synthesis regression still trips it.
+# ≥1.5× synthesis regression still trips it. REVISIT if CI shows this past ~250s:
+# the headroom is gone — dedup further, split the smoke, or reduce the seed sweep
+# rather than lifting the cap again (the SLOW marker is only a soft signal).
 [[profile.default.overrides]]
 filter = 'test(generated_beds_are_finite_phase_locked_and_in_the_sound_world)'
 slow-timeout = { period = "60s", terminate-after = 5 }

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -38,3 +38,18 @@ threads-required = "num-cpus"
 [[profile.default.overrides]]
 filter = 'test(connected_codex_rollout_becomes_a_sprite) | test(disconnected_codex_rollout_is_dropped_by_the_gate)'
 threads-required = "num-cpus"
+
+# `generated_beds_…` composes + synthesizes 4 full arrangements (2 moods × 2
+# seeds) — ~100s of IRREDUCIBLE unique work, and the ONE synth test that actually
+# tripped the 180s cap under contention (#736). It has no redundancy to cut (the
+# other two synth tests DID — they re-synthesized shared take-stems, now
+# de-duplicated), and its seed count is the author's stated minimum smoke ("a
+# couple suffice"; the musical invariants are the compose seed-sweep's job). So
+# NOT `threads-required` (giving a ~100s test the whole machine serialises it and
+# taxes every CI job's wall-clock) — instead raise only the hard KILL. Keep the
+# 60s SLOW marker so its growth stays VISIBLE every run; lift terminate to 5×60=300s
+# so coverage instrumentation (~2×) + CI contention can't false-red it while a real
+# ≥1.5× synthesis regression still trips it.
+[[profile.default.overrides]]
+filter = 'test(generated_beds_are_finite_phase_locked_and_in_the_sound_world)'
+slow-timeout = { period = "60s", terminate-after = 5 }

--- a/crates/pixtuoid-scene/src/audio/synth.rs
+++ b/crates/pixtuoid-scene/src/audio/synth.rs
@@ -1271,6 +1271,14 @@ mod tests {
             ),
         ];
         for (name, buf, ref_centroid, tol, bands) in cases {
+            // finite/peak on the day-takes lives HERE now: they are the heaviest
+            // buffers in the suite, and `every_buffer_is_finite_and_peak_bounded`
+            // used to RE-synthesize all 8 just to re-check this — assert it on the
+            // copies already built in `cases` instead of a second synthesis (#736).
+            assert!(
+                buf.iter().all(|v| v.is_finite() && v.abs() <= 1.0),
+                "{name}: NaN/over-peak"
+            );
             let c = centroid_hz(&buf);
             assert!(
                 (c - ref_centroid).abs() <= ref_centroid * 0.20,
@@ -1283,17 +1291,18 @@ mod tests {
                     "{name} band {lo}-{hi}: {s:.3} vs ratified {ref_share}"
                 );
             }
-        }
-        // the full-kit signatures night deliberately lacks: the snare's
-        // 400-3200 noise body and the open hat's long top-end ring both
-        // put audible energy in 3.5-6.5k
-        for take in [&score::DAY2, &score::DAY3] {
-            let drums = day_take_drums(take, &mut NoiseStream::new(4));
-            let hats = band_energy_share(&drums, 3500.0, 6500.0);
-            assert!(
-                hats > 0.0015,
-                "day-take hats/snare must be audible in 3.5-6.5k: {hats:.5}"
-            );
+            // the full-kit signatures night deliberately lacks: the snare's
+            // 400-3200 noise body and the open hat's long top-end ring both put
+            // audible energy in 3.5-6.5k. Reuse the drums buffer already built in
+            // `cases` — this was a second synthesis pass per take (#736). Same
+            // `NoiseStream::new(4)` seed, so it is the identical buffer.
+            if name.ends_with("drums") {
+                let hats = band_energy_share(&buf, 3500.0, 6500.0);
+                assert!(
+                    hats > 0.0015,
+                    "{name} hats/snare must be audible in 3.5-6.5k: {hats:.5}"
+                );
+            }
         }
     }
 
@@ -1467,14 +1476,12 @@ mod tests {
             ("night_keys", night_keys()),
             ("night_drums", night_drums(&mut rng)),
             ("night_texture", night_texture(&mut rng)),
-            ("day2_pad", day_take_pad(&score::DAY2)),
-            ("day2_sparkle", day_take_sparkle(&score::DAY2)),
-            ("day2_keys", day_take_keys(&score::DAY2)),
-            ("day2_drums", day_take_drums(&score::DAY2, &mut rng)),
-            ("day3_pad", day_take_pad(&score::DAY3)),
-            ("day3_sparkle", day_take_sparkle(&score::DAY3)),
-            ("day3_keys", day_take_keys(&score::DAY3)),
-            ("day3_drums", day_take_drums(&score::DAY3, &mut rng)),
+            // The 8 day2/day3 take-stems are the heaviest buffers in the suite and
+            // are ALREADY synthesized (+ finite/peak-checked) in
+            // `day_take_stems_match_the_ratified_fingerprints`; re-building them
+            // here was a duplicate synthesis pass (#736). pad/sparkle/keys are
+            // deterministic → identical there; drums' finite/peak is seed-agnostic
+            // and also covered by `generated_beds_…`'s per-seed beds.
         ] {
             assert!(!buf.is_empty(), "{name} empty");
             assert!(


### PR DESCRIPTION
Closes #736.

The three audio synth tests ran at ~77% of the 180s nextest cap and **red on contention, not on code** — `generated_beds_…` actually tripped `TIMEOUT [180.012s]` during a loaded preflight. #736 framed it as a decision; the design gate narrowed it:

- **Option 3 (cheaper synth) is blocked** — `SAMPLE_RATE` is woven through the DSP and the fingerprints are owner-LISTEN-ratified anchors; changing length/rate drifts them out of tolerance and needs re-ratification.
- **Blanket `threads-required` doesn't transfer** — the existing precedents exit on a positive signal ("exclusivity is nearly free"); these are ~100s of compute, so serialising all three → 2–3× every CI job's wall-clock.

So: **remove the real waste, then honestly size the gate for what's irreducible.**

## Dedup (safe lever — no pinned property touched)

- `every_buffer_is_finite_and_peak_bounded` re-synthesized the 8 heavy day2/day3 take-stems that `day_take_stems_match_the_ratified_fingerprints` already builds → dropped them there; assert their finite/peak in `day_take_stems_…` on the copies already in `cases`. pad/sparkle/keys are deterministic (identical); drums' finite/peak is seed-agnostic and also covered by `generated_beds_…`.
- `day_take_stems_…` built the day drums a 2nd time for the hats check → reuse the `cases` buffer (same `NoiseStream::new(4)` seed → identical).

**Measured (same box, nextest/debug):** `every_buffer` 54.9s→**30.0s** (−45%), `day_take_stems` 47.0s→**42.1s** (−10%). Under the full suite, the reduced total CPU also relieved `generated_beds`'s contention (it ran **76.2s**, was ~134s), and the suite dropped from **3 slow tests to 2**.

## Belt (the irreducible one)

`generated_beds_…` composes 4 unique arrangements (its seed count is the author's stated minimum smoke) — no redundancy to cut, and it's the test that timed out. Targeted nextest override: **keep the 60s SLOW marker** so its growth stays visible every run, **lift only the hard KILL to 5×60=300s** so coverage instrumentation (~2×) + contention can't false-red it while a real ≥1.5× regression still trips. **No `threads-required`** (no wall-clock tax), no blanket cap raise, no fingerprint risk. Inherited by the `ci` profile (coverage/macOS/Windows) like the existing overrides.

## Verification

`just preflight` green (2651 passed); `generated_beds` shows SLOW [>60s] at 76.2s and passes; nextest config parses + targets the test; clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2exCpj7ampnCeaF9y7vuF