### PR TITLE
ci: retighten coverage-windows/macos timeouts to observed cold worst-case (#757)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -475,13 +475,14 @@ jobs:
   coverage-windows:
     name: coverage-windows
     runs-on: windows-latest
-    # Generous vs windows-test's 30m: instrumented full suite on the slowest runner,
-    # and the FIRST run is cold — rust-cache keys the entry by RUSTFLAGS, so the
-    # `-C instrument-coverage` build has no prior cache until this job has run once.
-    # Per-test HANGS are already caught by nextest's slow-timeout, so this bound only
-    # has to cover total wall-clock + cold compile. Provisional — retighten to the
-    # observed p95 once CI reports it.
-    timeout-minutes: 60
+    # Instrumented full suite on the slowest runner. Per-test HANGS are already
+    # caught by nextest's slow-timeout, so this bound only has to cover total
+    # wall-clock + a cold instrumented compile (rust-cache keys the entry by
+    # RUSTFLAGS, so a cache miss rebuilds `-C instrument-coverage` from scratch).
+    # Retightened 60→20 after ~18 runs (incl. the first cold ones) measured a COLD
+    # worst-case of 10.3m (warm p95 ~8.7m) — 20m is ~2× the observed cold max, so it
+    # can't flake this now-required job while a 2×+ wall-clock regression trips (#757).
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
@@ -525,9 +526,9 @@ jobs:
     name: coverage-macos
     runs-on: macos-14
     # Apple Silicon is fast (the belted audio measured 52s instrumented), so a
-    # tighter bound than windows suffices; still generous for the cold instrumented
-    # cache. Provisional — retighten to the observed p95.
-    timeout-minutes: 45
+    # tighter bound than windows suffices. Retightened 45→15 after ~18 runs measured
+    # a COLD worst-case of 7.8m — ~2× headroom, same flake-safe sizing as windows (#757).
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
#757 action **2 of 2**. The #747 Gap-1 coverage jobs shipped with generous provisional bounds (windows **60m** / macos **45m**) pending real data.

## Data (measured, not estimated)
Across ~18 runs back to #758's first (cold, no-cache) runs — **zero flakes**, all green:

| job | provisional | warm p95 | **cold worst-case** | retightened |
|---|---|---|---|---|
| coverage-windows | 60m | ~8.7m | **10.3m** | **20m** |
| coverage-macos | 45m | ~7.8m | **7.8m** | **15m** |

**20/15 = ~2× the observed cold max** — a cache-miss cold instrumented compile clears without flaking the (soon-to-be-required) job, while a 2×+ total-wall-clock regression now trips. Per-test hangs are already caught separately by nextest's slow-timeout, so this bound only guards total wall-clock.

## The other half of #757 is yours
Action **1 of 2** — promoting `coverage-windows` + `coverage-macos` to **required** in branch protection (today they're measured but not enforced) — is a repo-settings change only you can make. **Refs #757, does NOT close it** — close once both this PR and the branch-protection promote land.

## Verify
- `actionlint` clean; diff is exactly the two coverage-job `timeout-minutes` (the matrix job at line 331, also 45, is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011DimXDbHGFurM5mU1h24s8