### PR TITLE
ci(coverage): per-OS lcov for the platform-gated surface + all-shells packaging test (#747)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,6 +421,19 @@ jobs:
       - uses: extractions/setup-just@v4
       - name: Generate coverage + JUnit XML (single test run)
         run: just coverage
+      # Negative control: `fail_ci_if_error: false` (below) plus all-informational
+      # Codecov statuses mean a BROKEN instrument that produces an empty/missing
+      # lcov would upload nothing and CI would stay green — the exact false-green
+      # class the oracle plan (#727) exists to kill. A broken GENERATION must red
+      # the job here; only the transient UPLOAD stays non-blocking.
+      - name: Assert coverage artifacts are non-empty (negative control)
+        shell: bash
+        run: |
+          set -euo pipefail
+          for f in lcov.info target/nextest/ci/junit.xml; do
+            [ -s "$f" ] || { echo "::error::coverage produced no $f — a broken instrument must red the job, not silently upload nothing"; exit 1; }
+          done
+          echo "lcov.info=$(wc -c < lcov.info)B junit.xml=$(wc -c < target/nextest/ci/junit.xml)B"
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
         with:
@@ -436,6 +449,113 @@ jobs:
           files: target/nextest/ci/junit.xml
           report-type: test_results
           flags: unit
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  # Per-OS line coverage for the platform-gated surface the ubuntu `coverage` job
+  # compiles OUT and therefore CANNOT measure: the `cfg(windows)` parity twins, the
+  # named-pipe transport, `platform::home_first_dir`'s Windows arm,
+  # `write_config_atomic`'s rename-retry, the macOS path/`launchd` arms. These run
+  # the SAME `just coverage` recipe as ubuntu (one source of truth) and upload lcov
+  # under the SAME per-OS flag the required *-test jobs already use for their JUnit
+  # (Codecov keeps coverage and test_results separate per report-type, so the flag
+  # now means "everything measured on this platform").
+  #
+  # Deliberately SEPARATE from the required windows-test / macos-test jobs, and NOT
+  # required themselves: those stay fast, uninstrumented pass/fail gates, so the
+  # ~2x coverage-instrumentation cost — and any first-run instrumentation surprise
+  # on the never-before-instrumented platform-gated code — can never couple into a
+  # REQUIRED merge gate. Safe to instrument now that #736/#756 sized the audio-synth
+  # per-test caps for the coverage slowdown (measured on Apple Silicon: the belted
+  # `generated_beds_` ran 52s instrumented vs its 300s cap; the shim latency twins
+  # 0.13s vs their 200ms bound). Promote to required in a follow-up once real runs
+  # confirm they stay green — especially the Windows shim/pipe latency twins, which
+  # no instrumented run has ever exercised (they are compiled out on ubuntu).
+  coverage-windows:
+    name: coverage-windows
+    runs-on: windows-latest
+    # Generous vs windows-test's 30m: instrumented full suite on the slowest runner,
+    # and the FIRST run is cold — rust-cache keys the entry by RUSTFLAGS, so the
+    # `-C instrument-coverage` build has no prior cache until this job has run once.
+    # Per-test HANGS are already caught by nextest's slow-timeout, so this bound only
+    # has to cover total wall-clock + cold compile. Provisional — retighten to the
+    # observed p95 once CI reports it.
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      # Shared v1-rust prefix like every other job: rust-cache already keys by job-id
+      # AND RUSTFLAGS, so this instrumented job gets its own cache entry without
+      # colliding with the uninstrumented windows-test (the sibling ubuntu `coverage`
+      # job is likewise instrumented on v1-rust).
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v1-rust # see the clippy job's note
+      - uses: extractions/setup-just@v4
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@cargo-nextest
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate coverage + JUnit XML (single instrumented test run)
+        run: just coverage
+      # Same false-green negative control as the ubuntu coverage job.
+      - name: Assert coverage artifacts are non-empty (negative control)
+        shell: bash
+        run: |
+          set -euo pipefail
+          for f in lcov.info target/nextest/ci/junit.xml; do
+            [ -s "$f" ] || { echo "::error::coverage produced no $f — a broken instrument must red the job, not silently upload nothing"; exit 1; }
+          done
+          echo "lcov.info=$(wc -c < lcov.info)B junit.xml=$(wc -c < target/nextest/ci/junit.xml)B"
+      # lcov ONLY — the required windows-test job already uploads this platform's
+      # JUnit under flag `windows`; re-uploading it here would double the test rows.
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          files: lcov.info
+          flags: windows
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  coverage-macos:
+    name: coverage-macos
+    runs-on: macos-14
+    # Apple Silicon is fast (the belted audio measured 52s instrumented), so a
+    # tighter bound than windows suffices; still generous for the cold instrumented
+    # cache. Provisional — retighten to the observed p95.
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v1-rust # see the clippy job's note
+      - uses: extractions/setup-just@v4
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@cargo-nextest
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate coverage + JUnit XML (single instrumented test run)
+        run: just coverage
+      - name: Assert coverage artifacts are non-empty (negative control)
+        shell: bash
+        run: |
+          set -euo pipefail
+          for f in lcov.info target/nextest/ci/junit.xml; do
+            [ -s "$f" ] || { echo "::error::coverage produced no $f — a broken instrument must red the job, not silently upload nothing"; exit 1; }
+          done
+          echo "lcov.info=$(wc -c < lcov.info)B junit.xml=$(wc -c < target/nextest/ci/junit.xml)B"
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          files: lcov.info
+          flags: macos
           fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/crates/pixtuoid/tests/cli_packaging.rs
+++ b/crates/pixtuoid/tests/cli_packaging.rs
@@ -1,50 +1,91 @@
 //! Integration coverage for the `completions` / `man` packaging dispatch in
 //! `main.rs`. The clap_complete / clap_mangen GENERATION is unit-tested in
-//! `cli.rs`, but the DISPATCH — that the SHELL arg actually reaches clap_complete
-//! and that stdout stays the clean artifact channel (tracing → stderr) — had no
-//! test tooth (the codecov-excluded `main.rs` arms, #398).
+//! `cli.rs`; these spawn the REAL binary and assert the dispatch itself — that
+//! the SHELL arg reaches clap_complete and that stdout stays the clean artifact
+//! channel (tracing → stderr) — which the codecov-excluded `main.rs` arms (#398)
+//! have no unit-test tooth for. This is the homebrew-core contract our
+//! packaging-build CI job parses, promoted to a real number over EVERY supported
+//! shell (the #747 "generated-doc surface" hardening).
 
+use clap::ValueEnum;
+
+/// Spawn the built binary with a HERMETIC env: strip `$RUST_LOG` / `$PIXTUOID_LOG`
+/// so an inherited dev/CI verbosity can't raise the tracing floor and leak onto
+/// the channels these assertions check. Per the #172 RUST_LOG policy the binary
+/// HONORS a non-empty `$RUST_LOG`, so a test asserting a clean channel must clear
+/// it rather than assume it's unset.
 fn run(args: &[&str]) -> std::process::Output {
     std::process::Command::new(env!("CARGO_BIN_EXE_pixtuoid"))
         .args(args)
+        .env_remove("RUST_LOG")
+        .env_remove("PIXTUOID_LOG")
         .output()
         .expect("run pixtuoid")
 }
 
+/// Every shell clap_complete supports must emit exactly one clean script: a
+/// non-empty artifact naming the binary on stdout, nothing on stderr, exit 0 —
+/// and the scripts must be pairwise-distinct (proof the SHELL arg is honored, not
+/// a hardcoded generator). Iterating `Shell::value_variants()` (not a hardcoded
+/// subset) means a shell clap_complete adds later is covered automatically, the
+/// way `registered_source_names()` auto-covers a new source.
 #[test]
-fn completions_emit_a_shell_script_naming_the_binary() {
-    let out = run(&["completions", "bash"]);
+fn completions_emit_a_clean_script_for_every_supported_shell() {
+    let shells = clap_complete::Shell::value_variants();
+    // Negative control: with 0 or 1 shell the per-shell loop AND the pairwise
+    // distinctness tooth below would pass vacuously (clap_complete ships 5).
+    assert!(
+        shells.len() >= 2,
+        "clap_complete exposes < 2 shells ({}) — the per-shell + distinctness coverage below is vacuous",
+        shells.len()
+    );
+
+    let mut scripts = std::collections::HashSet::new();
+    for shell in shells {
+        let name = shell
+            .to_possible_value()
+            .expect("every Shell variant has a value name")
+            .get_name()
+            .to_owned();
+        let out = run(&["completions", &name]);
+        assert!(
+            out.status.success(),
+            "completions {name} exited non-zero: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(
+            out.stderr.is_empty(),
+            "completions {name} wrote to stderr — the artifact channel must stay clean: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(
+            String::from_utf8_lossy(&out.stdout).contains("pixtuoid"),
+            "completions {name} script omits the binary name"
+        );
+        assert!(
+            scripts.insert(out.stdout),
+            "completions {name} produced a script identical to another shell's — the shell arg is ignored"
+        );
+    }
+}
+
+/// `man` emits a real roff man page on the clean stdout channel — the homebrew
+/// `Utils.safe_popen_read` capture greps `^.TH`.
+#[test]
+fn man_emits_clean_roff_to_stdout() {
+    let out = run(&["man"]);
     assert!(
         out.status.success(),
-        "completions bash exited non-zero: {}",
+        "man exited non-zero: {}",
         String::from_utf8_lossy(&out.stderr)
     );
-    let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(
-        stdout.contains("pixtuoid"),
-        "completion script omits the binary name"
+        out.stderr.is_empty(),
+        "man wrote to stderr — the artifact channel must stay clean: {}",
+        String::from_utf8_lossy(&out.stderr)
     );
-}
-
-#[test]
-fn completions_shell_arg_actually_reaches_clap_complete() {
-    // Proves the dispatch passes the SHELL through (not a hardcoded one): the bash
-    // and zsh completion scripts are structurally different.
-    let bash = run(&["completions", "bash"]).stdout;
-    let zsh = run(&["completions", "zsh"]).stdout;
-    assert_ne!(
-        bash, zsh,
-        "bash and zsh completions are identical — the shell arg is ignored"
-    );
-}
-
-#[test]
-fn man_emits_roff_to_stdout() {
-    let out = run(&["man"]);
-    assert!(out.status.success(), "man exited non-zero");
-    let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(
-        stdout.contains(".TH"),
+        String::from_utf8_lossy(&out.stdout).contains(".TH"),
         "man output is not roff (.TH header missing)"
     );
 }


### PR DESCRIPTION
## What

Both gaps of #747 (oracle plan Step 2 — turn UNKNOWN quality-instrument readings into real numbers).

### Gap 2 — the generated-doc surface as a real number (`c7dc9000`)
`crates/pixtuoid/tests/cli_packaging.rs`: replace the three single-shell dispatch tests with one loop over `clap_complete::Shell::value_variants()` (all five supported shells — bash/elvish/fish/powershell/zsh — plus any shell clap adds later, the way `registered_source_names()` auto-covers a new source), and strengthen the `man` test. New tooth: the **clean channel** — each command must emit exactly one non-empty artifact naming the binary on stdout with **nothing on stderr**, so a stray tracing/eprintln leak onto the packaging channel homebrew-core's `install` block captures fails in *our* CI, not only theirs on an autobump. Pairwise-distinctness preserves the old `bash != zsh` "shell arg honored" proof; a `>= 2` roster guard is the negative control; `run()` strips `$RUST_LOG`/`$PIXTUOID_LOG` for hermeticity. Green under `cargo test`, `nextest`, and instrumented `cargo-llvm-cov`; per-shell assertions mutation-checked.

### Gap 1 — per-OS line coverage for the platform-gated surface (`e015dc0e`)
`.github/workflows/ci.yml`: two new **non-required** jobs, `coverage-windows` / `coverage-macos`, run the same `just coverage` recipe as ubuntu and upload lcov under the per-OS Codecov flag the required `*-test` jobs already use for JUnit (Codecov keeps coverage and test_results separate per report-type). They measure what the ubuntu `coverage` job compiles *out* and structurally cannot see: the `cfg(windows)` parity twins, the named-pipe transport, `platform::home_first_dir`'s Windows arm, `write_config_atomic`'s rename-retry, the macOS path/`launchd` arms.

Deliberately **separate from and not required alongside** `windows-test`/`macos-test` — those stay fast, uninstrumented pass/fail gates, so the ~2× instrumentation cost and any first-run surprise on never-before-instrumented platform-gated code can't couple into a required merge gate. Safe to instrument now that #756 (closing #736) sized the audio-synth per-test caps for the coverage slowdown (measured on Apple Silicon: belted `generated_beds_` 52s vs its 300s cap; shim latency twins 0.13s vs their 200ms bound).

Plus a **false-green negative control** on all three coverage jobs: assert `lcov.info` + `junit.xml` are non-empty before the (non-blocking) Codecov upload, so a *broken instrument* reds the job instead of silently uploading nothing behind `fail_ci_if_error: false` + all-informational statuses — the exact false-green class the oracle plan (#727) exists to kill.

## Why this does NOT auto-close #747

The new jobs are non-required, so a red `coverage-windows` won't block this PR. **Confirm `coverage-windows` + `coverage-macos` are green here and the windows/macos Codecov flags populate the platform-gated lines** before closing #747 by hand. Promoting the jobs to required (a branch-protection edit) once they've proven stable is tracked in #757.

## Verification
- fmt / clippy (`-D warnings`) / actionlint (+ shellcheck on embedded scripts): green.
- Gap 2 test: green under cargo test / nextest / instrumented llvm-cov; mutation-checked; negative-control proven to red on an empty lcov.
- Two-lens merge review on both diffs; the one confirmed finding (redundant `v1-rust-cov` cache prefix) fixed — rust-cache@v2 keys by job-id + RUSTFLAGS, so instrumented jobs share `v1-rust` without thrash (fact-checked at source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FysCoSsr1D1HiLsmsgpuGw
