### PR TITLE
docs(api): api-surface goldens + missing_docs gate + crate-root doctests (#749)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,6 +397,30 @@ jobs:
       - uses: extractions/setup-just@v4
       - run: just semver
 
+  # Public-API surface golden (cargo-public-api) for the two published libs —
+  # COMPLEMENTS semver: the gate above says "major/minor?", this shows WHAT
+  # changed as a reviewable diff of api/<crate>.txt. rustdoc JSON is nightly-only,
+  # so `just api-surface-check` self-installs the pinned nightly (justfile
+  # API_NIGHTLY — kept there so the toolchain version lives in ONE place); this
+  # job only pins cargo-public-api to match the committed goldens. CI-only, like
+  # semver. cargo-public-api isn't in taiki-e/install-action, so binstall it.
+  api-surface:
+    name: api-surface
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v1-rust # see the clippy job's note
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-binstall
+      - name: Install cargo-public-api (pinned to match the committed goldens)
+        run: cargo binstall -y cargo-public-api@0.52.0
+      - uses: extractions/setup-just@v4
+      - run: just api-surface-check
+
   coverage:
     name: coverage
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,11 @@ git config core.hooksPath .githooks   # activate hooks once per clone
 Never pipe `preflight` through `tail`/`head` — the exit code becomes the
 pipe's and a real failure reads as green; redirect to a file and `echo $?`.
 CI-only gates: semver (pixtuoid-core + pixtuoid-scene — the binary's lib target is not a
-semver surface), coverage/smoke, gen-check, gen-readme-check, npm-check,
+semver surface), api-surface (`just api-surface-check` — a committed `cargo
+public-api` golden per published crate at `api/<crate>.txt`; the reviewable-diff
+twin of the semver gate: semver says "major/minor?", the golden says *what*
+changed — regenerate with `just api-surface` + commit when the public surface
+shifts), coverage/smoke, gen-check, gen-readme-check, npm-check,
 check-windows (cross-lint for msvc on every PR), snapshots (`cargo insta` —
 fails on a pending OR orphan `.snap`, the rot plain `cargo test` can't see).
 
@@ -260,6 +264,7 @@ issue labels (e.g. `bug` / `enhancement` / `upstream-drift` / `needs-human-verif
 - **Errors propagate via `anyhow::Result` in app code, `thiserror` in core** if a typed error becomes load-bearing. The hook listener and JSONL watcher log + continue on malformed input — they never panic.
 - **No `unwrap()` in non-test code.** Tests can unwrap freely.
 - **Layer-internal items stay `pub(crate)`, not `pub`.** `unreachable_pub` is `warn` in `[workspace.lints.rust]` and CI's `just clippy` (`-D warnings`) makes it a hard gate — a `pub` item in a private module tree fails the build. Reserve bare `pub` for genuinely cross-crate API (and in `pixtuoid-core`, only those reach the semver surface). The lint is the mechanical enforcement of "the install/uninstall entry points are `pub(crate)`, `crate::sources` is the only caller" and every other inter-layer seam.
+- **Every `pub` item in a PUBLISHED crate carries a doc comment.** `missing_docs` is `warn` via `#![warn(missing_docs)]` in `pixtuoid-core` + `pixtuoid-scene`'s `lib.rs` — NOT `[workspace.lints]`, because it's a public-API gate and the public API is exactly those two crates (the binary lib target isn't a semver surface), so it's scoped identically to the semver-checks + api-surface gates. `just clippy` (`-D warnings`) promotes it to a hard gate: a new `pub` item (or `pub` field/variant) in those two crates with no `///` fails the build. The corollary of the bullet above — once you've decided something is genuinely `pub`, document *what it is* (unit / provenance / invariant), not filler. A `#[doc(hidden)] pub` item (a workspace-internal seam that isn't stable API — the `overlay`/`board`/`footer` pattern in `pixtuoid-scene`) is exempt, which is the intended escape hatch for "public for mechanism, not contract".
 - **No scan-the-history logic.** Keep persistent state (a set, a map, a bool) updated as events arrive; never derive state by scanning backward through time.
 - **Match the surrounding shell** (zsh interactive / POSIX sh); `shellcheck` + `shfmt` any `.sh` you touch — run `just shfmt-fix` to format (both gated by `just lint` + the CI `hygiene` job). **macOS first**: BSD CLI, brew, launchd.
 - **Keep docs current.** A change that alters module structure, architecture, workflow, or public API updates the relevant `CLAUDE.md` + `README.md` in the same commit.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,12 @@ categories   = ["command-line-utilities", "visualization"]
 # `pub(crate)` — so a layer-internal item can't silently leak as crate API. It's
 # warn here; CI's `cargo clippy -- -D warnings` (just clippy) makes it a hard
 # gate. Semver-neutral: cargo-semver-checks never sees an unreachable item.
+#
+# `missing_docs` is NOT here on purpose: it is a PUBLIC-API gate, and the public
+# API is exactly the two PUBLISHED crates (the binary lib target is not a semver
+# surface). So it's enabled per-crate via `#![warn(missing_docs)]` in
+# pixtuoid-core/pixtuoid-scene `lib.rs` — scoped identically to the semver-checks
+# + api-surface gates, not fanned out over the binary crates' non-API internals.
 [workspace.lints.rust]
 unreachable_pub = "warn"
 

--- a/api/pixtuoid-core.txt
+++ b/api/pixtuoid-core.txt
@@ -1,0 +1,1772 @@
+pub mod pixtuoid_core
+pub mod pixtuoid_core::grid
+pub struct pixtuoid_core::grid::Grid<T>
+impl pixtuoid_core::grid::Grid<bool>
+pub fn pixtuoid_core::grid::Grid<bool>::is_walkable(&self, u16, u16) -> bool
+pub fn pixtuoid_core::grid::Grid<bool>::mark_blocked(&mut self, u16, u16, u16, u16, u16)
+pub fn pixtuoid_core::grid::Grid<bool>::mark_walkable(&mut self, u16, u16, u16, u16)
+pub fn pixtuoid_core::grid::Grid<bool>::new_open(u16, u16) -> Self
+impl<T: core::clone::Clone> pixtuoid_core::grid::Grid<T>
+pub fn pixtuoid_core::grid::Grid<T>::filled(u16, u16, T) -> Self
+impl<T: core::marker::Copy> pixtuoid_core::grid::Grid<T>
+pub fn pixtuoid_core::grid::Grid<T>::get_or(&self, u16, u16, T) -> T
+pub fn pixtuoid_core::grid::Grid<T>::resize_fill(&mut self, u16, u16, T)
+impl<T> pixtuoid_core::grid::Grid<T>
+pub fn pixtuoid_core::grid::Grid<T>::as_mut_slice(&mut self) -> &mut [T]
+pub fn pixtuoid_core::grid::Grid<T>::as_slice(&self) -> &[T]
+pub fn pixtuoid_core::grid::Grid<T>::from_vec(u16, u16, alloc::vec::Vec<T>) -> Self
+pub fn pixtuoid_core::grid::Grid<T>::get(&self, u16, u16) -> core::option::Option<&T>
+pub fn pixtuoid_core::grid::Grid<T>::set(&mut self, u16, u16, T)
+impl<T> pixtuoid_core::grid::Grid<T>
+pub fn pixtuoid_core::grid::Grid<T>::height(&self) -> u16
+pub fn pixtuoid_core::grid::Grid<T>::width(&self) -> u16
+impl<T: core::clone::Clone> core::clone::Clone for pixtuoid_core::grid::Grid<T>
+pub fn pixtuoid_core::grid::Grid<T>::clone(&self) -> pixtuoid_core::grid::Grid<T>
+impl<T: core::cmp::Eq> core::cmp::Eq for pixtuoid_core::grid::Grid<T>
+impl<T: core::cmp::PartialEq> core::cmp::PartialEq for pixtuoid_core::grid::Grid<T>
+pub fn pixtuoid_core::grid::Grid<T>::eq(&self, &pixtuoid_core::grid::Grid<T>) -> bool
+impl<T: core::cmp::PartialEq> core::marker::StructuralPartialEq for pixtuoid_core::grid::Grid<T>
+impl<T: core::default::Default> core::default::Default for pixtuoid_core::grid::Grid<T>
+pub fn pixtuoid_core::grid::Grid<T>::default() -> pixtuoid_core::grid::Grid<T>
+impl<T: core::fmt::Debug> core::fmt::Debug for pixtuoid_core::grid::Grid<T>
+pub fn pixtuoid_core::grid::Grid<T>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T> core::marker::Freeze for pixtuoid_core::grid::Grid<T>
+impl<T> core::marker::Send for pixtuoid_core::grid::Grid<T> where T: core::marker::Send
+impl<T> core::marker::Sync for pixtuoid_core::grid::Grid<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for pixtuoid_core::grid::Grid<T> where T: core::marker::Unpin
+impl<T> core::marker::UnsafeUnpin for pixtuoid_core::grid::Grid<T>
+impl<T> core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::grid::Grid<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for pixtuoid_core::grid::Grid<T> where T: core::panic::unwind_safe::UnwindSafe
+pub mod pixtuoid_core::id
+pub struct pixtuoid_core::id::AgentId(_)
+impl pixtuoid_core::id::AgentId
+pub fn pixtuoid_core::id::AgentId::from_parts(&str, &str) -> Self
+pub fn pixtuoid_core::id::AgentId::raw(self) -> u64
+impl core::clone::Clone for pixtuoid_core::id::AgentId
+pub fn pixtuoid_core::id::AgentId::clone(&self) -> pixtuoid_core::id::AgentId
+impl core::cmp::Eq for pixtuoid_core::id::AgentId
+impl core::cmp::Ord for pixtuoid_core::id::AgentId
+pub fn pixtuoid_core::id::AgentId::cmp(&self, &pixtuoid_core::id::AgentId) -> core::cmp::Ordering
+impl core::cmp::PartialEq for pixtuoid_core::id::AgentId
+pub fn pixtuoid_core::id::AgentId::eq(&self, &pixtuoid_core::id::AgentId) -> bool
+impl core::cmp::PartialOrd for pixtuoid_core::id::AgentId
+pub fn pixtuoid_core::id::AgentId::partial_cmp(&self, &pixtuoid_core::id::AgentId) -> core::option::Option<core::cmp::Ordering>
+impl core::fmt::Debug for pixtuoid_core::id::AgentId
+pub fn pixtuoid_core::id::AgentId::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for pixtuoid_core::id::AgentId
+pub fn pixtuoid_core::id::AgentId::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for pixtuoid_core::id::AgentId
+pub fn pixtuoid_core::id::AgentId::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for pixtuoid_core::id::AgentId
+impl core::marker::StructuralPartialEq for pixtuoid_core::id::AgentId
+impl serde_core::ser::Serialize for pixtuoid_core::id::AgentId
+pub fn pixtuoid_core::id::AgentId::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for pixtuoid_core::id::AgentId
+pub fn pixtuoid_core::id::AgentId::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for pixtuoid_core::id::AgentId
+impl core::marker::Send for pixtuoid_core::id::AgentId
+impl core::marker::Sync for pixtuoid_core::id::AgentId
+impl core::marker::Unpin for pixtuoid_core::id::AgentId
+impl core::marker::UnsafeUnpin for pixtuoid_core::id::AgentId
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::id::AgentId
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::id::AgentId
+pub mod pixtuoid_core::platform
+pub fn pixtuoid_core::platform::home_first_dir() -> core::option::Option<std::path::PathBuf>
+pub fn pixtuoid_core::platform::resolve_user_config_dir(&str, core::option::Option<alloc::string::String>, core::option::Option<alloc::string::String>, &std::path::Path) -> std::path::PathBuf
+pub fn pixtuoid_core::platform::resolve_user_home_opt(bool, core::option::Option<alloc::string::String>, core::option::Option<alloc::string::String>) -> core::option::Option<alloc::string::String>
+pub fn pixtuoid_core::platform::user_home_opt() -> core::option::Option<alloc::string::String>
+pub mod pixtuoid_core::source
+pub mod pixtuoid_core::source::antigravity
+pub struct pixtuoid_core::source::antigravity::AntigravitySource
+pub pixtuoid_core::source::antigravity::AntigravitySource::brain_root: std::path::PathBuf
+impl pixtuoid_core::source::antigravity::AntigravitySource
+pub fn pixtuoid_core::source::antigravity::AntigravitySource::default_paths() -> Self
+impl pixtuoid_core::Source for pixtuoid_core::source::antigravity::AntigravitySource
+pub fn pixtuoid_core::source::antigravity::AntigravitySource::name(&self) -> &str
+pub async fn pixtuoid_core::source::antigravity::AntigravitySource::run(alloc::boxed::Box<Self>, pixtuoid_core::TaggedSender) -> anyhow::Result<()>
+impl core::marker::Freeze for pixtuoid_core::source::antigravity::AntigravitySource
+impl core::marker::Send for pixtuoid_core::source::antigravity::AntigravitySource
+impl core::marker::Sync for pixtuoid_core::source::antigravity::AntigravitySource
+impl core::marker::Unpin for pixtuoid_core::source::antigravity::AntigravitySource
+impl core::marker::UnsafeUnpin for pixtuoid_core::source::antigravity::AntigravitySource
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::source::antigravity::AntigravitySource
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::source::antigravity::AntigravitySource
+pub const pixtuoid_core::source::antigravity::SOURCE_NAME: &str
+pub fn pixtuoid_core::source::antigravity::decode_ag_line(&str, &str, serde_json::value::Value) -> anyhow::Result<alloc::vec::Vec<pixtuoid_core::source::AgentEvent>>
+pub mod pixtuoid_core::source::claude_code
+pub struct pixtuoid_core::source::claude_code::ClaudeCodeSource
+pub pixtuoid_core::source::claude_code::ClaudeCodeSource::child_end_unclaims: core::option::Option<pixtuoid_core::source::jsonl::ChildEndUnclaims>
+pub pixtuoid_core::source::claude_code::ClaudeCodeSource::projects_root: std::path::PathBuf
+impl pixtuoid_core::source::claude_code::ClaudeCodeSource
+pub fn pixtuoid_core::source::claude_code::ClaudeCodeSource::default_paths() -> Self
+pub fn pixtuoid_core::source::claude_code::ClaudeCodeSource::default_socket_path() -> std::path::PathBuf
+impl pixtuoid_core::Source for pixtuoid_core::source::claude_code::ClaudeCodeSource
+pub fn pixtuoid_core::source::claude_code::ClaudeCodeSource::name(&self) -> &str
+pub async fn pixtuoid_core::source::claude_code::ClaudeCodeSource::run(alloc::boxed::Box<Self>, pixtuoid_core::TaggedSender) -> anyhow::Result<()>
+impl core::marker::Freeze for pixtuoid_core::source::claude_code::ClaudeCodeSource
+impl core::marker::Send for pixtuoid_core::source::claude_code::ClaudeCodeSource
+impl core::marker::Sync for pixtuoid_core::source::claude_code::ClaudeCodeSource
+impl core::marker::Unpin for pixtuoid_core::source::claude_code::ClaudeCodeSource
+impl core::marker::UnsafeUnpin for pixtuoid_core::source::claude_code::ClaudeCodeSource
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::source::claude_code::ClaudeCodeSource
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::source::claude_code::ClaudeCodeSource
+pub const pixtuoid_core::source::claude_code::SOURCE_NAME: &str
+pub fn pixtuoid_core::source::claude_code::cc_derive_label(&std::path::Path, &str, &std::path::Path) -> alloc::string::String
+pub fn pixtuoid_core::source::claude_code::cc_id_from_path(&std::path::Path) -> alloc::string::String
+pub fn pixtuoid_core::source::claude_code::cc_session_ended(&[u8]) -> bool
+pub fn pixtuoid_core::source::claude_code::decode_cc_line(&str, &str, serde_json::value::Value) -> anyhow::Result<alloc::vec::Vec<pixtuoid_core::source::AgentEvent>>
+pub fn pixtuoid_core::source::claude_code::live_cc_session_ids(&std::path::Path) -> core::option::Option<pixtuoid_core::source::jsonl::ProbeSnapshot>
+pub mod pixtuoid_core::source::codewhale
+pub const pixtuoid_core::source::codewhale::SOURCE_NAME: &str
+pub fn pixtuoid_core::source::codewhale::decode_cw_hook_payload(&serde_json::value::Value) -> anyhow::Result<alloc::vec::Vec<pixtuoid_core::source::AgentEvent>>
+pub mod pixtuoid_core::source::codex
+pub struct pixtuoid_core::source::codex::CodexSource
+pub pixtuoid_core::source::codex::CodexSource::child_end_unclaims: core::option::Option<pixtuoid_core::source::jsonl::ChildEndUnclaims>
+pub pixtuoid_core::source::codex::CodexSource::sessions_root: std::path::PathBuf
+impl pixtuoid_core::source::codex::CodexSource
+pub fn pixtuoid_core::source::codex::CodexSource::default_paths() -> Self
+impl pixtuoid_core::Source for pixtuoid_core::source::codex::CodexSource
+pub fn pixtuoid_core::source::codex::CodexSource::name(&self) -> &str
+pub async fn pixtuoid_core::source::codex::CodexSource::run(alloc::boxed::Box<Self>, pixtuoid_core::TaggedSender) -> anyhow::Result<()>
+impl core::marker::Freeze for pixtuoid_core::source::codex::CodexSource
+impl core::marker::Send for pixtuoid_core::source::codex::CodexSource
+impl core::marker::Sync for pixtuoid_core::source::codex::CodexSource
+impl core::marker::Unpin for pixtuoid_core::source::codex::CodexSource
+impl core::marker::UnsafeUnpin for pixtuoid_core::source::codex::CodexSource
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::source::codex::CodexSource
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::source::codex::CodexSource
+pub const pixtuoid_core::source::codex::SOURCE_NAME: &str
+pub fn pixtuoid_core::source::codex::codex_home() -> std::path::PathBuf
+pub fn pixtuoid_core::source::codex::codex_id_from_path(&std::path::Path) -> alloc::string::String
+pub fn pixtuoid_core::source::codex::decode_codex_line(&str, &str, serde_json::value::Value) -> anyhow::Result<alloc::vec::Vec<pixtuoid_core::source::AgentEvent>>
+pub fn pixtuoid_core::source::codex::live_codex_rollout_ids(&std::path::Path) -> core::option::Option<pixtuoid_core::source::jsonl::ProbeSnapshot>
+pub mod pixtuoid_core::source::copilot
+pub struct pixtuoid_core::source::copilot::CopilotSource
+pub pixtuoid_core::source::copilot::CopilotSource::sessions_root: std::path::PathBuf
+impl pixtuoid_core::source::copilot::CopilotSource
+pub fn pixtuoid_core::source::copilot::CopilotSource::default_paths() -> Self
+impl pixtuoid_core::Source for pixtuoid_core::source::copilot::CopilotSource
+pub fn pixtuoid_core::source::copilot::CopilotSource::name(&self) -> &str
+pub async fn pixtuoid_core::source::copilot::CopilotSource::run(alloc::boxed::Box<Self>, pixtuoid_core::TaggedSender) -> anyhow::Result<()>
+impl core::marker::Freeze for pixtuoid_core::source::copilot::CopilotSource
+impl core::marker::Send for pixtuoid_core::source::copilot::CopilotSource
+impl core::marker::Sync for pixtuoid_core::source::copilot::CopilotSource
+impl core::marker::Unpin for pixtuoid_core::source::copilot::CopilotSource
+impl core::marker::UnsafeUnpin for pixtuoid_core::source::copilot::CopilotSource
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::source::copilot::CopilotSource
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::source::copilot::CopilotSource
+pub const pixtuoid_core::source::copilot::SOURCE_NAME: &str
+pub fn pixtuoid_core::source::copilot::copilot_home() -> std::path::PathBuf
+pub fn pixtuoid_core::source::copilot::copilot_id_from_path(&std::path::Path) -> alloc::string::String
+pub fn pixtuoid_core::source::copilot::decode_copilot_line(&str, &str, serde_json::value::Value) -> anyhow::Result<alloc::vec::Vec<pixtuoid_core::source::AgentEvent>>
+pub mod pixtuoid_core::source::cursor
+pub const pixtuoid_core::source::cursor::SOURCE_NAME: &str
+pub fn pixtuoid_core::source::cursor::decode_cursor_hook_payload(&serde_json::value::Value) -> anyhow::Result<alloc::vec::Vec<pixtuoid_core::source::AgentEvent>>
+pub mod pixtuoid_core::source::daemon
+pub enum pixtuoid_core::source::daemon::DaemonPresenceUpdate
+pub pixtuoid_core::source::daemon::DaemonPresenceUpdate::GatewayDown
+pub pixtuoid_core::source::daemon::DaemonPresenceUpdate::GatewayUp
+pub pixtuoid_core::source::daemon::DaemonPresenceUpdate::GatewayUp::pid: core::option::Option<i32>
+pub pixtuoid_core::source::daemon::DaemonPresenceUpdate::PidExited
+pub pixtuoid_core::source::daemon::DaemonPresenceUpdate::PidExited::pid: i32
+pub pixtuoid_core::source::daemon::DaemonPresenceUpdate::PidSeen
+pub pixtuoid_core::source::daemon::DaemonPresenceUpdate::PidSeen::pid: i32
+pub pixtuoid_core::source::daemon::DaemonPresenceUpdate::RunEnded
+pub pixtuoid_core::source::daemon::DaemonPresenceUpdate::RunEnded::run_key: alloc::string::String
+pub pixtuoid_core::source::daemon::DaemonPresenceUpdate::RunFailed
+pub pixtuoid_core::source::daemon::DaemonPresenceUpdate::RunFailed::run_key: alloc::string::String
+pub pixtuoid_core::source::daemon::DaemonPresenceUpdate::RunStarted
+pub pixtuoid_core::source::daemon::DaemonPresenceUpdate::RunStarted::run_key: alloc::string::String
+pub pixtuoid_core::source::daemon::DaemonPresenceUpdate::SessionEnded
+pub pixtuoid_core::source::daemon::DaemonPresenceUpdate::SessionStarted
+impl pixtuoid_core::source::daemon::DaemonPresenceUpdate
+pub fn pixtuoid_core::source::daemon::DaemonPresenceUpdate::armable_pid(&self) -> core::option::Option<i32>
+impl core::clone::Clone for pixtuoid_core::source::daemon::DaemonPresenceUpdate
+pub fn pixtuoid_core::source::daemon::DaemonPresenceUpdate::clone(&self) -> pixtuoid_core::source::daemon::DaemonPresenceUpdate
+impl core::cmp::Eq for pixtuoid_core::source::daemon::DaemonPresenceUpdate
+impl core::cmp::PartialEq for pixtuoid_core::source::daemon::DaemonPresenceUpdate
+pub fn pixtuoid_core::source::daemon::DaemonPresenceUpdate::eq(&self, &pixtuoid_core::source::daemon::DaemonPresenceUpdate) -> bool
+impl core::fmt::Debug for pixtuoid_core::source::daemon::DaemonPresenceUpdate
+pub fn pixtuoid_core::source::daemon::DaemonPresenceUpdate::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for pixtuoid_core::source::daemon::DaemonPresenceUpdate
+impl core::marker::Freeze for pixtuoid_core::source::daemon::DaemonPresenceUpdate
+impl core::marker::Send for pixtuoid_core::source::daemon::DaemonPresenceUpdate
+impl core::marker::Sync for pixtuoid_core::source::daemon::DaemonPresenceUpdate
+impl core::marker::Unpin for pixtuoid_core::source::daemon::DaemonPresenceUpdate
+impl core::marker::UnsafeUnpin for pixtuoid_core::source::daemon::DaemonPresenceUpdate
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::source::daemon::DaemonPresenceUpdate
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::source::daemon::DaemonPresenceUpdate
+pub struct pixtuoid_core::source::daemon::PresenceExitWatch
+impl pixtuoid_core::source::daemon::PresenceExitWatch
+pub fn pixtuoid_core::source::daemon::PresenceExitWatch::watch(&self, &str, i32)
+impl core::marker::Freeze for pixtuoid_core::source::daemon::PresenceExitWatch
+impl core::marker::Send for pixtuoid_core::source::daemon::PresenceExitWatch
+impl core::marker::Sync for pixtuoid_core::source::daemon::PresenceExitWatch
+impl core::marker::Unpin for pixtuoid_core::source::daemon::PresenceExitWatch
+impl core::marker::UnsafeUnpin for pixtuoid_core::source::daemon::PresenceExitWatch
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::source::daemon::PresenceExitWatch
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::source::daemon::PresenceExitWatch
+pub struct pixtuoid_core::source::daemon::PresenceMsg
+pub pixtuoid_core::source::daemon::PresenceMsg::delta: pixtuoid_core::source::daemon::DaemonPresenceUpdate
+pub pixtuoid_core::source::daemon::PresenceMsg::source: alloc::string::String
+impl core::clone::Clone for pixtuoid_core::source::daemon::PresenceMsg
+pub fn pixtuoid_core::source::daemon::PresenceMsg::clone(&self) -> pixtuoid_core::source::daemon::PresenceMsg
+impl core::cmp::Eq for pixtuoid_core::source::daemon::PresenceMsg
+impl core::cmp::PartialEq for pixtuoid_core::source::daemon::PresenceMsg
+pub fn pixtuoid_core::source::daemon::PresenceMsg::eq(&self, &pixtuoid_core::source::daemon::PresenceMsg) -> bool
+impl core::fmt::Debug for pixtuoid_core::source::daemon::PresenceMsg
+pub fn pixtuoid_core::source::daemon::PresenceMsg::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for pixtuoid_core::source::daemon::PresenceMsg
+impl core::marker::Freeze for pixtuoid_core::source::daemon::PresenceMsg
+impl core::marker::Send for pixtuoid_core::source::daemon::PresenceMsg
+impl core::marker::Sync for pixtuoid_core::source::daemon::PresenceMsg
+impl core::marker::Unpin for pixtuoid_core::source::daemon::PresenceMsg
+impl core::marker::UnsafeUnpin for pixtuoid_core::source::daemon::PresenceMsg
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::source::daemon::PresenceMsg
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::source::daemon::PresenceMsg
+pub struct pixtuoid_core::source::daemon::PresenceTtl
+pub pixtuoid_core::source::daemon::PresenceTtl::busy_decay_ms: u64
+pub pixtuoid_core::source::daemon::PresenceTtl::down_remove_ms: u64
+pub pixtuoid_core::source::daemon::PresenceTtl::presence_ttl_ms: u64
+impl pixtuoid_core::source::daemon::PresenceTtl
+pub const pixtuoid_core::source::daemon::PresenceTtl::DEFAULT: pixtuoid_core::source::daemon::PresenceTtl
+impl core::clone::Clone for pixtuoid_core::source::daemon::PresenceTtl
+pub fn pixtuoid_core::source::daemon::PresenceTtl::clone(&self) -> pixtuoid_core::source::daemon::PresenceTtl
+impl core::cmp::Eq for pixtuoid_core::source::daemon::PresenceTtl
+impl core::cmp::PartialEq for pixtuoid_core::source::daemon::PresenceTtl
+pub fn pixtuoid_core::source::daemon::PresenceTtl::eq(&self, &pixtuoid_core::source::daemon::PresenceTtl) -> bool
+impl core::fmt::Debug for pixtuoid_core::source::daemon::PresenceTtl
+pub fn pixtuoid_core::source::daemon::PresenceTtl::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_core::source::daemon::PresenceTtl
+impl core::marker::StructuralPartialEq for pixtuoid_core::source::daemon::PresenceTtl
+impl core::marker::Freeze for pixtuoid_core::source::daemon::PresenceTtl
+impl core::marker::Send for pixtuoid_core::source::daemon::PresenceTtl
+impl core::marker::Sync for pixtuoid_core::source::daemon::PresenceTtl
+impl core::marker::Unpin for pixtuoid_core::source::daemon::PresenceTtl
+impl core::marker::UnsafeUnpin for pixtuoid_core::source::daemon::PresenceTtl
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::source::daemon::PresenceTtl
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::source::daemon::PresenceTtl
+pub fn pixtuoid_core::source::daemon::apply_presence(&mut pixtuoid_core::state::SceneState, &str, pixtuoid_core::source::daemon::DaemonPresenceUpdate, std::time::SystemTime)
+pub fn pixtuoid_core::source::daemon::mark_presence_down(&mut pixtuoid_core::state::SceneState, &str, std::time::SystemTime)
+pub fn pixtuoid_core::source::daemon::spawn_presence_exit_watch(pixtuoid_core::source::daemon::PresenceSender) -> core::option::Option<pixtuoid_core::source::daemon::PresenceExitWatch>
+pub fn pixtuoid_core::source::daemon::sweep_presence_ttl(&mut pixtuoid_core::state::SceneState, &str, pixtuoid_core::source::daemon::PresenceTtl, std::time::SystemTime)
+pub type pixtuoid_core::source::daemon::PresenceSender = tokio::sync::mpsc::unbounded::UnboundedSender<pixtuoid_core::source::daemon::PresenceMsg>
+pub mod pixtuoid_core::source::decoder
+pub fn pixtuoid_core::source::decoder::decode_hook_payload(serde_json::value::Value) -> anyhow::Result<alloc::vec::Vec<pixtuoid_core::source::AgentEvent>>
+pub type pixtuoid_core::source::decoder::CwdExtractor = fn(&serde_json::value::Value) -> core::option::Option<std::path::PathBuf>
+pub type pixtuoid_core::source::decoder::LineDecoder = fn(&str, &str, serde_json::value::Value) -> anyhow::Result<alloc::vec::Vec<pixtuoid_core::source::AgentEvent>>
+pub mod pixtuoid_core::source::drift
+pub const pixtuoid_core::source::drift::TARGET: &str
+pub fn pixtuoid_core::source::drift::missing_field(&str, &str, &str)
+pub fn pixtuoid_core::source::drift::shape_drift(&str, &str)
+pub fn pixtuoid_core::source::drift::unknown_dispatch(&str, &str)
+pub fn pixtuoid_core::source::drift::unknown_event(&str, &str)
+pub mod pixtuoid_core::source::grok
+pub struct pixtuoid_core::source::grok::GrokSource
+pub pixtuoid_core::source::grok::GrokSource::child_end_unclaims: core::option::Option<pixtuoid_core::source::jsonl::ChildEndUnclaims>
+pub pixtuoid_core::source::grok::GrokSource::sessions_root: std::path::PathBuf
+impl pixtuoid_core::source::grok::GrokSource
+pub fn pixtuoid_core::source::grok::GrokSource::default_paths() -> Self
+impl pixtuoid_core::Source for pixtuoid_core::source::grok::GrokSource
+pub fn pixtuoid_core::source::grok::GrokSource::name(&self) -> &str
+pub async fn pixtuoid_core::source::grok::GrokSource::run(alloc::boxed::Box<Self>, pixtuoid_core::TaggedSender) -> anyhow::Result<()>
+impl core::marker::Freeze for pixtuoid_core::source::grok::GrokSource
+impl core::marker::Send for pixtuoid_core::source::grok::GrokSource
+impl core::marker::Sync for pixtuoid_core::source::grok::GrokSource
+impl core::marker::Unpin for pixtuoid_core::source::grok::GrokSource
+impl core::marker::UnsafeUnpin for pixtuoid_core::source::grok::GrokSource
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::source::grok::GrokSource
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::source::grok::GrokSource
+pub const pixtuoid_core::source::grok::SOURCE_NAME: &str
+pub fn pixtuoid_core::source::grok::decode_grok_hook_payload(&serde_json::value::Value) -> anyhow::Result<alloc::vec::Vec<pixtuoid_core::source::AgentEvent>>
+pub fn pixtuoid_core::source::grok::decode_grok_line(&str, &str, serde_json::value::Value) -> anyhow::Result<alloc::vec::Vec<pixtuoid_core::source::AgentEvent>>
+pub fn pixtuoid_core::source::grok::grok_cwd_from_path(&std::path::Path) -> core::option::Option<std::path::PathBuf>
+pub fn pixtuoid_core::source::grok::grok_home() -> std::path::PathBuf
+pub fn pixtuoid_core::source::grok::grok_id_from_path(&std::path::Path) -> alloc::string::String
+pub fn pixtuoid_core::source::grok::grok_session_ended(&[u8]) -> bool
+pub fn pixtuoid_core::source::grok::live_grok_session_ids(&std::path::Path) -> core::option::Option<pixtuoid_core::source::jsonl::ProbeSnapshot>
+pub mod pixtuoid_core::source::hermes
+pub const pixtuoid_core::source::hermes::SOURCE_NAME: &str
+pub fn pixtuoid_core::source::hermes::decode_hermes_hook_payload(&serde_json::value::Value) -> anyhow::Result<alloc::vec::Vec<pixtuoid_core::source::AgentEvent>>
+pub fn pixtuoid_core::source::hermes::hermes_home() -> core::option::Option<std::path::PathBuf>
+pub mod pixtuoid_core::source::hook
+pub struct pixtuoid_core::source::hook::HookRouter
+impl pixtuoid_core::source::hook::HookRouter
+pub fn pixtuoid_core::source::hook::HookRouter::new(std::path::PathBuf) -> Self
+pub fn pixtuoid_core::source::hook::HookRouter::with_child_end_unclaims(self, core::option::Option<pixtuoid_core::source::jsonl::ChildEndUnclaims>) -> Self
+pub fn pixtuoid_core::source::hook::HookRouter::with_presence_tx(self, core::option::Option<pixtuoid_core::source::daemon::PresenceSender>) -> Self
+impl pixtuoid_core::Source for pixtuoid_core::source::hook::HookRouter
+pub fn pixtuoid_core::source::hook::HookRouter::name(&self) -> &str
+pub async fn pixtuoid_core::source::hook::HookRouter::run(alloc::boxed::Box<Self>, pixtuoid_core::TaggedSender) -> anyhow::Result<()>
+impl core::marker::Freeze for pixtuoid_core::source::hook::HookRouter
+impl core::marker::Send for pixtuoid_core::source::hook::HookRouter
+impl core::marker::Sync for pixtuoid_core::source::hook::HookRouter
+impl core::marker::Unpin for pixtuoid_core::source::hook::HookRouter
+impl core::marker::UnsafeUnpin for pixtuoid_core::source::hook::HookRouter
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::source::hook::HookRouter
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::source::hook::HookRouter
+pub struct pixtuoid_core::source::hook::HookSocketListener
+impl pixtuoid_core::source::hook::HookSocketListener
+pub async fn pixtuoid_core::source::hook::HookSocketListener::bind(impl core::convert::Into<std::path::PathBuf>) -> anyhow::Result<Self>
+pub fn pixtuoid_core::source::hook::HookSocketListener::path(&self) -> &std::path::Path
+pub async fn pixtuoid_core::source::hook::HookSocketListener::run(self, pixtuoid_core::TaggedSender) -> anyhow::Result<()>
+impl !core::marker::Freeze for pixtuoid_core::source::hook::HookSocketListener
+impl core::marker::Send for pixtuoid_core::source::hook::HookSocketListener
+impl core::marker::Sync for pixtuoid_core::source::hook::HookSocketListener
+impl core::marker::Unpin for pixtuoid_core::source::hook::HookSocketListener
+impl core::marker::UnsafeUnpin for pixtuoid_core::source::hook::HookSocketListener
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::source::hook::HookSocketListener
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::source::hook::HookSocketListener
+pub struct pixtuoid_core::source::hook::SocketBusy
+pub pixtuoid_core::source::hook::SocketBusy::path: std::path::PathBuf
+impl core::error::Error for pixtuoid_core::source::hook::SocketBusy
+impl core::fmt::Debug for pixtuoid_core::source::hook::SocketBusy
+pub fn pixtuoid_core::source::hook::SocketBusy::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for pixtuoid_core::source::hook::SocketBusy
+pub fn pixtuoid_core::source::hook::SocketBusy::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for pixtuoid_core::source::hook::SocketBusy
+impl core::marker::Send for pixtuoid_core::source::hook::SocketBusy
+impl core::marker::Sync for pixtuoid_core::source::hook::SocketBusy
+impl core::marker::Unpin for pixtuoid_core::source::hook::SocketBusy
+impl core::marker::UnsafeUnpin for pixtuoid_core::source::hook::SocketBusy
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::source::hook::SocketBusy
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::source::hook::SocketBusy
+pub mod pixtuoid_core::source::jsonl
+pub struct pixtuoid_core::source::jsonl::ChildEndUnclaims
+impl pixtuoid_core::source::jsonl::ChildEndUnclaims
+pub fn pixtuoid_core::source::jsonl::ChildEndUnclaims::new() -> Self
+pub fn pixtuoid_core::source::jsonl::ChildEndUnclaims::push(&self, pixtuoid_core::id::AgentId)
+pub fn pixtuoid_core::source::jsonl::ChildEndUnclaims::take_matching(&self, impl core::ops::function::FnMut(&pixtuoid_core::id::AgentId) -> bool) -> alloc::vec::Vec<pixtuoid_core::id::AgentId>
+impl core::clone::Clone for pixtuoid_core::source::jsonl::ChildEndUnclaims
+pub fn pixtuoid_core::source::jsonl::ChildEndUnclaims::clone(&self) -> pixtuoid_core::source::jsonl::ChildEndUnclaims
+impl core::default::Default for pixtuoid_core::source::jsonl::ChildEndUnclaims
+pub fn pixtuoid_core::source::jsonl::ChildEndUnclaims::default() -> Self
+impl core::marker::Freeze for pixtuoid_core::source::jsonl::ChildEndUnclaims
+impl core::marker::Send for pixtuoid_core::source::jsonl::ChildEndUnclaims
+impl core::marker::Sync for pixtuoid_core::source::jsonl::ChildEndUnclaims
+impl core::marker::Unpin for pixtuoid_core::source::jsonl::ChildEndUnclaims
+impl core::marker::UnsafeUnpin for pixtuoid_core::source::jsonl::ChildEndUnclaims
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::source::jsonl::ChildEndUnclaims
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::source::jsonl::ChildEndUnclaims
+pub struct pixtuoid_core::source::jsonl::JsonlWatcher
+impl pixtuoid_core::source::jsonl::JsonlWatcher
+pub fn pixtuoid_core::source::jsonl::JsonlWatcher::new(std::path::PathBuf, alloc::string::String, pixtuoid_core::source::decoder::LineDecoder, pixtuoid_core::source::jsonl::SessionEndChecker) -> Self
+pub async fn pixtuoid_core::source::jsonl::JsonlWatcher::run(self, pixtuoid_core::TaggedSender) -> anyhow::Result<()>
+pub fn pixtuoid_core::source::jsonl::JsonlWatcher::with_cwd_deriver(self, pixtuoid_core::source::jsonl::CwdDeriver) -> Self
+pub fn pixtuoid_core::source::jsonl::JsonlWatcher::with_id_deriver(self, pixtuoid_core::source::jsonl::IdDeriver) -> Self
+pub fn pixtuoid_core::source::jsonl::JsonlWatcher::with_initial_window(self, core::time::Duration) -> Self
+pub fn pixtuoid_core::source::jsonl::JsonlWatcher::with_label_deriver(self, pixtuoid_core::source::jsonl::LabelDeriver) -> Self
+pub fn pixtuoid_core::source::jsonl::JsonlWatcher::with_liveness_probe(self, pixtuoid_core::source::jsonl::LivenessProbe) -> Self
+pub fn pixtuoid_core::source::jsonl::JsonlWatcher::with_path_filter(self, pixtuoid_core::source::jsonl::PathFilter) -> Self
+impl core::marker::Freeze for pixtuoid_core::source::jsonl::JsonlWatcher
+impl core::marker::Send for pixtuoid_core::source::jsonl::JsonlWatcher
+impl core::marker::Sync for pixtuoid_core::source::jsonl::JsonlWatcher
+impl core::marker::Unpin for pixtuoid_core::source::jsonl::JsonlWatcher
+impl core::marker::UnsafeUnpin for pixtuoid_core::source::jsonl::JsonlWatcher
+impl !core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::source::jsonl::JsonlWatcher
+impl !core::panic::unwind_safe::UnwindSafe for pixtuoid_core::source::jsonl::JsonlWatcher
+pub struct pixtuoid_core::source::jsonl::ProbeSnapshot
+pub pixtuoid_core::source::jsonl::ProbeSnapshot::pid_of: std::collections::hash::map::HashMap<alloc::string::String, i32>
+impl pixtuoid_core::source::jsonl::ProbeSnapshot
+pub fn pixtuoid_core::source::jsonl::ProbeSnapshot::contains(&self, &str) -> bool
+pub fn pixtuoid_core::source::jsonl::ProbeSnapshot::ids(&self) -> impl core::iter::traits::iterator::Iterator<Item = &alloc::string::String>
+pub fn pixtuoid_core::source::jsonl::ProbeSnapshot::is_empty(&self) -> bool
+impl core::clone::Clone for pixtuoid_core::source::jsonl::ProbeSnapshot
+pub fn pixtuoid_core::source::jsonl::ProbeSnapshot::clone(&self) -> pixtuoid_core::source::jsonl::ProbeSnapshot
+impl core::default::Default for pixtuoid_core::source::jsonl::ProbeSnapshot
+pub fn pixtuoid_core::source::jsonl::ProbeSnapshot::default() -> pixtuoid_core::source::jsonl::ProbeSnapshot
+impl core::fmt::Debug for pixtuoid_core::source::jsonl::ProbeSnapshot
+pub fn pixtuoid_core::source::jsonl::ProbeSnapshot::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for pixtuoid_core::source::jsonl::ProbeSnapshot
+impl core::marker::Send for pixtuoid_core::source::jsonl::ProbeSnapshot
+impl core::marker::Sync for pixtuoid_core::source::jsonl::ProbeSnapshot
+impl core::marker::Unpin for pixtuoid_core::source::jsonl::ProbeSnapshot
+impl core::marker::UnsafeUnpin for pixtuoid_core::source::jsonl::ProbeSnapshot
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::source::jsonl::ProbeSnapshot
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::source::jsonl::ProbeSnapshot
+pub type pixtuoid_core::source::jsonl::CwdDeriver = fn(&std::path::Path) -> core::option::Option<std::path::PathBuf>
+pub type pixtuoid_core::source::jsonl::IdDeriver = fn(&std::path::Path) -> alloc::string::String
+pub type pixtuoid_core::source::jsonl::LabelDeriver = fn(&std::path::Path, &str, &std::path::Path) -> alloc::string::String
+pub type pixtuoid_core::source::jsonl::LineDecoder = fn(&str, &str, serde_json::value::Value) -> anyhow::Result<alloc::vec::Vec<pixtuoid_core::source::AgentEvent>>
+pub type pixtuoid_core::source::jsonl::LivenessProbe = alloc::sync::Arc<(dyn core::ops::function::Fn() -> core::option::Option<pixtuoid_core::source::jsonl::ProbeSnapshot> + core::marker::Send + core::marker::Sync)>
+pub type pixtuoid_core::source::jsonl::PathFilter = fn(&std::path::Path) -> bool
+pub type pixtuoid_core::source::jsonl::SessionEndChecker = fn(&[u8]) -> bool
+pub mod pixtuoid_core::source::kimi
+pub const pixtuoid_core::source::kimi::SOURCE_NAME: &str
+pub mod pixtuoid_core::source::manager
+#[non_exhaustive] pub struct pixtuoid_core::source::manager::SourceDeath
+pub pixtuoid_core::source::manager::SourceDeath::error: alloc::string::String
+pub pixtuoid_core::source::manager::SourceDeath::source: alloc::string::String
+impl pixtuoid_core::source::manager::SourceDeath
+pub fn pixtuoid_core::source::manager::SourceDeath::new(impl core::convert::Into<alloc::string::String>, impl core::convert::Into<alloc::string::String>) -> Self
+impl core::clone::Clone for pixtuoid_core::source::manager::SourceDeath
+pub fn pixtuoid_core::source::manager::SourceDeath::clone(&self) -> pixtuoid_core::source::manager::SourceDeath
+impl core::cmp::Eq for pixtuoid_core::source::manager::SourceDeath
+impl core::cmp::PartialEq for pixtuoid_core::source::manager::SourceDeath
+pub fn pixtuoid_core::source::manager::SourceDeath::eq(&self, &pixtuoid_core::source::manager::SourceDeath) -> bool
+impl core::fmt::Debug for pixtuoid_core::source::manager::SourceDeath
+pub fn pixtuoid_core::source::manager::SourceDeath::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for pixtuoid_core::source::manager::SourceDeath
+impl core::marker::Freeze for pixtuoid_core::source::manager::SourceDeath
+impl core::marker::Send for pixtuoid_core::source::manager::SourceDeath
+impl core::marker::Sync for pixtuoid_core::source::manager::SourceDeath
+impl core::marker::Unpin for pixtuoid_core::source::manager::SourceDeath
+impl core::marker::UnsafeUnpin for pixtuoid_core::source::manager::SourceDeath
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::source::manager::SourceDeath
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::source::manager::SourceDeath
+pub struct pixtuoid_core::source::manager::SourceManager
+impl pixtuoid_core::source::manager::SourceManager
+pub fn pixtuoid_core::source::manager::SourceManager::new() -> Self
+pub fn pixtuoid_core::source::manager::SourceManager::spawn(self, pixtuoid_core::TaggedSender) -> alloc::vec::Vec<tokio::runtime::task::join::JoinHandle<()>>
+pub fn pixtuoid_core::source::manager::SourceManager::spawn_with_health(self, pixtuoid_core::TaggedSender, tokio::sync::watch::Sender<alloc::vec::Vec<pixtuoid_core::source::manager::SourceDeath>>) -> alloc::vec::Vec<tokio::runtime::task::join::JoinHandle<()>>
+pub fn pixtuoid_core::source::manager::SourceManager::with_source(self, alloc::boxed::Box<dyn pixtuoid_core::source::DynSource>) -> Self
+impl core::default::Default for pixtuoid_core::source::manager::SourceManager
+pub fn pixtuoid_core::source::manager::SourceManager::default() -> pixtuoid_core::source::manager::SourceManager
+impl core::marker::Freeze for pixtuoid_core::source::manager::SourceManager
+impl core::marker::Send for pixtuoid_core::source::manager::SourceManager
+impl !core::marker::Sync for pixtuoid_core::source::manager::SourceManager
+impl core::marker::Unpin for pixtuoid_core::source::manager::SourceManager
+impl core::marker::UnsafeUnpin for pixtuoid_core::source::manager::SourceManager
+impl !core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::source::manager::SourceManager
+impl !core::panic::unwind_safe::UnwindSafe for pixtuoid_core::source::manager::SourceManager
+pub mod pixtuoid_core::source::omp
+pub struct pixtuoid_core::source::omp::OmpSource
+pub pixtuoid_core::source::omp::OmpSource::sessions_root: std::path::PathBuf
+impl pixtuoid_core::source::omp::OmpSource
+pub fn pixtuoid_core::source::omp::OmpSource::default_paths() -> Self
+impl pixtuoid_core::Source for pixtuoid_core::source::omp::OmpSource
+pub fn pixtuoid_core::source::omp::OmpSource::name(&self) -> &str
+pub async fn pixtuoid_core::source::omp::OmpSource::run(alloc::boxed::Box<Self>, pixtuoid_core::TaggedSender) -> anyhow::Result<()>
+impl core::marker::Freeze for pixtuoid_core::source::omp::OmpSource
+impl core::marker::Send for pixtuoid_core::source::omp::OmpSource
+impl core::marker::Sync for pixtuoid_core::source::omp::OmpSource
+impl core::marker::Unpin for pixtuoid_core::source::omp::OmpSource
+impl core::marker::UnsafeUnpin for pixtuoid_core::source::omp::OmpSource
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::source::omp::OmpSource
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::source::omp::OmpSource
+pub const pixtuoid_core::source::omp::SOURCE_NAME: &str
+pub fn pixtuoid_core::source::omp::decode_omp_line(&str, &str, serde_json::value::Value) -> anyhow::Result<alloc::vec::Vec<pixtuoid_core::source::AgentEvent>>
+pub fn pixtuoid_core::source::omp::omp_agent_dir() -> std::path::PathBuf
+pub fn pixtuoid_core::source::omp::omp_id_from_path(&std::path::Path) -> alloc::string::String
+pub mod pixtuoid_core::source::openclaw
+pub const pixtuoid_core::source::openclaw::SOURCE_NAME: &str
+pub fn pixtuoid_core::source::openclaw::decode_openclaw_hook_payload(&serde_json::value::Value) -> anyhow::Result<alloc::vec::Vec<pixtuoid_core::source::daemon::DaemonPresenceUpdate>>
+pub mod pixtuoid_core::source::opencode
+pub const pixtuoid_core::source::opencode::SOURCE_NAME: &str
+pub fn pixtuoid_core::source::opencode::decode_oc_hook_payload(&serde_json::value::Value) -> anyhow::Result<alloc::vec::Vec<pixtuoid_core::source::AgentEvent>>
+pub mod pixtuoid_core::source::reasonix
+pub const pixtuoid_core::source::reasonix::SOURCE_NAME: &str
+pub fn pixtuoid_core::source::reasonix::decode_rx_hook_payload(&serde_json::value::Value) -> anyhow::Result<alloc::vec::Vec<pixtuoid_core::source::AgentEvent>>
+#[non_exhaustive] pub enum pixtuoid_core::source::AgentEvent
+pub pixtuoid_core::source::AgentEvent::ActivityEnd
+pub pixtuoid_core::source::AgentEvent::ActivityEnd::agent_id: pixtuoid_core::id::AgentId
+pub pixtuoid_core::source::AgentEvent::ActivityEnd::tool_use_id: core::option::Option<alloc::string::String>
+pub pixtuoid_core::source::AgentEvent::ActivityStart
+pub pixtuoid_core::source::AgentEvent::ActivityStart::agent_id: pixtuoid_core::id::AgentId
+pub pixtuoid_core::source::AgentEvent::ActivityStart::detail: core::option::Option<pixtuoid_core::source::ToolDetail>
+pub pixtuoid_core::source::AgentEvent::ActivityStart::tool_use_id: core::option::Option<alloc::string::String>
+pub pixtuoid_core::source::AgentEvent::Identity
+pub pixtuoid_core::source::AgentEvent::Identity::agent_id: pixtuoid_core::id::AgentId
+pub pixtuoid_core::source::AgentEvent::Identity::cwd: core::option::Option<std::path::PathBuf>
+pub pixtuoid_core::source::AgentEvent::Identity::pid: core::option::Option<pixtuoid_core::source::PidIdentity>
+pub pixtuoid_core::source::AgentEvent::Identity::session_id: alloc::string::String
+pub pixtuoid_core::source::AgentEvent::Identity::source: alloc::string::String
+pub pixtuoid_core::source::AgentEvent::ModelInfo
+pub pixtuoid_core::source::AgentEvent::ModelInfo::agent_id: pixtuoid_core::id::AgentId
+pub pixtuoid_core::source::AgentEvent::ModelInfo::effort: core::option::Option<alloc::string::String>
+pub pixtuoid_core::source::AgentEvent::ModelInfo::model: core::option::Option<alloc::string::String>
+pub pixtuoid_core::source::AgentEvent::ProofOfLife
+pub pixtuoid_core::source::AgentEvent::ProofOfLife::agent_id: pixtuoid_core::id::AgentId
+pub pixtuoid_core::source::AgentEvent::Rename
+pub pixtuoid_core::source::AgentEvent::Rename::agent_id: pixtuoid_core::id::AgentId
+pub pixtuoid_core::source::AgentEvent::Rename::label: alloc::string::String
+pub pixtuoid_core::source::AgentEvent::SessionEnd
+pub pixtuoid_core::source::AgentEvent::SessionEnd::agent_id: pixtuoid_core::id::AgentId
+pub pixtuoid_core::source::AgentEvent::SessionEnd::as_child: bool
+pub pixtuoid_core::source::AgentEvent::SessionStart
+pub pixtuoid_core::source::AgentEvent::SessionStart::agent_id: pixtuoid_core::id::AgentId
+pub pixtuoid_core::source::AgentEvent::SessionStart::cwd: std::path::PathBuf
+pub pixtuoid_core::source::AgentEvent::SessionStart::parent_id: core::option::Option<pixtuoid_core::id::AgentId>
+pub pixtuoid_core::source::AgentEvent::SessionStart::session_id: alloc::string::String
+pub pixtuoid_core::source::AgentEvent::SessionStart::source: alloc::string::String
+pub pixtuoid_core::source::AgentEvent::Usage
+pub pixtuoid_core::source::AgentEvent::Usage::agent_id: pixtuoid_core::id::AgentId
+pub pixtuoid_core::source::AgentEvent::Usage::fresh_tokens: u64
+pub pixtuoid_core::source::AgentEvent::Waiting
+pub pixtuoid_core::source::AgentEvent::Waiting::agent_id: pixtuoid_core::id::AgentId
+pub pixtuoid_core::source::AgentEvent::Waiting::reason: alloc::string::String
+impl pixtuoid_core::source::AgentEvent
+pub fn pixtuoid_core::source::AgentEvent::agent_id(&self) -> pixtuoid_core::id::AgentId
+impl core::clone::Clone for pixtuoid_core::source::AgentEvent
+pub fn pixtuoid_core::source::AgentEvent::clone(&self) -> pixtuoid_core::source::AgentEvent
+impl core::cmp::Eq for pixtuoid_core::source::AgentEvent
+impl core::cmp::PartialEq for pixtuoid_core::source::AgentEvent
+pub fn pixtuoid_core::source::AgentEvent::eq(&self, &pixtuoid_core::source::AgentEvent) -> bool
+impl core::fmt::Debug for pixtuoid_core::source::AgentEvent
+pub fn pixtuoid_core::source::AgentEvent::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for pixtuoid_core::source::AgentEvent
+impl serde_core::ser::Serialize for pixtuoid_core::source::AgentEvent
+pub fn pixtuoid_core::source::AgentEvent::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for pixtuoid_core::source::AgentEvent
+pub fn pixtuoid_core::source::AgentEvent::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for pixtuoid_core::source::AgentEvent
+impl core::marker::Send for pixtuoid_core::source::AgentEvent
+impl core::marker::Sync for pixtuoid_core::source::AgentEvent
+impl core::marker::Unpin for pixtuoid_core::source::AgentEvent
+impl core::marker::UnsafeUnpin for pixtuoid_core::source::AgentEvent
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::source::AgentEvent
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::source::AgentEvent
+#[non_exhaustive] pub enum pixtuoid_core::source::ToolDetail
+pub pixtuoid_core::source::ToolDetail::Generic
+pub pixtuoid_core::source::ToolDetail::Generic::display: alloc::string::String
+pub pixtuoid_core::source::ToolDetail::Task
+impl pixtuoid_core::source::ToolDetail
+pub fn pixtuoid_core::source::ToolDetail::display(&self) -> &str
+pub fn pixtuoid_core::source::ToolDetail::is_task(&self) -> bool
+impl core::clone::Clone for pixtuoid_core::source::ToolDetail
+pub fn pixtuoid_core::source::ToolDetail::clone(&self) -> pixtuoid_core::source::ToolDetail
+impl core::cmp::Eq for pixtuoid_core::source::ToolDetail
+impl core::cmp::PartialEq for pixtuoid_core::source::ToolDetail
+pub fn pixtuoid_core::source::ToolDetail::eq(&self, &pixtuoid_core::source::ToolDetail) -> bool
+impl core::convert::From<&str> for pixtuoid_core::source::ToolDetail
+pub fn pixtuoid_core::source::ToolDetail::from(&str) -> Self
+impl core::fmt::Debug for pixtuoid_core::source::ToolDetail
+pub fn pixtuoid_core::source::ToolDetail::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for pixtuoid_core::source::ToolDetail
+impl serde_core::ser::Serialize for pixtuoid_core::source::ToolDetail
+pub fn pixtuoid_core::source::ToolDetail::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for pixtuoid_core::source::ToolDetail
+pub fn pixtuoid_core::source::ToolDetail::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for pixtuoid_core::source::ToolDetail
+impl core::marker::Send for pixtuoid_core::source::ToolDetail
+impl core::marker::Sync for pixtuoid_core::source::ToolDetail
+impl core::marker::Unpin for pixtuoid_core::source::ToolDetail
+impl core::marker::UnsafeUnpin for pixtuoid_core::source::ToolDetail
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::source::ToolDetail
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::source::ToolDetail
+#[non_exhaustive] pub enum pixtuoid_core::source::Transport
+pub pixtuoid_core::source::Transport::Hook
+pub pixtuoid_core::source::Transport::Jsonl
+impl core::clone::Clone for pixtuoid_core::source::Transport
+pub fn pixtuoid_core::source::Transport::clone(&self) -> pixtuoid_core::source::Transport
+impl core::cmp::Eq for pixtuoid_core::source::Transport
+impl core::cmp::PartialEq for pixtuoid_core::source::Transport
+pub fn pixtuoid_core::source::Transport::eq(&self, &pixtuoid_core::source::Transport) -> bool
+impl core::fmt::Debug for pixtuoid_core::source::Transport
+pub fn pixtuoid_core::source::Transport::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_core::source::Transport
+impl core::marker::StructuralPartialEq for pixtuoid_core::source::Transport
+impl core::marker::Freeze for pixtuoid_core::source::Transport
+impl core::marker::Send for pixtuoid_core::source::Transport
+impl core::marker::Sync for pixtuoid_core::source::Transport
+impl core::marker::Unpin for pixtuoid_core::source::Transport
+impl core::marker::UnsafeUnpin for pixtuoid_core::source::Transport
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::source::Transport
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::source::Transport
+#[non_exhaustive] pub struct pixtuoid_core::source::PidIdentity
+pub pixtuoid_core::source::PidIdentity::pid: i32
+pub pixtuoid_core::source::PidIdentity::started: core::option::Option<u64>
+impl pixtuoid_core::source::PidIdentity
+pub fn pixtuoid_core::source::PidIdentity::new(i32, core::option::Option<u64>) -> Self
+impl core::clone::Clone for pixtuoid_core::source::PidIdentity
+pub fn pixtuoid_core::source::PidIdentity::clone(&self) -> pixtuoid_core::source::PidIdentity
+impl core::cmp::Eq for pixtuoid_core::source::PidIdentity
+impl core::cmp::PartialEq for pixtuoid_core::source::PidIdentity
+pub fn pixtuoid_core::source::PidIdentity::eq(&self, &pixtuoid_core::source::PidIdentity) -> bool
+impl core::fmt::Debug for pixtuoid_core::source::PidIdentity
+pub fn pixtuoid_core::source::PidIdentity::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_core::source::PidIdentity
+impl core::marker::StructuralPartialEq for pixtuoid_core::source::PidIdentity
+impl serde_core::ser::Serialize for pixtuoid_core::source::PidIdentity
+pub fn pixtuoid_core::source::PidIdentity::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for pixtuoid_core::source::PidIdentity
+pub fn pixtuoid_core::source::PidIdentity::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for pixtuoid_core::source::PidIdentity
+impl core::marker::Send for pixtuoid_core::source::PidIdentity
+impl core::marker::Sync for pixtuoid_core::source::PidIdentity
+impl core::marker::Unpin for pixtuoid_core::source::PidIdentity
+impl core::marker::UnsafeUnpin for pixtuoid_core::source::PidIdentity
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::source::PidIdentity
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::source::PidIdentity
+pub const pixtuoid_core::source::EVENT_CHANNEL_CAPACITY: usize
+pub trait pixtuoid_core::source::DynSource: core::marker::Send + 'static
+pub fn pixtuoid_core::source::DynSource::name(&self) -> &str
+pub fn pixtuoid_core::source::DynSource::run(alloc::boxed::Box<Self>, pixtuoid_core::TaggedSender) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = anyhow::Result<()>> + core::marker::Send)>>
+impl<T: pixtuoid_core::Source> pixtuoid_core::source::DynSource for T
+pub fn T::name(&self) -> &str
+pub fn T::run(alloc::boxed::Box<T>, tokio::sync::mpsc::bounded::Sender<(pixtuoid_core::source::Transport, pixtuoid_core::source::AgentEvent)>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<(), anyhow::Error>> + core::marker::Send)>>
+pub trait pixtuoid_core::source::Source: core::marker::Send + 'static
+pub fn pixtuoid_core::source::Source::name(&self) -> &str
+pub fn pixtuoid_core::source::Source::run(alloc::boxed::Box<Self>, pixtuoid_core::TaggedSender) -> impl core::future::future::Future<Output = anyhow::Result<()>> + core::marker::Send
+impl pixtuoid_core::Source for pixtuoid_core::source::antigravity::AntigravitySource
+pub fn pixtuoid_core::source::antigravity::AntigravitySource::name(&self) -> &str
+pub async fn pixtuoid_core::source::antigravity::AntigravitySource::run(alloc::boxed::Box<Self>, pixtuoid_core::TaggedSender) -> anyhow::Result<()>
+impl pixtuoid_core::Source for pixtuoid_core::source::claude_code::ClaudeCodeSource
+pub fn pixtuoid_core::source::claude_code::ClaudeCodeSource::name(&self) -> &str
+pub async fn pixtuoid_core::source::claude_code::ClaudeCodeSource::run(alloc::boxed::Box<Self>, pixtuoid_core::TaggedSender) -> anyhow::Result<()>
+impl pixtuoid_core::Source for pixtuoid_core::source::codex::CodexSource
+pub fn pixtuoid_core::source::codex::CodexSource::name(&self) -> &str
+pub async fn pixtuoid_core::source::codex::CodexSource::run(alloc::boxed::Box<Self>, pixtuoid_core::TaggedSender) -> anyhow::Result<()>
+impl pixtuoid_core::Source for pixtuoid_core::source::copilot::CopilotSource
+pub fn pixtuoid_core::source::copilot::CopilotSource::name(&self) -> &str
+pub async fn pixtuoid_core::source::copilot::CopilotSource::run(alloc::boxed::Box<Self>, pixtuoid_core::TaggedSender) -> anyhow::Result<()>
+impl pixtuoid_core::Source for pixtuoid_core::source::grok::GrokSource
+pub fn pixtuoid_core::source::grok::GrokSource::name(&self) -> &str
+pub async fn pixtuoid_core::source::grok::GrokSource::run(alloc::boxed::Box<Self>, pixtuoid_core::TaggedSender) -> anyhow::Result<()>
+impl pixtuoid_core::Source for pixtuoid_core::source::hook::HookRouter
+pub fn pixtuoid_core::source::hook::HookRouter::name(&self) -> &str
+pub async fn pixtuoid_core::source::hook::HookRouter::run(alloc::boxed::Box<Self>, pixtuoid_core::TaggedSender) -> anyhow::Result<()>
+impl pixtuoid_core::Source for pixtuoid_core::source::omp::OmpSource
+pub fn pixtuoid_core::source::omp::OmpSource::name(&self) -> &str
+pub async fn pixtuoid_core::source::omp::OmpSource::run(alloc::boxed::Box<Self>, pixtuoid_core::TaggedSender) -> anyhow::Result<()>
+pub fn pixtuoid_core::source::cc_pid_for_session(&std::path::Path, &str) -> core::option::Option<i32>
+pub fn pixtuoid_core::source::cc_registry_dir(&std::path::Path) -> core::option::Option<std::path::PathBuf>
+pub fn pixtuoid_core::source::codex_pid_for_session(&std::path::Path, &str) -> core::option::Option<i32>
+pub fn pixtuoid_core::source::grok_pid_for_session(&std::path::Path, &str) -> core::option::Option<i32>
+pub fn pixtuoid_core::source::pid_start_marker(i32) -> core::option::Option<u64>
+pub type pixtuoid_core::source::TaggedReceiver = tokio::sync::mpsc::bounded::Receiver<(pixtuoid_core::source::Transport, pixtuoid_core::source::AgentEvent)>
+pub type pixtuoid_core::source::TaggedSender = tokio::sync::mpsc::bounded::Sender<(pixtuoid_core::source::Transport, pixtuoid_core::source::AgentEvent)>
+pub mod pixtuoid_core::sprite
+pub mod pixtuoid_core::sprite::blit
+pub fn pixtuoid_core::sprite::blit::blit_frame(&pixtuoid_core::sprite::Frame, u16, u16, &mut pixtuoid_core::sprite::RgbBuffer)
+pub mod pixtuoid_core::sprite::format
+pub struct pixtuoid_core::sprite::format::Pack
+pub pixtuoid_core::sprite::format::Pack::name: alloc::string::String
+pub pixtuoid_core::sprite::format::Pack::palette: pixtuoid_core::sprite::Palette
+pub pixtuoid_core::sprite::format::Pack::version: alloc::string::String
+impl pixtuoid_core::sprite::format::Pack
+pub fn pixtuoid_core::sprite::format::Pack::animation(&self, &str) -> core::option::Option<&pixtuoid_core::sprite::Sprite>
+pub fn pixtuoid_core::sprite::format::Pack::animation_names(&self) -> alloc::vec::Vec<alloc::string::String>
+pub fn pixtuoid_core::sprite::format::Pack::merge_from(&mut self, &pixtuoid_core::sprite::format::Pack)
+impl core::clone::Clone for pixtuoid_core::sprite::format::Pack
+pub fn pixtuoid_core::sprite::format::Pack::clone(&self) -> pixtuoid_core::sprite::format::Pack
+impl core::fmt::Debug for pixtuoid_core::sprite::format::Pack
+pub fn pixtuoid_core::sprite::format::Pack::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for pixtuoid_core::sprite::format::Pack
+impl core::marker::Send for pixtuoid_core::sprite::format::Pack
+impl core::marker::Sync for pixtuoid_core::sprite::format::Pack
+impl core::marker::Unpin for pixtuoid_core::sprite::format::Pack
+impl core::marker::UnsafeUnpin for pixtuoid_core::sprite::format::Pack
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::sprite::format::Pack
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::sprite::format::Pack
+pub struct pixtuoid_core::sprite::format::ValidationReport
+pub pixtuoid_core::sprite::format::ValidationReport::insufficient_frames: alloc::vec::Vec<(alloc::string::String, usize, usize)>
+pub pixtuoid_core::sprite::format::ValidationReport::missing_optional: alloc::vec::Vec<alloc::string::String>
+pub pixtuoid_core::sprite::format::ValidationReport::missing_required: alloc::vec::Vec<alloc::string::String>
+pub pixtuoid_core::sprite::format::ValidationReport::unknown: alloc::vec::Vec<alloc::string::String>
+impl pixtuoid_core::sprite::format::ValidationReport
+pub fn pixtuoid_core::sprite::format::ValidationReport::has_errors(&self) -> bool
+impl core::default::Default for pixtuoid_core::sprite::format::ValidationReport
+pub fn pixtuoid_core::sprite::format::ValidationReport::default() -> pixtuoid_core::sprite::format::ValidationReport
+impl core::fmt::Debug for pixtuoid_core::sprite::format::ValidationReport
+pub fn pixtuoid_core::sprite::format::ValidationReport::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for pixtuoid_core::sprite::format::ValidationReport
+impl core::marker::Send for pixtuoid_core::sprite::format::ValidationReport
+impl core::marker::Sync for pixtuoid_core::sprite::format::ValidationReport
+impl core::marker::Unpin for pixtuoid_core::sprite::format::ValidationReport
+impl core::marker::UnsafeUnpin for pixtuoid_core::sprite::format::ValidationReport
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::sprite::format::ValidationReport
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::sprite::format::ValidationReport
+pub const pixtuoid_core::sprite::format::OPTIONAL_CHARACTER_ANIMATIONS: &[&str]
+pub const pixtuoid_core::sprite::format::OPTIONAL_FURNITURE_ANIMATIONS: &[&str]
+pub const pixtuoid_core::sprite::format::RECOLOR_KEYS: [char; 4]
+pub const pixtuoid_core::sprite::format::REQUIRED_CHARACTER_ANIMATIONS: &[&str]
+pub fn pixtuoid_core::sprite::format::load_pack(&std::path::Path) -> anyhow::Result<pixtuoid_core::sprite::format::Pack>
+pub fn pixtuoid_core::sprite::format::load_pack_from_strings(&str, &[(&str, &str)]) -> anyhow::Result<pixtuoid_core::sprite::format::Pack>
+pub fn pixtuoid_core::sprite::format::parse_sprite_file(&str, &pixtuoid_core::sprite::Palette) -> anyhow::Result<alloc::vec::Vec<pixtuoid_core::sprite::Frame>>
+pub fn pixtuoid_core::sprite::format::validate_pack_animations(&pixtuoid_core::sprite::format::Pack) -> pixtuoid_core::sprite::format::ValidationReport
+pub struct pixtuoid_core::sprite::Frame(_)
+impl pixtuoid_core::sprite::Frame
+pub fn pixtuoid_core::sprite::Frame::from_pixels(u16, u16, alloc::vec::Vec<pixtuoid_core::sprite::Pixel>) -> Self
+pub fn pixtuoid_core::sprite::Frame::mirror_horizontal(&self) -> Self
+pub fn pixtuoid_core::sprite::Frame::mirror_vertical(&self) -> Self
+impl core::clone::Clone for pixtuoid_core::sprite::Frame
+pub fn pixtuoid_core::sprite::Frame::clone(&self) -> pixtuoid_core::sprite::Frame
+impl core::default::Default for pixtuoid_core::sprite::Frame
+pub fn pixtuoid_core::sprite::Frame::default() -> pixtuoid_core::sprite::Frame
+impl core::fmt::Debug for pixtuoid_core::sprite::Frame
+pub fn pixtuoid_core::sprite::Frame::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::ops::deref::Deref for pixtuoid_core::sprite::Frame
+pub type pixtuoid_core::sprite::Frame::Target = pixtuoid_core::grid::Grid<core::option::Option<pixtuoid_core::sprite::Rgb>>
+pub fn pixtuoid_core::sprite::Frame::deref(&self) -> &pixtuoid_core::grid::Grid<pixtuoid_core::sprite::Pixel>
+impl core::ops::deref::DerefMut for pixtuoid_core::sprite::Frame
+pub fn pixtuoid_core::sprite::Frame::deref_mut(&mut self) -> &mut pixtuoid_core::grid::Grid<pixtuoid_core::sprite::Pixel>
+impl core::marker::Freeze for pixtuoid_core::sprite::Frame
+impl core::marker::Send for pixtuoid_core::sprite::Frame
+impl core::marker::Sync for pixtuoid_core::sprite::Frame
+impl core::marker::Unpin for pixtuoid_core::sprite::Frame
+impl core::marker::UnsafeUnpin for pixtuoid_core::sprite::Frame
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::sprite::Frame
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::sprite::Frame
+pub struct pixtuoid_core::sprite::Palette
+impl pixtuoid_core::sprite::Palette
+pub fn pixtuoid_core::sprite::Palette::get(&self, char) -> core::option::Option<pixtuoid_core::sprite::Pixel>
+pub fn pixtuoid_core::sprite::Palette::insert(&mut self, char, pixtuoid_core::sprite::Pixel)
+pub fn pixtuoid_core::sprite::Palette::iter(&self) -> impl core::iter::traits::iterator::Iterator<Item = (char, pixtuoid_core::sprite::Pixel)> + '_
+pub fn pixtuoid_core::sprite::Palette::new() -> Self
+pub fn pixtuoid_core::sprite::Palette::with_override(&self, char, pixtuoid_core::sprite::Pixel) -> Self
+impl core::clone::Clone for pixtuoid_core::sprite::Palette
+pub fn pixtuoid_core::sprite::Palette::clone(&self) -> pixtuoid_core::sprite::Palette
+impl core::default::Default for pixtuoid_core::sprite::Palette
+pub fn pixtuoid_core::sprite::Palette::default() -> pixtuoid_core::sprite::Palette
+impl core::fmt::Debug for pixtuoid_core::sprite::Palette
+pub fn pixtuoid_core::sprite::Palette::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for pixtuoid_core::sprite::Palette
+impl core::marker::Send for pixtuoid_core::sprite::Palette
+impl core::marker::Sync for pixtuoid_core::sprite::Palette
+impl core::marker::Unpin for pixtuoid_core::sprite::Palette
+impl core::marker::UnsafeUnpin for pixtuoid_core::sprite::Palette
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::sprite::Palette
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::sprite::Palette
+pub struct pixtuoid_core::sprite::Rgb
+pub pixtuoid_core::sprite::Rgb::b: u8
+pub pixtuoid_core::sprite::Rgb::g: u8
+pub pixtuoid_core::sprite::Rgb::r: u8
+impl core::clone::Clone for pixtuoid_core::sprite::Rgb
+pub fn pixtuoid_core::sprite::Rgb::clone(&self) -> pixtuoid_core::sprite::Rgb
+impl core::cmp::Eq for pixtuoid_core::sprite::Rgb
+impl core::cmp::PartialEq for pixtuoid_core::sprite::Rgb
+pub fn pixtuoid_core::sprite::Rgb::eq(&self, &pixtuoid_core::sprite::Rgb) -> bool
+impl core::fmt::Debug for pixtuoid_core::sprite::Rgb
+pub fn pixtuoid_core::sprite::Rgb::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for pixtuoid_core::sprite::Rgb
+pub fn pixtuoid_core::sprite::Rgb::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for pixtuoid_core::sprite::Rgb
+impl core::marker::StructuralPartialEq for pixtuoid_core::sprite::Rgb
+impl core::marker::Freeze for pixtuoid_core::sprite::Rgb
+impl core::marker::Send for pixtuoid_core::sprite::Rgb
+impl core::marker::Sync for pixtuoid_core::sprite::Rgb
+impl core::marker::Unpin for pixtuoid_core::sprite::Rgb
+impl core::marker::UnsafeUnpin for pixtuoid_core::sprite::Rgb
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::sprite::Rgb
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::sprite::Rgb
+pub struct pixtuoid_core::sprite::RgbBuffer(_)
+impl pixtuoid_core::sprite::RgbBuffer
+pub fn pixtuoid_core::sprite::RgbBuffer::filled(u16, u16, pixtuoid_core::sprite::Rgb) -> Self
+pub fn pixtuoid_core::sprite::RgbBuffer::from_pixels(u16, u16, alloc::vec::Vec<pixtuoid_core::sprite::Rgb>) -> Self
+pub fn pixtuoid_core::sprite::RgbBuffer::get(&self, u16, u16) -> pixtuoid_core::sprite::Rgb
+pub fn pixtuoid_core::sprite::RgbBuffer::put(&mut self, u16, u16, pixtuoid_core::sprite::Rgb)
+pub fn pixtuoid_core::sprite::RgbBuffer::put_checked(&mut self, u16, u16, pixtuoid_core::sprite::Rgb)
+impl core::clone::Clone for pixtuoid_core::sprite::RgbBuffer
+pub fn pixtuoid_core::sprite::RgbBuffer::clone(&self) -> pixtuoid_core::sprite::RgbBuffer
+impl core::fmt::Debug for pixtuoid_core::sprite::RgbBuffer
+pub fn pixtuoid_core::sprite::RgbBuffer::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::ops::deref::Deref for pixtuoid_core::sprite::RgbBuffer
+pub type pixtuoid_core::sprite::RgbBuffer::Target = pixtuoid_core::grid::Grid<pixtuoid_core::sprite::Rgb>
+pub fn pixtuoid_core::sprite::RgbBuffer::deref(&self) -> &pixtuoid_core::grid::Grid<pixtuoid_core::sprite::Rgb>
+impl core::ops::deref::DerefMut for pixtuoid_core::sprite::RgbBuffer
+pub fn pixtuoid_core::sprite::RgbBuffer::deref_mut(&mut self) -> &mut pixtuoid_core::grid::Grid<pixtuoid_core::sprite::Rgb>
+impl core::marker::Freeze for pixtuoid_core::sprite::RgbBuffer
+impl core::marker::Send for pixtuoid_core::sprite::RgbBuffer
+impl core::marker::Sync for pixtuoid_core::sprite::RgbBuffer
+impl core::marker::Unpin for pixtuoid_core::sprite::RgbBuffer
+impl core::marker::UnsafeUnpin for pixtuoid_core::sprite::RgbBuffer
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::sprite::RgbBuffer
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::sprite::RgbBuffer
+pub struct pixtuoid_core::sprite::Sprite
+pub pixtuoid_core::sprite::Sprite::frame_ms: u32
+pub pixtuoid_core::sprite::Sprite::frames: alloc::vec::Vec<pixtuoid_core::sprite::Frame>
+impl core::clone::Clone for pixtuoid_core::sprite::Sprite
+pub fn pixtuoid_core::sprite::Sprite::clone(&self) -> pixtuoid_core::sprite::Sprite
+impl core::fmt::Debug for pixtuoid_core::sprite::Sprite
+pub fn pixtuoid_core::sprite::Sprite::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for pixtuoid_core::sprite::Sprite
+impl core::marker::Send for pixtuoid_core::sprite::Sprite
+impl core::marker::Sync for pixtuoid_core::sprite::Sprite
+impl core::marker::Unpin for pixtuoid_core::sprite::Sprite
+impl core::marker::UnsafeUnpin for pixtuoid_core::sprite::Sprite
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::sprite::Sprite
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::sprite::Sprite
+pub type pixtuoid_core::sprite::Pixel = core::option::Option<pixtuoid_core::sprite::Rgb>
+pub mod pixtuoid_core::state
+pub mod pixtuoid_core::state::reducer
+pub struct pixtuoid_core::state::reducer::Reducer
+impl pixtuoid_core::state::reducer::Reducer
+pub fn pixtuoid_core::state::reducer::Reducer::apply(&mut self, &mut pixtuoid_core::state::SceneState, pixtuoid_core::source::AgentEvent, std::time::SystemTime, pixtuoid_core::source::Transport)
+pub fn pixtuoid_core::state::reducer::Reducer::new() -> Self
+pub fn pixtuoid_core::state::reducer::Reducer::reconcile_connected(&self, &mut pixtuoid_core::state::SceneState, &std::collections::hash::set::HashSet<alloc::string::String>, std::time::SystemTime)
+pub fn pixtuoid_core::state::reducer::Reducer::tick(&mut self, &mut pixtuoid_core::state::SceneState, std::time::SystemTime)
+impl core::default::Default for pixtuoid_core::state::reducer::Reducer
+pub fn pixtuoid_core::state::reducer::Reducer::default() -> pixtuoid_core::state::reducer::Reducer
+impl core::fmt::Debug for pixtuoid_core::state::reducer::Reducer
+pub fn pixtuoid_core::state::reducer::Reducer::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for pixtuoid_core::state::reducer::Reducer
+impl core::marker::Send for pixtuoid_core::state::reducer::Reducer
+impl core::marker::Sync for pixtuoid_core::state::reducer::Reducer
+impl core::marker::Unpin for pixtuoid_core::state::reducer::Reducer
+impl core::marker::UnsafeUnpin for pixtuoid_core::state::reducer::Reducer
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::state::reducer::Reducer
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::state::reducer::Reducer
+pub const pixtuoid_core::state::reducer::EXIT_GRACE_WINDOW: core::time::Duration
+pub enum pixtuoid_core::state::ActivityState
+pub pixtuoid_core::state::ActivityState::Active
+pub pixtuoid_core::state::ActivityState::Active::detail: core::option::Option<alloc::sync::Arc<str>>
+pub pixtuoid_core::state::ActivityState::Active::kind: pixtuoid_core::state::ToolKind
+pub pixtuoid_core::state::ActivityState::Active::tool_use_id: core::option::Option<alloc::sync::Arc<str>>
+pub pixtuoid_core::state::ActivityState::Idle
+pub pixtuoid_core::state::ActivityState::Waiting
+pub pixtuoid_core::state::ActivityState::Waiting::reason: alloc::sync::Arc<str>
+impl core::clone::Clone for pixtuoid_core::state::ActivityState
+pub fn pixtuoid_core::state::ActivityState::clone(&self) -> pixtuoid_core::state::ActivityState
+impl core::cmp::Eq for pixtuoid_core::state::ActivityState
+impl core::cmp::PartialEq for pixtuoid_core::state::ActivityState
+pub fn pixtuoid_core::state::ActivityState::eq(&self, &pixtuoid_core::state::ActivityState) -> bool
+impl core::fmt::Debug for pixtuoid_core::state::ActivityState
+pub fn pixtuoid_core::state::ActivityState::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for pixtuoid_core::state::ActivityState
+impl serde_core::ser::Serialize for pixtuoid_core::state::ActivityState
+pub fn pixtuoid_core::state::ActivityState::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for pixtuoid_core::state::ActivityState
+pub fn pixtuoid_core::state::ActivityState::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for pixtuoid_core::state::ActivityState
+impl core::marker::Send for pixtuoid_core::state::ActivityState
+impl core::marker::Sync for pixtuoid_core::state::ActivityState
+impl core::marker::Unpin for pixtuoid_core::state::ActivityState
+impl core::marker::UnsafeUnpin for pixtuoid_core::state::ActivityState
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::state::ActivityState
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::state::ActivityState
+pub enum pixtuoid_core::state::DaemonLiveness
+pub pixtuoid_core::state::DaemonLiveness::Down
+pub pixtuoid_core::state::DaemonLiveness::Up
+pub pixtuoid_core::state::DaemonLiveness::Up::degraded: bool
+impl pixtuoid_core::state::DaemonLiveness
+pub const pixtuoid_core::state::DaemonLiveness::UP: pixtuoid_core::state::DaemonLiveness
+impl core::clone::Clone for pixtuoid_core::state::DaemonLiveness
+pub fn pixtuoid_core::state::DaemonLiveness::clone(&self) -> pixtuoid_core::state::DaemonLiveness
+impl core::cmp::Eq for pixtuoid_core::state::DaemonLiveness
+impl core::cmp::PartialEq for pixtuoid_core::state::DaemonLiveness
+pub fn pixtuoid_core::state::DaemonLiveness::eq(&self, &pixtuoid_core::state::DaemonLiveness) -> bool
+impl core::fmt::Debug for pixtuoid_core::state::DaemonLiveness
+pub fn pixtuoid_core::state::DaemonLiveness::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_core::state::DaemonLiveness
+impl core::marker::StructuralPartialEq for pixtuoid_core::state::DaemonLiveness
+impl serde_core::ser::Serialize for pixtuoid_core::state::DaemonLiveness
+pub fn pixtuoid_core::state::DaemonLiveness::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for pixtuoid_core::state::DaemonLiveness
+pub fn pixtuoid_core::state::DaemonLiveness::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for pixtuoid_core::state::DaemonLiveness
+impl core::marker::Send for pixtuoid_core::state::DaemonLiveness
+impl core::marker::Sync for pixtuoid_core::state::DaemonLiveness
+impl core::marker::Unpin for pixtuoid_core::state::DaemonLiveness
+impl core::marker::UnsafeUnpin for pixtuoid_core::state::DaemonLiveness
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::state::DaemonLiveness
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::state::DaemonLiveness
+pub enum pixtuoid_core::state::DaemonState
+pub pixtuoid_core::state::DaemonState::Busy
+pub pixtuoid_core::state::DaemonState::Degraded
+pub pixtuoid_core::state::DaemonState::Down
+pub pixtuoid_core::state::DaemonState::Idle
+impl core::clone::Clone for pixtuoid_core::state::DaemonState
+pub fn pixtuoid_core::state::DaemonState::clone(&self) -> pixtuoid_core::state::DaemonState
+impl core::cmp::Eq for pixtuoid_core::state::DaemonState
+impl core::cmp::PartialEq for pixtuoid_core::state::DaemonState
+pub fn pixtuoid_core::state::DaemonState::eq(&self, &pixtuoid_core::state::DaemonState) -> bool
+impl core::fmt::Debug for pixtuoid_core::state::DaemonState
+pub fn pixtuoid_core::state::DaemonState::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_core::state::DaemonState
+impl core::marker::StructuralPartialEq for pixtuoid_core::state::DaemonState
+impl serde_core::ser::Serialize for pixtuoid_core::state::DaemonState
+pub fn pixtuoid_core::state::DaemonState::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for pixtuoid_core::state::DaemonState
+pub fn pixtuoid_core::state::DaemonState::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for pixtuoid_core::state::DaemonState
+impl core::marker::Send for pixtuoid_core::state::DaemonState
+impl core::marker::Sync for pixtuoid_core::state::DaemonState
+impl core::marker::Unpin for pixtuoid_core::state::DaemonState
+impl core::marker::UnsafeUnpin for pixtuoid_core::state::DaemonState
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::state::DaemonState
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::state::DaemonState
+pub enum pixtuoid_core::state::LabelProvenance
+pub pixtuoid_core::state::LabelProvenance::CwdDerived
+pub pixtuoid_core::state::LabelProvenance::OrdinalGhost
+pub pixtuoid_core::state::LabelProvenance::PrefixFallback
+pub pixtuoid_core::state::LabelProvenance::Renamed
+impl core::clone::Clone for pixtuoid_core::state::LabelProvenance
+pub fn pixtuoid_core::state::LabelProvenance::clone(&self) -> pixtuoid_core::state::LabelProvenance
+impl core::cmp::Eq for pixtuoid_core::state::LabelProvenance
+impl core::cmp::PartialEq for pixtuoid_core::state::LabelProvenance
+pub fn pixtuoid_core::state::LabelProvenance::eq(&self, &pixtuoid_core::state::LabelProvenance) -> bool
+impl core::fmt::Debug for pixtuoid_core::state::LabelProvenance
+pub fn pixtuoid_core::state::LabelProvenance::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_core::state::LabelProvenance
+impl core::marker::StructuralPartialEq for pixtuoid_core::state::LabelProvenance
+impl serde_core::ser::Serialize for pixtuoid_core::state::LabelProvenance
+pub fn pixtuoid_core::state::LabelProvenance::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for pixtuoid_core::state::LabelProvenance
+pub fn pixtuoid_core::state::LabelProvenance::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for pixtuoid_core::state::LabelProvenance
+impl core::marker::Send for pixtuoid_core::state::LabelProvenance
+impl core::marker::Sync for pixtuoid_core::state::LabelProvenance
+impl core::marker::Unpin for pixtuoid_core::state::LabelProvenance
+impl core::marker::UnsafeUnpin for pixtuoid_core::state::LabelProvenance
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::state::LabelProvenance
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::state::LabelProvenance
+pub enum pixtuoid_core::state::ToolKind
+pub pixtuoid_core::state::ToolKind::Bash
+pub pixtuoid_core::state::ToolKind::Edit
+pub pixtuoid_core::state::ToolKind::Other
+pub pixtuoid_core::state::ToolKind::Read
+pub pixtuoid_core::state::ToolKind::Search
+pub pixtuoid_core::state::ToolKind::Task
+impl pixtuoid_core::state::ToolKind
+pub fn pixtuoid_core::state::ToolKind::from_detail(&pixtuoid_core::source::ToolDetail) -> Self
+pub fn pixtuoid_core::state::ToolKind::from_display(&str) -> Self
+impl core::clone::Clone for pixtuoid_core::state::ToolKind
+pub fn pixtuoid_core::state::ToolKind::clone(&self) -> pixtuoid_core::state::ToolKind
+impl core::cmp::Eq for pixtuoid_core::state::ToolKind
+impl core::cmp::PartialEq for pixtuoid_core::state::ToolKind
+pub fn pixtuoid_core::state::ToolKind::eq(&self, &pixtuoid_core::state::ToolKind) -> bool
+impl core::fmt::Debug for pixtuoid_core::state::ToolKind
+pub fn pixtuoid_core::state::ToolKind::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_core::state::ToolKind
+impl core::marker::StructuralPartialEq for pixtuoid_core::state::ToolKind
+impl serde_core::ser::Serialize for pixtuoid_core::state::ToolKind
+pub fn pixtuoid_core::state::ToolKind::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for pixtuoid_core::state::ToolKind
+pub fn pixtuoid_core::state::ToolKind::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for pixtuoid_core::state::ToolKind
+impl core::marker::Send for pixtuoid_core::state::ToolKind
+impl core::marker::Sync for pixtuoid_core::state::ToolKind
+impl core::marker::Unpin for pixtuoid_core::state::ToolKind
+impl core::marker::UnsafeUnpin for pixtuoid_core::state::ToolKind
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::state::ToolKind
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::state::ToolKind
+pub struct pixtuoid_core::state::AgentSlot
+pub pixtuoid_core::state::AgentSlot::active_ms: u64
+pub pixtuoid_core::state::AgentSlot::agent_id: pixtuoid_core::id::AgentId
+pub pixtuoid_core::state::AgentSlot::created_at: std::time::SystemTime
+pub pixtuoid_core::state::AgentSlot::cwd: alloc::sync::Arc<std::path::Path>
+pub pixtuoid_core::state::AgentSlot::desk_index: pixtuoid_core::state::GlobalDeskIndex
+pub pixtuoid_core::state::AgentSlot::effort: core::option::Option<pixtuoid_core::state::EffortObservation>
+pub pixtuoid_core::state::AgentSlot::exiting_at: core::option::Option<std::time::SystemTime>
+pub pixtuoid_core::state::AgentSlot::floor_idx: usize
+pub pixtuoid_core::state::AgentSlot::label: pixtuoid_core::state::SlotLabel
+pub pixtuoid_core::state::AgentSlot::last_event_at: std::time::SystemTime
+pub pixtuoid_core::state::AgentSlot::last_usage: core::option::Option<pixtuoid_core::state::UsageObservation>
+pub pixtuoid_core::state::AgentSlot::model: core::option::Option<alloc::sync::Arc<str>>
+pub pixtuoid_core::state::AgentSlot::parent_id: core::option::Option<pixtuoid_core::id::AgentId>
+pub pixtuoid_core::state::AgentSlot::pending_idle_at: core::option::Option<std::time::SystemTime>
+pub pixtuoid_core::state::AgentSlot::pid: core::option::Option<pixtuoid_core::source::PidIdentity>
+pub pixtuoid_core::state::AgentSlot::session_id: alloc::sync::Arc<str>
+pub pixtuoid_core::state::AgentSlot::source: alloc::sync::Arc<str>
+pub pixtuoid_core::state::AgentSlot::state: pixtuoid_core::state::ActivityState
+pub pixtuoid_core::state::AgentSlot::state_started_at: std::time::SystemTime
+pub pixtuoid_core::state::AgentSlot::tokens_used: u64
+pub pixtuoid_core::state::AgentSlot::tool_call_count: u32
+pub pixtuoid_core::state::AgentSlot::unknown_cwd: bool
+impl core::clone::Clone for pixtuoid_core::state::AgentSlot
+pub fn pixtuoid_core::state::AgentSlot::clone(&self) -> pixtuoid_core::state::AgentSlot
+impl core::fmt::Debug for pixtuoid_core::state::AgentSlot
+pub fn pixtuoid_core::state::AgentSlot::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde_core::ser::Serialize for pixtuoid_core::state::AgentSlot
+pub fn pixtuoid_core::state::AgentSlot::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for pixtuoid_core::state::AgentSlot
+pub fn pixtuoid_core::state::AgentSlot::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for pixtuoid_core::state::AgentSlot
+impl core::marker::Send for pixtuoid_core::state::AgentSlot
+impl core::marker::Sync for pixtuoid_core::state::AgentSlot
+impl core::marker::Unpin for pixtuoid_core::state::AgentSlot
+impl core::marker::UnsafeUnpin for pixtuoid_core::state::AgentSlot
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::state::AgentSlot
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::state::AgentSlot
+pub struct pixtuoid_core::state::DaemonPresence
+pub pixtuoid_core::state::DaemonPresence::active_sessions: u32
+pub pixtuoid_core::state::DaemonPresence::current_pid: core::option::Option<i32>
+pub pixtuoid_core::state::DaemonPresence::entered_at: std::time::SystemTime
+pub pixtuoid_core::state::DaemonPresence::in_flight_run_keys: std::collections::hash::set::HashSet<alloc::string::String>
+pub pixtuoid_core::state::DaemonPresence::last_seen: std::time::SystemTime
+pub pixtuoid_core::state::DaemonPresence::liveness: pixtuoid_core::state::DaemonLiveness
+impl pixtuoid_core::state::DaemonPresence
+pub fn pixtuoid_core::state::DaemonPresence::display_state(&self) -> pixtuoid_core::state::DaemonState
+pub fn pixtuoid_core::state::DaemonPresence::is_busy(&self) -> bool
+impl core::clone::Clone for pixtuoid_core::state::DaemonPresence
+pub fn pixtuoid_core::state::DaemonPresence::clone(&self) -> pixtuoid_core::state::DaemonPresence
+impl core::fmt::Debug for pixtuoid_core::state::DaemonPresence
+pub fn pixtuoid_core::state::DaemonPresence::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde_core::ser::Serialize for pixtuoid_core::state::DaemonPresence
+pub fn pixtuoid_core::state::DaemonPresence::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for pixtuoid_core::state::DaemonPresence
+pub fn pixtuoid_core::state::DaemonPresence::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for pixtuoid_core::state::DaemonPresence
+impl core::marker::Send for pixtuoid_core::state::DaemonPresence
+impl core::marker::Sync for pixtuoid_core::state::DaemonPresence
+impl core::marker::Unpin for pixtuoid_core::state::DaemonPresence
+impl core::marker::UnsafeUnpin for pixtuoid_core::state::DaemonPresence
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::state::DaemonPresence
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::state::DaemonPresence
+#[non_exhaustive] pub struct pixtuoid_core::state::EffortObservation
+pub pixtuoid_core::state::EffortObservation::seen_at: std::time::SystemTime
+pub pixtuoid_core::state::EffortObservation::value: alloc::sync::Arc<str>
+impl pixtuoid_core::state::EffortObservation
+pub fn pixtuoid_core::state::EffortObservation::new(alloc::sync::Arc<str>, std::time::SystemTime) -> Self
+impl core::clone::Clone for pixtuoid_core::state::EffortObservation
+pub fn pixtuoid_core::state::EffortObservation::clone(&self) -> pixtuoid_core::state::EffortObservation
+impl core::cmp::Eq for pixtuoid_core::state::EffortObservation
+impl core::cmp::PartialEq for pixtuoid_core::state::EffortObservation
+pub fn pixtuoid_core::state::EffortObservation::eq(&self, &pixtuoid_core::state::EffortObservation) -> bool
+impl core::fmt::Debug for pixtuoid_core::state::EffortObservation
+pub fn pixtuoid_core::state::EffortObservation::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for pixtuoid_core::state::EffortObservation
+impl serde_core::ser::Serialize for pixtuoid_core::state::EffortObservation
+pub fn pixtuoid_core::state::EffortObservation::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for pixtuoid_core::state::EffortObservation
+pub fn pixtuoid_core::state::EffortObservation::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for pixtuoid_core::state::EffortObservation
+impl core::marker::Send for pixtuoid_core::state::EffortObservation
+impl core::marker::Sync for pixtuoid_core::state::EffortObservation
+impl core::marker::Unpin for pixtuoid_core::state::EffortObservation
+impl core::marker::UnsafeUnpin for pixtuoid_core::state::EffortObservation
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::state::EffortObservation
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::state::EffortObservation
+pub struct pixtuoid_core::state::FloorLocalDeskIndex(pub usize)
+impl core::clone::Clone for pixtuoid_core::state::FloorLocalDeskIndex
+pub fn pixtuoid_core::state::FloorLocalDeskIndex::clone(&self) -> pixtuoid_core::state::FloorLocalDeskIndex
+impl core::cmp::Eq for pixtuoid_core::state::FloorLocalDeskIndex
+impl core::cmp::Ord for pixtuoid_core::state::FloorLocalDeskIndex
+pub fn pixtuoid_core::state::FloorLocalDeskIndex::cmp(&self, &pixtuoid_core::state::FloorLocalDeskIndex) -> core::cmp::Ordering
+impl core::cmp::PartialEq for pixtuoid_core::state::FloorLocalDeskIndex
+pub fn pixtuoid_core::state::FloorLocalDeskIndex::eq(&self, &pixtuoid_core::state::FloorLocalDeskIndex) -> bool
+impl core::cmp::PartialOrd for pixtuoid_core::state::FloorLocalDeskIndex
+pub fn pixtuoid_core::state::FloorLocalDeskIndex::partial_cmp(&self, &pixtuoid_core::state::FloorLocalDeskIndex) -> core::option::Option<core::cmp::Ordering>
+impl core::fmt::Debug for pixtuoid_core::state::FloorLocalDeskIndex
+pub fn pixtuoid_core::state::FloorLocalDeskIndex::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for pixtuoid_core::state::FloorLocalDeskIndex
+pub fn pixtuoid_core::state::FloorLocalDeskIndex::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for pixtuoid_core::state::FloorLocalDeskIndex
+impl core::marker::StructuralPartialEq for pixtuoid_core::state::FloorLocalDeskIndex
+impl core::marker::Freeze for pixtuoid_core::state::FloorLocalDeskIndex
+impl core::marker::Send for pixtuoid_core::state::FloorLocalDeskIndex
+impl core::marker::Sync for pixtuoid_core::state::FloorLocalDeskIndex
+impl core::marker::Unpin for pixtuoid_core::state::FloorLocalDeskIndex
+impl core::marker::UnsafeUnpin for pixtuoid_core::state::FloorLocalDeskIndex
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::state::FloorLocalDeskIndex
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::state::FloorLocalDeskIndex
+pub struct pixtuoid_core::state::GlobalDeskIndex(pub usize)
+impl pixtuoid_core::state::GlobalDeskIndex
+pub fn pixtuoid_core::state::GlobalDeskIndex::single_floor_local(self) -> pixtuoid_core::state::FloorLocalDeskIndex
+impl core::clone::Clone for pixtuoid_core::state::GlobalDeskIndex
+pub fn pixtuoid_core::state::GlobalDeskIndex::clone(&self) -> pixtuoid_core::state::GlobalDeskIndex
+impl core::cmp::Eq for pixtuoid_core::state::GlobalDeskIndex
+impl core::cmp::Ord for pixtuoid_core::state::GlobalDeskIndex
+pub fn pixtuoid_core::state::GlobalDeskIndex::cmp(&self, &pixtuoid_core::state::GlobalDeskIndex) -> core::cmp::Ordering
+impl core::cmp::PartialEq for pixtuoid_core::state::GlobalDeskIndex
+pub fn pixtuoid_core::state::GlobalDeskIndex::eq(&self, &pixtuoid_core::state::GlobalDeskIndex) -> bool
+impl core::cmp::PartialOrd for pixtuoid_core::state::GlobalDeskIndex
+pub fn pixtuoid_core::state::GlobalDeskIndex::partial_cmp(&self, &pixtuoid_core::state::GlobalDeskIndex) -> core::option::Option<core::cmp::Ordering>
+impl core::fmt::Debug for pixtuoid_core::state::GlobalDeskIndex
+pub fn pixtuoid_core::state::GlobalDeskIndex::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for pixtuoid_core::state::GlobalDeskIndex
+pub fn pixtuoid_core::state::GlobalDeskIndex::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for pixtuoid_core::state::GlobalDeskIndex
+impl core::marker::StructuralPartialEq for pixtuoid_core::state::GlobalDeskIndex
+impl serde_core::ser::Serialize for pixtuoid_core::state::GlobalDeskIndex
+pub fn pixtuoid_core::state::GlobalDeskIndex::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for pixtuoid_core::state::GlobalDeskIndex
+pub fn pixtuoid_core::state::GlobalDeskIndex::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for pixtuoid_core::state::GlobalDeskIndex
+impl core::marker::Send for pixtuoid_core::state::GlobalDeskIndex
+impl core::marker::Sync for pixtuoid_core::state::GlobalDeskIndex
+impl core::marker::Unpin for pixtuoid_core::state::GlobalDeskIndex
+impl core::marker::UnsafeUnpin for pixtuoid_core::state::GlobalDeskIndex
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::state::GlobalDeskIndex
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::state::GlobalDeskIndex
+pub struct pixtuoid_core::state::SceneState
+pub pixtuoid_core::state::SceneState::agents: alloc::collections::btree::map::BTreeMap<pixtuoid_core::id::AgentId, pixtuoid_core::state::AgentSlot>
+pub pixtuoid_core::state::SceneState::floor_capacities: [usize; 10]
+impl pixtuoid_core::state::SceneState
+pub fn pixtuoid_core::state::SceneState::daemons(&self) -> &alloc::collections::btree::map::BTreeMap<alloc::string::String, pixtuoid_core::state::DaemonPresence>
+pub fn pixtuoid_core::state::SceneState::daemons_mut(&mut self) -> &mut alloc::collections::btree::map::BTreeMap<alloc::string::String, pixtuoid_core::state::DaemonPresence>
+impl pixtuoid_core::state::SceneState
+pub fn pixtuoid_core::state::SceneState::floor_local_desk(&self, pixtuoid_core::state::GlobalDeskIndex) -> pixtuoid_core::state::FloorLocalDeskIndex
+pub fn pixtuoid_core::state::SceneState::floor_of(&self, pixtuoid_core::state::GlobalDeskIndex) -> usize
+pub fn pixtuoid_core::state::SceneState::floor_range(&self, usize) -> core::ops::range::Range<usize>
+pub fn pixtuoid_core::state::SceneState::new([usize; 10]) -> Self
+pub fn pixtuoid_core::state::SceneState::next_free_desk(&self) -> core::option::Option<pixtuoid_core::state::GlobalDeskIndex>
+pub fn pixtuoid_core::state::SceneState::total_capacity(&self) -> usize
+pub fn pixtuoid_core::state::SceneState::uniform(usize) -> Self
+impl core::clone::Clone for pixtuoid_core::state::SceneState
+pub fn pixtuoid_core::state::SceneState::clone(&self) -> pixtuoid_core::state::SceneState
+impl core::default::Default for pixtuoid_core::state::SceneState
+pub fn pixtuoid_core::state::SceneState::default() -> Self
+impl core::fmt::Debug for pixtuoid_core::state::SceneState
+pub fn pixtuoid_core::state::SceneState::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde_core::ser::Serialize for pixtuoid_core::state::SceneState
+pub fn pixtuoid_core::state::SceneState::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for pixtuoid_core::state::SceneState
+pub fn pixtuoid_core::state::SceneState::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for pixtuoid_core::state::SceneState
+impl core::marker::Send for pixtuoid_core::state::SceneState
+impl core::marker::Sync for pixtuoid_core::state::SceneState
+impl core::marker::Unpin for pixtuoid_core::state::SceneState
+impl core::marker::UnsafeUnpin for pixtuoid_core::state::SceneState
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::state::SceneState
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::state::SceneState
+pub struct pixtuoid_core::state::SlotLabel
+impl pixtuoid_core::state::SlotLabel
+pub fn pixtuoid_core::state::SlotLabel::cwd_derived(impl core::convert::Into<alloc::sync::Arc<str>>) -> Self
+pub fn pixtuoid_core::state::SlotLabel::is_upgradable(&self) -> bool
+pub fn pixtuoid_core::state::SlotLabel::new(impl core::convert::Into<alloc::sync::Arc<str>>, pixtuoid_core::state::LabelProvenance) -> Self
+pub fn pixtuoid_core::state::SlotLabel::ordinal_ghost(impl core::convert::Into<alloc::sync::Arc<str>>) -> Self
+pub fn pixtuoid_core::state::SlotLabel::prefix_fallback(impl core::convert::Into<alloc::sync::Arc<str>>) -> Self
+pub fn pixtuoid_core::state::SlotLabel::provenance(&self) -> pixtuoid_core::state::LabelProvenance
+pub fn pixtuoid_core::state::SlotLabel::renamed(impl core::convert::Into<alloc::sync::Arc<str>>) -> Self
+pub fn pixtuoid_core::state::SlotLabel::text(&self) -> alloc::sync::Arc<str>
+impl core::clone::Clone for pixtuoid_core::state::SlotLabel
+pub fn pixtuoid_core::state::SlotLabel::clone(&self) -> pixtuoid_core::state::SlotLabel
+impl core::convert::AsRef<str> for pixtuoid_core::state::SlotLabel
+pub fn pixtuoid_core::state::SlotLabel::as_ref(&self) -> &str
+impl core::convert::From<&str> for pixtuoid_core::state::SlotLabel
+pub fn pixtuoid_core::state::SlotLabel::from(&str) -> Self
+impl core::convert::From<alloc::string::String> for pixtuoid_core::state::SlotLabel
+pub fn pixtuoid_core::state::SlotLabel::from(alloc::string::String) -> Self
+impl core::fmt::Debug for pixtuoid_core::state::SlotLabel
+pub fn pixtuoid_core::state::SlotLabel::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for pixtuoid_core::state::SlotLabel
+pub fn pixtuoid_core::state::SlotLabel::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::ops::deref::Deref for pixtuoid_core::state::SlotLabel
+pub type pixtuoid_core::state::SlotLabel::Target = str
+pub fn pixtuoid_core::state::SlotLabel::deref(&self) -> &str
+impl serde_core::ser::Serialize for pixtuoid_core::state::SlotLabel
+pub fn pixtuoid_core::state::SlotLabel::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for pixtuoid_core::state::SlotLabel
+pub fn pixtuoid_core::state::SlotLabel::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for pixtuoid_core::state::SlotLabel
+impl core::marker::Send for pixtuoid_core::state::SlotLabel
+impl core::marker::Sync for pixtuoid_core::state::SlotLabel
+impl core::marker::Unpin for pixtuoid_core::state::SlotLabel
+impl core::marker::UnsafeUnpin for pixtuoid_core::state::SlotLabel
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::state::SlotLabel
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::state::SlotLabel
+#[non_exhaustive] pub struct pixtuoid_core::state::UsageObservation
+pub pixtuoid_core::state::UsageObservation::delta: u64
+pub pixtuoid_core::state::UsageObservation::seen_at: std::time::SystemTime
+impl pixtuoid_core::state::UsageObservation
+pub fn pixtuoid_core::state::UsageObservation::new(u64, std::time::SystemTime) -> Self
+impl core::clone::Clone for pixtuoid_core::state::UsageObservation
+pub fn pixtuoid_core::state::UsageObservation::clone(&self) -> pixtuoid_core::state::UsageObservation
+impl core::cmp::Eq for pixtuoid_core::state::UsageObservation
+impl core::cmp::PartialEq for pixtuoid_core::state::UsageObservation
+pub fn pixtuoid_core::state::UsageObservation::eq(&self, &pixtuoid_core::state::UsageObservation) -> bool
+impl core::fmt::Debug for pixtuoid_core::state::UsageObservation
+pub fn pixtuoid_core::state::UsageObservation::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_core::state::UsageObservation
+impl core::marker::StructuralPartialEq for pixtuoid_core::state::UsageObservation
+impl serde_core::ser::Serialize for pixtuoid_core::state::UsageObservation
+pub fn pixtuoid_core::state::UsageObservation::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for pixtuoid_core::state::UsageObservation
+pub fn pixtuoid_core::state::UsageObservation::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for pixtuoid_core::state::UsageObservation
+impl core::marker::Send for pixtuoid_core::state::UsageObservation
+impl core::marker::Sync for pixtuoid_core::state::UsageObservation
+impl core::marker::Unpin for pixtuoid_core::state::UsageObservation
+impl core::marker::UnsafeUnpin for pixtuoid_core::state::UsageObservation
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::state::UsageObservation
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::state::UsageObservation
+pub const pixtuoid_core::state::MAX_FLOORS: usize
+pub mod pixtuoid_core::walkable
+pub struct pixtuoid_core::walkable::OccupancyOverlay
+impl pixtuoid_core::walkable::OccupancyOverlay
+pub fn pixtuoid_core::walkable::OccupancyOverlay::add(&mut self, u16, u16, u16, u16)
+pub fn pixtuoid_core::walkable::OccupancyOverlay::blocks(&self, u16, u16) -> bool
+pub fn pixtuoid_core::walkable::OccupancyOverlay::clear(&mut self)
+pub fn pixtuoid_core::walkable::OccupancyOverlay::is_empty(&self) -> bool
+pub fn pixtuoid_core::walkable::OccupancyOverlay::len(&self) -> usize
+pub fn pixtuoid_core::walkable::OccupancyOverlay::new() -> Self
+pub fn pixtuoid_core::walkable::OccupancyOverlay::signature(&self) -> u64
+impl core::clone::Clone for pixtuoid_core::walkable::OccupancyOverlay
+pub fn pixtuoid_core::walkable::OccupancyOverlay::clone(&self) -> pixtuoid_core::walkable::OccupancyOverlay
+impl core::default::Default for pixtuoid_core::walkable::OccupancyOverlay
+pub fn pixtuoid_core::walkable::OccupancyOverlay::default() -> pixtuoid_core::walkable::OccupancyOverlay
+impl core::fmt::Debug for pixtuoid_core::walkable::OccupancyOverlay
+pub fn pixtuoid_core::walkable::OccupancyOverlay::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for pixtuoid_core::walkable::OccupancyOverlay
+impl core::marker::Send for pixtuoid_core::walkable::OccupancyOverlay
+impl core::marker::Sync for pixtuoid_core::walkable::OccupancyOverlay
+impl core::marker::Unpin for pixtuoid_core::walkable::OccupancyOverlay
+impl core::marker::UnsafeUnpin for pixtuoid_core::walkable::OccupancyOverlay
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::walkable::OccupancyOverlay
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::walkable::OccupancyOverlay
+pub type pixtuoid_core::walkable::WalkableMask = pixtuoid_core::grid::Grid<bool>
+pub enum pixtuoid_core::ActivityState
+pub pixtuoid_core::ActivityState::Active
+pub pixtuoid_core::ActivityState::Active::detail: core::option::Option<alloc::sync::Arc<str>>
+pub pixtuoid_core::ActivityState::Active::kind: pixtuoid_core::state::ToolKind
+pub pixtuoid_core::ActivityState::Active::tool_use_id: core::option::Option<alloc::sync::Arc<str>>
+pub pixtuoid_core::ActivityState::Idle
+pub pixtuoid_core::ActivityState::Waiting
+pub pixtuoid_core::ActivityState::Waiting::reason: alloc::sync::Arc<str>
+impl core::clone::Clone for pixtuoid_core::state::ActivityState
+pub fn pixtuoid_core::state::ActivityState::clone(&self) -> pixtuoid_core::state::ActivityState
+impl core::cmp::Eq for pixtuoid_core::state::ActivityState
+impl core::cmp::PartialEq for pixtuoid_core::state::ActivityState
+pub fn pixtuoid_core::state::ActivityState::eq(&self, &pixtuoid_core::state::ActivityState) -> bool
+impl core::fmt::Debug for pixtuoid_core::state::ActivityState
+pub fn pixtuoid_core::state::ActivityState::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for pixtuoid_core::state::ActivityState
+impl serde_core::ser::Serialize for pixtuoid_core::state::ActivityState
+pub fn pixtuoid_core::state::ActivityState::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for pixtuoid_core::state::ActivityState
+pub fn pixtuoid_core::state::ActivityState::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for pixtuoid_core::state::ActivityState
+impl core::marker::Send for pixtuoid_core::state::ActivityState
+impl core::marker::Sync for pixtuoid_core::state::ActivityState
+impl core::marker::Unpin for pixtuoid_core::state::ActivityState
+impl core::marker::UnsafeUnpin for pixtuoid_core::state::ActivityState
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::state::ActivityState
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::state::ActivityState
+#[non_exhaustive] pub enum pixtuoid_core::AgentEvent
+pub pixtuoid_core::AgentEvent::ActivityEnd
+pub pixtuoid_core::AgentEvent::ActivityEnd::agent_id: pixtuoid_core::id::AgentId
+pub pixtuoid_core::AgentEvent::ActivityEnd::tool_use_id: core::option::Option<alloc::string::String>
+pub pixtuoid_core::AgentEvent::ActivityStart
+pub pixtuoid_core::AgentEvent::ActivityStart::agent_id: pixtuoid_core::id::AgentId
+pub pixtuoid_core::AgentEvent::ActivityStart::detail: core::option::Option<pixtuoid_core::source::ToolDetail>
+pub pixtuoid_core::AgentEvent::ActivityStart::tool_use_id: core::option::Option<alloc::string::String>
+pub pixtuoid_core::AgentEvent::Identity
+pub pixtuoid_core::AgentEvent::Identity::agent_id: pixtuoid_core::id::AgentId
+pub pixtuoid_core::AgentEvent::Identity::cwd: core::option::Option<std::path::PathBuf>
+pub pixtuoid_core::AgentEvent::Identity::pid: core::option::Option<pixtuoid_core::source::PidIdentity>
+pub pixtuoid_core::AgentEvent::Identity::session_id: alloc::string::String
+pub pixtuoid_core::AgentEvent::Identity::source: alloc::string::String
+pub pixtuoid_core::AgentEvent::ModelInfo
+pub pixtuoid_core::AgentEvent::ModelInfo::agent_id: pixtuoid_core::id::AgentId
+pub pixtuoid_core::AgentEvent::ModelInfo::effort: core::option::Option<alloc::string::String>
+pub pixtuoid_core::AgentEvent::ModelInfo::model: core::option::Option<alloc::string::String>
+pub pixtuoid_core::AgentEvent::ProofOfLife
+pub pixtuoid_core::AgentEvent::ProofOfLife::agent_id: pixtuoid_core::id::AgentId
+pub pixtuoid_core::AgentEvent::Rename
+pub pixtuoid_core::AgentEvent::Rename::agent_id: pixtuoid_core::id::AgentId
+pub pixtuoid_core::AgentEvent::Rename::label: alloc::string::String
+pub pixtuoid_core::AgentEvent::SessionEnd
+pub pixtuoid_core::AgentEvent::SessionEnd::agent_id: pixtuoid_core::id::AgentId
+pub pixtuoid_core::AgentEvent::SessionEnd::as_child: bool
+pub pixtuoid_core::AgentEvent::SessionStart
+pub pixtuoid_core::AgentEvent::SessionStart::agent_id: pixtuoid_core::id::AgentId
+pub pixtuoid_core::AgentEvent::SessionStart::cwd: std::path::PathBuf
+pub pixtuoid_core::AgentEvent::SessionStart::parent_id: core::option::Option<pixtuoid_core::id::AgentId>
+pub pixtuoid_core::AgentEvent::SessionStart::session_id: alloc::string::String
+pub pixtuoid_core::AgentEvent::SessionStart::source: alloc::string::String
+pub pixtuoid_core::AgentEvent::Usage
+pub pixtuoid_core::AgentEvent::Usage::agent_id: pixtuoid_core::id::AgentId
+pub pixtuoid_core::AgentEvent::Usage::fresh_tokens: u64
+pub pixtuoid_core::AgentEvent::Waiting
+pub pixtuoid_core::AgentEvent::Waiting::agent_id: pixtuoid_core::id::AgentId
+pub pixtuoid_core::AgentEvent::Waiting::reason: alloc::string::String
+impl pixtuoid_core::source::AgentEvent
+pub fn pixtuoid_core::source::AgentEvent::agent_id(&self) -> pixtuoid_core::id::AgentId
+impl core::clone::Clone for pixtuoid_core::source::AgentEvent
+pub fn pixtuoid_core::source::AgentEvent::clone(&self) -> pixtuoid_core::source::AgentEvent
+impl core::cmp::Eq for pixtuoid_core::source::AgentEvent
+impl core::cmp::PartialEq for pixtuoid_core::source::AgentEvent
+pub fn pixtuoid_core::source::AgentEvent::eq(&self, &pixtuoid_core::source::AgentEvent) -> bool
+impl core::fmt::Debug for pixtuoid_core::source::AgentEvent
+pub fn pixtuoid_core::source::AgentEvent::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for pixtuoid_core::source::AgentEvent
+impl serde_core::ser::Serialize for pixtuoid_core::source::AgentEvent
+pub fn pixtuoid_core::source::AgentEvent::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for pixtuoid_core::source::AgentEvent
+pub fn pixtuoid_core::source::AgentEvent::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for pixtuoid_core::source::AgentEvent
+impl core::marker::Send for pixtuoid_core::source::AgentEvent
+impl core::marker::Sync for pixtuoid_core::source::AgentEvent
+impl core::marker::Unpin for pixtuoid_core::source::AgentEvent
+impl core::marker::UnsafeUnpin for pixtuoid_core::source::AgentEvent
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::source::AgentEvent
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::source::AgentEvent
+pub enum pixtuoid_core::LabelProvenance
+pub pixtuoid_core::LabelProvenance::CwdDerived
+pub pixtuoid_core::LabelProvenance::OrdinalGhost
+pub pixtuoid_core::LabelProvenance::PrefixFallback
+pub pixtuoid_core::LabelProvenance::Renamed
+impl core::clone::Clone for pixtuoid_core::state::LabelProvenance
+pub fn pixtuoid_core::state::LabelProvenance::clone(&self) -> pixtuoid_core::state::LabelProvenance
+impl core::cmp::Eq for pixtuoid_core::state::LabelProvenance
+impl core::cmp::PartialEq for pixtuoid_core::state::LabelProvenance
+pub fn pixtuoid_core::state::LabelProvenance::eq(&self, &pixtuoid_core::state::LabelProvenance) -> bool
+impl core::fmt::Debug for pixtuoid_core::state::LabelProvenance
+pub fn pixtuoid_core::state::LabelProvenance::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_core::state::LabelProvenance
+impl core::marker::StructuralPartialEq for pixtuoid_core::state::LabelProvenance
+impl serde_core::ser::Serialize for pixtuoid_core::state::LabelProvenance
+pub fn pixtuoid_core::state::LabelProvenance::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for pixtuoid_core::state::LabelProvenance
+pub fn pixtuoid_core::state::LabelProvenance::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for pixtuoid_core::state::LabelProvenance
+impl core::marker::Send for pixtuoid_core::state::LabelProvenance
+impl core::marker::Sync for pixtuoid_core::state::LabelProvenance
+impl core::marker::Unpin for pixtuoid_core::state::LabelProvenance
+impl core::marker::UnsafeUnpin for pixtuoid_core::state::LabelProvenance
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::state::LabelProvenance
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::state::LabelProvenance
+#[non_exhaustive] pub enum pixtuoid_core::ToolDetail
+pub pixtuoid_core::ToolDetail::Generic
+pub pixtuoid_core::ToolDetail::Generic::display: alloc::string::String
+pub pixtuoid_core::ToolDetail::Task
+impl pixtuoid_core::source::ToolDetail
+pub fn pixtuoid_core::source::ToolDetail::display(&self) -> &str
+pub fn pixtuoid_core::source::ToolDetail::is_task(&self) -> bool
+impl core::clone::Clone for pixtuoid_core::source::ToolDetail
+pub fn pixtuoid_core::source::ToolDetail::clone(&self) -> pixtuoid_core::source::ToolDetail
+impl core::cmp::Eq for pixtuoid_core::source::ToolDetail
+impl core::cmp::PartialEq for pixtuoid_core::source::ToolDetail
+pub fn pixtuoid_core::source::ToolDetail::eq(&self, &pixtuoid_core::source::ToolDetail) -> bool
+impl core::convert::From<&str> for pixtuoid_core::source::ToolDetail
+pub fn pixtuoid_core::source::ToolDetail::from(&str) -> Self
+impl core::fmt::Debug for pixtuoid_core::source::ToolDetail
+pub fn pixtuoid_core::source::ToolDetail::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for pixtuoid_core::source::ToolDetail
+impl serde_core::ser::Serialize for pixtuoid_core::source::ToolDetail
+pub fn pixtuoid_core::source::ToolDetail::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for pixtuoid_core::source::ToolDetail
+pub fn pixtuoid_core::source::ToolDetail::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for pixtuoid_core::source::ToolDetail
+impl core::marker::Send for pixtuoid_core::source::ToolDetail
+impl core::marker::Sync for pixtuoid_core::source::ToolDetail
+impl core::marker::Unpin for pixtuoid_core::source::ToolDetail
+impl core::marker::UnsafeUnpin for pixtuoid_core::source::ToolDetail
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::source::ToolDetail
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::source::ToolDetail
+pub enum pixtuoid_core::ToolKind
+pub pixtuoid_core::ToolKind::Bash
+pub pixtuoid_core::ToolKind::Edit
+pub pixtuoid_core::ToolKind::Other
+pub pixtuoid_core::ToolKind::Read
+pub pixtuoid_core::ToolKind::Search
+pub pixtuoid_core::ToolKind::Task
+impl pixtuoid_core::state::ToolKind
+pub fn pixtuoid_core::state::ToolKind::from_detail(&pixtuoid_core::source::ToolDetail) -> Self
+pub fn pixtuoid_core::state::ToolKind::from_display(&str) -> Self
+impl core::clone::Clone for pixtuoid_core::state::ToolKind
+pub fn pixtuoid_core::state::ToolKind::clone(&self) -> pixtuoid_core::state::ToolKind
+impl core::cmp::Eq for pixtuoid_core::state::ToolKind
+impl core::cmp::PartialEq for pixtuoid_core::state::ToolKind
+pub fn pixtuoid_core::state::ToolKind::eq(&self, &pixtuoid_core::state::ToolKind) -> bool
+impl core::fmt::Debug for pixtuoid_core::state::ToolKind
+pub fn pixtuoid_core::state::ToolKind::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_core::state::ToolKind
+impl core::marker::StructuralPartialEq for pixtuoid_core::state::ToolKind
+impl serde_core::ser::Serialize for pixtuoid_core::state::ToolKind
+pub fn pixtuoid_core::state::ToolKind::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for pixtuoid_core::state::ToolKind
+pub fn pixtuoid_core::state::ToolKind::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for pixtuoid_core::state::ToolKind
+impl core::marker::Send for pixtuoid_core::state::ToolKind
+impl core::marker::Sync for pixtuoid_core::state::ToolKind
+impl core::marker::Unpin for pixtuoid_core::state::ToolKind
+impl core::marker::UnsafeUnpin for pixtuoid_core::state::ToolKind
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::state::ToolKind
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::state::ToolKind
+#[non_exhaustive] pub enum pixtuoid_core::Transport
+pub pixtuoid_core::Transport::Hook
+pub pixtuoid_core::Transport::Jsonl
+impl core::clone::Clone for pixtuoid_core::source::Transport
+pub fn pixtuoid_core::source::Transport::clone(&self) -> pixtuoid_core::source::Transport
+impl core::cmp::Eq for pixtuoid_core::source::Transport
+impl core::cmp::PartialEq for pixtuoid_core::source::Transport
+pub fn pixtuoid_core::source::Transport::eq(&self, &pixtuoid_core::source::Transport) -> bool
+impl core::fmt::Debug for pixtuoid_core::source::Transport
+pub fn pixtuoid_core::source::Transport::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_core::source::Transport
+impl core::marker::StructuralPartialEq for pixtuoid_core::source::Transport
+impl core::marker::Freeze for pixtuoid_core::source::Transport
+impl core::marker::Send for pixtuoid_core::source::Transport
+impl core::marker::Sync for pixtuoid_core::source::Transport
+impl core::marker::Unpin for pixtuoid_core::source::Transport
+impl core::marker::UnsafeUnpin for pixtuoid_core::source::Transport
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::source::Transport
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::source::Transport
+pub struct pixtuoid_core::AgentId(_)
+impl pixtuoid_core::id::AgentId
+pub fn pixtuoid_core::id::AgentId::from_parts(&str, &str) -> Self
+pub fn pixtuoid_core::id::AgentId::raw(self) -> u64
+impl core::clone::Clone for pixtuoid_core::id::AgentId
+pub fn pixtuoid_core::id::AgentId::clone(&self) -> pixtuoid_core::id::AgentId
+impl core::cmp::Eq for pixtuoid_core::id::AgentId
+impl core::cmp::Ord for pixtuoid_core::id::AgentId
+pub fn pixtuoid_core::id::AgentId::cmp(&self, &pixtuoid_core::id::AgentId) -> core::cmp::Ordering
+impl core::cmp::PartialEq for pixtuoid_core::id::AgentId
+pub fn pixtuoid_core::id::AgentId::eq(&self, &pixtuoid_core::id::AgentId) -> bool
+impl core::cmp::PartialOrd for pixtuoid_core::id::AgentId
+pub fn pixtuoid_core::id::AgentId::partial_cmp(&self, &pixtuoid_core::id::AgentId) -> core::option::Option<core::cmp::Ordering>
+impl core::fmt::Debug for pixtuoid_core::id::AgentId
+pub fn pixtuoid_core::id::AgentId::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for pixtuoid_core::id::AgentId
+pub fn pixtuoid_core::id::AgentId::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for pixtuoid_core::id::AgentId
+pub fn pixtuoid_core::id::AgentId::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for pixtuoid_core::id::AgentId
+impl core::marker::StructuralPartialEq for pixtuoid_core::id::AgentId
+impl serde_core::ser::Serialize for pixtuoid_core::id::AgentId
+pub fn pixtuoid_core::id::AgentId::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for pixtuoid_core::id::AgentId
+pub fn pixtuoid_core::id::AgentId::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for pixtuoid_core::id::AgentId
+impl core::marker::Send for pixtuoid_core::id::AgentId
+impl core::marker::Sync for pixtuoid_core::id::AgentId
+impl core::marker::Unpin for pixtuoid_core::id::AgentId
+impl core::marker::UnsafeUnpin for pixtuoid_core::id::AgentId
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::id::AgentId
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::id::AgentId
+pub struct pixtuoid_core::AgentSlot
+pub pixtuoid_core::AgentSlot::active_ms: u64
+pub pixtuoid_core::AgentSlot::agent_id: pixtuoid_core::id::AgentId
+pub pixtuoid_core::AgentSlot::created_at: std::time::SystemTime
+pub pixtuoid_core::AgentSlot::cwd: alloc::sync::Arc<std::path::Path>
+pub pixtuoid_core::AgentSlot::desk_index: pixtuoid_core::state::GlobalDeskIndex
+pub pixtuoid_core::AgentSlot::effort: core::option::Option<pixtuoid_core::state::EffortObservation>
+pub pixtuoid_core::AgentSlot::exiting_at: core::option::Option<std::time::SystemTime>
+pub pixtuoid_core::AgentSlot::floor_idx: usize
+pub pixtuoid_core::AgentSlot::label: pixtuoid_core::state::SlotLabel
+pub pixtuoid_core::AgentSlot::last_event_at: std::time::SystemTime
+pub pixtuoid_core::AgentSlot::last_usage: core::option::Option<pixtuoid_core::state::UsageObservation>
+pub pixtuoid_core::AgentSlot::model: core::option::Option<alloc::sync::Arc<str>>
+pub pixtuoid_core::AgentSlot::parent_id: core::option::Option<pixtuoid_core::id::AgentId>
+pub pixtuoid_core::AgentSlot::pending_idle_at: core::option::Option<std::time::SystemTime>
+pub pixtuoid_core::AgentSlot::pid: core::option::Option<pixtuoid_core::source::PidIdentity>
+pub pixtuoid_core::AgentSlot::session_id: alloc::sync::Arc<str>
+pub pixtuoid_core::AgentSlot::source: alloc::sync::Arc<str>
+pub pixtuoid_core::AgentSlot::state: pixtuoid_core::state::ActivityState
+pub pixtuoid_core::AgentSlot::state_started_at: std::time::SystemTime
+pub pixtuoid_core::AgentSlot::tokens_used: u64
+pub pixtuoid_core::AgentSlot::tool_call_count: u32
+pub pixtuoid_core::AgentSlot::unknown_cwd: bool
+impl core::clone::Clone for pixtuoid_core::state::AgentSlot
+pub fn pixtuoid_core::state::AgentSlot::clone(&self) -> pixtuoid_core::state::AgentSlot
+impl core::fmt::Debug for pixtuoid_core::state::AgentSlot
+pub fn pixtuoid_core::state::AgentSlot::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde_core::ser::Serialize for pixtuoid_core::state::AgentSlot
+pub fn pixtuoid_core::state::AgentSlot::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for pixtuoid_core::state::AgentSlot
+pub fn pixtuoid_core::state::AgentSlot::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for pixtuoid_core::state::AgentSlot
+impl core::marker::Send for pixtuoid_core::state::AgentSlot
+impl core::marker::Sync for pixtuoid_core::state::AgentSlot
+impl core::marker::Unpin for pixtuoid_core::state::AgentSlot
+impl core::marker::UnsafeUnpin for pixtuoid_core::state::AgentSlot
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::state::AgentSlot
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::state::AgentSlot
+pub struct pixtuoid_core::FloorLocalDeskIndex(pub usize)
+impl core::clone::Clone for pixtuoid_core::state::FloorLocalDeskIndex
+pub fn pixtuoid_core::state::FloorLocalDeskIndex::clone(&self) -> pixtuoid_core::state::FloorLocalDeskIndex
+impl core::cmp::Eq for pixtuoid_core::state::FloorLocalDeskIndex
+impl core::cmp::Ord for pixtuoid_core::state::FloorLocalDeskIndex
+pub fn pixtuoid_core::state::FloorLocalDeskIndex::cmp(&self, &pixtuoid_core::state::FloorLocalDeskIndex) -> core::cmp::Ordering
+impl core::cmp::PartialEq for pixtuoid_core::state::FloorLocalDeskIndex
+pub fn pixtuoid_core::state::FloorLocalDeskIndex::eq(&self, &pixtuoid_core::state::FloorLocalDeskIndex) -> bool
+impl core::cmp::PartialOrd for pixtuoid_core::state::FloorLocalDeskIndex
+pub fn pixtuoid_core::state::FloorLocalDeskIndex::partial_cmp(&self, &pixtuoid_core::state::FloorLocalDeskIndex) -> core::option::Option<core::cmp::Ordering>
+impl core::fmt::Debug for pixtuoid_core::state::FloorLocalDeskIndex
+pub fn pixtuoid_core::state::FloorLocalDeskIndex::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for pixtuoid_core::state::FloorLocalDeskIndex
+pub fn pixtuoid_core::state::FloorLocalDeskIndex::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for pixtuoid_core::state::FloorLocalDeskIndex
+impl core::marker::StructuralPartialEq for pixtuoid_core::state::FloorLocalDeskIndex
+impl core::marker::Freeze for pixtuoid_core::state::FloorLocalDeskIndex
+impl core::marker::Send for pixtuoid_core::state::FloorLocalDeskIndex
+impl core::marker::Sync for pixtuoid_core::state::FloorLocalDeskIndex
+impl core::marker::Unpin for pixtuoid_core::state::FloorLocalDeskIndex
+impl core::marker::UnsafeUnpin for pixtuoid_core::state::FloorLocalDeskIndex
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::state::FloorLocalDeskIndex
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::state::FloorLocalDeskIndex
+pub struct pixtuoid_core::Frame(_)
+impl pixtuoid_core::sprite::Frame
+pub fn pixtuoid_core::sprite::Frame::from_pixels(u16, u16, alloc::vec::Vec<pixtuoid_core::sprite::Pixel>) -> Self
+pub fn pixtuoid_core::sprite::Frame::mirror_horizontal(&self) -> Self
+pub fn pixtuoid_core::sprite::Frame::mirror_vertical(&self) -> Self
+impl core::clone::Clone for pixtuoid_core::sprite::Frame
+pub fn pixtuoid_core::sprite::Frame::clone(&self) -> pixtuoid_core::sprite::Frame
+impl core::default::Default for pixtuoid_core::sprite::Frame
+pub fn pixtuoid_core::sprite::Frame::default() -> pixtuoid_core::sprite::Frame
+impl core::fmt::Debug for pixtuoid_core::sprite::Frame
+pub fn pixtuoid_core::sprite::Frame::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::ops::deref::Deref for pixtuoid_core::sprite::Frame
+pub type pixtuoid_core::sprite::Frame::Target = pixtuoid_core::grid::Grid<core::option::Option<pixtuoid_core::sprite::Rgb>>
+pub fn pixtuoid_core::sprite::Frame::deref(&self) -> &pixtuoid_core::grid::Grid<pixtuoid_core::sprite::Pixel>
+impl core::ops::deref::DerefMut for pixtuoid_core::sprite::Frame
+pub fn pixtuoid_core::sprite::Frame::deref_mut(&mut self) -> &mut pixtuoid_core::grid::Grid<pixtuoid_core::sprite::Pixel>
+impl core::marker::Freeze for pixtuoid_core::sprite::Frame
+impl core::marker::Send for pixtuoid_core::sprite::Frame
+impl core::marker::Sync for pixtuoid_core::sprite::Frame
+impl core::marker::Unpin for pixtuoid_core::sprite::Frame
+impl core::marker::UnsafeUnpin for pixtuoid_core::sprite::Frame
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::sprite::Frame
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::sprite::Frame
+pub struct pixtuoid_core::GlobalDeskIndex(pub usize)
+impl pixtuoid_core::state::GlobalDeskIndex
+pub fn pixtuoid_core::state::GlobalDeskIndex::single_floor_local(self) -> pixtuoid_core::state::FloorLocalDeskIndex
+impl core::clone::Clone for pixtuoid_core::state::GlobalDeskIndex
+pub fn pixtuoid_core::state::GlobalDeskIndex::clone(&self) -> pixtuoid_core::state::GlobalDeskIndex
+impl core::cmp::Eq for pixtuoid_core::state::GlobalDeskIndex
+impl core::cmp::Ord for pixtuoid_core::state::GlobalDeskIndex
+pub fn pixtuoid_core::state::GlobalDeskIndex::cmp(&self, &pixtuoid_core::state::GlobalDeskIndex) -> core::cmp::Ordering
+impl core::cmp::PartialEq for pixtuoid_core::state::GlobalDeskIndex
+pub fn pixtuoid_core::state::GlobalDeskIndex::eq(&self, &pixtuoid_core::state::GlobalDeskIndex) -> bool
+impl core::cmp::PartialOrd for pixtuoid_core::state::GlobalDeskIndex
+pub fn pixtuoid_core::state::GlobalDeskIndex::partial_cmp(&self, &pixtuoid_core::state::GlobalDeskIndex) -> core::option::Option<core::cmp::Ordering>
+impl core::fmt::Debug for pixtuoid_core::state::GlobalDeskIndex
+pub fn pixtuoid_core::state::GlobalDeskIndex::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for pixtuoid_core::state::GlobalDeskIndex
+pub fn pixtuoid_core::state::GlobalDeskIndex::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for pixtuoid_core::state::GlobalDeskIndex
+impl core::marker::StructuralPartialEq for pixtuoid_core::state::GlobalDeskIndex
+impl serde_core::ser::Serialize for pixtuoid_core::state::GlobalDeskIndex
+pub fn pixtuoid_core::state::GlobalDeskIndex::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for pixtuoid_core::state::GlobalDeskIndex
+pub fn pixtuoid_core::state::GlobalDeskIndex::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for pixtuoid_core::state::GlobalDeskIndex
+impl core::marker::Send for pixtuoid_core::state::GlobalDeskIndex
+impl core::marker::Sync for pixtuoid_core::state::GlobalDeskIndex
+impl core::marker::Unpin for pixtuoid_core::state::GlobalDeskIndex
+impl core::marker::UnsafeUnpin for pixtuoid_core::state::GlobalDeskIndex
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::state::GlobalDeskIndex
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::state::GlobalDeskIndex
+pub struct pixtuoid_core::Grid<T>
+impl pixtuoid_core::grid::Grid<bool>
+pub fn pixtuoid_core::grid::Grid<bool>::is_walkable(&self, u16, u16) -> bool
+pub fn pixtuoid_core::grid::Grid<bool>::mark_blocked(&mut self, u16, u16, u16, u16, u16)
+pub fn pixtuoid_core::grid::Grid<bool>::mark_walkable(&mut self, u16, u16, u16, u16)
+pub fn pixtuoid_core::grid::Grid<bool>::new_open(u16, u16) -> Self
+impl<T: core::clone::Clone> pixtuoid_core::grid::Grid<T>
+pub fn pixtuoid_core::grid::Grid<T>::filled(u16, u16, T) -> Self
+impl<T: core::marker::Copy> pixtuoid_core::grid::Grid<T>
+pub fn pixtuoid_core::grid::Grid<T>::get_or(&self, u16, u16, T) -> T
+pub fn pixtuoid_core::grid::Grid<T>::resize_fill(&mut self, u16, u16, T)
+impl<T> pixtuoid_core::grid::Grid<T>
+pub fn pixtuoid_core::grid::Grid<T>::as_mut_slice(&mut self) -> &mut [T]
+pub fn pixtuoid_core::grid::Grid<T>::as_slice(&self) -> &[T]
+pub fn pixtuoid_core::grid::Grid<T>::from_vec(u16, u16, alloc::vec::Vec<T>) -> Self
+pub fn pixtuoid_core::grid::Grid<T>::get(&self, u16, u16) -> core::option::Option<&T>
+pub fn pixtuoid_core::grid::Grid<T>::set(&mut self, u16, u16, T)
+impl<T> pixtuoid_core::grid::Grid<T>
+pub fn pixtuoid_core::grid::Grid<T>::height(&self) -> u16
+pub fn pixtuoid_core::grid::Grid<T>::width(&self) -> u16
+impl<T: core::clone::Clone> core::clone::Clone for pixtuoid_core::grid::Grid<T>
+pub fn pixtuoid_core::grid::Grid<T>::clone(&self) -> pixtuoid_core::grid::Grid<T>
+impl<T: core::cmp::Eq> core::cmp::Eq for pixtuoid_core::grid::Grid<T>
+impl<T: core::cmp::PartialEq> core::cmp::PartialEq for pixtuoid_core::grid::Grid<T>
+pub fn pixtuoid_core::grid::Grid<T>::eq(&self, &pixtuoid_core::grid::Grid<T>) -> bool
+impl<T: core::cmp::PartialEq> core::marker::StructuralPartialEq for pixtuoid_core::grid::Grid<T>
+impl<T: core::default::Default> core::default::Default for pixtuoid_core::grid::Grid<T>
+pub fn pixtuoid_core::grid::Grid<T>::default() -> pixtuoid_core::grid::Grid<T>
+impl<T: core::fmt::Debug> core::fmt::Debug for pixtuoid_core::grid::Grid<T>
+pub fn pixtuoid_core::grid::Grid<T>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T> core::marker::Freeze for pixtuoid_core::grid::Grid<T>
+impl<T> core::marker::Send for pixtuoid_core::grid::Grid<T> where T: core::marker::Send
+impl<T> core::marker::Sync for pixtuoid_core::grid::Grid<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for pixtuoid_core::grid::Grid<T> where T: core::marker::Unpin
+impl<T> core::marker::UnsafeUnpin for pixtuoid_core::grid::Grid<T>
+impl<T> core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::grid::Grid<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for pixtuoid_core::grid::Grid<T> where T: core::panic::unwind_safe::UnwindSafe
+pub struct pixtuoid_core::OccupancyOverlay
+impl pixtuoid_core::walkable::OccupancyOverlay
+pub fn pixtuoid_core::walkable::OccupancyOverlay::add(&mut self, u16, u16, u16, u16)
+pub fn pixtuoid_core::walkable::OccupancyOverlay::blocks(&self, u16, u16) -> bool
+pub fn pixtuoid_core::walkable::OccupancyOverlay::clear(&mut self)
+pub fn pixtuoid_core::walkable::OccupancyOverlay::is_empty(&self) -> bool
+pub fn pixtuoid_core::walkable::OccupancyOverlay::len(&self) -> usize
+pub fn pixtuoid_core::walkable::OccupancyOverlay::new() -> Self
+pub fn pixtuoid_core::walkable::OccupancyOverlay::signature(&self) -> u64
+impl core::clone::Clone for pixtuoid_core::walkable::OccupancyOverlay
+pub fn pixtuoid_core::walkable::OccupancyOverlay::clone(&self) -> pixtuoid_core::walkable::OccupancyOverlay
+impl core::default::Default for pixtuoid_core::walkable::OccupancyOverlay
+pub fn pixtuoid_core::walkable::OccupancyOverlay::default() -> pixtuoid_core::walkable::OccupancyOverlay
+impl core::fmt::Debug for pixtuoid_core::walkable::OccupancyOverlay
+pub fn pixtuoid_core::walkable::OccupancyOverlay::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for pixtuoid_core::walkable::OccupancyOverlay
+impl core::marker::Send for pixtuoid_core::walkable::OccupancyOverlay
+impl core::marker::Sync for pixtuoid_core::walkable::OccupancyOverlay
+impl core::marker::Unpin for pixtuoid_core::walkable::OccupancyOverlay
+impl core::marker::UnsafeUnpin for pixtuoid_core::walkable::OccupancyOverlay
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::walkable::OccupancyOverlay
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::walkable::OccupancyOverlay
+pub struct pixtuoid_core::Palette
+impl pixtuoid_core::sprite::Palette
+pub fn pixtuoid_core::sprite::Palette::get(&self, char) -> core::option::Option<pixtuoid_core::sprite::Pixel>
+pub fn pixtuoid_core::sprite::Palette::insert(&mut self, char, pixtuoid_core::sprite::Pixel)
+pub fn pixtuoid_core::sprite::Palette::iter(&self) -> impl core::iter::traits::iterator::Iterator<Item = (char, pixtuoid_core::sprite::Pixel)> + '_
+pub fn pixtuoid_core::sprite::Palette::new() -> Self
+pub fn pixtuoid_core::sprite::Palette::with_override(&self, char, pixtuoid_core::sprite::Pixel) -> Self
+impl core::clone::Clone for pixtuoid_core::sprite::Palette
+pub fn pixtuoid_core::sprite::Palette::clone(&self) -> pixtuoid_core::sprite::Palette
+impl core::default::Default for pixtuoid_core::sprite::Palette
+pub fn pixtuoid_core::sprite::Palette::default() -> pixtuoid_core::sprite::Palette
+impl core::fmt::Debug for pixtuoid_core::sprite::Palette
+pub fn pixtuoid_core::sprite::Palette::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for pixtuoid_core::sprite::Palette
+impl core::marker::Send for pixtuoid_core::sprite::Palette
+impl core::marker::Sync for pixtuoid_core::sprite::Palette
+impl core::marker::Unpin for pixtuoid_core::sprite::Palette
+impl core::marker::UnsafeUnpin for pixtuoid_core::sprite::Palette
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::sprite::Palette
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::sprite::Palette
+pub struct pixtuoid_core::Reducer
+impl pixtuoid_core::state::reducer::Reducer
+pub fn pixtuoid_core::state::reducer::Reducer::apply(&mut self, &mut pixtuoid_core::state::SceneState, pixtuoid_core::source::AgentEvent, std::time::SystemTime, pixtuoid_core::source::Transport)
+pub fn pixtuoid_core::state::reducer::Reducer::new() -> Self
+pub fn pixtuoid_core::state::reducer::Reducer::reconcile_connected(&self, &mut pixtuoid_core::state::SceneState, &std::collections::hash::set::HashSet<alloc::string::String>, std::time::SystemTime)
+pub fn pixtuoid_core::state::reducer::Reducer::tick(&mut self, &mut pixtuoid_core::state::SceneState, std::time::SystemTime)
+impl core::default::Default for pixtuoid_core::state::reducer::Reducer
+pub fn pixtuoid_core::state::reducer::Reducer::default() -> pixtuoid_core::state::reducer::Reducer
+impl core::fmt::Debug for pixtuoid_core::state::reducer::Reducer
+pub fn pixtuoid_core::state::reducer::Reducer::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for pixtuoid_core::state::reducer::Reducer
+impl core::marker::Send for pixtuoid_core::state::reducer::Reducer
+impl core::marker::Sync for pixtuoid_core::state::reducer::Reducer
+impl core::marker::Unpin for pixtuoid_core::state::reducer::Reducer
+impl core::marker::UnsafeUnpin for pixtuoid_core::state::reducer::Reducer
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::state::reducer::Reducer
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::state::reducer::Reducer
+pub struct pixtuoid_core::Rgb
+pub pixtuoid_core::Rgb::b: u8
+pub pixtuoid_core::Rgb::g: u8
+pub pixtuoid_core::Rgb::r: u8
+impl core::clone::Clone for pixtuoid_core::sprite::Rgb
+pub fn pixtuoid_core::sprite::Rgb::clone(&self) -> pixtuoid_core::sprite::Rgb
+impl core::cmp::Eq for pixtuoid_core::sprite::Rgb
+impl core::cmp::PartialEq for pixtuoid_core::sprite::Rgb
+pub fn pixtuoid_core::sprite::Rgb::eq(&self, &pixtuoid_core::sprite::Rgb) -> bool
+impl core::fmt::Debug for pixtuoid_core::sprite::Rgb
+pub fn pixtuoid_core::sprite::Rgb::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for pixtuoid_core::sprite::Rgb
+pub fn pixtuoid_core::sprite::Rgb::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for pixtuoid_core::sprite::Rgb
+impl core::marker::StructuralPartialEq for pixtuoid_core::sprite::Rgb
+impl core::marker::Freeze for pixtuoid_core::sprite::Rgb
+impl core::marker::Send for pixtuoid_core::sprite::Rgb
+impl core::marker::Sync for pixtuoid_core::sprite::Rgb
+impl core::marker::Unpin for pixtuoid_core::sprite::Rgb
+impl core::marker::UnsafeUnpin for pixtuoid_core::sprite::Rgb
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::sprite::Rgb
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::sprite::Rgb
+pub struct pixtuoid_core::RgbBuffer(_)
+impl pixtuoid_core::sprite::RgbBuffer
+pub fn pixtuoid_core::sprite::RgbBuffer::filled(u16, u16, pixtuoid_core::sprite::Rgb) -> Self
+pub fn pixtuoid_core::sprite::RgbBuffer::from_pixels(u16, u16, alloc::vec::Vec<pixtuoid_core::sprite::Rgb>) -> Self
+pub fn pixtuoid_core::sprite::RgbBuffer::get(&self, u16, u16) -> pixtuoid_core::sprite::Rgb
+pub fn pixtuoid_core::sprite::RgbBuffer::put(&mut self, u16, u16, pixtuoid_core::sprite::Rgb)
+pub fn pixtuoid_core::sprite::RgbBuffer::put_checked(&mut self, u16, u16, pixtuoid_core::sprite::Rgb)
+impl core::clone::Clone for pixtuoid_core::sprite::RgbBuffer
+pub fn pixtuoid_core::sprite::RgbBuffer::clone(&self) -> pixtuoid_core::sprite::RgbBuffer
+impl core::fmt::Debug for pixtuoid_core::sprite::RgbBuffer
+pub fn pixtuoid_core::sprite::RgbBuffer::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::ops::deref::Deref for pixtuoid_core::sprite::RgbBuffer
+pub type pixtuoid_core::sprite::RgbBuffer::Target = pixtuoid_core::grid::Grid<pixtuoid_core::sprite::Rgb>
+pub fn pixtuoid_core::sprite::RgbBuffer::deref(&self) -> &pixtuoid_core::grid::Grid<pixtuoid_core::sprite::Rgb>
+impl core::ops::deref::DerefMut for pixtuoid_core::sprite::RgbBuffer
+pub fn pixtuoid_core::sprite::RgbBuffer::deref_mut(&mut self) -> &mut pixtuoid_core::grid::Grid<pixtuoid_core::sprite::Rgb>
+impl core::marker::Freeze for pixtuoid_core::sprite::RgbBuffer
+impl core::marker::Send for pixtuoid_core::sprite::RgbBuffer
+impl core::marker::Sync for pixtuoid_core::sprite::RgbBuffer
+impl core::marker::Unpin for pixtuoid_core::sprite::RgbBuffer
+impl core::marker::UnsafeUnpin for pixtuoid_core::sprite::RgbBuffer
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::sprite::RgbBuffer
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::sprite::RgbBuffer
+pub struct pixtuoid_core::SceneState
+pub pixtuoid_core::SceneState::agents: alloc::collections::btree::map::BTreeMap<pixtuoid_core::id::AgentId, pixtuoid_core::state::AgentSlot>
+pub pixtuoid_core::SceneState::floor_capacities: [usize; 10]
+impl pixtuoid_core::state::SceneState
+pub fn pixtuoid_core::state::SceneState::daemons(&self) -> &alloc::collections::btree::map::BTreeMap<alloc::string::String, pixtuoid_core::state::DaemonPresence>
+pub fn pixtuoid_core::state::SceneState::daemons_mut(&mut self) -> &mut alloc::collections::btree::map::BTreeMap<alloc::string::String, pixtuoid_core::state::DaemonPresence>
+impl pixtuoid_core::state::SceneState
+pub fn pixtuoid_core::state::SceneState::floor_local_desk(&self, pixtuoid_core::state::GlobalDeskIndex) -> pixtuoid_core::state::FloorLocalDeskIndex
+pub fn pixtuoid_core::state::SceneState::floor_of(&self, pixtuoid_core::state::GlobalDeskIndex) -> usize
+pub fn pixtuoid_core::state::SceneState::floor_range(&self, usize) -> core::ops::range::Range<usize>
+pub fn pixtuoid_core::state::SceneState::new([usize; 10]) -> Self
+pub fn pixtuoid_core::state::SceneState::next_free_desk(&self) -> core::option::Option<pixtuoid_core::state::GlobalDeskIndex>
+pub fn pixtuoid_core::state::SceneState::total_capacity(&self) -> usize
+pub fn pixtuoid_core::state::SceneState::uniform(usize) -> Self
+impl core::clone::Clone for pixtuoid_core::state::SceneState
+pub fn pixtuoid_core::state::SceneState::clone(&self) -> pixtuoid_core::state::SceneState
+impl core::default::Default for pixtuoid_core::state::SceneState
+pub fn pixtuoid_core::state::SceneState::default() -> Self
+impl core::fmt::Debug for pixtuoid_core::state::SceneState
+pub fn pixtuoid_core::state::SceneState::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde_core::ser::Serialize for pixtuoid_core::state::SceneState
+pub fn pixtuoid_core::state::SceneState::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for pixtuoid_core::state::SceneState
+pub fn pixtuoid_core::state::SceneState::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for pixtuoid_core::state::SceneState
+impl core::marker::Send for pixtuoid_core::state::SceneState
+impl core::marker::Sync for pixtuoid_core::state::SceneState
+impl core::marker::Unpin for pixtuoid_core::state::SceneState
+impl core::marker::UnsafeUnpin for pixtuoid_core::state::SceneState
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::state::SceneState
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::state::SceneState
+pub struct pixtuoid_core::SlotLabel
+impl pixtuoid_core::state::SlotLabel
+pub fn pixtuoid_core::state::SlotLabel::cwd_derived(impl core::convert::Into<alloc::sync::Arc<str>>) -> Self
+pub fn pixtuoid_core::state::SlotLabel::is_upgradable(&self) -> bool
+pub fn pixtuoid_core::state::SlotLabel::new(impl core::convert::Into<alloc::sync::Arc<str>>, pixtuoid_core::state::LabelProvenance) -> Self
+pub fn pixtuoid_core::state::SlotLabel::ordinal_ghost(impl core::convert::Into<alloc::sync::Arc<str>>) -> Self
+pub fn pixtuoid_core::state::SlotLabel::prefix_fallback(impl core::convert::Into<alloc::sync::Arc<str>>) -> Self
+pub fn pixtuoid_core::state::SlotLabel::provenance(&self) -> pixtuoid_core::state::LabelProvenance
+pub fn pixtuoid_core::state::SlotLabel::renamed(impl core::convert::Into<alloc::sync::Arc<str>>) -> Self
+pub fn pixtuoid_core::state::SlotLabel::text(&self) -> alloc::sync::Arc<str>
+impl core::clone::Clone for pixtuoid_core::state::SlotLabel
+pub fn pixtuoid_core::state::SlotLabel::clone(&self) -> pixtuoid_core::state::SlotLabel
+impl core::convert::AsRef<str> for pixtuoid_core::state::SlotLabel
+pub fn pixtuoid_core::state::SlotLabel::as_ref(&self) -> &str
+impl core::convert::From<&str> for pixtuoid_core::state::SlotLabel
+pub fn pixtuoid_core::state::SlotLabel::from(&str) -> Self
+impl core::convert::From<alloc::string::String> for pixtuoid_core::state::SlotLabel
+pub fn pixtuoid_core::state::SlotLabel::from(alloc::string::String) -> Self
+impl core::fmt::Debug for pixtuoid_core::state::SlotLabel
+pub fn pixtuoid_core::state::SlotLabel::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for pixtuoid_core::state::SlotLabel
+pub fn pixtuoid_core::state::SlotLabel::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::ops::deref::Deref for pixtuoid_core::state::SlotLabel
+pub type pixtuoid_core::state::SlotLabel::Target = str
+pub fn pixtuoid_core::state::SlotLabel::deref(&self) -> &str
+impl serde_core::ser::Serialize for pixtuoid_core::state::SlotLabel
+pub fn pixtuoid_core::state::SlotLabel::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for pixtuoid_core::state::SlotLabel
+pub fn pixtuoid_core::state::SlotLabel::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for pixtuoid_core::state::SlotLabel
+impl core::marker::Send for pixtuoid_core::state::SlotLabel
+impl core::marker::Sync for pixtuoid_core::state::SlotLabel
+impl core::marker::Unpin for pixtuoid_core::state::SlotLabel
+impl core::marker::UnsafeUnpin for pixtuoid_core::state::SlotLabel
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::state::SlotLabel
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::state::SlotLabel
+pub struct pixtuoid_core::Sprite
+pub pixtuoid_core::Sprite::frame_ms: u32
+pub pixtuoid_core::Sprite::frames: alloc::vec::Vec<pixtuoid_core::sprite::Frame>
+impl core::clone::Clone for pixtuoid_core::sprite::Sprite
+pub fn pixtuoid_core::sprite::Sprite::clone(&self) -> pixtuoid_core::sprite::Sprite
+impl core::fmt::Debug for pixtuoid_core::sprite::Sprite
+pub fn pixtuoid_core::sprite::Sprite::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for pixtuoid_core::sprite::Sprite
+impl core::marker::Send for pixtuoid_core::sprite::Sprite
+impl core::marker::Sync for pixtuoid_core::sprite::Sprite
+impl core::marker::Unpin for pixtuoid_core::sprite::Sprite
+impl core::marker::UnsafeUnpin for pixtuoid_core::sprite::Sprite
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::sprite::Sprite
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::sprite::Sprite
+pub trait pixtuoid_core::Source: core::marker::Send + 'static
+pub fn pixtuoid_core::Source::name(&self) -> &str
+pub fn pixtuoid_core::Source::run(alloc::boxed::Box<Self>, pixtuoid_core::TaggedSender) -> impl core::future::future::Future<Output = anyhow::Result<()>> + core::marker::Send
+impl pixtuoid_core::Source for pixtuoid_core::source::antigravity::AntigravitySource
+pub fn pixtuoid_core::source::antigravity::AntigravitySource::name(&self) -> &str
+pub async fn pixtuoid_core::source::antigravity::AntigravitySource::run(alloc::boxed::Box<Self>, pixtuoid_core::TaggedSender) -> anyhow::Result<()>
+impl pixtuoid_core::Source for pixtuoid_core::source::claude_code::ClaudeCodeSource
+pub fn pixtuoid_core::source::claude_code::ClaudeCodeSource::name(&self) -> &str
+pub async fn pixtuoid_core::source::claude_code::ClaudeCodeSource::run(alloc::boxed::Box<Self>, pixtuoid_core::TaggedSender) -> anyhow::Result<()>
+impl pixtuoid_core::Source for pixtuoid_core::source::codex::CodexSource
+pub fn pixtuoid_core::source::codex::CodexSource::name(&self) -> &str
+pub async fn pixtuoid_core::source::codex::CodexSource::run(alloc::boxed::Box<Self>, pixtuoid_core::TaggedSender) -> anyhow::Result<()>
+impl pixtuoid_core::Source for pixtuoid_core::source::copilot::CopilotSource
+pub fn pixtuoid_core::source::copilot::CopilotSource::name(&self) -> &str
+pub async fn pixtuoid_core::source::copilot::CopilotSource::run(alloc::boxed::Box<Self>, pixtuoid_core::TaggedSender) -> anyhow::Result<()>
+impl pixtuoid_core::Source for pixtuoid_core::source::grok::GrokSource
+pub fn pixtuoid_core::source::grok::GrokSource::name(&self) -> &str
+pub async fn pixtuoid_core::source::grok::GrokSource::run(alloc::boxed::Box<Self>, pixtuoid_core::TaggedSender) -> anyhow::Result<()>
+impl pixtuoid_core::Source for pixtuoid_core::source::hook::HookRouter
+pub fn pixtuoid_core::source::hook::HookRouter::name(&self) -> &str
+pub async fn pixtuoid_core::source::hook::HookRouter::run(alloc::boxed::Box<Self>, pixtuoid_core::TaggedSender) -> anyhow::Result<()>
+impl pixtuoid_core::Source for pixtuoid_core::source::omp::OmpSource
+pub fn pixtuoid_core::source::omp::OmpSource::name(&self) -> &str
+pub async fn pixtuoid_core::source::omp::OmpSource::run(alloc::boxed::Box<Self>, pixtuoid_core::TaggedSender) -> anyhow::Result<()>
+pub type pixtuoid_core::Pixel = core::option::Option<pixtuoid_core::sprite::Rgb>
+pub type pixtuoid_core::TaggedReceiver = tokio::sync::mpsc::bounded::Receiver<(pixtuoid_core::source::Transport, pixtuoid_core::source::AgentEvent)>
+pub type pixtuoid_core::TaggedSender = tokio::sync::mpsc::bounded::Sender<(pixtuoid_core::source::Transport, pixtuoid_core::source::AgentEvent)>
+pub type pixtuoid_core::WalkableMask = pixtuoid_core::grid::Grid<bool>

--- a/api/pixtuoid-scene.txt
+++ b/api/pixtuoid-scene.txt
@@ -1,0 +1,1767 @@
+pub mod pixtuoid_scene
+pub mod pixtuoid_scene::chitchat
+pub enum pixtuoid_scene::chitchat::VenueKey
+pub pixtuoid_scene::chitchat::VenueKey::Room
+pub pixtuoid_scene::chitchat::VenueKey::Room::floor_idx: usize
+pub pixtuoid_scene::chitchat::VenueKey::Room::room_id: usize
+pub pixtuoid_scene::chitchat::VenueKey::Waypoint
+pub pixtuoid_scene::chitchat::VenueKey::Waypoint::floor_idx: usize
+pub pixtuoid_scene::chitchat::VenueKey::Waypoint::wp_idx: usize
+impl core::clone::Clone for pixtuoid_scene::chitchat::VenueKey
+pub fn pixtuoid_scene::chitchat::VenueKey::clone(&self) -> pixtuoid_scene::chitchat::VenueKey
+impl core::cmp::Eq for pixtuoid_scene::chitchat::VenueKey
+impl core::cmp::PartialEq for pixtuoid_scene::chitchat::VenueKey
+pub fn pixtuoid_scene::chitchat::VenueKey::eq(&self, &pixtuoid_scene::chitchat::VenueKey) -> bool
+impl core::fmt::Debug for pixtuoid_scene::chitchat::VenueKey
+pub fn pixtuoid_scene::chitchat::VenueKey::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for pixtuoid_scene::chitchat::VenueKey
+pub fn pixtuoid_scene::chitchat::VenueKey::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for pixtuoid_scene::chitchat::VenueKey
+impl core::marker::StructuralPartialEq for pixtuoid_scene::chitchat::VenueKey
+impl core::marker::Freeze for pixtuoid_scene::chitchat::VenueKey
+impl core::marker::Send for pixtuoid_scene::chitchat::VenueKey
+impl core::marker::Sync for pixtuoid_scene::chitchat::VenueKey
+impl core::marker::Unpin for pixtuoid_scene::chitchat::VenueKey
+impl core::marker::UnsafeUnpin for pixtuoid_scene::chitchat::VenueKey
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::chitchat::VenueKey
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::chitchat::VenueKey
+pub struct pixtuoid_scene::chitchat::ActiveChitchat
+pub pixtuoid_scene::chitchat::ActiveChitchat::participants: alloc::vec::Vec<pixtuoid_core::id::AgentId>
+pub pixtuoid_scene::chitchat::ActiveChitchat::started_at: std::time::SystemTime
+pub pixtuoid_scene::chitchat::ActiveChitchat::venue: pixtuoid_scene::chitchat::VenueKey
+impl pixtuoid_scene::chitchat::ActiveChitchat
+pub fn pixtuoid_scene::chitchat::ActiveChitchat::current_bubble(&self, std::time::SystemTime) -> core::option::Option<(pixtuoid_core::id::AgentId, &'static str)>
+pub fn pixtuoid_scene::chitchat::ActiveChitchat::is_expired(&self, std::time::SystemTime) -> bool
+pub fn pixtuoid_scene::chitchat::ActiveChitchat::new(pixtuoid_scene::chitchat::VenueKey, alloc::vec::Vec<pixtuoid_core::id::AgentId>, std::time::SystemTime) -> Self
+pub fn pixtuoid_scene::chitchat::ActiveChitchat::set_participants(&mut self, alloc::vec::Vec<pixtuoid_core::id::AgentId>)
+impl core::marker::Freeze for pixtuoid_scene::chitchat::ActiveChitchat
+impl core::marker::Send for pixtuoid_scene::chitchat::ActiveChitchat
+impl core::marker::Sync for pixtuoid_scene::chitchat::ActiveChitchat
+impl core::marker::Unpin for pixtuoid_scene::chitchat::ActiveChitchat
+impl core::marker::UnsafeUnpin for pixtuoid_scene::chitchat::ActiveChitchat
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::chitchat::ActiveChitchat
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::chitchat::ActiveChitchat
+pub struct pixtuoid_scene::chitchat::ChitchatBubble
+pub pixtuoid_scene::chitchat::ChitchatBubble::anchor: pixtuoid_scene::layout::Point
+pub pixtuoid_scene::chitchat::ChitchatBubble::text: &'static str
+impl core::marker::Freeze for pixtuoid_scene::chitchat::ChitchatBubble
+impl core::marker::Send for pixtuoid_scene::chitchat::ChitchatBubble
+impl core::marker::Sync for pixtuoid_scene::chitchat::ChitchatBubble
+impl core::marker::Unpin for pixtuoid_scene::chitchat::ChitchatBubble
+impl core::marker::UnsafeUnpin for pixtuoid_scene::chitchat::ChitchatBubble
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::chitchat::ChitchatBubble
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::chitchat::ChitchatBubble
+pub struct pixtuoid_scene::chitchat::Visitor
+pub pixtuoid_scene::chitchat::Visitor::agent_id: pixtuoid_core::id::AgentId
+pub pixtuoid_scene::chitchat::Visitor::anchor: pixtuoid_scene::layout::Point
+pub pixtuoid_scene::chitchat::Visitor::room_id: core::option::Option<usize>
+pub pixtuoid_scene::chitchat::Visitor::wp_idx: usize
+impl core::clone::Clone for pixtuoid_scene::chitchat::Visitor
+pub fn pixtuoid_scene::chitchat::Visitor::clone(&self) -> pixtuoid_scene::chitchat::Visitor
+impl core::fmt::Debug for pixtuoid_scene::chitchat::Visitor
+pub fn pixtuoid_scene::chitchat::Visitor::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_scene::chitchat::Visitor
+impl core::marker::Freeze for pixtuoid_scene::chitchat::Visitor
+impl core::marker::Send for pixtuoid_scene::chitchat::Visitor
+impl core::marker::Sync for pixtuoid_scene::chitchat::Visitor
+impl core::marker::Unpin for pixtuoid_scene::chitchat::Visitor
+impl core::marker::UnsafeUnpin for pixtuoid_scene::chitchat::Visitor
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::chitchat::Visitor
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::chitchat::Visitor
+pub const pixtuoid_scene::chitchat::CHITCHAT_LINES: &[&str]
+pub const pixtuoid_scene::chitchat::CHITCHAT_TOTAL_MS: u64
+pub fn pixtuoid_scene::chitchat::supports_chitchat(pixtuoid_scene::layout::WaypointKind) -> bool
+pub fn pixtuoid_scene::chitchat::update_and_collect(&mut std::collections::hash::map::HashMap<pixtuoid_scene::chitchat::VenueKey, pixtuoid_scene::chitchat::ActiveChitchat>, usize, &[pixtuoid_scene::chitchat::Visitor], std::time::SystemTime) -> alloc::vec::Vec<pixtuoid_scene::chitchat::ChitchatBubble>
+pub fn pixtuoid_scene::chitchat::venue_wp_idx(pixtuoid_scene::layout::WaypointKind, usize, &[pixtuoid_scene::layout::Waypoint]) -> usize
+pub mod pixtuoid_scene::embedded_pack
+pub fn pixtuoid_scene::embedded_pack::load_sprite_pack(core::option::Option<std::path::PathBuf>) -> anyhow::Result<pixtuoid_core::sprite::format::Pack>
+pub mod pixtuoid_scene::floor
+pub use pixtuoid_scene::floor::MAX_FLOORS
+pub struct pixtuoid_scene::floor::AudioObserver
+impl pixtuoid_scene::floor::AudioObserver
+pub fn pixtuoid_scene::floor::AudioObserver::frame(&mut self, &pixtuoid_core::state::SceneState, &std::collections::hash::set::HashSet<usize>, impl core::ops::function::Fn(usize) -> core::option::Option<pixtuoid_scene::layout::WaypointKind>, usize, std::time::SystemTime) -> AudioFrame
+pub fn pixtuoid_scene::floor::AudioObserver::new() -> Self
+impl core::default::Default for pixtuoid_scene::floor::AudioObserver
+pub fn pixtuoid_scene::floor::AudioObserver::default() -> pixtuoid_scene::floor::AudioObserver
+impl core::fmt::Debug for pixtuoid_scene::floor::AudioObserver
+pub fn pixtuoid_scene::floor::AudioObserver::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for pixtuoid_scene::floor::AudioObserver
+impl core::marker::Send for pixtuoid_scene::floor::AudioObserver
+impl core::marker::Sync for pixtuoid_scene::floor::AudioObserver
+impl core::marker::Unpin for pixtuoid_scene::floor::AudioObserver
+impl core::marker::UnsafeUnpin for pixtuoid_scene::floor::AudioObserver
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::floor::AudioObserver
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::floor::AudioObserver
+pub struct pixtuoid_scene::floor::CoffeeState(_)
+impl pixtuoid_scene::floor::CoffeeState
+pub const pixtuoid_scene::floor::CoffeeState::STEAM_WINDOW_SECS: u64
+pub fn pixtuoid_scene::floor::CoffeeState::evict_missing(&mut self, &pixtuoid_core::state::SceneState)
+pub fn pixtuoid_scene::floor::CoffeeState::insert(&mut self, pixtuoid_core::id::AgentId, std::time::SystemTime)
+pub fn pixtuoid_scene::floor::CoffeeState::map(&self) -> &std::collections::hash::map::HashMap<pixtuoid_core::id::AgentId, std::time::SystemTime>
+pub fn pixtuoid_scene::floor::CoffeeState::new() -> Self
+pub fn pixtuoid_scene::floor::CoffeeState::record(&mut self, impl core::iter::traits::collect::IntoIterator<Item = pixtuoid_core::id::AgentId>, std::time::SystemTime)
+impl core::default::Default for pixtuoid_scene::floor::CoffeeState
+pub fn pixtuoid_scene::floor::CoffeeState::default() -> pixtuoid_scene::floor::CoffeeState
+impl core::fmt::Debug for pixtuoid_scene::floor::CoffeeState
+pub fn pixtuoid_scene::floor::CoffeeState::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for pixtuoid_scene::floor::CoffeeState
+impl core::marker::Send for pixtuoid_scene::floor::CoffeeState
+impl core::marker::Sync for pixtuoid_scene::floor::CoffeeState
+impl core::marker::Unpin for pixtuoid_scene::floor::CoffeeState
+impl core::marker::UnsafeUnpin for pixtuoid_scene::floor::CoffeeState
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::floor::CoffeeState
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::floor::CoffeeState
+pub struct pixtuoid_scene::floor::FloorCtx
+pub pixtuoid_scene::floor::FloorCtx::cache: crate::frame_cache::FrameCache
+pub pixtuoid_scene::floor::FloorCtx::door_anim_max_ms: u64
+pub pixtuoid_scene::floor::FloorCtx::history: pixtuoid_scene::pose::PoseHistory
+pub pixtuoid_scene::floor::FloorCtx::light: pixtuoid_scene::floor::LightingState
+pub pixtuoid_scene::floor::FloorCtx::motion: std::collections::hash::map::HashMap<pixtuoid_core::id::AgentId, pixtuoid_scene::motion::MotionState>
+pub pixtuoid_scene::floor::FloorCtx::overlay: pixtuoid_core::walkable::OccupancyOverlay
+pub pixtuoid_scene::floor::FloorCtx::router: pixtuoid_scene::pathfind::AStarRouter
+impl pixtuoid_scene::floor::FloorCtx
+pub fn pixtuoid_scene::floor::FloorCtx::evict_missing(&mut self, &pixtuoid_core::state::SceneState)
+pub fn pixtuoid_scene::floor::FloorCtx::frame_layout(&mut self, u16, u16, u64) -> core::option::Option<alloc::sync::Arc<pixtuoid_scene::layout::Layout>>
+pub fn pixtuoid_scene::floor::FloorCtx::new() -> Self
+pub fn pixtuoid_scene::floor::FloorCtx::recompute_door_anim_max_ms(&mut self, std::time::SystemTime)
+pub fn pixtuoid_scene::floor::FloorCtx::route_ctx(&mut self) -> pixtuoid_scene::pose::RouteCtx<'_>
+impl core::default::Default for pixtuoid_scene::floor::FloorCtx
+pub fn pixtuoid_scene::floor::FloorCtx::default() -> Self
+impl core::marker::Freeze for pixtuoid_scene::floor::FloorCtx
+impl core::marker::Send for pixtuoid_scene::floor::FloorCtx
+impl core::marker::Sync for pixtuoid_scene::floor::FloorCtx
+impl core::marker::Unpin for pixtuoid_scene::floor::FloorCtx
+impl core::marker::UnsafeUnpin for pixtuoid_scene::floor::FloorCtx
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::floor::FloorCtx
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::floor::FloorCtx
+pub struct pixtuoid_scene::floor::FloorFrame
+pub pixtuoid_scene::floor::FloorFrame::layout: alloc::sync::Arc<pixtuoid_scene::layout::Layout>
+pub pixtuoid_scene::floor::FloorFrame::occupied_waypoints: std::collections::hash::set::HashSet<usize>
+impl core::marker::Freeze for pixtuoid_scene::floor::FloorFrame
+impl core::marker::Send for pixtuoid_scene::floor::FloorFrame
+impl core::marker::Sync for pixtuoid_scene::floor::FloorFrame
+impl core::marker::Unpin for pixtuoid_scene::floor::FloorFrame
+impl core::marker::UnsafeUnpin for pixtuoid_scene::floor::FloorFrame
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::floor::FloorFrame
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::floor::FloorFrame
+pub struct pixtuoid_scene::floor::FloorMeta
+pub pixtuoid_scene::floor::FloorMeta::altitude: f32
+pub pixtuoid_scene::floor::FloorMeta::floor_idx: usize
+pub pixtuoid_scene::floor::FloorMeta::floor_seed: u64
+impl pixtuoid_scene::floor::FloorMeta
+pub fn pixtuoid_scene::floor::FloorMeta::for_floor(usize, usize) -> Self
+pub fn pixtuoid_scene::floor::FloorMeta::ground() -> Self
+impl core::clone::Clone for pixtuoid_scene::floor::FloorMeta
+pub fn pixtuoid_scene::floor::FloorMeta::clone(&self) -> pixtuoid_scene::floor::FloorMeta
+impl core::fmt::Debug for pixtuoid_scene::floor::FloorMeta
+pub fn pixtuoid_scene::floor::FloorMeta::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_scene::floor::FloorMeta
+impl core::marker::Freeze for pixtuoid_scene::floor::FloorMeta
+impl core::marker::Send for pixtuoid_scene::floor::FloorMeta
+impl core::marker::Sync for pixtuoid_scene::floor::FloorMeta
+impl core::marker::Unpin for pixtuoid_scene::floor::FloorMeta
+impl core::marker::UnsafeUnpin for pixtuoid_scene::floor::FloorMeta
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::floor::FloorMeta
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::floor::FloorMeta
+pub struct pixtuoid_scene::floor::FloorSession
+pub pixtuoid_scene::floor::FloorSession::floor: pixtuoid_scene::floor::PerFloor
+pub pixtuoid_scene::floor::FloorSession::office: pixtuoid_scene::floor::PerOffice
+impl pixtuoid_scene::floor::FloorSession
+pub fn pixtuoid_scene::floor::FloorSession::audio_frame(&mut self, &pixtuoid_core::state::SceneState, usize, std::time::SystemTime) -> AudioFrame
+pub fn pixtuoid_scene::floor::FloorSession::board(&self, &pixtuoid_core::state::SceneState, std::time::SystemTime, core::option::Option<(usize, usize)>) -> crate::board::BoardModel
+pub fn pixtuoid_scene::floor::FloorSession::buf(&self) -> &pixtuoid_core::sprite::RgbBuffer
+pub fn pixtuoid_scene::floor::FloorSession::evict_missing(&mut self, &pixtuoid_core::state::SceneState)
+pub fn pixtuoid_scene::floor::FloorSession::new() -> Self
+pub fn pixtuoid_scene::floor::FloorSession::observe(&mut self, &pixtuoid_core::state::SceneState, &pixtuoid_core::sprite::format::Pack, u16, u16, pixtuoid_scene::floor::FloorMeta, std::time::SystemTime) -> core::option::Option<pixtuoid_scene::pixel_painter::SimFrame>
+pub fn pixtuoid_scene::floor::FloorSession::overlay(&mut self, &pixtuoid_core::state::SceneState, std::time::SystemTime, core::option::Option<pixtuoid_core::id::AgentId>) -> alloc::vec::Vec<crate::overlay::LabelElement>
+pub fn pixtuoid_scene::floor::FloorSession::render(&mut self, pixtuoid_scene::floor::FrameInputs<'_>) -> core::option::Option<alloc::sync::Arc<pixtuoid_scene::layout::Layout>>
+pub fn pixtuoid_scene::floor::FloorSession::reset_frame_cache(&mut self)
+impl core::default::Default for pixtuoid_scene::floor::FloorSession
+pub fn pixtuoid_scene::floor::FloorSession::default() -> Self
+impl core::marker::Freeze for pixtuoid_scene::floor::FloorSession
+impl core::marker::Send for pixtuoid_scene::floor::FloorSession
+impl core::marker::Sync for pixtuoid_scene::floor::FloorSession
+impl core::marker::Unpin for pixtuoid_scene::floor::FloorSession
+impl core::marker::UnsafeUnpin for pixtuoid_scene::floor::FloorSession
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::floor::FloorSession
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::floor::FloorSession
+pub struct pixtuoid_scene::floor::FloorTransition
+pub pixtuoid_scene::floor::FloorTransition::duration_ms: u64
+pub pixtuoid_scene::floor::FloorTransition::from_floor: usize
+pub pixtuoid_scene::floor::FloorTransition::started_at: std::time::SystemTime
+pub pixtuoid_scene::floor::FloorTransition::to_floor: usize
+impl pixtuoid_scene::floor::FloorTransition
+pub fn pixtuoid_scene::floor::FloorTransition::is_done(&self, std::time::SystemTime) -> bool
+pub fn pixtuoid_scene::floor::FloorTransition::new(usize, usize, std::time::SystemTime) -> Self
+pub fn pixtuoid_scene::floor::FloorTransition::t(&self, std::time::SystemTime) -> f32
+impl core::marker::Freeze for pixtuoid_scene::floor::FloorTransition
+impl core::marker::Send for pixtuoid_scene::floor::FloorTransition
+impl core::marker::Sync for pixtuoid_scene::floor::FloorTransition
+impl core::marker::Unpin for pixtuoid_scene::floor::FloorTransition
+impl core::marker::UnsafeUnpin for pixtuoid_scene::floor::FloorTransition
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::floor::FloorTransition
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::floor::FloorTransition
+pub struct pixtuoid_scene::floor::FrameInputs<'a>
+pub pixtuoid_scene::floor::FrameInputs::active_pet: core::option::Option<&'a pixtuoid_scene::pet::PetState>
+pub pixtuoid_scene::floor::FrameInputs::debug_walkable: bool
+pub pixtuoid_scene::floor::FrameInputs::floor_meta: pixtuoid_scene::floor::FloorMeta
+pub pixtuoid_scene::floor::FrameInputs::floor_pet: core::option::Option<&'a pixtuoid_scene::pet::Pet>
+pub pixtuoid_scene::floor::FrameInputs::now: std::time::SystemTime
+pub pixtuoid_scene::floor::FrameInputs::pack: &'a pixtuoid_core::sprite::format::Pack
+pub pixtuoid_scene::floor::FrameInputs::scene: &'a pixtuoid_core::state::SceneState
+pub pixtuoid_scene::floor::FrameInputs::size: pixtuoid_scene::layout::Size
+pub pixtuoid_scene::floor::FrameInputs::theme: &'static pixtuoid_scene::theme::Theme
+impl<'a> core::marker::Freeze for pixtuoid_scene::floor::FrameInputs<'a>
+impl<'a> core::marker::Send for pixtuoid_scene::floor::FrameInputs<'a>
+impl<'a> core::marker::Sync for pixtuoid_scene::floor::FrameInputs<'a>
+impl<'a> core::marker::Unpin for pixtuoid_scene::floor::FrameInputs<'a>
+impl<'a> core::marker::UnsafeUnpin for pixtuoid_scene::floor::FrameInputs<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::floor::FrameInputs<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::floor::FrameInputs<'a>
+pub struct pixtuoid_scene::floor::LightingState
+impl pixtuoid_scene::floor::LightingState
+pub const pixtuoid_scene::floor::LightingState::EMPTY_DEBOUNCE_MS: u64
+pub const pixtuoid_scene::floor::LightingState::EMPTY_FLOOR_DIM_BOOST: f32
+pub const pixtuoid_scene::floor::LightingState::FADE_TAU_MS: u64
+pub const pixtuoid_scene::floor::LightingState::MIN_LEVEL: f32
+pub fn pixtuoid_scene::floor::LightingState::level(&self) -> f32
+pub fn pixtuoid_scene::floor::LightingState::new() -> Self
+pub fn pixtuoid_scene::floor::LightingState::snap_to_empty(&mut self)
+pub fn pixtuoid_scene::floor::LightingState::tick(&mut self, bool, std::time::SystemTime) -> f32
+impl core::default::Default for pixtuoid_scene::floor::LightingState
+pub fn pixtuoid_scene::floor::LightingState::default() -> Self
+impl core::marker::Freeze for pixtuoid_scene::floor::LightingState
+impl core::marker::Send for pixtuoid_scene::floor::LightingState
+impl core::marker::Sync for pixtuoid_scene::floor::LightingState
+impl core::marker::Unpin for pixtuoid_scene::floor::LightingState
+impl core::marker::UnsafeUnpin for pixtuoid_scene::floor::LightingState
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::floor::LightingState
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::floor::LightingState
+pub struct pixtuoid_scene::floor::PerFloor
+pub pixtuoid_scene::floor::PerFloor::buf: pixtuoid_core::sprite::RgbBuffer
+pub pixtuoid_scene::floor::PerFloor::ctx: pixtuoid_scene::floor::FloorCtx
+impl pixtuoid_scene::floor::PerFloor
+pub fn pixtuoid_scene::floor::PerFloor::evict_missing(&mut self, &pixtuoid_core::state::SceneState)
+pub fn pixtuoid_scene::floor::PerFloor::new() -> Self
+impl core::default::Default for pixtuoid_scene::floor::PerFloor
+pub fn pixtuoid_scene::floor::PerFloor::default() -> Self
+impl core::marker::Freeze for pixtuoid_scene::floor::PerFloor
+impl core::marker::Send for pixtuoid_scene::floor::PerFloor
+impl core::marker::Sync for pixtuoid_scene::floor::PerFloor
+impl core::marker::Unpin for pixtuoid_scene::floor::PerFloor
+impl core::marker::UnsafeUnpin for pixtuoid_scene::floor::PerFloor
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::floor::PerFloor
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::floor::PerFloor
+pub struct pixtuoid_scene::floor::PerOffice
+pub pixtuoid_scene::floor::PerOffice::audio: pixtuoid_scene::floor::AudioObserver
+pub pixtuoid_scene::floor::PerOffice::chitchat: std::collections::hash::map::HashMap<pixtuoid_scene::chitchat::VenueKey, pixtuoid_scene::chitchat::ActiveChitchat>
+pub pixtuoid_scene::floor::PerOffice::coffee: pixtuoid_scene::floor::CoffeeState
+impl pixtuoid_scene::floor::PerOffice
+pub fn pixtuoid_scene::floor::PerOffice::evict_missing(&mut self, &pixtuoid_core::state::SceneState)
+pub fn pixtuoid_scene::floor::PerOffice::new() -> Self
+impl core::default::Default for pixtuoid_scene::floor::PerOffice
+pub fn pixtuoid_scene::floor::PerOffice::default() -> pixtuoid_scene::floor::PerOffice
+impl core::marker::Freeze for pixtuoid_scene::floor::PerOffice
+impl core::marker::Send for pixtuoid_scene::floor::PerOffice
+impl core::marker::Sync for pixtuoid_scene::floor::PerOffice
+impl core::marker::Unpin for pixtuoid_scene::floor::PerOffice
+impl core::marker::UnsafeUnpin for pixtuoid_scene::floor::PerOffice
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::floor::PerOffice
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::floor::PerOffice
+pub struct pixtuoid_scene::floor::ProjectedSlot
+pub pixtuoid_scene::floor::ProjectedSlot::desk: pixtuoid_core::state::FloorLocalDeskIndex
+pub pixtuoid_scene::floor::ProjectedSlot::slot: pixtuoid_core::state::AgentSlot
+impl core::marker::Freeze for pixtuoid_scene::floor::ProjectedSlot
+impl core::marker::Send for pixtuoid_scene::floor::ProjectedSlot
+impl core::marker::Sync for pixtuoid_scene::floor::ProjectedSlot
+impl core::marker::Unpin for pixtuoid_scene::floor::ProjectedSlot
+impl core::marker::UnsafeUnpin for pixtuoid_scene::floor::ProjectedSlot
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::floor::ProjectedSlot
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::floor::ProjectedSlot
+pub const pixtuoid_scene::floor::FLOOR_SEED_MULTIPLIER: u64
+pub fn pixtuoid_scene::floor::build_floor_scene(&pixtuoid_core::state::SceneState, usize) -> alloc::vec::Vec<pixtuoid_scene::floor::ProjectedSlot>
+pub fn pixtuoid_scene::floor::floor_capacity(u16, u16, u64) -> usize
+pub fn pixtuoid_scene::floor::floor_seed(usize) -> u64
+pub fn pixtuoid_scene::floor::frame_epilogue(&mut pixtuoid_scene::floor::FloorCtx, &mut pixtuoid_scene::floor::CoffeeState, impl core::iter::traits::collect::IntoIterator<Item = pixtuoid_core::id::AgentId>, std::time::SystemTime)
+pub fn pixtuoid_scene::floor::num_floors(&pixtuoid_core::state::SceneState) -> usize
+pub fn pixtuoid_scene::floor::project_floor_scene(&pixtuoid_core::state::SceneState, usize) -> pixtuoid_core::state::SceneState
+pub fn pixtuoid_scene::floor::render_floor(&mut pixtuoid_scene::floor::FloorCtx, &mut pixtuoid_core::sprite::RgbBuffer, &mut pixtuoid_scene::floor::CoffeeState, &mut std::collections::hash::map::HashMap<pixtuoid_scene::chitchat::VenueKey, pixtuoid_scene::chitchat::ActiveChitchat>, pixtuoid_scene::floor::FrameInputs<'_>) -> core::option::Option<pixtuoid_scene::floor::FloorFrame>
+pub fn pixtuoid_scene::floor::track_for(std::time::SystemTime) -> crate::audio::TrackId
+pub fn pixtuoid_scene::floor::waypoint_kind_of(core::option::Option<&pixtuoid_scene::layout::Layout>, usize) -> core::option::Option<pixtuoid_scene::layout::WaypointKind>
+pub mod pixtuoid_scene::layout
+pub enum pixtuoid_scene::layout::Anchor
+pub pixtuoid_scene::layout::Anchor::Center
+pub pixtuoid_scene::layout::Anchor::TopLeft
+impl core::clone::Clone for pixtuoid_scene::layout::Anchor
+pub fn pixtuoid_scene::layout::Anchor::clone(&self) -> pixtuoid_scene::layout::Anchor
+impl core::cmp::Eq for pixtuoid_scene::layout::Anchor
+impl core::cmp::PartialEq for pixtuoid_scene::layout::Anchor
+pub fn pixtuoid_scene::layout::Anchor::eq(&self, &pixtuoid_scene::layout::Anchor) -> bool
+impl core::fmt::Debug for pixtuoid_scene::layout::Anchor
+pub fn pixtuoid_scene::layout::Anchor::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_scene::layout::Anchor
+impl core::marker::StructuralPartialEq for pixtuoid_scene::layout::Anchor
+impl core::marker::Freeze for pixtuoid_scene::layout::Anchor
+impl core::marker::Send for pixtuoid_scene::layout::Anchor
+impl core::marker::Sync for pixtuoid_scene::layout::Anchor
+impl core::marker::Unpin for pixtuoid_scene::layout::Anchor
+impl core::marker::UnsafeUnpin for pixtuoid_scene::layout::Anchor
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::layout::Anchor
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::layout::Anchor
+pub enum pixtuoid_scene::layout::Facing
+pub pixtuoid_scene::layout::Facing::East
+pub pixtuoid_scene::layout::Facing::North
+pub pixtuoid_scene::layout::Facing::South
+pub pixtuoid_scene::layout::Facing::West
+impl core::clone::Clone for pixtuoid_scene::layout::Facing
+pub fn pixtuoid_scene::layout::Facing::clone(&self) -> pixtuoid_scene::layout::Facing
+impl core::cmp::Eq for pixtuoid_scene::layout::Facing
+impl core::cmp::PartialEq for pixtuoid_scene::layout::Facing
+pub fn pixtuoid_scene::layout::Facing::eq(&self, &pixtuoid_scene::layout::Facing) -> bool
+impl core::fmt::Debug for pixtuoid_scene::layout::Facing
+pub fn pixtuoid_scene::layout::Facing::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for pixtuoid_scene::layout::Facing
+pub fn pixtuoid_scene::layout::Facing::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for pixtuoid_scene::layout::Facing
+impl core::marker::StructuralPartialEq for pixtuoid_scene::layout::Facing
+impl core::marker::Freeze for pixtuoid_scene::layout::Facing
+impl core::marker::Send for pixtuoid_scene::layout::Facing
+impl core::marker::Sync for pixtuoid_scene::layout::Facing
+impl core::marker::Unpin for pixtuoid_scene::layout::Facing
+impl core::marker::UnsafeUnpin for pixtuoid_scene::layout::Facing
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::layout::Facing
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::layout::Facing
+pub enum pixtuoid_scene::layout::Furniture
+pub pixtuoid_scene::layout::Furniture::Bookshelf
+pub pixtuoid_scene::layout::Furniture::BulletinBoard
+pub pixtuoid_scene::layout::Furniture::Couch
+pub pixtuoid_scene::layout::Furniture::Desk
+pub pixtuoid_scene::layout::Furniture::ExitSign
+pub pixtuoid_scene::layout::Furniture::FishTank
+pub pixtuoid_scene::layout::Furniture::FloorLamp
+pub pixtuoid_scene::layout::Furniture::IslandStand
+pub pixtuoid_scene::layout::Furniture::KitchenIsland
+pub pixtuoid_scene::layout::Furniture::LoungeSideTable
+pub pixtuoid_scene::layout::Furniture::MeetingChair
+pub pixtuoid_scene::layout::Furniture::MeetingScreen
+pub pixtuoid_scene::layout::Furniture::MeetingSofa
+pub pixtuoid_scene::layout::Furniture::MeetingSofaBody
+pub pixtuoid_scene::layout::Furniture::MeetingTable
+pub pixtuoid_scene::layout::Furniture::Pantry
+pub pixtuoid_scene::layout::Furniture::PhoneBooth
+pub pixtuoid_scene::layout::Furniture::PlantFicus
+pub pixtuoid_scene::layout::Furniture::PlantFlower
+pub pixtuoid_scene::layout::Furniture::PlantSucculent
+pub pixtuoid_scene::layout::Furniture::PlantTall
+pub pixtuoid_scene::layout::Furniture::Printer
+pub pixtuoid_scene::layout::Furniture::SnackShelf
+pub pixtuoid_scene::layout::Furniture::StandingDesk
+pub pixtuoid_scene::layout::Furniture::Tv
+pub pixtuoid_scene::layout::Furniture::VendingMachine
+pub pixtuoid_scene::layout::Furniture::Whiteboard
+impl pixtuoid_scene::layout::Furniture
+pub const pixtuoid_scene::layout::Furniture::ALL: &'static [pixtuoid_scene::layout::Furniture]
+impl core::clone::Clone for pixtuoid_scene::layout::Furniture
+pub fn pixtuoid_scene::layout::Furniture::clone(&self) -> pixtuoid_scene::layout::Furniture
+impl core::cmp::Eq for pixtuoid_scene::layout::Furniture
+impl core::cmp::PartialEq for pixtuoid_scene::layout::Furniture
+pub fn pixtuoid_scene::layout::Furniture::eq(&self, &pixtuoid_scene::layout::Furniture) -> bool
+impl core::fmt::Debug for pixtuoid_scene::layout::Furniture
+pub fn pixtuoid_scene::layout::Furniture::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for pixtuoid_scene::layout::Furniture
+pub fn pixtuoid_scene::layout::Furniture::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for pixtuoid_scene::layout::Furniture
+impl core::marker::StructuralPartialEq for pixtuoid_scene::layout::Furniture
+impl core::marker::Freeze for pixtuoid_scene::layout::Furniture
+impl core::marker::Send for pixtuoid_scene::layout::Furniture
+impl core::marker::Sync for pixtuoid_scene::layout::Furniture
+impl core::marker::Unpin for pixtuoid_scene::layout::Furniture
+impl core::marker::UnsafeUnpin for pixtuoid_scene::layout::Furniture
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::layout::Furniture
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::layout::Furniture
+pub enum pixtuoid_scene::layout::PlantKind
+pub pixtuoid_scene::layout::PlantKind::Ficus
+pub pixtuoid_scene::layout::PlantKind::Flower
+pub pixtuoid_scene::layout::PlantKind::Succulent
+pub pixtuoid_scene::layout::PlantKind::Tall
+impl pixtuoid_scene::layout::PlantKind
+pub const fn pixtuoid_scene::layout::PlantKind::furniture(self) -> pixtuoid_scene::layout::Furniture
+pub const fn pixtuoid_scene::layout::PlantKind::sprite_name(self) -> &'static str
+impl core::clone::Clone for pixtuoid_scene::layout::PlantKind
+pub fn pixtuoid_scene::layout::PlantKind::clone(&self) -> pixtuoid_scene::layout::PlantKind
+impl core::cmp::Eq for pixtuoid_scene::layout::PlantKind
+impl core::cmp::PartialEq for pixtuoid_scene::layout::PlantKind
+pub fn pixtuoid_scene::layout::PlantKind::eq(&self, &pixtuoid_scene::layout::PlantKind) -> bool
+impl core::fmt::Debug for pixtuoid_scene::layout::PlantKind
+pub fn pixtuoid_scene::layout::PlantKind::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for pixtuoid_scene::layout::PlantKind
+pub fn pixtuoid_scene::layout::PlantKind::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for pixtuoid_scene::layout::PlantKind
+impl core::marker::StructuralPartialEq for pixtuoid_scene::layout::PlantKind
+impl core::marker::Freeze for pixtuoid_scene::layout::PlantKind
+impl core::marker::Send for pixtuoid_scene::layout::PlantKind
+impl core::marker::Sync for pixtuoid_scene::layout::PlantKind
+impl core::marker::Unpin for pixtuoid_scene::layout::PlantKind
+impl core::marker::UnsafeUnpin for pixtuoid_scene::layout::PlantKind
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::layout::PlantKind
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::layout::PlantKind
+pub enum pixtuoid_scene::layout::PodDecor
+pub pixtuoid_scene::layout::PodDecor::PhoneBooth
+pub pixtuoid_scene::layout::PodDecor::PlantTall
+pub pixtuoid_scene::layout::PodDecor::StandingDesk
+pub pixtuoid_scene::layout::PodDecor::Tv
+pub pixtuoid_scene::layout::PodDecor::Whiteboard
+impl pixtuoid_scene::layout::PodDecor
+pub const pixtuoid_scene::layout::PodDecor::ALL: &'static [pixtuoid_scene::layout::PodDecor]
+pub const fn pixtuoid_scene::layout::PodDecor::furniture(self) -> pixtuoid_scene::layout::Furniture
+pub const fn pixtuoid_scene::layout::PodDecor::sprite_name(self) -> &'static str
+impl core::clone::Clone for pixtuoid_scene::layout::PodDecor
+pub fn pixtuoid_scene::layout::PodDecor::clone(&self) -> pixtuoid_scene::layout::PodDecor
+impl core::cmp::Eq for pixtuoid_scene::layout::PodDecor
+impl core::cmp::PartialEq for pixtuoid_scene::layout::PodDecor
+pub fn pixtuoid_scene::layout::PodDecor::eq(&self, &pixtuoid_scene::layout::PodDecor) -> bool
+impl core::fmt::Debug for pixtuoid_scene::layout::PodDecor
+pub fn pixtuoid_scene::layout::PodDecor::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for pixtuoid_scene::layout::PodDecor
+pub fn pixtuoid_scene::layout::PodDecor::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for pixtuoid_scene::layout::PodDecor
+impl core::marker::StructuralPartialEq for pixtuoid_scene::layout::PodDecor
+impl core::marker::Freeze for pixtuoid_scene::layout::PodDecor
+impl core::marker::Send for pixtuoid_scene::layout::PodDecor
+impl core::marker::Sync for pixtuoid_scene::layout::PodDecor
+impl core::marker::Unpin for pixtuoid_scene::layout::PodDecor
+impl core::marker::UnsafeUnpin for pixtuoid_scene::layout::PodDecor
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::layout::PodDecor
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::layout::PodDecor
+pub enum pixtuoid_scene::layout::WallDecor
+pub pixtuoid_scene::layout::WallDecor::Bookshelf
+pub pixtuoid_scene::layout::WallDecor::BulletinBoard
+pub pixtuoid_scene::layout::WallDecor::ExitSign
+pub pixtuoid_scene::layout::WallDecor::MeetingScreen
+pub pixtuoid_scene::layout::WallDecor::Whiteboard
+impl pixtuoid_scene::layout::WallDecor
+pub const fn pixtuoid_scene::layout::WallDecor::furniture(self) -> pixtuoid_scene::layout::Furniture
+pub const fn pixtuoid_scene::layout::WallDecor::sprite_name(self) -> &'static str
+impl core::clone::Clone for pixtuoid_scene::layout::WallDecor
+pub fn pixtuoid_scene::layout::WallDecor::clone(&self) -> pixtuoid_scene::layout::WallDecor
+impl core::cmp::Eq for pixtuoid_scene::layout::WallDecor
+impl core::cmp::PartialEq for pixtuoid_scene::layout::WallDecor
+pub fn pixtuoid_scene::layout::WallDecor::eq(&self, &pixtuoid_scene::layout::WallDecor) -> bool
+impl core::fmt::Debug for pixtuoid_scene::layout::WallDecor
+pub fn pixtuoid_scene::layout::WallDecor::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for pixtuoid_scene::layout::WallDecor
+pub fn pixtuoid_scene::layout::WallDecor::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for pixtuoid_scene::layout::WallDecor
+impl core::marker::StructuralPartialEq for pixtuoid_scene::layout::WallDecor
+impl core::marker::Freeze for pixtuoid_scene::layout::WallDecor
+impl core::marker::Send for pixtuoid_scene::layout::WallDecor
+impl core::marker::Sync for pixtuoid_scene::layout::WallDecor
+impl core::marker::Unpin for pixtuoid_scene::layout::WallDecor
+impl core::marker::UnsafeUnpin for pixtuoid_scene::layout::WallDecor
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::layout::WallDecor
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::layout::WallDecor
+pub enum pixtuoid_scene::layout::WaypointKind
+pub pixtuoid_scene::layout::WaypointKind::Couch
+pub pixtuoid_scene::layout::WaypointKind::Island
+pub pixtuoid_scene::layout::WaypointKind::MeetingChair
+pub pixtuoid_scene::layout::WaypointKind::MeetingSofa
+pub pixtuoid_scene::layout::WaypointKind::Pantry
+pub pixtuoid_scene::layout::WaypointKind::PhoneBooth
+pub pixtuoid_scene::layout::WaypointKind::Printer
+pub pixtuoid_scene::layout::WaypointKind::SnackShelf
+pub pixtuoid_scene::layout::WaypointKind::StandingDesk
+pub pixtuoid_scene::layout::WaypointKind::VendingMachine
+impl pixtuoid_scene::layout::WaypointKind
+pub const pixtuoid_scene::layout::WaypointKind::ALL: &'static [pixtuoid_scene::layout::WaypointKind]
+pub const fn pixtuoid_scene::layout::WaypointKind::furniture(self) -> pixtuoid_scene::layout::Furniture
+impl core::clone::Clone for pixtuoid_scene::layout::WaypointKind
+pub fn pixtuoid_scene::layout::WaypointKind::clone(&self) -> pixtuoid_scene::layout::WaypointKind
+impl core::cmp::Eq for pixtuoid_scene::layout::WaypointKind
+impl core::cmp::PartialEq for pixtuoid_scene::layout::WaypointKind
+pub fn pixtuoid_scene::layout::WaypointKind::eq(&self, &pixtuoid_scene::layout::WaypointKind) -> bool
+impl core::fmt::Debug for pixtuoid_scene::layout::WaypointKind
+pub fn pixtuoid_scene::layout::WaypointKind::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for pixtuoid_scene::layout::WaypointKind
+pub fn pixtuoid_scene::layout::WaypointKind::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for pixtuoid_scene::layout::WaypointKind
+impl core::marker::StructuralPartialEq for pixtuoid_scene::layout::WaypointKind
+impl core::marker::Freeze for pixtuoid_scene::layout::WaypointKind
+impl core::marker::Send for pixtuoid_scene::layout::WaypointKind
+impl core::marker::Sync for pixtuoid_scene::layout::WaypointKind
+impl core::marker::Unpin for pixtuoid_scene::layout::WaypointKind
+impl core::marker::UnsafeUnpin for pixtuoid_scene::layout::WaypointKind
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::layout::WaypointKind
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::layout::WaypointKind
+pub struct pixtuoid_scene::layout::ApproachSides
+pub pixtuoid_scene::layout::ApproachSides::e: bool
+pub pixtuoid_scene::layout::ApproachSides::n: bool
+pub pixtuoid_scene::layout::ApproachSides::s: bool
+pub pixtuoid_scene::layout::ApproachSides::w: bool
+impl pixtuoid_scene::layout::ApproachSides
+pub const pixtuoid_scene::layout::ApproachSides::ALL: Self
+pub fn pixtuoid_scene::layout::ApproachSides::allows(self, pixtuoid_scene::layout::Facing, (i32, i32)) -> bool
+pub fn pixtuoid_scene::layout::ApproachSides::rotated(self, pixtuoid_scene::layout::Facing) -> Self
+impl core::clone::Clone for pixtuoid_scene::layout::ApproachSides
+pub fn pixtuoid_scene::layout::ApproachSides::clone(&self) -> pixtuoid_scene::layout::ApproachSides
+impl core::cmp::Eq for pixtuoid_scene::layout::ApproachSides
+impl core::cmp::PartialEq for pixtuoid_scene::layout::ApproachSides
+pub fn pixtuoid_scene::layout::ApproachSides::eq(&self, &pixtuoid_scene::layout::ApproachSides) -> bool
+impl core::fmt::Debug for pixtuoid_scene::layout::ApproachSides
+pub fn pixtuoid_scene::layout::ApproachSides::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_scene::layout::ApproachSides
+impl core::marker::StructuralPartialEq for pixtuoid_scene::layout::ApproachSides
+impl core::marker::Freeze for pixtuoid_scene::layout::ApproachSides
+impl core::marker::Send for pixtuoid_scene::layout::ApproachSides
+impl core::marker::Sync for pixtuoid_scene::layout::ApproachSides
+impl core::marker::Unpin for pixtuoid_scene::layout::ApproachSides
+impl core::marker::UnsafeUnpin for pixtuoid_scene::layout::ApproachSides
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::layout::ApproachSides
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::layout::ApproachSides
+pub struct pixtuoid_scene::layout::Bounds
+pub pixtuoid_scene::layout::Bounds::height: u16
+pub pixtuoid_scene::layout::Bounds::width: u16
+pub pixtuoid_scene::layout::Bounds::x: u16
+pub pixtuoid_scene::layout::Bounds::y: u16
+impl core::clone::Clone for pixtuoid_scene::layout::Bounds
+pub fn pixtuoid_scene::layout::Bounds::clone(&self) -> pixtuoid_scene::layout::Bounds
+impl core::cmp::Eq for pixtuoid_scene::layout::Bounds
+impl core::cmp::PartialEq for pixtuoid_scene::layout::Bounds
+pub fn pixtuoid_scene::layout::Bounds::eq(&self, &pixtuoid_scene::layout::Bounds) -> bool
+impl core::fmt::Debug for pixtuoid_scene::layout::Bounds
+pub fn pixtuoid_scene::layout::Bounds::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for pixtuoid_scene::layout::Bounds
+pub fn pixtuoid_scene::layout::Bounds::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for pixtuoid_scene::layout::Bounds
+impl core::marker::StructuralPartialEq for pixtuoid_scene::layout::Bounds
+impl core::marker::Freeze for pixtuoid_scene::layout::Bounds
+impl core::marker::Send for pixtuoid_scene::layout::Bounds
+impl core::marker::Sync for pixtuoid_scene::layout::Bounds
+impl core::marker::Unpin for pixtuoid_scene::layout::Bounds
+impl core::marker::UnsafeUnpin for pixtuoid_scene::layout::Bounds
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::layout::Bounds
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::layout::Bounds
+pub struct pixtuoid_scene::layout::Doorway
+pub pixtuoid_scene::layout::Doorway::end: pixtuoid_scene::layout::Point
+pub pixtuoid_scene::layout::Doorway::start: pixtuoid_scene::layout::Point
+impl core::clone::Clone for pixtuoid_scene::layout::Doorway
+pub fn pixtuoid_scene::layout::Doorway::clone(&self) -> pixtuoid_scene::layout::Doorway
+impl core::cmp::Eq for pixtuoid_scene::layout::Doorway
+impl core::cmp::PartialEq for pixtuoid_scene::layout::Doorway
+pub fn pixtuoid_scene::layout::Doorway::eq(&self, &pixtuoid_scene::layout::Doorway) -> bool
+impl core::fmt::Debug for pixtuoid_scene::layout::Doorway
+pub fn pixtuoid_scene::layout::Doorway::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for pixtuoid_scene::layout::Doorway
+pub fn pixtuoid_scene::layout::Doorway::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for pixtuoid_scene::layout::Doorway
+impl core::marker::StructuralPartialEq for pixtuoid_scene::layout::Doorway
+impl core::marker::Freeze for pixtuoid_scene::layout::Doorway
+impl core::marker::Send for pixtuoid_scene::layout::Doorway
+impl core::marker::Sync for pixtuoid_scene::layout::Doorway
+impl core::marker::Unpin for pixtuoid_scene::layout::Doorway
+impl core::marker::UnsafeUnpin for pixtuoid_scene::layout::Doorway
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::layout::Doorway
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::layout::Doorway
+pub struct pixtuoid_scene::layout::DwellWindow
+pub pixtuoid_scene::layout::DwellWindow::base_ms: u64
+pub pixtuoid_scene::layout::DwellWindow::range_ms: u64
+impl pixtuoid_scene::layout::DwellWindow
+pub const pixtuoid_scene::layout::DwellWindow::DECOR: pixtuoid_scene::layout::DwellWindow
+impl core::clone::Clone for pixtuoid_scene::layout::DwellWindow
+pub fn pixtuoid_scene::layout::DwellWindow::clone(&self) -> pixtuoid_scene::layout::DwellWindow
+impl core::cmp::Eq for pixtuoid_scene::layout::DwellWindow
+impl core::cmp::PartialEq for pixtuoid_scene::layout::DwellWindow
+pub fn pixtuoid_scene::layout::DwellWindow::eq(&self, &pixtuoid_scene::layout::DwellWindow) -> bool
+impl core::fmt::Debug for pixtuoid_scene::layout::DwellWindow
+pub fn pixtuoid_scene::layout::DwellWindow::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_scene::layout::DwellWindow
+impl core::marker::StructuralPartialEq for pixtuoid_scene::layout::DwellWindow
+impl core::marker::Freeze for pixtuoid_scene::layout::DwellWindow
+impl core::marker::Send for pixtuoid_scene::layout::DwellWindow
+impl core::marker::Sync for pixtuoid_scene::layout::DwellWindow
+impl core::marker::Unpin for pixtuoid_scene::layout::DwellWindow
+impl core::marker::UnsafeUnpin for pixtuoid_scene::layout::DwellWindow
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::layout::DwellWindow
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::layout::DwellWindow
+pub struct pixtuoid_scene::layout::FurnitureDef
+pub pixtuoid_scene::layout::FurnitureDef::approach: pixtuoid_scene::layout::ApproachSides
+pub pixtuoid_scene::layout::FurnitureDef::dwell: pixtuoid_scene::layout::DwellWindow
+pub pixtuoid_scene::layout::FurnitureDef::exclusive: bool
+pub pixtuoid_scene::layout::FurnitureDef::footprint: core::option::Option<pixtuoid_scene::layout::Size>
+pub pixtuoid_scene::layout::FurnitureDef::ground_x: pixtuoid_scene::layout::decor::GroundAlign
+pub pixtuoid_scene::layout::FurnitureDef::ground_y: pixtuoid_scene::layout::decor::GroundAlign
+pub pixtuoid_scene::layout::FurnitureDef::occupies_pos: bool
+pub pixtuoid_scene::layout::FurnitureDef::visual: pixtuoid_scene::layout::Size
+impl core::clone::Clone for pixtuoid_scene::layout::FurnitureDef
+pub fn pixtuoid_scene::layout::FurnitureDef::clone(&self) -> pixtuoid_scene::layout::FurnitureDef
+impl core::cmp::Eq for pixtuoid_scene::layout::FurnitureDef
+impl core::cmp::PartialEq for pixtuoid_scene::layout::FurnitureDef
+pub fn pixtuoid_scene::layout::FurnitureDef::eq(&self, &pixtuoid_scene::layout::FurnitureDef) -> bool
+impl core::fmt::Debug for pixtuoid_scene::layout::FurnitureDef
+pub fn pixtuoid_scene::layout::FurnitureDef::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_scene::layout::FurnitureDef
+impl core::marker::StructuralPartialEq for pixtuoid_scene::layout::FurnitureDef
+impl core::marker::Freeze for pixtuoid_scene::layout::FurnitureDef
+impl core::marker::Send for pixtuoid_scene::layout::FurnitureDef
+impl core::marker::Sync for pixtuoid_scene::layout::FurnitureDef
+impl core::marker::Unpin for pixtuoid_scene::layout::FurnitureDef
+impl core::marker::UnsafeUnpin for pixtuoid_scene::layout::FurnitureDef
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::layout::FurnitureDef
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::layout::FurnitureDef
+pub struct pixtuoid_scene::layout::Lounge
+pub pixtuoid_scene::layout::Lounge::couch_center: pixtuoid_scene::layout::Point
+pub pixtuoid_scene::layout::Lounge::fish_tank: core::option::Option<pixtuoid_scene::layout::Point>
+pub pixtuoid_scene::layout::Lounge::floor_lamp: pixtuoid_scene::layout::Point
+pub pixtuoid_scene::layout::Lounge::side_table: pixtuoid_scene::layout::Point
+impl core::clone::Clone for pixtuoid_scene::layout::Lounge
+pub fn pixtuoid_scene::layout::Lounge::clone(&self) -> pixtuoid_scene::layout::Lounge
+impl core::cmp::Eq for pixtuoid_scene::layout::Lounge
+impl core::cmp::PartialEq for pixtuoid_scene::layout::Lounge
+pub fn pixtuoid_scene::layout::Lounge::eq(&self, &pixtuoid_scene::layout::Lounge) -> bool
+impl core::fmt::Debug for pixtuoid_scene::layout::Lounge
+pub fn pixtuoid_scene::layout::Lounge::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_scene::layout::Lounge
+impl core::marker::StructuralPartialEq for pixtuoid_scene::layout::Lounge
+impl core::marker::Freeze for pixtuoid_scene::layout::Lounge
+impl core::marker::Send for pixtuoid_scene::layout::Lounge
+impl core::marker::Sync for pixtuoid_scene::layout::Lounge
+impl core::marker::Unpin for pixtuoid_scene::layout::Lounge
+impl core::marker::UnsafeUnpin for pixtuoid_scene::layout::Lounge
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::layout::Lounge
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::layout::Lounge
+pub struct pixtuoid_scene::layout::MeetingRoom
+pub pixtuoid_scene::layout::MeetingRoom::bounds: pixtuoid_scene::layout::Bounds
+pub pixtuoid_scene::layout::MeetingRoom::trio: core::option::Option<pixtuoid_scene::layout::MeetingTrio>
+impl pixtuoid_scene::layout::MeetingRoom
+pub fn pixtuoid_scene::layout::MeetingRoom::coat_rack_pos(&self) -> core::option::Option<pixtuoid_scene::layout::Point>
+pub fn pixtuoid_scene::layout::MeetingRoom::doormat_rect(&self) -> core::option::Option<pixtuoid_scene::layout::Bounds>
+impl core::clone::Clone for pixtuoid_scene::layout::MeetingRoom
+pub fn pixtuoid_scene::layout::MeetingRoom::clone(&self) -> pixtuoid_scene::layout::MeetingRoom
+impl core::cmp::Eq for pixtuoid_scene::layout::MeetingRoom
+impl core::cmp::PartialEq for pixtuoid_scene::layout::MeetingRoom
+pub fn pixtuoid_scene::layout::MeetingRoom::eq(&self, &pixtuoid_scene::layout::MeetingRoom) -> bool
+impl core::fmt::Debug for pixtuoid_scene::layout::MeetingRoom
+pub fn pixtuoid_scene::layout::MeetingRoom::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for pixtuoid_scene::layout::MeetingRoom
+pub fn pixtuoid_scene::layout::MeetingRoom::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for pixtuoid_scene::layout::MeetingRoom
+impl core::marker::StructuralPartialEq for pixtuoid_scene::layout::MeetingRoom
+impl core::marker::Freeze for pixtuoid_scene::layout::MeetingRoom
+impl core::marker::Send for pixtuoid_scene::layout::MeetingRoom
+impl core::marker::Sync for pixtuoid_scene::layout::MeetingRoom
+impl core::marker::Unpin for pixtuoid_scene::layout::MeetingRoom
+impl core::marker::UnsafeUnpin for pixtuoid_scene::layout::MeetingRoom
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::layout::MeetingRoom
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::layout::MeetingRoom
+pub struct pixtuoid_scene::layout::MeetingTrio
+pub pixtuoid_scene::layout::MeetingTrio::sofas: [pixtuoid_scene::layout::Point; 2]
+pub pixtuoid_scene::layout::MeetingTrio::table: pixtuoid_scene::layout::Point
+impl core::clone::Clone for pixtuoid_scene::layout::MeetingTrio
+pub fn pixtuoid_scene::layout::MeetingTrio::clone(&self) -> pixtuoid_scene::layout::MeetingTrio
+impl core::cmp::Eq for pixtuoid_scene::layout::MeetingTrio
+impl core::cmp::PartialEq for pixtuoid_scene::layout::MeetingTrio
+pub fn pixtuoid_scene::layout::MeetingTrio::eq(&self, &pixtuoid_scene::layout::MeetingTrio) -> bool
+impl core::fmt::Debug for pixtuoid_scene::layout::MeetingTrio
+pub fn pixtuoid_scene::layout::MeetingTrio::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for pixtuoid_scene::layout::MeetingTrio
+pub fn pixtuoid_scene::layout::MeetingTrio::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for pixtuoid_scene::layout::MeetingTrio
+impl core::marker::StructuralPartialEq for pixtuoid_scene::layout::MeetingTrio
+impl core::marker::Freeze for pixtuoid_scene::layout::MeetingTrio
+impl core::marker::Send for pixtuoid_scene::layout::MeetingTrio
+impl core::marker::Sync for pixtuoid_scene::layout::MeetingTrio
+impl core::marker::Unpin for pixtuoid_scene::layout::MeetingTrio
+impl core::marker::UnsafeUnpin for pixtuoid_scene::layout::MeetingTrio
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::layout::MeetingTrio
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::layout::MeetingTrio
+pub struct pixtuoid_scene::layout::PantryRoom
+pub pixtuoid_scene::layout::PantryRoom::bounds: pixtuoid_scene::layout::Bounds
+pub pixtuoid_scene::layout::PantryRoom::counter_size: pixtuoid_scene::layout::Size
+pub pixtuoid_scene::layout::PantryRoom::kitchen_island: core::option::Option<pixtuoid_scene::layout::Point>
+impl pixtuoid_scene::layout::PantryRoom
+pub fn pixtuoid_scene::layout::PantryRoom::trash_bin_rect(&self) -> core::option::Option<pixtuoid_scene::layout::Bounds>
+pub fn pixtuoid_scene::layout::PantryRoom::water_cooler_rect(&self) -> core::option::Option<pixtuoid_scene::layout::Bounds>
+impl core::clone::Clone for pixtuoid_scene::layout::PantryRoom
+pub fn pixtuoid_scene::layout::PantryRoom::clone(&self) -> pixtuoid_scene::layout::PantryRoom
+impl core::cmp::Eq for pixtuoid_scene::layout::PantryRoom
+impl core::cmp::PartialEq for pixtuoid_scene::layout::PantryRoom
+pub fn pixtuoid_scene::layout::PantryRoom::eq(&self, &pixtuoid_scene::layout::PantryRoom) -> bool
+impl core::fmt::Debug for pixtuoid_scene::layout::PantryRoom
+pub fn pixtuoid_scene::layout::PantryRoom::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for pixtuoid_scene::layout::PantryRoom
+pub fn pixtuoid_scene::layout::PantryRoom::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for pixtuoid_scene::layout::PantryRoom
+impl core::marker::StructuralPartialEq for pixtuoid_scene::layout::PantryRoom
+impl core::marker::Freeze for pixtuoid_scene::layout::PantryRoom
+impl core::marker::Send for pixtuoid_scene::layout::PantryRoom
+impl core::marker::Sync for pixtuoid_scene::layout::PantryRoom
+impl core::marker::Unpin for pixtuoid_scene::layout::PantryRoom
+impl core::marker::UnsafeUnpin for pixtuoid_scene::layout::PantryRoom
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::layout::PantryRoom
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::layout::PantryRoom
+pub struct pixtuoid_scene::layout::PlantItem
+pub pixtuoid_scene::layout::PlantItem::kind: pixtuoid_scene::layout::PlantKind
+pub pixtuoid_scene::layout::PlantItem::pos: pixtuoid_scene::layout::Point
+impl core::clone::Clone for pixtuoid_scene::layout::PlantItem
+pub fn pixtuoid_scene::layout::PlantItem::clone(&self) -> pixtuoid_scene::layout::PlantItem
+impl core::cmp::Eq for pixtuoid_scene::layout::PlantItem
+impl core::cmp::PartialEq for pixtuoid_scene::layout::PlantItem
+pub fn pixtuoid_scene::layout::PlantItem::eq(&self, &pixtuoid_scene::layout::PlantItem) -> bool
+impl core::fmt::Debug for pixtuoid_scene::layout::PlantItem
+pub fn pixtuoid_scene::layout::PlantItem::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_scene::layout::PlantItem
+impl core::marker::StructuralPartialEq for pixtuoid_scene::layout::PlantItem
+impl core::marker::Freeze for pixtuoid_scene::layout::PlantItem
+impl core::marker::Send for pixtuoid_scene::layout::PlantItem
+impl core::marker::Sync for pixtuoid_scene::layout::PlantItem
+impl core::marker::Unpin for pixtuoid_scene::layout::PlantItem
+impl core::marker::UnsafeUnpin for pixtuoid_scene::layout::PlantItem
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::layout::PlantItem
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::layout::PlantItem
+pub struct pixtuoid_scene::layout::PodDecorItem
+pub pixtuoid_scene::layout::PodDecorItem::kind: pixtuoid_scene::layout::PodDecor
+pub pixtuoid_scene::layout::PodDecorItem::pos: pixtuoid_scene::layout::Point
+impl core::clone::Clone for pixtuoid_scene::layout::PodDecorItem
+pub fn pixtuoid_scene::layout::PodDecorItem::clone(&self) -> pixtuoid_scene::layout::PodDecorItem
+impl core::cmp::Eq for pixtuoid_scene::layout::PodDecorItem
+impl core::cmp::PartialEq for pixtuoid_scene::layout::PodDecorItem
+pub fn pixtuoid_scene::layout::PodDecorItem::eq(&self, &pixtuoid_scene::layout::PodDecorItem) -> bool
+impl core::fmt::Debug for pixtuoid_scene::layout::PodDecorItem
+pub fn pixtuoid_scene::layout::PodDecorItem::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_scene::layout::PodDecorItem
+impl core::marker::StructuralPartialEq for pixtuoid_scene::layout::PodDecorItem
+impl core::marker::Freeze for pixtuoid_scene::layout::PodDecorItem
+impl core::marker::Send for pixtuoid_scene::layout::PodDecorItem
+impl core::marker::Sync for pixtuoid_scene::layout::PodDecorItem
+impl core::marker::Unpin for pixtuoid_scene::layout::PodDecorItem
+impl core::marker::UnsafeUnpin for pixtuoid_scene::layout::PodDecorItem
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::layout::PodDecorItem
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::layout::PodDecorItem
+pub struct pixtuoid_scene::layout::Point
+pub pixtuoid_scene::layout::Point::x: u16
+pub pixtuoid_scene::layout::Point::y: u16
+impl core::clone::Clone for pixtuoid_scene::layout::Point
+pub fn pixtuoid_scene::layout::Point::clone(&self) -> pixtuoid_scene::layout::Point
+impl core::cmp::Eq for pixtuoid_scene::layout::Point
+impl core::cmp::PartialEq for pixtuoid_scene::layout::Point
+pub fn pixtuoid_scene::layout::Point::eq(&self, &pixtuoid_scene::layout::Point) -> bool
+impl core::fmt::Debug for pixtuoid_scene::layout::Point
+pub fn pixtuoid_scene::layout::Point::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for pixtuoid_scene::layout::Point
+pub fn pixtuoid_scene::layout::Point::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for pixtuoid_scene::layout::Point
+impl core::marker::StructuralPartialEq for pixtuoid_scene::layout::Point
+impl core::marker::Freeze for pixtuoid_scene::layout::Point
+impl core::marker::Send for pixtuoid_scene::layout::Point
+impl core::marker::Sync for pixtuoid_scene::layout::Point
+impl core::marker::Unpin for pixtuoid_scene::layout::Point
+impl core::marker::UnsafeUnpin for pixtuoid_scene::layout::Point
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::layout::Point
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::layout::Point
+pub struct pixtuoid_scene::layout::ReachSet
+impl pixtuoid_scene::layout::ReachSet
+pub fn pixtuoid_scene::layout::ReachSet::from_mask(&pixtuoid_core::walkable::WalkableMask, pixtuoid_scene::layout::Point) -> pixtuoid_scene::layout::ReachSet
+pub fn pixtuoid_scene::layout::ReachSet::reaches(&self, pixtuoid_scene::layout::Point) -> bool
+impl core::clone::Clone for pixtuoid_scene::layout::ReachSet
+pub fn pixtuoid_scene::layout::ReachSet::clone(&self) -> pixtuoid_scene::layout::ReachSet
+impl core::cmp::Eq for pixtuoid_scene::layout::ReachSet
+impl core::cmp::PartialEq for pixtuoid_scene::layout::ReachSet
+pub fn pixtuoid_scene::layout::ReachSet::eq(&self, &pixtuoid_scene::layout::ReachSet) -> bool
+impl core::default::Default for pixtuoid_scene::layout::ReachSet
+pub fn pixtuoid_scene::layout::ReachSet::default() -> pixtuoid_scene::layout::ReachSet
+impl core::fmt::Debug for pixtuoid_scene::layout::ReachSet
+pub fn pixtuoid_scene::layout::ReachSet::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for pixtuoid_scene::layout::ReachSet
+impl core::marker::Freeze for pixtuoid_scene::layout::ReachSet
+impl core::marker::Send for pixtuoid_scene::layout::ReachSet
+impl core::marker::Sync for pixtuoid_scene::layout::ReachSet
+impl core::marker::Unpin for pixtuoid_scene::layout::ReachSet
+impl core::marker::UnsafeUnpin for pixtuoid_scene::layout::ReachSet
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::layout::ReachSet
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::layout::ReachSet
+pub struct pixtuoid_scene::layout::SceneLayout
+pub pixtuoid_scene::layout::SceneLayout::buf_h: u16
+pub pixtuoid_scene::layout::SceneLayout::buf_w: u16
+pub pixtuoid_scene::layout::SceneLayout::corridor: core::option::Option<pixtuoid_scene::layout::Bounds>
+pub pixtuoid_scene::layout::SceneLayout::cubicle_aisle: pixtuoid_scene::layout::Bounds
+pub pixtuoid_scene::layout::SceneLayout::cubicle_band: pixtuoid_scene::layout::Bounds
+pub pixtuoid_scene::layout::SceneLayout::door: core::option::Option<pixtuoid_scene::layout::Point>
+pub pixtuoid_scene::layout::SceneLayout::door_threshold: core::option::Option<pixtuoid_scene::layout::Point>
+pub pixtuoid_scene::layout::SceneLayout::doorways: alloc::vec::Vec<pixtuoid_scene::layout::Doorway>
+pub pixtuoid_scene::layout::SceneLayout::home_desks: alloc::vec::Vec<pixtuoid_scene::layout::Point>
+pub pixtuoid_scene::layout::SceneLayout::lounge: core::option::Option<pixtuoid_scene::layout::Lounge>
+pub pixtuoid_scene::layout::SceneLayout::meeting_rooms: alloc::vec::Vec<pixtuoid_scene::layout::MeetingRoom>
+pub pixtuoid_scene::layout::SceneLayout::pantry: core::option::Option<pixtuoid_scene::layout::PantryRoom>
+pub pixtuoid_scene::layout::SceneLayout::plants: alloc::vec::Vec<pixtuoid_scene::layout::PlantItem>
+pub pixtuoid_scene::layout::SceneLayout::pod_decor: alloc::vec::Vec<pixtuoid_scene::layout::PodDecorItem>
+pub pixtuoid_scene::layout::SceneLayout::reachable: pixtuoid_scene::layout::ReachSet
+pub pixtuoid_scene::layout::SceneLayout::room_walls: alloc::vec::Vec<pixtuoid_scene::layout::WallSegment>
+pub pixtuoid_scene::layout::SceneLayout::top_margin: u16
+pub pixtuoid_scene::layout::SceneLayout::walkable: pixtuoid_core::walkable::WalkableMask
+pub pixtuoid_scene::layout::SceneLayout::wall_decor: alloc::vec::Vec<pixtuoid_scene::layout::WallDecorItem>
+pub pixtuoid_scene::layout::SceneLayout::waypoints: alloc::vec::Vec<pixtuoid_scene::layout::Waypoint>
+impl pixtuoid_scene::layout::SceneLayout
+pub fn pixtuoid_scene::layout::SceneLayout::approach_point(&self, pixtuoid_scene::layout::Furniture, pixtuoid_scene::layout::Point, pixtuoid_scene::layout::Point, pixtuoid_scene::layout::Facing) -> pixtuoid_scene::layout::Point
+pub fn pixtuoid_scene::layout::SceneLayout::compute(u16, u16, core::option::Option<usize>) -> core::option::Option<Self>
+pub fn pixtuoid_scene::layout::SceneLayout::compute_with_seed(u16, u16, core::option::Option<usize>, u64) -> core::option::Option<Self>
+pub fn pixtuoid_scene::layout::SceneLayout::couch_sprite_center(&self) -> core::option::Option<pixtuoid_scene::layout::Point>
+pub fn pixtuoid_scene::layout::SceneLayout::fish_tank(&self) -> core::option::Option<pixtuoid_scene::layout::Point>
+pub fn pixtuoid_scene::layout::SceneLayout::floor_lamp(&self) -> core::option::Option<pixtuoid_scene::layout::Point>
+pub fn pixtuoid_scene::layout::SceneLayout::home_desk(&self, pixtuoid_core::state::FloorLocalDeskIndex) -> core::option::Option<pixtuoid_scene::layout::Point>
+pub fn pixtuoid_scene::layout::SceneLayout::is_walkable(&self, u16, u16) -> bool
+pub fn pixtuoid_scene::layout::SceneLayout::lounge_side_table(&self) -> core::option::Option<pixtuoid_scene::layout::Point>
+pub fn pixtuoid_scene::layout::SceneLayout::meeting_room_bounds(&self, usize) -> core::option::Option<pixtuoid_scene::layout::Bounds>
+pub fn pixtuoid_scene::layout::SceneLayout::pantry_counter_size(&self) -> pixtuoid_scene::layout::Size
+pub fn pixtuoid_scene::layout::SceneLayout::stand_point(&self, pixtuoid_scene::layout::WaypointKind, pixtuoid_scene::layout::Point, pixtuoid_scene::layout::Point, pixtuoid_scene::layout::Facing) -> pixtuoid_scene::layout::Point
+pub fn pixtuoid_scene::layout::SceneLayout::wall_band_h(&self) -> u16
+impl core::clone::Clone for pixtuoid_scene::layout::SceneLayout
+pub fn pixtuoid_scene::layout::SceneLayout::clone(&self) -> pixtuoid_scene::layout::SceneLayout
+impl core::fmt::Debug for pixtuoid_scene::layout::SceneLayout
+pub fn pixtuoid_scene::layout::SceneLayout::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for pixtuoid_scene::layout::SceneLayout
+impl core::marker::Send for pixtuoid_scene::layout::SceneLayout
+impl core::marker::Sync for pixtuoid_scene::layout::SceneLayout
+impl core::marker::Unpin for pixtuoid_scene::layout::SceneLayout
+impl core::marker::UnsafeUnpin for pixtuoid_scene::layout::SceneLayout
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::layout::SceneLayout
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::layout::SceneLayout
+pub struct pixtuoid_scene::layout::Size
+pub pixtuoid_scene::layout::Size::h: u16
+pub pixtuoid_scene::layout::Size::w: u16
+impl core::clone::Clone for pixtuoid_scene::layout::Size
+pub fn pixtuoid_scene::layout::Size::clone(&self) -> pixtuoid_scene::layout::Size
+impl core::cmp::Eq for pixtuoid_scene::layout::Size
+impl core::cmp::PartialEq for pixtuoid_scene::layout::Size
+pub fn pixtuoid_scene::layout::Size::eq(&self, &pixtuoid_scene::layout::Size) -> bool
+impl core::fmt::Debug for pixtuoid_scene::layout::Size
+pub fn pixtuoid_scene::layout::Size::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for pixtuoid_scene::layout::Size
+pub fn pixtuoid_scene::layout::Size::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for pixtuoid_scene::layout::Size
+impl core::marker::StructuralPartialEq for pixtuoid_scene::layout::Size
+impl core::marker::Freeze for pixtuoid_scene::layout::Size
+impl core::marker::Send for pixtuoid_scene::layout::Size
+impl core::marker::Sync for pixtuoid_scene::layout::Size
+impl core::marker::Unpin for pixtuoid_scene::layout::Size
+impl core::marker::UnsafeUnpin for pixtuoid_scene::layout::Size
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::layout::Size
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::layout::Size
+pub struct pixtuoid_scene::layout::WallDecorItem
+pub pixtuoid_scene::layout::WallDecorItem::kind: pixtuoid_scene::layout::WallDecor
+pub pixtuoid_scene::layout::WallDecorItem::pos: pixtuoid_scene::layout::Point
+impl core::clone::Clone for pixtuoid_scene::layout::WallDecorItem
+pub fn pixtuoid_scene::layout::WallDecorItem::clone(&self) -> pixtuoid_scene::layout::WallDecorItem
+impl core::cmp::Eq for pixtuoid_scene::layout::WallDecorItem
+impl core::cmp::PartialEq for pixtuoid_scene::layout::WallDecorItem
+pub fn pixtuoid_scene::layout::WallDecorItem::eq(&self, &pixtuoid_scene::layout::WallDecorItem) -> bool
+impl core::fmt::Debug for pixtuoid_scene::layout::WallDecorItem
+pub fn pixtuoid_scene::layout::WallDecorItem::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_scene::layout::WallDecorItem
+impl core::marker::StructuralPartialEq for pixtuoid_scene::layout::WallDecorItem
+impl core::marker::Freeze for pixtuoid_scene::layout::WallDecorItem
+impl core::marker::Send for pixtuoid_scene::layout::WallDecorItem
+impl core::marker::Sync for pixtuoid_scene::layout::WallDecorItem
+impl core::marker::Unpin for pixtuoid_scene::layout::WallDecorItem
+impl core::marker::UnsafeUnpin for pixtuoid_scene::layout::WallDecorItem
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::layout::WallDecorItem
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::layout::WallDecorItem
+pub struct pixtuoid_scene::layout::WallSegment
+pub pixtuoid_scene::layout::WallSegment::end: pixtuoid_scene::layout::Point
+pub pixtuoid_scene::layout::WallSegment::start: pixtuoid_scene::layout::Point
+impl core::clone::Clone for pixtuoid_scene::layout::WallSegment
+pub fn pixtuoid_scene::layout::WallSegment::clone(&self) -> pixtuoid_scene::layout::WallSegment
+impl core::cmp::Eq for pixtuoid_scene::layout::WallSegment
+impl core::cmp::PartialEq for pixtuoid_scene::layout::WallSegment
+pub fn pixtuoid_scene::layout::WallSegment::eq(&self, &pixtuoid_scene::layout::WallSegment) -> bool
+impl core::fmt::Debug for pixtuoid_scene::layout::WallSegment
+pub fn pixtuoid_scene::layout::WallSegment::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for pixtuoid_scene::layout::WallSegment
+pub fn pixtuoid_scene::layout::WallSegment::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for pixtuoid_scene::layout::WallSegment
+impl core::marker::StructuralPartialEq for pixtuoid_scene::layout::WallSegment
+impl core::marker::Freeze for pixtuoid_scene::layout::WallSegment
+impl core::marker::Send for pixtuoid_scene::layout::WallSegment
+impl core::marker::Sync for pixtuoid_scene::layout::WallSegment
+impl core::marker::Unpin for pixtuoid_scene::layout::WallSegment
+impl core::marker::UnsafeUnpin for pixtuoid_scene::layout::WallSegment
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::layout::WallSegment
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::layout::WallSegment
+pub struct pixtuoid_scene::layout::Waypoint
+pub pixtuoid_scene::layout::Waypoint::facing: pixtuoid_scene::layout::Facing
+pub pixtuoid_scene::layout::Waypoint::kind: pixtuoid_scene::layout::WaypointKind
+pub pixtuoid_scene::layout::Waypoint::pos: pixtuoid_scene::layout::Point
+pub pixtuoid_scene::layout::Waypoint::room_id: core::option::Option<usize>
+impl core::clone::Clone for pixtuoid_scene::layout::Waypoint
+pub fn pixtuoid_scene::layout::Waypoint::clone(&self) -> pixtuoid_scene::layout::Waypoint
+impl core::cmp::Eq for pixtuoid_scene::layout::Waypoint
+impl core::cmp::PartialEq for pixtuoid_scene::layout::Waypoint
+pub fn pixtuoid_scene::layout::Waypoint::eq(&self, &pixtuoid_scene::layout::Waypoint) -> bool
+impl core::fmt::Debug for pixtuoid_scene::layout::Waypoint
+pub fn pixtuoid_scene::layout::Waypoint::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_scene::layout::Waypoint
+impl core::marker::StructuralPartialEq for pixtuoid_scene::layout::Waypoint
+impl core::marker::Freeze for pixtuoid_scene::layout::Waypoint
+impl core::marker::Send for pixtuoid_scene::layout::Waypoint
+impl core::marker::Sync for pixtuoid_scene::layout::Waypoint
+impl core::marker::Unpin for pixtuoid_scene::layout::Waypoint
+impl core::marker::UnsafeUnpin for pixtuoid_scene::layout::Waypoint
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::layout::Waypoint
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::layout::Waypoint
+pub const pixtuoid_scene::layout::CHARACTER_SPRITE_H_CELLS: u16
+pub const pixtuoid_scene::layout::CHARACTER_SPRITE_W: u16
+pub const pixtuoid_scene::layout::CLASSIC_OFFICE_DESKS: usize
+pub const pixtuoid_scene::layout::DESK_APPROACH: pixtuoid_scene::layout::ApproachSides
+pub const pixtuoid_scene::layout::DESK_GAP_X: u16
+pub const pixtuoid_scene::layout::DESK_GAP_Y: u16
+pub const pixtuoid_scene::layout::DESK_H: u16
+pub const pixtuoid_scene::layout::DESK_W: u16
+pub const pixtuoid_scene::layout::ELEVATOR_H: u16
+pub const pixtuoid_scene::layout::ELEVATOR_W: u16
+pub const pixtuoid_scene::layout::INTER_POD_AISLE_X: u16
+pub const pixtuoid_scene::layout::INTER_POD_AISLE_Y: u16
+pub const pixtuoid_scene::layout::INTRA_POD_GAP_X: u16
+pub const pixtuoid_scene::layout::INTRA_POD_GAP_Y: u16
+pub const pixtuoid_scene::layout::MIN_TOP_MARGIN: u16
+pub const pixtuoid_scene::layout::OBSTACLE_PAD_PX: u16
+pub const pixtuoid_scene::layout::PANTRY_COUNTER_LARGE_W: u16
+pub const pixtuoid_scene::layout::PANTRY_FOOTPRINT_DEPTH: u16
+pub const pixtuoid_scene::layout::POD_SIDE: u16
+pub const pixtuoid_scene::layout::SEAT_RENDER_Y_OFF: u16
+pub const pixtuoid_scene::layout::TEST_DEFAULT_DESKS: usize
+pub const pixtuoid_scene::layout::WALKING_Y_OFF: u16
+pub const pixtuoid_scene::layout::WALL_BAND_TO_TOP_MARGIN: u16
+pub const pixtuoid_scene::layout::WALL_THICK_H: u16
+pub const pixtuoid_scene::layout::WALL_THICK_V: u16
+pub fn pixtuoid_scene::layout::anchored_top_left(pixtuoid_scene::layout::Anchor, pixtuoid_scene::layout::Point, u16, u16) -> pixtuoid_scene::layout::Point
+pub const fn pixtuoid_scene::layout::desk_furniture_def() -> pixtuoid_scene::layout::FurnitureDef
+pub fn pixtuoid_scene::layout::desk_walk_anchor(pixtuoid_scene::layout::Point) -> pixtuoid_scene::layout::Point
+pub const fn pixtuoid_scene::layout::furniture_def(pixtuoid_scene::layout::Furniture) -> pixtuoid_scene::layout::FurnitureDef
+pub fn pixtuoid_scene::layout::seated_foot_cell(pixtuoid_scene::layout::Furniture, pixtuoid_scene::layout::Point) -> core::option::Option<pixtuoid_scene::layout::Point>
+pub fn pixtuoid_scene::layout::z_sort_row(pixtuoid_scene::layout::Anchor, pixtuoid_scene::layout::Point, u16) -> u16
+pub type pixtuoid_scene::layout::Layout = pixtuoid_scene::layout::SceneLayout
+pub mod pixtuoid_scene::motion
+pub enum pixtuoid_scene::motion::WanderKind
+pub pixtuoid_scene::motion::WanderKind::Aimless
+pub pixtuoid_scene::motion::WanderKind::Named
+pub pixtuoid_scene::motion::WanderKind::Named::kind: pixtuoid_scene::layout::WaypointKind
+pub pixtuoid_scene::motion::WanderKind::Named::seat: core::option::Option<pixtuoid_scene::layout::Point>
+pub pixtuoid_scene::motion::WanderKind::Named::wp_idx: usize
+impl core::clone::Clone for pixtuoid_scene::motion::WanderKind
+pub fn pixtuoid_scene::motion::WanderKind::clone(&self) -> pixtuoid_scene::motion::WanderKind
+impl core::cmp::Eq for pixtuoid_scene::motion::WanderKind
+impl core::cmp::PartialEq for pixtuoid_scene::motion::WanderKind
+pub fn pixtuoid_scene::motion::WanderKind::eq(&self, &pixtuoid_scene::motion::WanderKind) -> bool
+impl core::fmt::Debug for pixtuoid_scene::motion::WanderKind
+pub fn pixtuoid_scene::motion::WanderKind::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_scene::motion::WanderKind
+impl core::marker::StructuralPartialEq for pixtuoid_scene::motion::WanderKind
+impl core::marker::Freeze for pixtuoid_scene::motion::WanderKind
+impl core::marker::Send for pixtuoid_scene::motion::WanderKind
+impl core::marker::Sync for pixtuoid_scene::motion::WanderKind
+impl core::marker::Unpin for pixtuoid_scene::motion::WanderKind
+impl core::marker::UnsafeUnpin for pixtuoid_scene::motion::WanderKind
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::motion::WanderKind
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::motion::WanderKind
+pub enum pixtuoid_scene::motion::WanderPhase
+pub pixtuoid_scene::motion::WanderPhase::AtWaypoint(pixtuoid_scene::physics::WalkProfile)
+pub pixtuoid_scene::motion::WanderPhase::Seated
+pub pixtuoid_scene::motion::WanderPhase::WalkingBack(pixtuoid_scene::physics::WalkProfile)
+pub pixtuoid_scene::motion::WanderPhase::WalkingOut(pixtuoid_scene::physics::WalkProfile)
+impl core::clone::Clone for pixtuoid_scene::motion::WanderPhase
+pub fn pixtuoid_scene::motion::WanderPhase::clone(&self) -> pixtuoid_scene::motion::WanderPhase
+impl core::cmp::PartialEq for pixtuoid_scene::motion::WanderPhase
+pub fn pixtuoid_scene::motion::WanderPhase::eq(&self, &pixtuoid_scene::motion::WanderPhase) -> bool
+impl core::fmt::Debug for pixtuoid_scene::motion::WanderPhase
+pub fn pixtuoid_scene::motion::WanderPhase::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_scene::motion::WanderPhase
+impl core::marker::StructuralPartialEq for pixtuoid_scene::motion::WanderPhase
+impl core::marker::Freeze for pixtuoid_scene::motion::WanderPhase
+impl core::marker::Send for pixtuoid_scene::motion::WanderPhase
+impl core::marker::Sync for pixtuoid_scene::motion::WanderPhase
+impl core::marker::Unpin for pixtuoid_scene::motion::WanderPhase
+impl core::marker::UnsafeUnpin for pixtuoid_scene::motion::WanderPhase
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::motion::WanderPhase
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::motion::WanderPhase
+pub struct pixtuoid_scene::motion::MotionState
+pub pixtuoid_scene::motion::MotionState::agent_id: pixtuoid_core::id::AgentId
+pub pixtuoid_scene::motion::MotionState::entry: core::option::Option<(std::time::SystemTime, pixtuoid_scene::physics::WalkProfile)>
+pub pixtuoid_scene::motion::MotionState::exit: core::option::Option<pixtuoid_scene::motion::WalkLeg>
+pub pixtuoid_scene::motion::MotionState::snap_back: core::option::Option<pixtuoid_scene::motion::WalkLeg>
+pub pixtuoid_scene::motion::MotionState::walk_path: core::option::Option<pixtuoid_scene::motion::WalkPathSnapshot>
+pub pixtuoid_scene::motion::MotionState::wander: pixtuoid_scene::motion::WanderState
+impl pixtuoid_scene::motion::MotionState
+pub fn pixtuoid_scene::motion::MotionState::new(pixtuoid_core::id::AgentId) -> Self
+impl core::clone::Clone for pixtuoid_scene::motion::MotionState
+pub fn pixtuoid_scene::motion::MotionState::clone(&self) -> pixtuoid_scene::motion::MotionState
+impl core::fmt::Debug for pixtuoid_scene::motion::MotionState
+pub fn pixtuoid_scene::motion::MotionState::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for pixtuoid_scene::motion::MotionState
+impl core::marker::Send for pixtuoid_scene::motion::MotionState
+impl core::marker::Sync for pixtuoid_scene::motion::MotionState
+impl core::marker::Unpin for pixtuoid_scene::motion::MotionState
+impl core::marker::UnsafeUnpin for pixtuoid_scene::motion::MotionState
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::motion::MotionState
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::motion::MotionState
+pub struct pixtuoid_scene::motion::WalkLeg
+pub pixtuoid_scene::motion::WalkLeg::from: pixtuoid_scene::layout::Point
+pub pixtuoid_scene::motion::WalkLeg::profile: pixtuoid_scene::physics::WalkProfile
+pub pixtuoid_scene::motion::WalkLeg::started_at: std::time::SystemTime
+impl core::clone::Clone for pixtuoid_scene::motion::WalkLeg
+pub fn pixtuoid_scene::motion::WalkLeg::clone(&self) -> pixtuoid_scene::motion::WalkLeg
+impl core::fmt::Debug for pixtuoid_scene::motion::WalkLeg
+pub fn pixtuoid_scene::motion::WalkLeg::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for pixtuoid_scene::motion::WalkLeg
+impl core::marker::Send for pixtuoid_scene::motion::WalkLeg
+impl core::marker::Sync for pixtuoid_scene::motion::WalkLeg
+impl core::marker::Unpin for pixtuoid_scene::motion::WalkLeg
+impl core::marker::UnsafeUnpin for pixtuoid_scene::motion::WalkLeg
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::motion::WalkLeg
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::motion::WalkLeg
+pub struct pixtuoid_scene::motion::WalkPathSnapshot
+pub pixtuoid_scene::motion::WalkPathSnapshot::from: pixtuoid_scene::layout::Point
+pub pixtuoid_scene::motion::WalkPathSnapshot::path: alloc::vec::Vec<pixtuoid_scene::layout::Point>
+pub pixtuoid_scene::motion::WalkPathSnapshot::to: pixtuoid_scene::layout::Point
+impl core::clone::Clone for pixtuoid_scene::motion::WalkPathSnapshot
+pub fn pixtuoid_scene::motion::WalkPathSnapshot::clone(&self) -> pixtuoid_scene::motion::WalkPathSnapshot
+impl core::cmp::Eq for pixtuoid_scene::motion::WalkPathSnapshot
+impl core::cmp::PartialEq for pixtuoid_scene::motion::WalkPathSnapshot
+pub fn pixtuoid_scene::motion::WalkPathSnapshot::eq(&self, &pixtuoid_scene::motion::WalkPathSnapshot) -> bool
+impl core::fmt::Debug for pixtuoid_scene::motion::WalkPathSnapshot
+pub fn pixtuoid_scene::motion::WalkPathSnapshot::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for pixtuoid_scene::motion::WalkPathSnapshot
+impl core::marker::Freeze for pixtuoid_scene::motion::WalkPathSnapshot
+impl core::marker::Send for pixtuoid_scene::motion::WalkPathSnapshot
+impl core::marker::Sync for pixtuoid_scene::motion::WalkPathSnapshot
+impl core::marker::Unpin for pixtuoid_scene::motion::WalkPathSnapshot
+impl core::marker::UnsafeUnpin for pixtuoid_scene::motion::WalkPathSnapshot
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::motion::WalkPathSnapshot
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::motion::WalkPathSnapshot
+pub struct pixtuoid_scene::motion::WanderFrame
+pub pixtuoid_scene::motion::WanderFrame::dest: pixtuoid_scene::layout::Point
+pub pixtuoid_scene::motion::WanderFrame::kind: pixtuoid_scene::motion::WanderKind
+pub pixtuoid_scene::motion::WanderFrame::phase: pixtuoid_scene::motion::WanderPhase
+pub pixtuoid_scene::motion::WanderFrame::phase_started_at: std::time::SystemTime
+pub pixtuoid_scene::motion::WanderFrame::t_x1000: u16
+impl core::clone::Clone for pixtuoid_scene::motion::WanderFrame
+pub fn pixtuoid_scene::motion::WanderFrame::clone(&self) -> pixtuoid_scene::motion::WanderFrame
+impl core::fmt::Debug for pixtuoid_scene::motion::WanderFrame
+pub fn pixtuoid_scene::motion::WanderFrame::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_scene::motion::WanderFrame
+impl core::marker::Freeze for pixtuoid_scene::motion::WanderFrame
+impl core::marker::Send for pixtuoid_scene::motion::WanderFrame
+impl core::marker::Sync for pixtuoid_scene::motion::WanderFrame
+impl core::marker::Unpin for pixtuoid_scene::motion::WanderFrame
+impl core::marker::UnsafeUnpin for pixtuoid_scene::motion::WanderFrame
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::motion::WanderFrame
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::motion::WanderFrame
+pub struct pixtuoid_scene::motion::WanderState
+pub pixtuoid_scene::motion::WanderState::cycle_n: u64
+pub pixtuoid_scene::motion::WanderState::last_advanced_at: std::time::SystemTime
+pub pixtuoid_scene::motion::WanderState::phase: pixtuoid_scene::motion::WanderPhase
+pub pixtuoid_scene::motion::WanderState::phase_started_at: std::time::SystemTime
+pub pixtuoid_scene::motion::WanderState::target: pixtuoid_scene::motion::WanderTarget
+impl core::clone::Clone for pixtuoid_scene::motion::WanderState
+pub fn pixtuoid_scene::motion::WanderState::clone(&self) -> pixtuoid_scene::motion::WanderState
+impl core::fmt::Debug for pixtuoid_scene::motion::WanderState
+pub fn pixtuoid_scene::motion::WanderState::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for pixtuoid_scene::motion::WanderState
+impl core::marker::Send for pixtuoid_scene::motion::WanderState
+impl core::marker::Sync for pixtuoid_scene::motion::WanderState
+impl core::marker::Unpin for pixtuoid_scene::motion::WanderState
+impl core::marker::UnsafeUnpin for pixtuoid_scene::motion::WanderState
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::motion::WanderState
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::motion::WanderState
+pub struct pixtuoid_scene::motion::WanderTarget
+pub pixtuoid_scene::motion::WanderTarget::dest: pixtuoid_scene::layout::Point
+pub pixtuoid_scene::motion::WanderTarget::kind: pixtuoid_scene::motion::WanderKind
+impl core::clone::Clone for pixtuoid_scene::motion::WanderTarget
+pub fn pixtuoid_scene::motion::WanderTarget::clone(&self) -> pixtuoid_scene::motion::WanderTarget
+impl core::cmp::Eq for pixtuoid_scene::motion::WanderTarget
+impl core::cmp::PartialEq for pixtuoid_scene::motion::WanderTarget
+pub fn pixtuoid_scene::motion::WanderTarget::eq(&self, &pixtuoid_scene::motion::WanderTarget) -> bool
+impl core::fmt::Debug for pixtuoid_scene::motion::WanderTarget
+pub fn pixtuoid_scene::motion::WanderTarget::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_scene::motion::WanderTarget
+impl core::marker::StructuralPartialEq for pixtuoid_scene::motion::WanderTarget
+impl core::marker::Freeze for pixtuoid_scene::motion::WanderTarget
+impl core::marker::Send for pixtuoid_scene::motion::WanderTarget
+impl core::marker::Sync for pixtuoid_scene::motion::WanderTarget
+impl core::marker::Unpin for pixtuoid_scene::motion::WanderTarget
+impl core::marker::UnsafeUnpin for pixtuoid_scene::motion::WanderTarget
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::motion::WanderTarget
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::motion::WanderTarget
+pub fn pixtuoid_scene::motion::advance_wander(&pixtuoid_core::state::AgentSlot, std::time::SystemTime, &pixtuoid_scene::layout::Layout, &mut dyn pixtuoid_scene::pathfind::Router, &pixtuoid_core::walkable::OccupancyOverlay, &mut std::collections::hash::map::HashMap<pixtuoid_core::id::AgentId, pixtuoid_scene::motion::MotionState>) -> pixtuoid_scene::motion::WanderFrame
+pub fn pixtuoid_scene::motion::octile_path_len(&[pixtuoid_scene::layout::Point]) -> u32
+pub mod pixtuoid_scene::pathfind
+pub struct pixtuoid_scene::pathfind::AStarRouter
+impl pixtuoid_scene::pathfind::AStarRouter
+pub fn pixtuoid_scene::pathfind::AStarRouter::is_empty(&self) -> bool
+pub fn pixtuoid_scene::pathfind::AStarRouter::len(&self) -> usize
+pub fn pixtuoid_scene::pathfind::AStarRouter::new() -> Self
+impl core::clone::Clone for pixtuoid_scene::pathfind::AStarRouter
+pub fn pixtuoid_scene::pathfind::AStarRouter::clone(&self) -> pixtuoid_scene::pathfind::AStarRouter
+impl core::default::Default for pixtuoid_scene::pathfind::AStarRouter
+pub fn pixtuoid_scene::pathfind::AStarRouter::default() -> pixtuoid_scene::pathfind::AStarRouter
+impl core::fmt::Debug for pixtuoid_scene::pathfind::AStarRouter
+pub fn pixtuoid_scene::pathfind::AStarRouter::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl pixtuoid_scene::pathfind::Router for pixtuoid_scene::pathfind::AStarRouter
+pub fn pixtuoid_scene::pathfind::AStarRouter::invalidate(&mut self)
+pub fn pixtuoid_scene::pathfind::AStarRouter::route(&mut self, &pixtuoid_core::walkable::WalkableMask, &pixtuoid_core::walkable::OccupancyOverlay, pixtuoid_scene::layout::Point, pixtuoid_scene::layout::Point) -> alloc::vec::Vec<pixtuoid_scene::layout::Point>
+pub fn pixtuoid_scene::pathfind::AStarRouter::set_preferred_zone(&mut self, core::option::Option<pixtuoid_scene::layout::Bounds>)
+impl core::marker::Freeze for pixtuoid_scene::pathfind::AStarRouter
+impl core::marker::Send for pixtuoid_scene::pathfind::AStarRouter
+impl core::marker::Sync for pixtuoid_scene::pathfind::AStarRouter
+impl core::marker::Unpin for pixtuoid_scene::pathfind::AStarRouter
+impl core::marker::UnsafeUnpin for pixtuoid_scene::pathfind::AStarRouter
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::pathfind::AStarRouter
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::pathfind::AStarRouter
+pub const pixtuoid_scene::pathfind::CELL_SIZE: u16
+pub trait pixtuoid_scene::pathfind::Router
+pub fn pixtuoid_scene::pathfind::Router::invalidate(&mut self)
+pub fn pixtuoid_scene::pathfind::Router::route(&mut self, &pixtuoid_core::walkable::WalkableMask, &pixtuoid_core::walkable::OccupancyOverlay, pixtuoid_scene::layout::Point, pixtuoid_scene::layout::Point) -> alloc::vec::Vec<pixtuoid_scene::layout::Point>
+pub fn pixtuoid_scene::pathfind::Router::set_preferred_zone(&mut self, core::option::Option<pixtuoid_scene::layout::Bounds>)
+impl pixtuoid_scene::pathfind::Router for pixtuoid_scene::pathfind::AStarRouter
+pub fn pixtuoid_scene::pathfind::AStarRouter::invalidate(&mut self)
+pub fn pixtuoid_scene::pathfind::AStarRouter::route(&mut self, &pixtuoid_core::walkable::WalkableMask, &pixtuoid_core::walkable::OccupancyOverlay, pixtuoid_scene::layout::Point, pixtuoid_scene::layout::Point) -> alloc::vec::Vec<pixtuoid_scene::layout::Point>
+pub fn pixtuoid_scene::pathfind::AStarRouter::set_preferred_zone(&mut self, core::option::Option<pixtuoid_scene::layout::Bounds>)
+pub fn pixtuoid_scene::pathfind::find_path(&pixtuoid_core::walkable::WalkableMask, &pixtuoid_core::walkable::OccupancyOverlay, core::option::Option<pixtuoid_scene::layout::Bounds>, pixtuoid_scene::layout::Point, pixtuoid_scene::layout::Point) -> core::option::Option<alloc::vec::Vec<pixtuoid_scene::layout::Point>>
+pub fn pixtuoid_scene::pathfind::point_in_walkable_cell(&pixtuoid_core::walkable::WalkableMask, pixtuoid_scene::layout::Point) -> bool
+pub fn pixtuoid_scene::pathfind::snap_point_to_walkable(&pixtuoid_core::walkable::WalkableMask, pixtuoid_scene::layout::Point) -> core::option::Option<pixtuoid_scene::layout::Point>
+pub mod pixtuoid_scene::pet
+pub enum pixtuoid_scene::pet::PetKind
+pub pixtuoid_scene::pet::PetKind::Cat
+pub pixtuoid_scene::pet::PetKind::Dog
+impl pixtuoid_scene::pet::PetKind
+pub const pixtuoid_scene::pet::PetKind::ALL: &'static [pixtuoid_scene::pet::PetKind]
+pub fn pixtuoid_scene::pet::PetKind::default_name(self) -> &'static str
+pub fn pixtuoid_scene::pet::PetKind::from_config_name(&str) -> core::option::Option<Self>
+pub fn pixtuoid_scene::pet::PetKind::hitbox(self, &str) -> pixtuoid_scene::layout::Size
+pub fn pixtuoid_scene::pet::PetKind::sit_anim(self) -> &'static str
+pub fn pixtuoid_scene::pet::PetKind::sleep_anim(self) -> &'static str
+pub fn pixtuoid_scene::pet::PetKind::sleeps_near_idle(self) -> bool
+pub fn pixtuoid_scene::pet::PetKind::walk_anim(self) -> &'static str
+impl core::clone::Clone for pixtuoid_scene::pet::PetKind
+pub fn pixtuoid_scene::pet::PetKind::clone(&self) -> pixtuoid_scene::pet::PetKind
+impl core::cmp::Eq for pixtuoid_scene::pet::PetKind
+impl core::cmp::PartialEq for pixtuoid_scene::pet::PetKind
+pub fn pixtuoid_scene::pet::PetKind::eq(&self, &pixtuoid_scene::pet::PetKind) -> bool
+impl core::fmt::Debug for pixtuoid_scene::pet::PetKind
+pub fn pixtuoid_scene::pet::PetKind::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for pixtuoid_scene::pet::PetKind
+pub fn pixtuoid_scene::pet::PetKind::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for pixtuoid_scene::pet::PetKind
+impl core::marker::StructuralPartialEq for pixtuoid_scene::pet::PetKind
+impl core::marker::Freeze for pixtuoid_scene::pet::PetKind
+impl core::marker::Send for pixtuoid_scene::pet::PetKind
+impl core::marker::Sync for pixtuoid_scene::pet::PetKind
+impl core::marker::Unpin for pixtuoid_scene::pet::PetKind
+impl core::marker::UnsafeUnpin for pixtuoid_scene::pet::PetKind
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::pet::PetKind
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::pet::PetKind
+pub struct pixtuoid_scene::pet::Pet
+pub pixtuoid_scene::pet::Pet::kind: pixtuoid_scene::pet::PetKind
+pub pixtuoid_scene::pet::Pet::name: alloc::string::String
+impl pixtuoid_scene::pet::Pet
+pub fn pixtuoid_scene::pet::Pet::defaulted(pixtuoid_scene::pet::PetKind) -> Self
+impl core::clone::Clone for pixtuoid_scene::pet::Pet
+pub fn pixtuoid_scene::pet::Pet::clone(&self) -> pixtuoid_scene::pet::Pet
+impl core::cmp::Eq for pixtuoid_scene::pet::Pet
+impl core::cmp::PartialEq for pixtuoid_scene::pet::Pet
+pub fn pixtuoid_scene::pet::Pet::eq(&self, &pixtuoid_scene::pet::Pet) -> bool
+impl core::fmt::Debug for pixtuoid_scene::pet::Pet
+pub fn pixtuoid_scene::pet::Pet::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for pixtuoid_scene::pet::Pet
+impl core::marker::Freeze for pixtuoid_scene::pet::Pet
+impl core::marker::Send for pixtuoid_scene::pet::Pet
+impl core::marker::Sync for pixtuoid_scene::pet::Pet
+impl core::marker::Unpin for pixtuoid_scene::pet::Pet
+impl core::marker::UnsafeUnpin for pixtuoid_scene::pet::Pet
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::pet::Pet
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::pet::Pet
+pub struct pixtuoid_scene::pet::PetFrame
+pub pixtuoid_scene::pet::PetFrame::anim: &'static str
+pub pixtuoid_scene::pet::PetFrame::kind: pixtuoid_scene::pet::PetKind
+pub pixtuoid_scene::pet::PetFrame::pos: pixtuoid_scene::layout::Point
+impl core::clone::Clone for pixtuoid_scene::pet::PetFrame
+pub fn pixtuoid_scene::pet::PetFrame::clone(&self) -> pixtuoid_scene::pet::PetFrame
+impl core::marker::Copy for pixtuoid_scene::pet::PetFrame
+impl core::marker::Freeze for pixtuoid_scene::pet::PetFrame
+impl core::marker::Send for pixtuoid_scene::pet::PetFrame
+impl core::marker::Sync for pixtuoid_scene::pet::PetFrame
+impl core::marker::Unpin for pixtuoid_scene::pet::PetFrame
+impl core::marker::UnsafeUnpin for pixtuoid_scene::pet::PetFrame
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::pet::PetFrame
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::pet::PetFrame
+pub struct pixtuoid_scene::pet::PetState
+pub pixtuoid_scene::pet::PetState::floor_idx: usize
+pub pixtuoid_scene::pet::PetState::kind: pixtuoid_scene::pet::PetKind
+pub pixtuoid_scene::pet::PetState::pet_pos: pixtuoid_scene::layout::Point
+pub pixtuoid_scene::pet::PetState::petted_at: std::time::SystemTime
+impl pixtuoid_scene::pet::PetState
+pub fn pixtuoid_scene::pet::PetState::elapsed_ms(&self, std::time::SystemTime) -> u64
+pub fn pixtuoid_scene::pet::PetState::is_active(&self, std::time::SystemTime) -> bool
+impl core::marker::Freeze for pixtuoid_scene::pet::PetState
+impl core::marker::Send for pixtuoid_scene::pet::PetState
+impl core::marker::Sync for pixtuoid_scene::pet::PetState
+impl core::marker::Unpin for pixtuoid_scene::pet::PetState
+impl core::marker::UnsafeUnpin for pixtuoid_scene::pet::PetState
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::pet::PetState
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::pet::PetState
+pub const pixtuoid_scene::pet::PET_DURATION_MS: u64
+pub fn pixtuoid_scene::pet::select_pet_for_floor(u64, &[pixtuoid_scene::pet::Pet]) -> core::option::Option<&pixtuoid_scene::pet::Pet>
+pub mod pixtuoid_scene::physics
+pub enum pixtuoid_scene::physics::WalkIntent
+pub pixtuoid_scene::physics::WalkIntent::Entry
+pub pixtuoid_scene::physics::WalkIntent::Exit
+pub pixtuoid_scene::physics::WalkIntent::SnapBack
+pub pixtuoid_scene::physics::WalkIntent::WanderBack
+pub pixtuoid_scene::physics::WalkIntent::WanderOut
+impl core::clone::Clone for pixtuoid_scene::physics::WalkIntent
+pub fn pixtuoid_scene::physics::WalkIntent::clone(&self) -> pixtuoid_scene::physics::WalkIntent
+impl core::cmp::Eq for pixtuoid_scene::physics::WalkIntent
+impl core::cmp::PartialEq for pixtuoid_scene::physics::WalkIntent
+pub fn pixtuoid_scene::physics::WalkIntent::eq(&self, &pixtuoid_scene::physics::WalkIntent) -> bool
+impl core::fmt::Debug for pixtuoid_scene::physics::WalkIntent
+pub fn pixtuoid_scene::physics::WalkIntent::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_scene::physics::WalkIntent
+impl core::marker::StructuralPartialEq for pixtuoid_scene::physics::WalkIntent
+impl core::marker::Freeze for pixtuoid_scene::physics::WalkIntent
+impl core::marker::Send for pixtuoid_scene::physics::WalkIntent
+impl core::marker::Sync for pixtuoid_scene::physics::WalkIntent
+impl core::marker::Unpin for pixtuoid_scene::physics::WalkIntent
+impl core::marker::UnsafeUnpin for pixtuoid_scene::physics::WalkIntent
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::physics::WalkIntent
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::physics::WalkIntent
+pub struct pixtuoid_scene::physics::WalkProfile
+pub pixtuoid_scene::physics::WalkProfile::accel: f32
+pub pixtuoid_scene::physics::WalkProfile::duration_ms: u64
+pub pixtuoid_scene::physics::WalkProfile::path_len_octile: u32
+pub pixtuoid_scene::physics::WalkProfile::pause_ms: u64
+pub pixtuoid_scene::physics::WalkProfile::v_cruise: f32
+impl core::clone::Clone for pixtuoid_scene::physics::WalkProfile
+pub fn pixtuoid_scene::physics::WalkProfile::clone(&self) -> pixtuoid_scene::physics::WalkProfile
+impl core::cmp::PartialEq for pixtuoid_scene::physics::WalkProfile
+pub fn pixtuoid_scene::physics::WalkProfile::eq(&self, &pixtuoid_scene::physics::WalkProfile) -> bool
+impl core::fmt::Debug for pixtuoid_scene::physics::WalkProfile
+pub fn pixtuoid_scene::physics::WalkProfile::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_scene::physics::WalkProfile
+impl core::marker::StructuralPartialEq for pixtuoid_scene::physics::WalkProfile
+impl core::marker::Freeze for pixtuoid_scene::physics::WalkProfile
+impl core::marker::Send for pixtuoid_scene::physics::WalkProfile
+impl core::marker::Sync for pixtuoid_scene::physics::WalkProfile
+impl core::marker::Unpin for pixtuoid_scene::physics::WalkProfile
+impl core::marker::UnsafeUnpin for pixtuoid_scene::physics::WalkProfile
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::physics::WalkProfile
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::physics::WalkProfile
+pub const pixtuoid_scene::physics::PAUSE_MS_MAX: u64
+pub const pixtuoid_scene::physics::PAUSE_MS_MIN: u64
+pub const pixtuoid_scene::physics::PROGRESS_SCALE: u16
+pub const pixtuoid_scene::physics::SPEED_MULT_MAX: f32
+pub const pixtuoid_scene::physics::SPEED_MULT_MIN: f32
+pub const pixtuoid_scene::physics::V_CRUISE_COMMUTE: f32
+pub const pixtuoid_scene::physics::V_CRUISE_SNAPBACK: f32
+pub const pixtuoid_scene::physics::V_CRUISE_WANDER: f32
+pub const pixtuoid_scene::physics::WALK_ACCEL: f32
+pub const pixtuoid_scene::physics::WALK_ACCEL_SNAPBACK: f32
+pub fn pixtuoid_scene::physics::pause_ms_for(pixtuoid_core::id::AgentId) -> u64
+pub fn pixtuoid_scene::physics::speed_mult(pixtuoid_core::id::AgentId) -> f32
+pub fn pixtuoid_scene::physics::walk_arrived(&pixtuoid_scene::physics::WalkProfile, u64) -> bool
+pub fn pixtuoid_scene::physics::walk_profile(u32, pixtuoid_scene::physics::WalkIntent, pixtuoid_core::id::AgentId) -> pixtuoid_scene::physics::WalkProfile
+pub fn pixtuoid_scene::physics::walk_progress(&pixtuoid_scene::physics::WalkProfile, u64) -> u16
+pub mod pixtuoid_scene::pixel_painter
+pub enum pixtuoid_scene::pixel_painter::CharacterGlow
+pub pixtuoid_scene::pixel_painter::CharacterGlow::None
+pub pixtuoid_scene::pixel_painter::CharacterGlow::Thinking
+pub pixtuoid_scene::pixel_painter::CharacterGlow::Tool
+impl core::clone::Clone for pixtuoid_scene::pixel_painter::CharacterGlow
+pub fn pixtuoid_scene::pixel_painter::CharacterGlow::clone(&self) -> pixtuoid_scene::pixel_painter::CharacterGlow
+impl core::cmp::Eq for pixtuoid_scene::pixel_painter::CharacterGlow
+impl core::cmp::PartialEq for pixtuoid_scene::pixel_painter::CharacterGlow
+pub fn pixtuoid_scene::pixel_painter::CharacterGlow::eq(&self, &pixtuoid_scene::pixel_painter::CharacterGlow) -> bool
+impl core::fmt::Debug for pixtuoid_scene::pixel_painter::CharacterGlow
+pub fn pixtuoid_scene::pixel_painter::CharacterGlow::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_scene::pixel_painter::CharacterGlow
+impl core::marker::StructuralPartialEq for pixtuoid_scene::pixel_painter::CharacterGlow
+impl core::marker::Freeze for pixtuoid_scene::pixel_painter::CharacterGlow
+impl core::marker::Send for pixtuoid_scene::pixel_painter::CharacterGlow
+impl core::marker::Sync for pixtuoid_scene::pixel_painter::CharacterGlow
+impl core::marker::Unpin for pixtuoid_scene::pixel_painter::CharacterGlow
+impl core::marker::UnsafeUnpin for pixtuoid_scene::pixel_painter::CharacterGlow
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::pixel_painter::CharacterGlow
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::pixel_painter::CharacterGlow
+pub struct pixtuoid_scene::pixel_painter::CharacterPlacement
+pub pixtuoid_scene::pixel_painter::CharacterPlacement::agent_idx: usize
+pub pixtuoid_scene::pixel_painter::CharacterPlacement::anchor: pixtuoid_scene::layout::Point
+pub pixtuoid_scene::pixel_painter::CharacterPlacement::anchor_y: u16
+pub pixtuoid_scene::pixel_painter::CharacterPlacement::anim_name: &'static str
+pub pixtuoid_scene::pixel_painter::CharacterPlacement::flip_x: bool
+pub pixtuoid_scene::pixel_painter::CharacterPlacement::frame_idx: usize
+pub pixtuoid_scene::pixel_painter::CharacterPlacement::glow: pixtuoid_scene::pixel_painter::CharacterGlow
+pub pixtuoid_scene::pixel_painter::CharacterPlacement::sleep_z_seed: core::option::Option<u64>
+pub pixtuoid_scene::pixel_painter::CharacterPlacement::waiting_bubble: bool
+pub pixtuoid_scene::pixel_painter::CharacterPlacement::walking_dust_frame: core::option::Option<usize>
+impl core::clone::Clone for pixtuoid_scene::pixel_painter::CharacterPlacement
+pub fn pixtuoid_scene::pixel_painter::CharacterPlacement::clone(&self) -> pixtuoid_scene::pixel_painter::CharacterPlacement
+impl core::fmt::Debug for pixtuoid_scene::pixel_painter::CharacterPlacement
+pub fn pixtuoid_scene::pixel_painter::CharacterPlacement::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_scene::pixel_painter::CharacterPlacement
+impl core::marker::Freeze for pixtuoid_scene::pixel_painter::CharacterPlacement
+impl core::marker::Send for pixtuoid_scene::pixel_painter::CharacterPlacement
+impl core::marker::Sync for pixtuoid_scene::pixel_painter::CharacterPlacement
+impl core::marker::Unpin for pixtuoid_scene::pixel_painter::CharacterPlacement
+impl core::marker::UnsafeUnpin for pixtuoid_scene::pixel_painter::CharacterPlacement
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::pixel_painter::CharacterPlacement
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::pixel_painter::CharacterPlacement
+pub struct pixtuoid_scene::pixel_painter::MascotFrame
+pub pixtuoid_scene::pixel_painter::MascotFrame::active_sessions: u32
+pub pixtuoid_scene::pixel_painter::MascotFrame::busy: bool
+pub pixtuoid_scene::pixel_painter::MascotFrame::degraded: bool
+pub pixtuoid_scene::pixel_painter::MascotFrame::h: u16
+pub pixtuoid_scene::pixel_painter::MascotFrame::name: &'static str
+pub pixtuoid_scene::pixel_painter::MascotFrame::pos: pixtuoid_scene::layout::Point
+pub pixtuoid_scene::pixel_painter::MascotFrame::w: u16
+impl core::clone::Clone for pixtuoid_scene::pixel_painter::MascotFrame
+pub fn pixtuoid_scene::pixel_painter::MascotFrame::clone(&self) -> pixtuoid_scene::pixel_painter::MascotFrame
+impl core::marker::Copy for pixtuoid_scene::pixel_painter::MascotFrame
+impl core::marker::Freeze for pixtuoid_scene::pixel_painter::MascotFrame
+impl core::marker::Send for pixtuoid_scene::pixel_painter::MascotFrame
+impl core::marker::Sync for pixtuoid_scene::pixel_painter::MascotFrame
+impl core::marker::Unpin for pixtuoid_scene::pixel_painter::MascotFrame
+impl core::marker::UnsafeUnpin for pixtuoid_scene::pixel_painter::MascotFrame
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::pixel_painter::MascotFrame
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::pixel_painter::MascotFrame
+pub struct pixtuoid_scene::pixel_painter::PixelCtx<'a>
+pub pixtuoid_scene::pixel_painter::PixelCtx::active_pet: core::option::Option<&'a pixtuoid_scene::pet::PetState>
+pub pixtuoid_scene::pixel_painter::PixelCtx::buf: &'a mut pixtuoid_core::sprite::RgbBuffer
+pub pixtuoid_scene::pixel_painter::PixelCtx::chitchat_state: &'a mut std::collections::hash::map::HashMap<pixtuoid_scene::chitchat::VenueKey, pixtuoid_scene::chitchat::ActiveChitchat>
+pub pixtuoid_scene::pixel_painter::PixelCtx::coffee: &'a std::collections::hash::map::HashMap<pixtuoid_core::id::AgentId, std::time::SystemTime>
+pub pixtuoid_scene::pixel_painter::PixelCtx::debug_walkable: bool
+pub pixtuoid_scene::pixel_painter::PixelCtx::floor: pixtuoid_scene::floor::FloorMeta
+pub pixtuoid_scene::pixel_painter::PixelCtx::floor_pet: core::option::Option<&'a pixtuoid_scene::pet::Pet>
+pub pixtuoid_scene::pixel_painter::PixelCtx::layout: &'a pixtuoid_scene::layout::Layout
+pub pixtuoid_scene::pixel_painter::PixelCtx::now: std::time::SystemTime
+pub pixtuoid_scene::pixel_painter::PixelCtx::pack: &'a pixtuoid_core::sprite::format::Pack
+pub pixtuoid_scene::pixel_painter::PixelCtx::scene: &'a pixtuoid_core::state::SceneState
+pub pixtuoid_scene::pixel_painter::PixelCtx::store: &'a mut pixtuoid_scene::floor::FloorCtx
+pub pixtuoid_scene::pixel_painter::PixelCtx::theme: &'a pixtuoid_scene::theme::Theme
+impl<'a> core::marker::Freeze for pixtuoid_scene::pixel_painter::PixelCtx<'a>
+impl<'a> core::marker::Send for pixtuoid_scene::pixel_painter::PixelCtx<'a>
+impl<'a> core::marker::Sync for pixtuoid_scene::pixel_painter::PixelCtx<'a>
+impl<'a> core::marker::Unpin for pixtuoid_scene::pixel_painter::PixelCtx<'a>
+impl<'a> core::marker::UnsafeUnpin for pixtuoid_scene::pixel_painter::PixelCtx<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::pixel_painter::PixelCtx<'a>
+impl<'a> !core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::pixel_painter::PixelCtx<'a>
+pub struct pixtuoid_scene::pixel_painter::PixelPassResult
+pub pixtuoid_scene::pixel_painter::PixelPassResult::chitchat_bubbles: alloc::vec::Vec<pixtuoid_scene::chitchat::ChitchatBubble>
+pub pixtuoid_scene::pixel_painter::PixelPassResult::mascot_pos: core::option::Option<pixtuoid_scene::pixel_painter::MascotFrame>
+pub pixtuoid_scene::pixel_painter::PixelPassResult::new_coffee_carriers: alloc::vec::Vec<pixtuoid_core::id::AgentId>
+pub pixtuoid_scene::pixel_painter::PixelPassResult::occupied_waypoints: std::collections::hash::set::HashSet<usize>
+pub pixtuoid_scene::pixel_painter::PixelPassResult::pet_pos: core::option::Option<pixtuoid_scene::pet::PetFrame>
+impl core::marker::Freeze for pixtuoid_scene::pixel_painter::PixelPassResult
+impl core::marker::Send for pixtuoid_scene::pixel_painter::PixelPassResult
+impl core::marker::Sync for pixtuoid_scene::pixel_painter::PixelPassResult
+impl core::marker::Unpin for pixtuoid_scene::pixel_painter::PixelPassResult
+impl core::marker::UnsafeUnpin for pixtuoid_scene::pixel_painter::PixelPassResult
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::pixel_painter::PixelPassResult
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::pixel_painter::PixelPassResult
+pub struct pixtuoid_scene::pixel_painter::SimFrame
+pub pixtuoid_scene::pixel_painter::SimFrame::agents: alloc::vec::Vec<pixtuoid_core::state::AgentSlot>
+pub pixtuoid_scene::pixel_painter::SimFrame::characters: alloc::vec::Vec<pixtuoid_scene::pixel_painter::CharacterPlacement>
+pub pixtuoid_scene::pixel_painter::SimFrame::chitchat_bubbles: alloc::vec::Vec<pixtuoid_scene::chitchat::ChitchatBubble>
+pub pixtuoid_scene::pixel_painter::SimFrame::indoor_scale: f32
+pub pixtuoid_scene::pixel_painter::SimFrame::new_coffee_carriers: alloc::vec::Vec<pixtuoid_core::id::AgentId>
+pub pixtuoid_scene::pixel_painter::SimFrame::occupied_waypoints: std::collections::hash::set::HashSet<usize>
+pub pixtuoid_scene::pixel_painter::SimFrame::poses: std::collections::hash::map::HashMap<pixtuoid_core::id::AgentId, core::option::Option<pixtuoid_scene::pose::Pose>>
+pub pixtuoid_scene::pixel_painter::SimFrame::seated_agents: std::collections::hash::map::HashMap<pixtuoid_core::state::FloorLocalDeskIndex, bool>
+impl core::marker::Freeze for pixtuoid_scene::pixel_painter::SimFrame
+impl core::marker::Send for pixtuoid_scene::pixel_painter::SimFrame
+impl core::marker::Sync for pixtuoid_scene::pixel_painter::SimFrame
+impl core::marker::Unpin for pixtuoid_scene::pixel_painter::SimFrame
+impl core::marker::UnsafeUnpin for pixtuoid_scene::pixel_painter::SimFrame
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::pixel_painter::SimFrame
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::pixel_painter::SimFrame
+pub const pixtuoid_scene::pixel_painter::NEON_PANEL_INNER_H: u16
+pub const pixtuoid_scene::pixel_painter::NEON_PANEL_INNER_W: u16
+pub const pixtuoid_scene::pixel_painter::NEON_PANEL_INNER_X: u16
+pub const pixtuoid_scene::pixel_painter::NEON_PANEL_INNER_Y: u16
+pub const pixtuoid_scene::pixel_painter::NEON_PANEL_W: u16
+pub const pixtuoid_scene::pixel_painter::PANTRY_COFFEE_COLS_LARGE: (u16, u16)
+pub const pixtuoid_scene::pixel_painter::PANTRY_COFFEE_COLS_SMALL: (u16, u16)
+pub fn pixtuoid_scene::pixel_painter::character_anchor(&pixtuoid_core::state::AgentSlot, &pixtuoid_scene::layout::Layout, std::time::SystemTime, &mut pixtuoid_scene::pose::RouteCtx<'_>) -> core::option::Option<pixtuoid_scene::layout::Point>
+pub fn pixtuoid_scene::pixel_painter::force_weather(core::option::Option<&str>) -> core::result::Result<(), alloc::vec::Vec<&'static str>>
+pub fn pixtuoid_scene::pixel_painter::hour_is_day(f32) -> bool
+pub fn pixtuoid_scene::pixel_painter::is_day_at(std::time::SystemTime) -> bool
+pub fn pixtuoid_scene::pixel_painter::precipitation_level(std::time::SystemTime) -> f32
+pub fn pixtuoid_scene::pixel_painter::render_to_rgb_buffer(&mut pixtuoid_scene::pixel_painter::PixelCtx<'_>) -> pixtuoid_scene::pixel_painter::PixelPassResult
+pub fn pixtuoid_scene::pixel_painter::tool_glow_for_kind(pixtuoid_core::state::ToolKind, &pixtuoid_scene::theme::ToolGlowColors) -> pixtuoid_core::sprite::Rgb
+pub fn pixtuoid_scene::pixel_painter::weather_names() -> alloc::vec::Vec<&'static str>
+pub mod pixtuoid_scene::pose
+pub enum pixtuoid_scene::pose::Pose
+pub pixtuoid_scene::pose::Pose::AimlessAt
+pub pixtuoid_scene::pose::Pose::AimlessAt::dest: pixtuoid_scene::layout::Point
+pub pixtuoid_scene::pose::Pose::AtWaypoint
+pub pixtuoid_scene::pose::Pose::AtWaypoint::kind: pixtuoid_scene::layout::WaypointKind
+pub pixtuoid_scene::pose::Pose::AtWaypoint::wp: usize
+pub pixtuoid_scene::pose::Pose::SeatedIdle
+pub pixtuoid_scene::pose::Pose::SeatedThinking
+pub pixtuoid_scene::pose::Pose::SeatedTyping
+pub pixtuoid_scene::pose::Pose::SeatedTyping::frame: usize
+pub pixtuoid_scene::pose::Pose::StandingAtDesk
+pub pixtuoid_scene::pose::Pose::Walking
+pub pixtuoid_scene::pose::Pose::Walking::carrying_coffee: bool
+pub pixtuoid_scene::pose::Pose::Walking::frame: usize
+pub pixtuoid_scene::pose::Pose::Walking::from: pixtuoid_scene::layout::Point
+pub pixtuoid_scene::pose::Pose::Walking::t_x1000: u16
+pub pixtuoid_scene::pose::Pose::Walking::to: pixtuoid_scene::layout::Point
+impl core::clone::Clone for pixtuoid_scene::pose::Pose
+pub fn pixtuoid_scene::pose::Pose::clone(&self) -> pixtuoid_scene::pose::Pose
+impl core::cmp::Eq for pixtuoid_scene::pose::Pose
+impl core::cmp::PartialEq for pixtuoid_scene::pose::Pose
+pub fn pixtuoid_scene::pose::Pose::eq(&self, &pixtuoid_scene::pose::Pose) -> bool
+impl core::fmt::Debug for pixtuoid_scene::pose::Pose
+pub fn pixtuoid_scene::pose::Pose::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_scene::pose::Pose
+impl core::marker::StructuralPartialEq for pixtuoid_scene::pose::Pose
+impl core::marker::Freeze for pixtuoid_scene::pose::Pose
+impl core::marker::Send for pixtuoid_scene::pose::Pose
+impl core::marker::Sync for pixtuoid_scene::pose::Pose
+impl core::marker::Unpin for pixtuoid_scene::pose::Pose
+impl core::marker::UnsafeUnpin for pixtuoid_scene::pose::Pose
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::pose::Pose
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::pose::Pose
+pub struct pixtuoid_scene::pose::Personality
+pub pixtuoid_scene::pose::Personality::aimless_pref_pct: u8
+pub pixtuoid_scene::pose::Personality::trip_chance_pct: u8
+impl core::clone::Clone for pixtuoid_scene::pose::Personality
+pub fn pixtuoid_scene::pose::Personality::clone(&self) -> pixtuoid_scene::pose::Personality
+impl core::cmp::Eq for pixtuoid_scene::pose::Personality
+impl core::cmp::PartialEq for pixtuoid_scene::pose::Personality
+pub fn pixtuoid_scene::pose::Personality::eq(&self, &pixtuoid_scene::pose::Personality) -> bool
+impl core::fmt::Debug for pixtuoid_scene::pose::Personality
+pub fn pixtuoid_scene::pose::Personality::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_scene::pose::Personality
+impl core::marker::StructuralPartialEq for pixtuoid_scene::pose::Personality
+impl core::marker::Freeze for pixtuoid_scene::pose::Personality
+impl core::marker::Send for pixtuoid_scene::pose::Personality
+impl core::marker::Sync for pixtuoid_scene::pose::Personality
+impl core::marker::Unpin for pixtuoid_scene::pose::Personality
+impl core::marker::UnsafeUnpin for pixtuoid_scene::pose::Personality
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::pose::Personality
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::pose::Personality
+pub struct pixtuoid_scene::pose::PoseHistory
+impl pixtuoid_scene::pose::PoseHistory
+pub fn pixtuoid_scene::pose::PoseHistory::contains(&self, pixtuoid_core::id::AgentId) -> bool
+pub fn pixtuoid_scene::pose::PoseHistory::evict_missing(&mut self, &pixtuoid_core::state::SceneState)
+pub fn pixtuoid_scene::pose::PoseHistory::new() -> Self
+pub fn pixtuoid_scene::pose::PoseHistory::recent(&self, pixtuoid_core::id::AgentId, u64, std::time::SystemTime) -> core::option::Option<pixtuoid_scene::layout::Point>
+pub fn pixtuoid_scene::pose::PoseHistory::record(&mut self, pixtuoid_core::id::AgentId, pixtuoid_scene::layout::Point, std::time::SystemTime)
+impl core::clone::Clone for pixtuoid_scene::pose::PoseHistory
+pub fn pixtuoid_scene::pose::PoseHistory::clone(&self) -> pixtuoid_scene::pose::PoseHistory
+impl core::default::Default for pixtuoid_scene::pose::PoseHistory
+pub fn pixtuoid_scene::pose::PoseHistory::default() -> pixtuoid_scene::pose::PoseHistory
+impl core::fmt::Debug for pixtuoid_scene::pose::PoseHistory
+pub fn pixtuoid_scene::pose::PoseHistory::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for pixtuoid_scene::pose::PoseHistory
+impl core::marker::Send for pixtuoid_scene::pose::PoseHistory
+impl core::marker::Sync for pixtuoid_scene::pose::PoseHistory
+impl core::marker::Unpin for pixtuoid_scene::pose::PoseHistory
+impl core::marker::UnsafeUnpin for pixtuoid_scene::pose::PoseHistory
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::pose::PoseHistory
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::pose::PoseHistory
+pub struct pixtuoid_scene::pose::RouteCtx<'a>
+pub pixtuoid_scene::pose::RouteCtx::history: &'a mut pixtuoid_scene::pose::PoseHistory
+pub pixtuoid_scene::pose::RouteCtx::motion: &'a mut std::collections::hash::map::HashMap<pixtuoid_core::id::AgentId, pixtuoid_scene::motion::MotionState>
+pub pixtuoid_scene::pose::RouteCtx::overlay: &'a pixtuoid_core::walkable::OccupancyOverlay
+pub pixtuoid_scene::pose::RouteCtx::router: &'a mut dyn pixtuoid_scene::pathfind::Router
+impl<'a> core::marker::Freeze for pixtuoid_scene::pose::RouteCtx<'a>
+impl<'a> !core::marker::Send for pixtuoid_scene::pose::RouteCtx<'a>
+impl<'a> !core::marker::Sync for pixtuoid_scene::pose::RouteCtx<'a>
+impl<'a> core::marker::Unpin for pixtuoid_scene::pose::RouteCtx<'a>
+impl<'a> core::marker::UnsafeUnpin for pixtuoid_scene::pose::RouteCtx<'a>
+impl<'a> !core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::pose::RouteCtx<'a>
+impl<'a> !core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::pose::RouteCtx<'a>
+pub const pixtuoid_scene::pose::ENTRY_ANIMATION_MS: u64
+pub const pixtuoid_scene::pose::STALE_RESUME_GAP_BASE_MS: u64
+pub const pixtuoid_scene::pose::STALE_RESUME_GAP_RANGE_MS: u64
+pub const pixtuoid_scene::pose::THINKING_WINDOW_SECS: u64
+pub const pixtuoid_scene::pose::TYPING_FRAMES: usize
+pub const pixtuoid_scene::pose::TYPING_FRAME_MS: u64
+pub const pixtuoid_scene::pose::WALKING_FRAMES: usize
+pub const pixtuoid_scene::pose::WALKING_FRAME_MS: u64
+pub const pixtuoid_scene::pose::WANDER_DWELL_EST_MS: u64
+pub const pixtuoid_scene::pose::WANDER_WALK_EST_MS: u64
+pub fn pixtuoid_scene::pose::aimless_wander_seed(pixtuoid_core::id::AgentId, u64) -> u64
+pub fn pixtuoid_scene::pose::derive(&pixtuoid_core::state::AgentSlot, std::time::SystemTime, &pixtuoid_scene::layout::SceneLayout) -> core::option::Option<pixtuoid_scene::pose::Pose>
+pub fn pixtuoid_scene::pose::derive_state_only(&pixtuoid_core::state::AgentSlot, std::time::SystemTime, &pixtuoid_scene::layout::SceneLayout) -> core::option::Option<pixtuoid_scene::pose::Pose>
+pub fn pixtuoid_scene::pose::derive_with_routing(&pixtuoid_core::state::AgentSlot, std::time::SystemTime, &pixtuoid_scene::layout::Layout, &mut pixtuoid_scene::pose::RouteCtx<'_>) -> core::option::Option<pixtuoid_scene::pose::Pose>
+pub fn pixtuoid_scene::pose::dwell_ms(pixtuoid_scene::layout::WaypointKind, pixtuoid_core::id::AgentId) -> u64
+pub fn pixtuoid_scene::pose::est_wander_cycle_ms(pixtuoid_core::id::AgentId) -> u64
+pub fn pixtuoid_scene::pose::is_aimless_cycle(pixtuoid_core::id::AgentId, u64) -> bool
+pub fn pixtuoid_scene::pose::personality_for(pixtuoid_core::id::AgentId) -> pixtuoid_scene::pose::Personality
+pub fn pixtuoid_scene::pose::pick_aimless_dest(&pixtuoid_scene::layout::SceneLayout, u64, pixtuoid_scene::layout::Point) -> pixtuoid_scene::layout::Point
+pub fn pixtuoid_scene::pose::seated_dwell_ms(pixtuoid_core::id::AgentId) -> u64
+pub fn pixtuoid_scene::pose::stale_resume_gap_ms(pixtuoid_core::id::AgentId) -> u64
+pub fn pixtuoid_scene::pose::takes_trip(pixtuoid_core::id::AgentId, u64) -> bool
+pub fn pixtuoid_scene::pose::walking_frame(u64) -> usize
+pub fn pixtuoid_scene::pose::waypoint_index_for_cycle(pixtuoid_core::id::AgentId, u64, usize) -> usize
+pub mod pixtuoid_scene::theme
+pub enum pixtuoid_scene::theme::ThemeKind
+pub pixtuoid_scene::theme::ThemeKind::Dark
+pub pixtuoid_scene::theme::ThemeKind::Light
+impl core::clone::Clone for pixtuoid_scene::theme::ThemeKind
+pub fn pixtuoid_scene::theme::ThemeKind::clone(&self) -> pixtuoid_scene::theme::ThemeKind
+impl core::cmp::Eq for pixtuoid_scene::theme::ThemeKind
+impl core::cmp::PartialEq for pixtuoid_scene::theme::ThemeKind
+pub fn pixtuoid_scene::theme::ThemeKind::eq(&self, &pixtuoid_scene::theme::ThemeKind) -> bool
+impl core::fmt::Debug for pixtuoid_scene::theme::ThemeKind
+pub fn pixtuoid_scene::theme::ThemeKind::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for pixtuoid_scene::theme::ThemeKind
+impl core::marker::StructuralPartialEq for pixtuoid_scene::theme::ThemeKind
+impl core::marker::Freeze for pixtuoid_scene::theme::ThemeKind
+impl core::marker::Send for pixtuoid_scene::theme::ThemeKind
+impl core::marker::Sync for pixtuoid_scene::theme::ThemeKind
+impl core::marker::Unpin for pixtuoid_scene::theme::ThemeKind
+impl core::marker::UnsafeUnpin for pixtuoid_scene::theme::ThemeKind
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::theme::ThemeKind
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::theme::ThemeKind
+pub struct pixtuoid_scene::theme::ApplianceColors
+pub pixtuoid_scene::theme::ApplianceColors::coats: [pixtuoid_core::sprite::Rgb; 3]
+pub pixtuoid_scene::theme::ApplianceColors::printer_body: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::ApplianceColors::printer_glass: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::ApplianceColors::printer_paper: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::ApplianceColors::printer_top: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::ApplianceColors::printer_tray: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::ApplianceColors::vending_body: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::ApplianceColors::vending_dark: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::ApplianceColors::vending_drinks: [pixtuoid_core::sprite::Rgb; 4]
+pub pixtuoid_scene::theme::ApplianceColors::vending_panel: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::ApplianceColors::vending_trim: pixtuoid_core::sprite::Rgb
+impl core::clone::Clone for pixtuoid_scene::theme::ApplianceColors
+pub fn pixtuoid_scene::theme::ApplianceColors::clone(&self) -> pixtuoid_scene::theme::ApplianceColors
+impl core::fmt::Debug for pixtuoid_scene::theme::ApplianceColors
+pub fn pixtuoid_scene::theme::ApplianceColors::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for pixtuoid_scene::theme::ApplianceColors
+impl core::marker::Send for pixtuoid_scene::theme::ApplianceColors
+impl core::marker::Sync for pixtuoid_scene::theme::ApplianceColors
+impl core::marker::Unpin for pixtuoid_scene::theme::ApplianceColors
+impl core::marker::UnsafeUnpin for pixtuoid_scene::theme::ApplianceColors
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::theme::ApplianceColors
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::theme::ApplianceColors
+pub struct pixtuoid_scene::theme::EffectColors
+pub pixtuoid_scene::theme::EffectColors::coffee_steam: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::EffectColors::monitor_frame_lit: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::EffectColors::sleep_z: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::EffectColors::waiting_bubble: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::EffectColors::walking_dust: pixtuoid_core::sprite::Rgb
+impl core::clone::Clone for pixtuoid_scene::theme::EffectColors
+pub fn pixtuoid_scene::theme::EffectColors::clone(&self) -> pixtuoid_scene::theme::EffectColors
+impl core::fmt::Debug for pixtuoid_scene::theme::EffectColors
+pub fn pixtuoid_scene::theme::EffectColors::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for pixtuoid_scene::theme::EffectColors
+impl core::marker::Send for pixtuoid_scene::theme::EffectColors
+impl core::marker::Sync for pixtuoid_scene::theme::EffectColors
+impl core::marker::Unpin for pixtuoid_scene::theme::EffectColors
+impl core::marker::UnsafeUnpin for pixtuoid_scene::theme::EffectColors
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::theme::EffectColors
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::theme::EffectColors
+pub struct pixtuoid_scene::theme::FurnitureColors
+pub pixtuoid_scene::theme::FurnitureColors::chair_trim: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::FurnitureColors::coffee_cup: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::FurnitureColors::coffee_cup_shadow: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::FurnitureColors::magazine: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::FurnitureColors::magazine_trim: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::FurnitureColors::paper: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::FurnitureColors::paper_shade: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::FurnitureColors::rug_accent: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::FurnitureColors::rug_field: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::FurnitureColors::rug_trim: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::FurnitureColors::tank_fish: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::FurnitureColors::tank_fish_alt: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::FurnitureColors::tank_plant: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::FurnitureColors::tank_water: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::FurnitureColors::tank_water_line: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::FurnitureColors::wood_top: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::FurnitureColors::wood_trim: pixtuoid_core::sprite::Rgb
+impl core::clone::Clone for pixtuoid_scene::theme::FurnitureColors
+pub fn pixtuoid_scene::theme::FurnitureColors::clone(&self) -> pixtuoid_scene::theme::FurnitureColors
+impl core::fmt::Debug for pixtuoid_scene::theme::FurnitureColors
+pub fn pixtuoid_scene::theme::FurnitureColors::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for pixtuoid_scene::theme::FurnitureColors
+impl core::marker::Send for pixtuoid_scene::theme::FurnitureColors
+impl core::marker::Sync for pixtuoid_scene::theme::FurnitureColors
+impl core::marker::Unpin for pixtuoid_scene::theme::FurnitureColors
+impl core::marker::UnsafeUnpin for pixtuoid_scene::theme::FurnitureColors
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::theme::FurnitureColors
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::theme::FurnitureColors
+pub struct pixtuoid_scene::theme::LightingColors
+pub pixtuoid_scene::theme::LightingColors::ceiling_pool: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::LightingColors::day_sky_a: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::LightingColors::day_sky_b: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::LightingColors::floor_lamp_halo: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::LightingColors::moon_core: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::LightingColors::night_sky_a: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::LightingColors::night_sky_b: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::LightingColors::night_tint: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::LightingColors::sun_core: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::LightingColors::sun_spill: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::LightingColors::twilight_a: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::LightingColors::twilight_b: pixtuoid_core::sprite::Rgb
+impl core::clone::Clone for pixtuoid_scene::theme::LightingColors
+pub fn pixtuoid_scene::theme::LightingColors::clone(&self) -> pixtuoid_scene::theme::LightingColors
+impl core::fmt::Debug for pixtuoid_scene::theme::LightingColors
+pub fn pixtuoid_scene::theme::LightingColors::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for pixtuoid_scene::theme::LightingColors
+impl core::marker::Send for pixtuoid_scene::theme::LightingColors
+impl core::marker::Sync for pixtuoid_scene::theme::LightingColors
+impl core::marker::Unpin for pixtuoid_scene::theme::LightingColors
+impl core::marker::UnsafeUnpin for pixtuoid_scene::theme::LightingColors
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::theme::LightingColors
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::theme::LightingColors
+pub struct pixtuoid_scene::theme::OfficeColors
+pub pixtuoid_scene::theme::OfficeColors::building_dark: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::OfficeColors::building_light: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::OfficeColors::city_dark_window: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::OfficeColors::city_lit_windows: [pixtuoid_core::sprite::Rgb; 3]
+pub pixtuoid_scene::theme::OfficeColors::clock_face: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::OfficeColors::clock_hand: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::OfficeColors::clock_rim: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::OfficeColors::cubicle_divider: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::OfficeColors::neon_frame_base: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::OfficeColors::neon_panel_bg: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::OfficeColors::room_wall_trim_dark: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::OfficeColors::room_wall_trim_light: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::OfficeColors::runner_base: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::OfficeColors::runner_edge: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::OfficeColors::runner_stripe: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::OfficeColors::shadow: pixtuoid_core::sprite::Rgb
+impl core::clone::Clone for pixtuoid_scene::theme::OfficeColors
+pub fn pixtuoid_scene::theme::OfficeColors::clone(&self) -> pixtuoid_scene::theme::OfficeColors
+impl core::fmt::Debug for pixtuoid_scene::theme::OfficeColors
+pub fn pixtuoid_scene::theme::OfficeColors::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for pixtuoid_scene::theme::OfficeColors
+impl core::marker::Send for pixtuoid_scene::theme::OfficeColors
+impl core::marker::Sync for pixtuoid_scene::theme::OfficeColors
+impl core::marker::Unpin for pixtuoid_scene::theme::OfficeColors
+impl core::marker::UnsafeUnpin for pixtuoid_scene::theme::OfficeColors
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::theme::OfficeColors
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::theme::OfficeColors
+pub struct pixtuoid_scene::theme::SourceColors
+pub pixtuoid_scene::theme::SourceColors::antigravity: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::SourceColors::claude_code: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::SourceColors::codewhale: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::SourceColors::codex: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::SourceColors::copilot: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::SourceColors::cursor: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::SourceColors::grok: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::SourceColors::hermes: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::SourceColors::kimi: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::SourceColors::omp: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::SourceColors::openclaw: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::SourceColors::opencode: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::SourceColors::reasonix: pixtuoid_core::sprite::Rgb
+impl pixtuoid_scene::theme::SourceColors
+pub fn pixtuoid_scene::theme::SourceColors::all(&self) -> [pixtuoid_core::sprite::Rgb; 13]
+pub fn pixtuoid_scene::theme::SourceColors::by_prefix(&self, &str) -> core::option::Option<pixtuoid_core::sprite::Rgb>
+impl core::clone::Clone for pixtuoid_scene::theme::SourceColors
+pub fn pixtuoid_scene::theme::SourceColors::clone(&self) -> pixtuoid_scene::theme::SourceColors
+impl core::fmt::Debug for pixtuoid_scene::theme::SourceColors
+pub fn pixtuoid_scene::theme::SourceColors::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for pixtuoid_scene::theme::SourceColors
+impl core::marker::Send for pixtuoid_scene::theme::SourceColors
+impl core::marker::Sync for pixtuoid_scene::theme::SourceColors
+impl core::marker::Unpin for pixtuoid_scene::theme::SourceColors
+impl core::marker::UnsafeUnpin for pixtuoid_scene::theme::SourceColors
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::theme::SourceColors
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::theme::SourceColors
+pub struct pixtuoid_scene::theme::SurfaceColors
+pub pixtuoid_scene::theme::SurfaceColors::bg_fallback: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::SurfaceColors::carpet_base: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::SurfaceColors::carpet_dark: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::SurfaceColors::carpet_light: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::SurfaceColors::wall: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::SurfaceColors::wall_trim: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::SurfaceColors::window_frame: pixtuoid_core::sprite::Rgb
+impl core::clone::Clone for pixtuoid_scene::theme::SurfaceColors
+pub fn pixtuoid_scene::theme::SurfaceColors::clone(&self) -> pixtuoid_scene::theme::SurfaceColors
+impl core::fmt::Debug for pixtuoid_scene::theme::SurfaceColors
+pub fn pixtuoid_scene::theme::SurfaceColors::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for pixtuoid_scene::theme::SurfaceColors
+impl core::marker::Send for pixtuoid_scene::theme::SurfaceColors
+impl core::marker::Sync for pixtuoid_scene::theme::SurfaceColors
+impl core::marker::Unpin for pixtuoid_scene::theme::SurfaceColors
+impl core::marker::UnsafeUnpin for pixtuoid_scene::theme::SurfaceColors
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::theme::SurfaceColors
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::theme::SurfaceColors
+pub struct pixtuoid_scene::theme::Theme
+pub pixtuoid_scene::theme::Theme::appliance: pixtuoid_scene::theme::ApplianceColors
+pub pixtuoid_scene::theme::Theme::effects: pixtuoid_scene::theme::EffectColors
+pub pixtuoid_scene::theme::Theme::furniture: pixtuoid_scene::theme::FurnitureColors
+pub pixtuoid_scene::theme::Theme::kind: pixtuoid_scene::theme::ThemeKind
+pub pixtuoid_scene::theme::Theme::lighting: pixtuoid_scene::theme::LightingColors
+pub pixtuoid_scene::theme::Theme::name: &'static str
+pub pixtuoid_scene::theme::Theme::office: pixtuoid_scene::theme::OfficeColors
+pub pixtuoid_scene::theme::Theme::source: pixtuoid_scene::theme::SourceColors
+pub pixtuoid_scene::theme::Theme::surface: pixtuoid_scene::theme::SurfaceColors
+pub pixtuoid_scene::theme::Theme::tool_glow: pixtuoid_scene::theme::ToolGlowColors
+pub pixtuoid_scene::theme::Theme::ui: pixtuoid_scene::theme::UiColors
+impl core::clone::Clone for pixtuoid_scene::theme::Theme
+pub fn pixtuoid_scene::theme::Theme::clone(&self) -> pixtuoid_scene::theme::Theme
+impl core::fmt::Debug for pixtuoid_scene::theme::Theme
+pub fn pixtuoid_scene::theme::Theme::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for pixtuoid_scene::theme::Theme
+impl core::marker::Send for pixtuoid_scene::theme::Theme
+impl core::marker::Sync for pixtuoid_scene::theme::Theme
+impl core::marker::Unpin for pixtuoid_scene::theme::Theme
+impl core::marker::UnsafeUnpin for pixtuoid_scene::theme::Theme
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::theme::Theme
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::theme::Theme
+pub struct pixtuoid_scene::theme::ToolGlowColors
+pub pixtuoid_scene::theme::ToolGlowColors::agent: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::ToolGlowColors::bash: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::ToolGlowColors::default: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::ToolGlowColors::edit: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::ToolGlowColors::grep: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::ToolGlowColors::read: pixtuoid_core::sprite::Rgb
+impl core::clone::Clone for pixtuoid_scene::theme::ToolGlowColors
+pub fn pixtuoid_scene::theme::ToolGlowColors::clone(&self) -> pixtuoid_scene::theme::ToolGlowColors
+impl core::fmt::Debug for pixtuoid_scene::theme::ToolGlowColors
+pub fn pixtuoid_scene::theme::ToolGlowColors::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for pixtuoid_scene::theme::ToolGlowColors
+impl core::marker::Send for pixtuoid_scene::theme::ToolGlowColors
+impl core::marker::Sync for pixtuoid_scene::theme::ToolGlowColors
+impl core::marker::Unpin for pixtuoid_scene::theme::ToolGlowColors
+impl core::marker::UnsafeUnpin for pixtuoid_scene::theme::ToolGlowColors
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::theme::ToolGlowColors
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::theme::ToolGlowColors
+pub struct pixtuoid_scene::theme::UiColors
+pub pixtuoid_scene::theme::UiColors::label_active: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::UiColors::label_exiting: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::UiColors::label_idle: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::UiColors::label_waiting: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::UiColors::neon_brand: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::UiColors::neon_star: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::UiColors::tooltip_bg: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::UiColors::tooltip_dim: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::UiColors::tooltip_text: pixtuoid_core::sprite::Rgb
+pub pixtuoid_scene::theme::UiColors::tooltip_title: pixtuoid_core::sprite::Rgb
+impl core::clone::Clone for pixtuoid_scene::theme::UiColors
+pub fn pixtuoid_scene::theme::UiColors::clone(&self) -> pixtuoid_scene::theme::UiColors
+impl core::fmt::Debug for pixtuoid_scene::theme::UiColors
+pub fn pixtuoid_scene::theme::UiColors::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for pixtuoid_scene::theme::UiColors
+impl core::marker::Send for pixtuoid_scene::theme::UiColors
+impl core::marker::Sync for pixtuoid_scene::theme::UiColors
+impl core::marker::Unpin for pixtuoid_scene::theme::UiColors
+impl core::marker::UnsafeUnpin for pixtuoid_scene::theme::UiColors
+impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_scene::theme::UiColors
+impl core::panic::unwind_safe::UnwindSafe for pixtuoid_scene::theme::UiColors
+pub static pixtuoid_scene::theme::ALL_THEMES: &[&pixtuoid_scene::theme::Theme]
+pub static pixtuoid_scene::theme::CATPPUCCIN: pixtuoid_scene::theme::Theme
+pub static pixtuoid_scene::theme::CYBERPUNK: pixtuoid_scene::theme::Theme
+pub static pixtuoid_scene::theme::DRACULA: pixtuoid_scene::theme::Theme
+pub static pixtuoid_scene::theme::GRUVBOX: pixtuoid_scene::theme::Theme
+pub static pixtuoid_scene::theme::NORMAL: pixtuoid_scene::theme::Theme
+pub static pixtuoid_scene::theme::TOKYO_NIGHT: pixtuoid_scene::theme::Theme
+pub fn pixtuoid_scene::theme::theme_by_name(&str) -> core::option::Option<&'static pixtuoid_scene::theme::Theme>
+pub mod pixtuoid_scene::token_meter
+pub fn pixtuoid_scene::token_meter::compact_tokens(u64) -> alloc::string::String
+pub fn pixtuoid_scene::token_meter::token_tier(u64) -> u8

--- a/crates/pixtuoid-core/src/id.rs
+++ b/crates/pixtuoid-core/src/id.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+/// An opaque, source-namespaced session identifier — a 64-bit FNV-1a hash of
+/// `(source, opaque_id)` (see [`AgentId::from_parts`]), so two sources never
+/// collide on the same opaque id.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct AgentId(u64);
 
@@ -117,6 +120,8 @@ impl AgentId {
         AgentId(hash)
     }
 
+    /// The underlying 64-bit hash — the personality slicers key per-agent
+    /// variation off it by taking a bit window (see [`splitmix64`]).
     pub fn raw(self) -> u64 {
         self.0
     }

--- a/crates/pixtuoid-core/src/lib.rs
+++ b/crates/pixtuoid-core/src/lib.rs
@@ -1,4 +1,38 @@
 //! pixtuoid-core: headless logic for the pixtuoid TUI.
+//!
+//! The crate turns a stream of decoded agent-CLI events into an office
+//! [`SceneState`]: [`Reducer::apply`] folds each [`AgentEvent`] (tagged with the
+//! [`Transport`] it arrived on) into the per-agent slots a renderer then paints.
+//! It has no terminal dependency — the pixel/terminal painters live crate-up in
+//! `pixtuoid-scene` and the `pixtuoid` binary.
+//!
+//! ```
+//! use std::path::PathBuf;
+//! use std::time::SystemTime;
+//!
+//! use pixtuoid_core::{AgentEvent, AgentId, Reducer, SceneState, Transport};
+//!
+//! let mut scene = SceneState::uniform(4); // one floor, 4 desks
+//! let mut reducer = Reducer::new();
+//! let id = AgentId::from_parts("claude-code", "session-1");
+//!
+//! reducer.apply(
+//!     &mut scene,
+//!     AgentEvent::SessionStart {
+//!         agent_id: id,
+//!         source: "claude-code".into(),
+//!         session_id: "session-1".into(),
+//!         cwd: PathBuf::from("/repo"),
+//!         parent_id: None,
+//!     },
+//!     SystemTime::now(),
+//!     Transport::Hook,
+//! );
+//!
+//! // The session now occupies a desk, labelled `<source-prefix>·<cwd-basename>`.
+//! let slot = scene.agents.get(&id).expect("the session took a desk");
+//! assert_eq!(&*slot.label, "cc·repo");
+//! ```
 
 // Invariant #1: this crate is headless and must never write to a terminal.
 // `just arch` greps the dep tree (ratatui/crossterm), but a raw `println!`
@@ -6,12 +40,24 @@
 // gap (a hard error under the workspace `-D warnings`). Non-test builds only,
 // so test diagnostics may print freely.
 #![cfg_attr(not(test), warn(clippy::print_stdout, clippy::print_stderr))]
+// Public-API doc gate. Scoped to this PUBLISHED crate (not `[workspace.lints]`)
+// because the binary crates' `pub` items aren't a semver surface — the same
+// two-crate scope as the semver-checks + api-surface gates. `-D warnings`
+// (`just clippy`) promotes it to a hard gate; `#[doc(hidden)] pub` is exempt.
+#![warn(missing_docs)]
 
 pub mod grid;
+/// Agent identity: the `AgentId` session key and its path/parts derivations.
 pub mod id;
 pub mod platform;
+/// The source/decoder seam — the `Source` trait, per-CLI transcript/hook
+/// decoders, listeners, and the `SourceManager`.
 pub mod source;
+/// Sprite vocabulary: `Frame`/`Sprite`/`Palette`, the `RgbBuffer` blit target,
+/// and the `.sprite`/`pack.toml` pack loader.
 pub mod sprite;
+/// The reducer and `SceneState` — the event coordinator turning `AgentEvent`s
+/// into per-agent slot state.
 pub mod state;
 // Coherence-bound residue of the sim-geometry move to `pixtuoid-scene`:
 // `WalkableMask` is an ALIAS for `Grid<bool>` whose obstacle ops are an

--- a/crates/pixtuoid-core/src/source/antigravity.rs
+++ b/crates/pixtuoid-core/src/source/antigravity.rs
@@ -13,8 +13,10 @@ mod native;
 #[cfg(feature = "native")]
 pub use native::AntigravitySource;
 
+/// The Antigravity CLI source's registry name (its `SourceDescriptor.name`).
 pub const SOURCE_NAME: &str = "antigravity";
 
+/// Decode one Antigravity CLI transcript line into `AgentEvent`s (the step_index / tool_calls JSONL schema).
 pub fn decode_ag_line(transcript_path: &str, source: &str, v: Value) -> Result<Vec<AgentEvent>> {
     let agent_id = AgentId::from_parts(source, transcript_path);
     let Some(obj) = v.as_object() else {

--- a/crates/pixtuoid-core/src/source/antigravity/native.rs
+++ b/crates/pixtuoid-core/src/source/antigravity/native.rs
@@ -17,6 +17,7 @@ use crate::source::{Source, TaggedSender};
 /// Uses JsonlWatcher with a custom decoder for the Antigravity JSONL
 /// format (step_index/PLANNER_RESPONSE/tool_calls schema).
 pub struct AntigravitySource {
+    /// The watched Antigravity brain-dir root; conversation-log JSONL lives under it.
     pub brain_root: PathBuf,
 }
 

--- a/crates/pixtuoid-core/src/source/claude_code/native.rs
+++ b/crates/pixtuoid-core/src/source/claude_code/native.rs
@@ -25,6 +25,7 @@ use crate::source::{Source, TaggedSender};
 /// ride that one socket), so this is now ONLY the `~/.claude/projects` JSONL
 /// watcher: no socket bind, no presence/pid plumbing, no dual-task `select!`.
 pub struct ClaudeCodeSource {
+    /// The watched `~/.claude/projects` transcript root.
     pub projects_root: PathBuf,
     /// The #246 child-end un-claim side-channel — CONSUMER only now (its watcher
     /// releases CC child-transcript claims on the rare blocked-stop continuation;
@@ -39,6 +40,7 @@ impl ClaudeCodeSource {
     // binds the socket — the `HookRouter` does — but this is the shim↔daemon
     // parity bridge anchor, pinned by tests/socket_path_parity.rs). The driver
     // resolves it here and hands it to `HookRouter::new`.
+    /// Resolve the hook rendezvous path — a Unix socket (or Windows named pipe) the shim connects to and the daemon binds.
     pub fn default_socket_path() -> PathBuf {
         if let Ok(p) = std::env::var("PIXTUOID_SOCKET") {
             // Set-but-empty/whitespace = unset (the #172 RUST_LOG policy): an
@@ -77,6 +79,7 @@ impl ClaudeCodeSource {
         }
     }
 
+    /// Construct pointed at the default `~/.claude/projects` root.
     pub fn default_paths() -> Self {
         let projects_root = claude_config_dir()
             .unwrap_or_else(|| PathBuf::from(crate::platform::user_home()).join(".claude"))

--- a/crates/pixtuoid-core/src/source/codewhale.rs
+++ b/crates/pixtuoid-core/src/source/codewhale.rs
@@ -68,6 +68,7 @@ use serde_json::Value;
 use crate::source::{AgentEvent, ToolDetail};
 use crate::AgentId;
 
+/// The CodeWhale CLI source's registry name (its `SourceDescriptor.name`).
 pub const SOURCE_NAME: &str = "codewhale";
 
 /// CodeWhale tools that dispatch a sub-agent (`crates/tui/src/tools/subagent`

--- a/crates/pixtuoid-core/src/source/codex.rs
+++ b/crates/pixtuoid-core/src/source/codex.rs
@@ -26,6 +26,7 @@ mod native;
 #[cfg(feature = "native")]
 pub use native::{live_codex_rollout_ids, CodexSource};
 
+/// The Codex CLI source's registry name (its `SourceDescriptor.name`).
 pub const SOURCE_NAME: &str = "codex";
 
 /// Trailing canonical UUID (`8-4-4-4-12`) of a `rollout-<ts>-<UUID>.jsonl`

--- a/crates/pixtuoid-core/src/source/codex/native.rs
+++ b/crates/pixtuoid-core/src/source/codex/native.rs
@@ -90,6 +90,7 @@ fn codex_probe_root_resolved(sessions_root: &Path, home: &Path) -> Option<PathBu
 
 /// Source that watches the Codex session transcript directory.
 pub struct CodexSource {
+    /// The watched Codex `sessions` rollout root (`~/.codex/sessions`).
     pub sessions_root: PathBuf,
     /// The #246 child-end un-claim side-channel — Codex is consumer-only:
     /// its `SubagentStop` hooks ride the shared socket the `HookRouter`
@@ -102,6 +103,7 @@ pub struct CodexSource {
 }
 
 impl CodexSource {
+    /// Construct pointed at the default Codex `sessions` rollout root.
     pub fn default_paths() -> Self {
         Self {
             sessions_root: codex_home().join("sessions"),

--- a/crates/pixtuoid-core/src/source/copilot.rs
+++ b/crates/pixtuoid-core/src/source/copilot.rs
@@ -49,6 +49,7 @@ mod native;
 #[cfg(feature = "native")]
 pub use native::CopilotSource;
 
+/// The GitHub Copilot CLI source's registry name (its `SourceDescriptor.name`).
 pub const SOURCE_NAME: &str = "copilot";
 
 /// `$COPILOT_HOME` if set, else `~/.copilot`. An empty OR whitespace-only

--- a/crates/pixtuoid-core/src/source/copilot/native.rs
+++ b/crates/pixtuoid-core/src/source/copilot/native.rs
@@ -35,10 +35,12 @@ fn copilot_session_ended(tail: &[u8]) -> bool {
 
 /// Source that watches the Copilot session-state directory.
 pub struct CopilotSource {
+    /// The watched Copilot `session-state` root; each session's `events.jsonl` lives under it.
     pub sessions_root: PathBuf,
 }
 
 impl CopilotSource {
+    /// Construct pointed at the default Copilot `session-state` root.
     pub fn default_paths() -> Self {
         Self {
             sessions_root: copilot_home().join("session-state"),

--- a/crates/pixtuoid-core/src/source/cursor.rs
+++ b/crates/pixtuoid-core/src/source/cursor.rs
@@ -66,6 +66,7 @@ use serde_json::Value;
 use crate::source::{AgentEvent, ToolDetail};
 use crate::AgentId;
 
+/// The Cursor CLI source's registry name (its `SourceDescriptor.name`).
 pub const SOURCE_NAME: &str = "cursor";
 
 /// Decode one Cursor hook payload (already identified by

--- a/crates/pixtuoid-core/src/source/daemon.rs
+++ b/crates/pixtuoid-core/src/source/daemon.rs
@@ -39,7 +39,10 @@ pub use native::{spawn_presence_exit_watch, PresenceExitWatch, PresenceSender};
 pub enum DaemonPresenceUpdate {
     /// `gateway_start` — the daemon is up; `pid` (its `process.pid`) is armed
     /// for `ExitWatch`. UP-winning + idempotent; resets the session count.
-    GatewayUp { pid: Option<i32> },
+    GatewayUp {
+        /// The gateway's `process.pid`, armed for the abrupt-down exit watch (`None` if unknown).
+        pid: Option<i32>,
+    },
     /// `gateway_stop` — clean shutdown.
     GatewayDown,
     /// `session_start` — a multiplexed session began (bumps the bubble count).
@@ -47,21 +50,36 @@ pub enum DaemonPresenceUpdate {
     /// `session_end` — a session ended.
     SessionEnded,
     /// `before_agent_run` — a turn entered flight, keyed for self-healing busy.
-    RunStarted { run_key: String },
+    RunStarted {
+        /// Correlates this turn with its later `RunEnded`/`RunFailed`.
+        run_key: String,
+    },
     /// `agent_end` with `success: true` — a turn completed OK.
-    RunEnded { run_key: String },
+    RunEnded {
+        /// The completed turn's correlation key (matches its `RunStarted`).
+        run_key: String,
+    },
     /// `agent_end` with `success: false` (#317) — a turn FAILED (the model
     /// backend is broken: auth revoked, provider down). Drives `Degraded`.
-    RunFailed { run_key: String },
+    RunFailed {
+        /// The failed turn's correlation key (matches its `RunStarted`).
+        run_key: String,
+    },
     /// A live gateway pid OBSERVED on any event carrying `_pid` (#318) — adopted
     /// into `current_pid` ONLY when it was `None`, so a MID-ATTACH or a
     /// reconnect-while-alive can still arm the abrupt-down exit watch even though
     /// it never saw the `gateway_start` that carries the pid via `GatewayUp`.
     /// Does NOT change `DaemonState` (it's a pure pid adoption). `GatewayUp` still
     /// owns restart-rebinds (overwrites), so `PidSeen` never clobbers a known pid.
-    PidSeen { pid: i32 },
+    PidSeen {
+        /// The live gateway pid observed on the event.
+        pid: i32,
+    },
     /// The armed gateway pid died (from the `ExitWatch` drain, not a decoder).
-    PidExited { pid: i32 },
+    PidExited {
+        /// The gateway pid that exited.
+        pid: i32,
+    },
 }
 
 /// A presence delta tagged with WHICH daemon it belongs to — the routing key for
@@ -71,7 +89,9 @@ pub enum DaemonPresenceUpdate {
 /// read positionally at the seam.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PresenceMsg {
+    /// The daemon source name this delta routes to (`daemons[source]`).
     pub source: String,
+    /// The presence delta to apply to that daemon.
     pub delta: DaemonPresenceUpdate,
 }
 

--- a/crates/pixtuoid-core/src/source/grok.rs
+++ b/crates/pixtuoid-core/src/source/grok.rs
@@ -62,6 +62,7 @@ mod native;
 #[cfg(feature = "native")]
 pub use native::{live_grok_session_ids, GrokSource};
 
+/// The Grok Build source's registry name (its `SourceDescriptor.name`).
 pub const SOURCE_NAME: &str = "grok";
 
 /// Decode one grok hook payload (already identified by

--- a/crates/pixtuoid-core/src/source/grok/native.rs
+++ b/crates/pixtuoid-core/src/source/grok/native.rs
@@ -329,6 +329,7 @@ fn grok_probe_root_resolved(sessions_root: &Path, home: &Path) -> Option<PathBuf
 
 /// Source that watches the grok session transcript tree.
 pub struct GrokSource {
+    /// The watched grok session-transcript root; per-session `updates.jsonl` lives under it.
     pub sessions_root: PathBuf,
     /// The #246 child-end un-claim side-channel — grok is consumer-only like
     /// Codex: its `subagent_stop`/`subagent_end` hooks decode to Hook-transport
@@ -341,6 +342,7 @@ pub struct GrokSource {
 }
 
 impl GrokSource {
+    /// Construct pointed at the default grok `sessions` root.
     pub fn default_paths() -> Self {
         Self {
             sessions_root: grok_home().join("sessions"),

--- a/crates/pixtuoid-core/src/source/grok/native.rs
+++ b/crates/pixtuoid-core/src/source/grok/native.rs
@@ -91,6 +91,9 @@ pub fn live_grok_session_ids(grok_root: &Path) -> Option<ProbeSnapshot> {
     }
 }
 
+/// Non-Unix stub — grok's `active_sessions.json` liveness probe is Unix-only
+/// (the pid-liveness + kernel-start recycle check it needs), so on Windows it
+/// always returns `None` and grok liveness degrades to pure mtime gating.
 #[cfg(not(unix))]
 pub fn live_grok_session_ids(_grok_root: &Path) -> Option<ProbeSnapshot> {
     None

--- a/crates/pixtuoid-core/src/source/hermes.rs
+++ b/crates/pixtuoid-core/src/source/hermes.rs
@@ -61,6 +61,7 @@ use serde_json::Value;
 use crate::source::{AgentEvent, ToolDetail};
 use crate::AgentId;
 
+/// The Hermes CLI source's registry name (its `SourceDescriptor.name`).
 pub const SOURCE_NAME: &str = "hermes";
 
 /// The Hermes home dir, mirroring Hermes's OWN resolution (verified via

--- a/crates/pixtuoid-core/src/source/hook/mod.rs
+++ b/crates/pixtuoid-core/src/source/hook/mod.rs
@@ -36,6 +36,7 @@ pub(crate) const CONN_TIMEOUT: std::time::Duration = std::time::Duration::from_s
 /// tasks. Every other bind error stays fatal → `SourceDeath`.
 #[derive(Debug)]
 pub struct SocketBusy {
+    /// The socket/pipe path a live owner already holds.
     pub path: PathBuf,
 }
 
@@ -52,6 +53,10 @@ impl std::fmt::Display for SocketBusy {
 
 impl std::error::Error for SocketBusy {}
 
+/// Listener for the shared hook socket (Unix domain socket / Windows named
+/// pipe) every CLI's hook shim connects to. Frames + decodes each payload onto
+/// the tagged `AgentEvent` channel; optionally attaches a pid-exit watch and the
+/// daemon presence side-channel.
 pub struct HookSocketListener {
     inner: imp::Listener,
     path: PathBuf,
@@ -73,6 +78,8 @@ pub struct HookSocketListener {
 pub(crate) type PresenceSender = crate::source::daemon::PresenceSender;
 
 impl HookSocketListener {
+    /// Bind the listener at `path`, returning [`SocketBusy`] if a live owner
+    /// already holds it (the recoverable-bind case).
     pub async fn bind(path: impl Into<PathBuf>) -> Result<Self> {
         let path = path.into();
         let inner = imp::Listener::bind(&path).await?;
@@ -84,6 +91,7 @@ impl HookSocketListener {
         })
     }
 
+    /// The bound socket/pipe path.
     pub fn path(&self) -> &Path {
         &self.path
     }
@@ -104,6 +112,9 @@ impl HookSocketListener {
         self
     }
 
+    /// Accept connections forever, decoding each hook payload onto `tx` (and, if
+    /// wired, the pid-watch / presence side-channel). Returns [`SocketBusy`]'s
+    /// quiet `Ok(())` degradation path via the caller when the plane is ceded.
     pub async fn run(self, tx: TaggedSender) -> Result<()> {
         self.inner.run(tx, self.pid_watch, self.presence_tx).await
     }

--- a/crates/pixtuoid-core/src/source/hook/router.rs
+++ b/crates/pixtuoid-core/src/source/hook/router.rs
@@ -76,6 +76,8 @@ pub struct HookRouter {
 }
 
 impl HookRouter {
+    /// Construct a router bound to `socket_path`, with the child-end-unclaim tee
+    /// and presence side-channel disabled (attach them via the builder methods).
     pub fn new(socket_path: PathBuf) -> Self {
         Self {
             socket_path,

--- a/crates/pixtuoid-core/src/source/jsonl/mod.rs
+++ b/crates/pixtuoid-core/src/source/jsonl/mod.rs
@@ -56,6 +56,9 @@ fn default_prefixed_label(_path: &Path, source: &str, cwd: &Path) -> String {
     crate::source::decoder::derive_prefixed_label(source, cwd)
 }
 
+/// Predicate on a transcript's raw bytes: `true` when they carry a session-end
+/// marker. The first-sight gate consults it so an already-ended transcript is
+/// never seeded as a live sprite.
 pub type SessionEndChecker = fn(&[u8]) -> bool;
 
 /// Derives the opaque session-id string used to build the generic
@@ -164,6 +167,10 @@ impl ScanState {
     }
 }
 
+/// Tails a source's transcript directory, decoding each `.jsonl` append into
+/// `AgentEvent`s. Built with [`JsonlWatcher::new`] plus the `with_*` builders
+/// (id/label/cwd derivers, path filter, liveness probe); [`JsonlWatcher::run`]
+/// drives the watch loop.
 pub struct JsonlWatcher {
     root: PathBuf,
     initial_window: Duration,
@@ -199,6 +206,9 @@ pub fn force_polling_backend_for_tests(interval: Duration) {
 static TEST_POLL_OVERRIDE: OnceLock<Duration> = OnceLock::new();
 
 impl JsonlWatcher {
+    /// A watcher over `root` for `source`, decoding each transcript line with
+    /// `decode_line` and gating ended sessions with `check_session_ended`.
+    /// Deriver/filter/probe defaults are set by the `with_*` builders.
     pub fn new(
         root: PathBuf,
         source: String,
@@ -222,6 +232,8 @@ impl JsonlWatcher {
         }
     }
 
+    /// Override the recency window a first-sight transcript must fall within to
+    /// seed at EOF (default `DEFAULT_INITIAL_WINDOW`).
     pub fn with_initial_window(mut self, window: Duration) -> Self {
         self.initial_window = window;
         self
@@ -248,6 +260,9 @@ impl JsonlWatcher {
         self
     }
 
+    /// Override how the opaque session-id string is derived from a transcript
+    /// path (default [`IdDeriver`], the normalized path). CC and Codex use it to
+    /// key on the session UUID in the filename stem instead.
     pub fn with_id_deriver(mut self, id_derive: IdDeriver) -> Self {
         self.id_derive = id_derive;
         self
@@ -278,6 +293,9 @@ impl JsonlWatcher {
         self
     }
 
+    /// Attach a liveness probe (default: none) so the watcher gates first-sight
+    /// seeding on a live-session check and drives ongoing liveness (proof-of-life,
+    /// exit detection) rather than transcript content.
     pub fn with_liveness_probe(mut self, probe: LivenessProbe) -> Self {
         self.liveness_probe = Some(probe);
         self
@@ -327,6 +345,9 @@ impl JsonlWatcher {
         }
     }
 
+    /// Consume the watcher and drive the watch loop — initial seed, a 250ms
+    /// rescan, the 60s poll backstop, and notify events — feeding each decoded
+    /// event to `tx`. Runs until the channel closes or a fatal error.
     pub async fn run(self, tx: TaggedSender) -> Result<()> {
         let cursors: Arc<Mutex<HashMap<PathBuf, u64>>> = Arc::new(Mutex::new(HashMap::new()));
         let seen_sessions: Arc<Mutex<HashMap<PathBuf, bool>>> =

--- a/crates/pixtuoid-core/src/source/jsonl/unclaim.rs
+++ b/crates/pixtuoid-core/src/source/jsonl/unclaim.rs
@@ -55,6 +55,8 @@ pub struct ChildEndUnclaims {
 }
 
 impl ChildEndUnclaims {
+    /// An empty side-channel with the default prune TTL
+    /// (`CHILD_END_UNCLAIM_TTL`).
     pub fn new() -> Self {
         Self::with_ttl(CHILD_END_UNCLAIM_TTL)
     }

--- a/crates/pixtuoid-core/src/source/kimi.rs
+++ b/crates/pixtuoid-core/src/source/kimi.rs
@@ -48,6 +48,7 @@ use serde_json::{Map, Value};
 use crate::source::AgentEvent;
 use crate::AgentId;
 
+/// The Kimi CLI source's registry name (its `SourceDescriptor.name`).
 pub const SOURCE_NAME: &str = "kimi";
 
 /// Decode the two Kimi hook events the shared CC-shaped arms don't handle, and

--- a/crates/pixtuoid-core/src/source/manager.rs
+++ b/crates/pixtuoid-core/src/source/manager.rs
@@ -12,13 +12,14 @@ use crate::source::{DynSource, TaggedSender};
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct SourceDeath {
-    /// [`Source::name`] of the source that died (e.g. "claude-code").
+    /// The dead source's registry name (e.g. "claude-code").
     pub source: String,
     /// Display rendering of the fatal error.
     pub error: String,
 }
 
 impl SourceDeath {
+    /// Build a `SourceDeath` from the dead source's name and its display error.
     pub fn new(source: impl Into<String>, error: impl Into<String>) -> Self {
         Self {
             source: source.into(),
@@ -37,6 +38,7 @@ pub struct SourceManager {
 }
 
 impl SourceManager {
+    /// An empty `SourceManager` — register sources with `with_source`, then `spawn`.
     pub fn new() -> Self {
         Self::default()
     }

--- a/crates/pixtuoid-core/src/source/mod.rs
+++ b/crates/pixtuoid-core/src/source/mod.rs
@@ -36,7 +36,9 @@ pub const EVENT_CHANNEL_CAPACITY: usize = 256;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Transport {
+    /// Arrived over the hook socket/named pipe — live; wins hook-vs-JSONL dedup.
     Hook,
+    /// Read from a transcript JSONL file (may be a historical replay).
     Jsonl,
 }
 
@@ -56,16 +58,21 @@ pub enum ToolDetail {
     Task,
     /// Any other tool. `display` is the user-facing label
     /// (e.g. `"Bash: ls"`, `"Edit foo.rs"`) used for the AgentSlot detail.
-    Generic { display: String },
+    Generic {
+        /// The user-facing tool label (e.g. `"Bash: ls"`).
+        display: String,
+    },
 }
 
 impl ToolDetail {
+    /// The user-facing label for this tool detail.
     pub fn display(&self) -> &str {
         match self {
             ToolDetail::Task => "Delegating",
             ToolDetail::Generic { display } => display,
         }
     }
+    /// Whether this is the `Task` delegation category.
     pub fn is_task(&self) -> bool {
         matches!(self, ToolDetail::Task)
     }
@@ -100,33 +107,53 @@ impl From<&str> for ToolDetail {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum AgentEvent {
+    /// A session began — registers a new agent slot at the next free desk.
     SessionStart {
+        /// The new session's agent id.
         agent_id: AgentId,
+        /// The originating CLI (registry source name, e.g. `"claude-code"`).
         source: String,
+        /// The CLI's own session identifier.
         session_id: String,
+        /// The session's working directory (drives the desk label + team outfit).
         cwd: PathBuf,
+        /// The parent agent when this is a subagent, else `None`.
         parent_id: Option<AgentId>,
     },
+    /// A tool call started — the slot goes Active.
     ActivityStart {
+        /// The acting agent.
         agent_id: AgentId,
+        /// The tool call's id, used to pair with its `ActivityEnd` (hook-wins dedup).
         tool_use_id: Option<String>,
+        /// Structured tool detail (e.g. a subagent-dispatch `Task`), when known.
         detail: Option<ToolDetail>,
     },
+    /// A tool call finished — arms the debounced return to Idle.
     ActivityEnd {
+        /// The acting agent.
         agent_id: AgentId,
+        /// The completing tool call's id (pairs with its `ActivityStart`).
         tool_use_id: Option<String>,
     },
+    /// The agent is blocked on a permission/input prompt — the slot goes Waiting.
     Waiting {
+        /// The waiting agent.
         agent_id: AgentId,
+        /// Why it is waiting (the prompt/notification reason).
         reason: String,
     },
     /// Late-discovered display name (e.g. CC subagent `attributionAgent`).
     /// Reducer overrides the slot label; noop if the slot doesn't exist.
     Rename {
+        /// The agent to relabel.
         agent_id: AgentId,
+        /// The new display label.
         label: String,
     },
+    /// A session ended — marks the slot exiting (GC'd after the grace window).
     SessionEnd {
+        /// The ending agent.
         agent_id: AgentId,
         /// True ONLY when this end's SUBJECT is a CHILD agent ending *as a
         /// child* — stamped by the subagent-END decoders: the CC/Codex
@@ -163,6 +190,7 @@ pub enum AgentEvent {
     /// stay driven by real events). When the live signal disappears the
     /// emissions stop and normal staleness sweeps resume after the TTL.
     ProofOfLife {
+        /// The vouched-live agent whose sweep-exemption to refresh.
         agent_id: AgentId,
     },
     /// Identity context a hook decoder attaches IMMEDIATELY AHEAD of a
@@ -177,8 +205,11 @@ pub enum AgentEvent {
     /// it never touches labels, activity state, or `last_event_at` (the
     /// paired activity event right behind it carries those).
     Identity {
+        /// The agent this identity context describes.
         agent_id: AgentId,
+        /// The originating CLI (registry source name).
         source: String,
+        /// The CLI's own session identifier.
         session_id: String,
         /// `None` when the payload carries no usable cwd (e.g. CC PostToolUse,
         /// Codex PermissionRequest) — the registration is then label-ordinal
@@ -206,6 +237,7 @@ pub enum AgentEvent {
     /// model line never registers a session) and dedups per field; decoders
     /// may emit per sighting.
     ModelInfo {
+        /// The agent this observation is attributed to.
         agent_id: AgentId,
         /// `Some` = a model observation (e.g. `"claude-fable-5"`).
         model: Option<String>,
@@ -226,6 +258,7 @@ pub enum AgentEvent {
     /// sheet-fall window) lives in `pixtuoid-scene::token_meter` — the
     /// RAW-store/interpret-at-paint posture `ModelInfo` documents.
     Usage {
+        /// The agent whose token spend this reading records.
         agent_id: AgentId,
         /// Fresh tokens this reading: new input + cache writes + output.
         fresh_tokens: u64,
@@ -255,6 +288,7 @@ pub struct PidIdentity {
 }
 
 impl PidIdentity {
+    /// Bundle a pid with its start marker (`None` where the OS can't provide one).
     pub fn new(pid: i32, started: Option<u64>) -> Self {
         Self { pid, started }
     }
@@ -282,6 +316,7 @@ impl AgentEvent {
         }
     }
 
+    /// The agent id this event concerns (every variant carries one).
     pub fn agent_id(&self) -> AgentId {
         match self {
             AgentEvent::SessionStart { agent_id, .. } => *agent_id,
@@ -348,6 +383,7 @@ pub fn grok_pid_for_session(grok_root: &std::path::Path, session_id: &str) -> Op
 /// Shared ACP (Agent Client Protocol) wire-vocabulary decode — reused by any
 /// source whose transcript speaks ACP (grok today). Internal: `pub(crate)`.
 pub(crate) mod acp;
+/// Antigravity (Google IDE CLI) transcript source: decoder + `Source` adapter.
 pub mod antigravity;
 // The async runtime + watcher + liveness-probe layer: gated out of a wasm
 // (`--no-default-features`) build. These modules own all the tokio/notify/libc
@@ -358,6 +394,7 @@ pub mod antigravity;
 // public paths don't move.
 #[cfg(feature = "native")]
 pub(crate) mod cc_probe;
+/// Claude Code transcript source: line/hook decoders + the `Source` adapter.
 pub mod claude_code;
 pub mod codewhale;
 pub mod codex;
@@ -376,11 +413,15 @@ pub(crate) mod fd_probe;
 pub mod grok;
 pub mod hermes;
 #[cfg(feature = "native")]
+/// The shared hook socket listener + router every CLI's hook shim connects to.
 pub mod hook;
 #[cfg(feature = "native")]
+/// The JSONL transcript watcher: tails per-session `.jsonl` files with the
+/// first-sight gate + liveness probe ladder.
 pub mod jsonl;
 pub mod kimi;
 #[cfg(feature = "native")]
+/// `SourceManager` — spawns sources and surfaces a fatal source exit as `SourceDeath`.
 pub mod manager;
 // The async transport seam (tagged channel + `Source`/`DynSource`); the
 // re-export keeps the pre-split `source::{Source, TaggedSender, …}` paths.

--- a/crates/pixtuoid-core/src/source/native.rs
+++ b/crates/pixtuoid-core/src/source/native.rs
@@ -10,6 +10,7 @@ use super::{AgentEvent, Transport};
 
 /// Events sent on a tagged channel so the reducer knows which transport produced them.
 pub type TaggedSender = mpsc::Sender<(Transport, AgentEvent)>;
+/// Receiving half of the `Transport`-tagged event channel (see `TaggedSender`).
 pub type TaggedReceiver = mpsc::Receiver<(Transport, AgentEvent)>;
 
 /// A `Source` produces `AgentEvent`s from one agent CLI flavor (Claude Code,
@@ -42,7 +43,10 @@ pub type TaggedReceiver = mpsc::Receiver<(Transport, AgentEvent)>;
 ///
 /// [`AgentId::from_parts`]: crate::AgentId::from_parts
 pub trait Source: Send + 'static {
+    /// Stable, lowercase identifier for this source (e.g. `"claude-code"`).
     fn name(&self) -> &str;
+    /// Consume the source and pump its `AgentEvent`s onto `tx` until the stream
+    /// ends or a fatal error; never panic (log + continue on malformed input).
     fn run(
         self: Box<Self>,
         tx: TaggedSender,
@@ -59,7 +63,9 @@ pub trait Source: Send + 'static {
 /// `with_source(Box::new(my_source))` work directly; implement [`Source`]
 /// only.
 pub trait DynSource: Send + 'static {
+    /// This source's stable identifier — mirrors `Source::name`.
     fn name(&self) -> &str;
+    /// Boxed-future form of `Source::run` — the dyn-safe erasure point `SourceManager` awaits.
     fn run(
         self: Box<Self>,
         tx: TaggedSender,

--- a/crates/pixtuoid-core/src/source/omp.rs
+++ b/crates/pixtuoid-core/src/source/omp.rs
@@ -67,6 +67,7 @@ mod native;
 #[cfg(feature = "native")]
 pub use native::OmpSource;
 
+/// The Oh My Pi (omp) source's registry name (its `SourceDescriptor.name`).
 pub const SOURCE_NAME: &str = "omp";
 
 /// omp's agent config dir: `$PI_CODING_AGENT_DIR` if set non-empty (omp's own

--- a/crates/pixtuoid-core/src/source/omp/native.rs
+++ b/crates/pixtuoid-core/src/source/omp/native.rs
@@ -37,10 +37,12 @@ fn omp_session_ended(tail: &[u8]) -> bool {
 /// transcripts sit under per-cwd encoded dirs, subagent transcripts nest one
 /// level deeper per delegation).
 pub struct OmpSource {
+    /// The watched omp `sessions` root (per-cwd root transcripts plus nested subagent transcripts).
     pub sessions_root: PathBuf,
 }
 
 impl OmpSource {
+    /// Construct pointed at the default omp `sessions` root.
     pub fn default_paths() -> Self {
         Self {
             sessions_root: omp_agent_dir().join("sessions"),

--- a/crates/pixtuoid-core/src/source/openclaw.rs
+++ b/crates/pixtuoid-core/src/source/openclaw.rs
@@ -48,6 +48,7 @@ use serde_json::Value;
 // `crate::source::daemon` layer. This module keeps ONLY OpenClaw's wire decode.
 use crate::source::daemon::DaemonPresenceUpdate;
 
+/// The OpenClaw daemon source's registry name (its `SourceDescriptor.name`).
 pub const SOURCE_NAME: &str = "openclaw";
 
 /// The busy pairing key: prefer a non-empty `runId`; if `runId` is ABSENT (not

--- a/crates/pixtuoid-core/src/source/opencode.rs
+++ b/crates/pixtuoid-core/src/source/opencode.rs
@@ -66,6 +66,7 @@ use crate::source::decoder::{ellipsize, MAX_DECODED_FIELD_CHARS};
 use crate::source::{AgentEvent, ToolDetail};
 use crate::AgentId;
 
+/// The opencode CLI source's registry name (its `SourceDescriptor.name`).
 pub const SOURCE_NAME: &str = "opencode";
 
 /// opencode's sub-agent dispatch tool. opencode's `task` tool calls

--- a/crates/pixtuoid-core/src/source/reasonix.rs
+++ b/crates/pixtuoid-core/src/source/reasonix.rs
@@ -58,6 +58,7 @@ use crate::source::decoder::{ellipsize, MAX_DECODED_FIELD_CHARS};
 use crate::source::{AgentEvent, ToolDetail};
 use crate::AgentId;
 
+/// The Reasonix CLI source's registry name (its `SourceDescriptor.name`).
 pub const SOURCE_NAME: &str = "reasonix";
 
 /// Reasonix tools that dispatch an in-process subagent (`internal/agent/task.go`

--- a/crates/pixtuoid-core/src/sprite/format.rs
+++ b/crates/pixtuoid-core/src/sprite/format.rs
@@ -190,19 +190,25 @@ struct AnimationToml {
     frame_ms: u32,
 }
 
+/// A loaded sprite pack: a named, versioned palette plus its animations.
 #[derive(Debug, Clone)]
 pub struct Pack {
+    /// Pack name from the `[pack]` table in `pack.toml`.
     pub name: String,
+    /// Pack version string from the `[pack]` table in `pack.toml`.
     pub version: String,
+    /// The shared color palette its frames reference by single-char code.
     pub palette: Palette,
     animations: HashMap<String, Sprite>,
 }
 
 impl Pack {
+    /// The animation registered under `key`, if the pack defines one.
     pub fn animation(&self, key: &str) -> Option<&Sprite> {
         self.animations.get(key)
     }
 
+    /// The names of every animation in this pack.
     pub fn animation_names(&self) -> Vec<String> {
         self.animations.keys().cloned().collect()
     }
@@ -258,6 +264,8 @@ fn build_pack(parsed: PackToml, mut get_src: impl FnMut(&str) -> Result<String>)
     })
 }
 
+/// Load a `Pack` from `dir/pack.toml` and its on-disk frame files, guarding
+/// each frame path against directory traversal outside `dir`.
 pub fn load_pack(dir: &Path) -> Result<Pack> {
     let toml_path = dir.join("pack.toml");
     let toml_src = std::fs::read_to_string(&toml_path)
@@ -371,6 +379,8 @@ fn build_palette(map: &HashMap<String, String>) -> Result<Palette> {
 // Animation registry — canonical list of animation names the renderer uses.
 // ---------------------------------------------------------------------------
 
+/// Character animation names every pack MUST provide; `validate_pack_animations`
+/// reports any that are missing as an error.
 pub const REQUIRED_CHARACTER_ANIMATIONS: &[&str] = &[
     "seated",
     "typing",
@@ -385,8 +395,13 @@ pub const REQUIRED_CHARACTER_ANIMATIONS: &[&str] = &[
 
 // side_seated is optional-by-design: the chair render degrades to the front
 // `seated` pose when a pack lacks it (seat_sprite_in_pack), never invisible.
+/// Character animation names a pack MAY omit; the renderer degrades gracefully
+/// when absent (e.g. `side_seated` falls back to the front `seated` pose).
 pub const OPTIONAL_CHARACTER_ANIMATIONS: &[&str] = &["walking_coffee", "side_seated"];
 
+/// Environment/furniture animation names a pack MAY provide; `Pack::merge_from`
+/// inherits any of these that are missing from the base pack (character
+/// animations are never inherited).
 pub const OPTIONAL_FURNITURE_ANIMATIONS: &[&str] = &[
     "desk",
     "filing_cabinet",
@@ -429,20 +444,31 @@ const MULTI_FRAME_REQUIREMENTS: &[(&str, usize)] = &[
     ("lobster_walk", 2),
 ];
 
+/// Per-category tally of a pack's animation discrepancies, produced by
+/// `validate_pack_animations`.
 #[derive(Debug, Default)]
 pub struct ValidationReport {
+    /// Required character-animation names absent from the pack — an error.
     pub missing_required: Vec<String>,
+    /// Optional animation names absent from the pack — reported, not an error.
     pub missing_optional: Vec<String>,
+    /// `(name, have, need)` for each animation with fewer frames than its
+    /// multi-frame minimum (e.g. `typing` needs 2).
     pub insufficient_frames: Vec<(String, usize, usize)>,
+    /// Animation names present in the pack but in none of the known registries.
     pub unknown: Vec<String>,
 }
 
 impl ValidationReport {
+    /// True when the pack is unusable — a required animation is missing or one
+    /// has too few frames. Missing OPTIONAL animations do not count.
     pub fn has_errors(&self) -> bool {
         !self.missing_required.is_empty() || !self.insufficient_frames.is_empty()
     }
 }
 
+/// Check a pack's animations against the required/optional/multi-frame
+/// registries, collecting every discrepancy into a [`ValidationReport`].
 pub fn validate_pack_animations(pack: &Pack) -> ValidationReport {
     let mut report = ValidationReport::default();
     let known_names = || {

--- a/crates/pixtuoid-core/src/sprite/mod.rs
+++ b/crates/pixtuoid-core/src/sprite/mod.rs
@@ -2,33 +2,47 @@ use std::collections::HashMap;
 
 use crate::grid::Grid;
 
+/// Compositing a `Frame` onto an `RgbBuffer` (`blit_frame`), skipping
+/// transparent pixels.
 pub mod blit;
+/// Sprite-pack file format: `pack.toml` + `.sprite` parsing, the recolor-key
+/// palette guard, and pack loading.
 pub mod format;
 
+/// An opaque 24-bit color.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Rgb {
+    /// Red channel, 0–255.
     pub r: u8,
+    /// Green channel, 0–255.
     pub g: u8,
+    /// Blue channel, 0–255.
     pub b: u8,
 }
 
 /// A single pixel: `Some(rgb)` or `None` (transparent).
 pub type Pixel = Option<Rgb>;
 
+/// A map from single-character frame codes to pixels (opaque `Rgb` or
+/// transparent).
 #[derive(Debug, Clone, Default)]
 pub struct Palette {
     map: HashMap<char, Pixel>,
 }
 
 impl Palette {
+    /// A palette with no keys.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Map `key` to `pixel` (opaque `Some(rgb)` or transparent `None`).
     pub fn insert(&mut self, key: char, pixel: Pixel) {
         self.map.insert(key, pixel);
     }
 
+    /// Look up `key`: `None` if the key is undefined, else `Some(pixel)` (the
+    /// pixel itself may be transparent).
     pub fn get(&self, key: char) -> Option<Pixel> {
         self.map.get(&key).copied()
     }
@@ -106,9 +120,12 @@ impl Frame {
     }
 }
 
+/// An animation: an ordered list of frames plus the per-frame hold time.
 #[derive(Debug, Clone)]
 pub struct Sprite {
+    /// The frames, played in order.
     pub frames: Vec<Frame>,
+    /// How long each frame holds before advancing, in milliseconds.
     pub frame_ms: u32,
 }
 
@@ -131,6 +148,7 @@ impl std::ops::DerefMut for RgbBuffer {
 }
 
 impl RgbBuffer {
+    /// A `width × height` buffer with every pixel set to `fill`.
     pub fn filled(width: u16, height: u16, fill: Rgb) -> Self {
         RgbBuffer(Grid::filled(width, height, fill))
     }
@@ -163,12 +181,17 @@ impl RgbBuffer {
         self.raw_index(x, y)
     }
 
+    /// Read the `Rgb` at `(x, y)`. Debug-asserts the point is in bounds;
+    /// unchecked in release (the hot blit path clips first).
     pub fn get(&self, x: u16, y: u16) -> Rgb {
         // Unchecked index in release (every caller clips first); this is a
         // public primitive the v2 PNG/web renderers are meant to reuse.
         self.0.as_slice()[self.checked_index(x, y)]
     }
 
+    /// Write `rgb` at `(x, y)`. Debug-asserts the point is in bounds; unchecked
+    /// in release. Use [`put_checked`](Self::put_checked) when `(x, y)` may fall
+    /// outside the buffer.
     pub fn put(&mut self, x: u16, y: u16, rgb: Rgb) {
         let i = self.checked_index(x, y);
         self.0.as_mut_slice()[i] = rgb;

--- a/crates/pixtuoid-core/src/state/mod.rs
+++ b/crates/pixtuoid-core/src/state/mod.rs
@@ -9,9 +9,11 @@ use crate::id::AgentId;
 
 mod correlation;
 mod fsm;
+/// The event coordinator: [`reducer::Reducer`] folds `AgentEvent`s into `SceneState`.
 pub mod reducer;
 mod scope;
 
+/// Maximum number of office floors a `SceneState` tracks.
 pub const MAX_FLOORS: usize = 10;
 
 // serde adapters for the `Arc<str>` / `Arc<Path>` slot fields (#279). serde has
@@ -132,7 +134,9 @@ pub enum ToolKind {
     Task,
     /// Edit / Write / MultiEdit.
     Edit,
+    /// Read.
     Read,
+    /// Bash.
     Bash,
     /// Grep / Glob.
     Search,
@@ -178,15 +182,22 @@ impl ToolKind {
 /// this turns ~5N allocations/frame into 0.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ActivityState {
+    /// No tool running (debounced — see the `Active` sharp edge).
     Idle,
+    /// A tool call is in flight (or within the Active→Idle grace window).
     Active {
+        /// The in-flight tool call's id (pairs Start↔End).
         #[serde(with = "opt_arc_str_serde")]
         tool_use_id: Option<Arc<str>>,
+        /// The tool's display detail, when known.
         #[serde(with = "opt_arc_str_serde")]
         detail: Option<Arc<str>>,
+        /// The bucketed tool kind (drives the per-tool glow/tally).
         kind: ToolKind,
     },
+    /// Blocked on a permission/input prompt.
     Waiting {
+        /// Why the agent is waiting (the prompt reason).
         #[serde(with = "arc_str_serde")]
         reason: Arc<str>,
     },
@@ -215,9 +226,13 @@ pub enum ActivityState {
 /// never clobbered by a back-fill.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum LabelProvenance {
+    /// Monotonic `{prefix}#N` ordinal minted with no cwd — no information, upgradable.
     OrdinalGhost,
+    /// Bare registry prefix from an empty-cwd deriver fallback — upgradable.
     PrefixFallback,
+    /// Derived from the cwd basename (`cc·repo`-style) — real information, never clobbered.
     CwdDerived,
+    /// Externally supplied display name (subagent name, a rename) — never clobbered.
     Renamed,
 }
 
@@ -231,6 +246,7 @@ pub struct SlotLabel {
 }
 
 impl SlotLabel {
+    /// Construct a label carrying an explicit provenance.
     pub fn new(text: impl Into<Arc<str>>, provenance: LabelProvenance) -> Self {
         Self {
             text: text.into(),
@@ -238,18 +254,22 @@ impl SlotLabel {
         }
     }
 
+    /// A monotonic `{prefix}#N` ordinal label minted with no cwd (upgradable).
     pub fn ordinal_ghost(text: impl Into<Arc<str>>) -> Self {
         Self::new(text, LabelProvenance::OrdinalGhost)
     }
 
+    /// A bare source-prefix label from an empty-cwd deriver fallback (upgradable).
     pub fn prefix_fallback(text: impl Into<Arc<str>>) -> Self {
         Self::new(text, LabelProvenance::PrefixFallback)
     }
 
+    /// A label derived from the cwd basename — real information, never clobbered.
     pub fn cwd_derived(text: impl Into<Arc<str>>) -> Self {
         Self::new(text, LabelProvenance::CwdDerived)
     }
 
+    /// A label from an externally supplied display name — never clobbered.
     pub fn renamed(text: impl Into<Arc<str>>) -> Self {
         Self::new(text, LabelProvenance::Renamed)
     }
@@ -259,6 +279,7 @@ impl SlotLabel {
         Arc::clone(&self.text)
     }
 
+    /// How this label was minted (see `LabelProvenance`).
     pub fn provenance(&self) -> LabelProvenance {
         self.provenance
     }
@@ -311,16 +332,30 @@ impl From<String> for SlotLabel {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// One live agent's full state: identity, working directory, current activity,
+/// desk/floor assignment, and the per-session meters (tool count, tokens,
+/// effort). The Arc-backed strings/paths keep the per-frame `SceneState` clone
+/// cheap.
 pub struct AgentSlot {
+    /// This agent's stable identity — the `SceneState::agents` map key.
     pub agent_id: AgentId,
+    /// Registry name of the source that produced this agent (e.g. `cc`, `codex`).
     #[serde(with = "arc_str_serde")]
     pub source: Arc<str>,
+    /// Source-native session identifier this slot is keyed under.
     #[serde(with = "arc_str_serde")]
     pub session_id: Arc<str>,
+    /// The agent's working directory; its basename drives the derived label
+    /// (`unknown_cwd` marks a placeholder).
     #[serde(with = "arc_path_serde")]
     pub cwd: Arc<Path>,
+    /// Display name + how it was derived (see `SlotLabel`).
     pub label: SlotLabel,
+    /// Current activity — Idle, Active (running a tool), or Waiting.
     pub state: ActivityState,
+    /// Wall-clock time the current `state` was entered (reset on every state
+    /// change). `SystemTime` is process-local — the tree serializes for debug
+    /// dumps, not as a wire contract.
     pub state_started_at: SystemTime,
     /// Wall-clock time of the most recent event (any type) from this
     /// agent. The stale-agent sweep uses this as the primary liveness
@@ -352,9 +387,13 @@ pub struct AgentSlot {
     /// lifetime so capacity growth never silently migrates agents between
     /// floors.
     pub floor_idx: usize,
+    /// Monotonic count of tool calls this agent has made this session.
     pub tool_call_count: u32,
+    /// Cumulative milliseconds spent in the `Active` state.
     pub active_ms: u64,
+    /// Set when the source reported no working directory, so `cwd` is a placeholder.
     pub unknown_cwd: bool,
+    /// The dispatching parent, for a subagent slot (`None` for a top-level session).
     pub parent_id: Option<AgentId>,
     /// The agent process's pid + recycle marker — the focus-jump channel for
     /// hook-only sources (filled from the shim/plugin `_pid` riding each
@@ -411,12 +450,15 @@ fn u64_is_zero(v: &u64) -> bool {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct EffortObservation {
+    /// The RAW effort string as observed on the wire (uninterpreted).
     #[serde(with = "arc_str_serde")]
     pub value: Arc<str>,
+    /// When `value` was last observed — the burn-tier freshness clock.
     pub seen_at: SystemTime,
 }
 
 impl EffortObservation {
+    /// Bundle a raw effort string with the time it was observed.
     pub fn new(value: Arc<str>, seen_at: SystemTime) -> Self {
         Self { value, seen_at }
     }
@@ -433,10 +475,12 @@ impl EffortObservation {
 pub struct UsageObservation {
     /// Fresh tokens in this one reading (new input + cache writes + output).
     pub delta: u64,
+    /// When this reading was applied — the falling-sheet window anchor.
     pub seen_at: SystemTime,
 }
 
 impl UsageObservation {
+    /// Bundle a fresh-token `delta` with the time it was applied.
     pub fn new(delta: u64, seen_at: SystemTime) -> Self {
         Self { delta, seen_at }
     }
@@ -451,7 +495,9 @@ impl UsageObservation {
 /// floor); `Down` = the daemon was seen and then died (the lobster walks out).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DaemonState {
+    /// Alive with no run in flight — the mascot ambles.
     Idle,
+    /// ≥1 run in flight (projected from `DaemonPresence::in_flight_run_keys`).
     Busy,
     /// Gateway is UP but its model backend is failing every run (#317) — the
     /// Apr-2026 Anthropic-ban failure mode: `gateway_start`/`session_start`/
@@ -460,6 +506,7 @@ pub enum DaemonState {
     /// a failed run; self-heals on the next successful run (or a new run start /
     /// gateway restart). The mascot renders distressed (sickly red, sluggish).
     Degraded,
+    /// Seen and then died — the mascot walks out (distinct from *absent*).
     Down,
 }
 
@@ -476,7 +523,11 @@ pub enum DaemonLiveness {
     /// The gateway is alive. `degraded` (#317): alive-but-broken (auth revoked /
     /// provider down), rendered distressed; healed by the next clean run / new
     /// attempt / restart.
-    Up { degraded: bool },
+    Up {
+        /// Alive-but-broken (#317): every model run is failing (auth revoked /
+        /// provider down), so the mascot renders distressed.
+        degraded: bool,
+    },
     /// The gateway was seen and then died (the mascot walks out). Distinct from
     /// *absent* (no map entry = never configured / plugin not loaded).
     Down,
@@ -550,8 +601,12 @@ impl DaemonPresence {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// The whole-office snapshot the reducer maintains and the render layer reads:
+/// live agent slots, per-floor desk capacities, and the daemon mascots.
 pub struct SceneState {
+    /// Live agent slots, keyed by `AgentId`.
     pub agents: BTreeMap<AgentId, AgentSlot>,
+    /// Desk capacity per floor, indexed by floor (`0..MAX_FLOORS`).
     pub floor_capacities: [usize; MAX_FLOORS],
     /// Daemon-style sources (the OpenClaw gateway is instance #1) rendered as
     /// wandering mascots, keyed on the registry source name. Empty for an
@@ -583,6 +638,7 @@ impl Default for SceneState {
 }
 
 impl SceneState {
+    /// An empty scene with the given per-floor desk capacities.
     pub fn new(floor_capacities: [usize; MAX_FLOORS]) -> Self {
         Self {
             agents: BTreeMap::new(),
@@ -591,10 +647,12 @@ impl SceneState {
         }
     }
 
+    /// A scene with the same desk capacity on every floor.
     pub fn uniform(cap: usize) -> Self {
         Self::new([cap; MAX_FLOORS])
     }
 
+    /// Total desk count across all floors (sum of `floor_capacities`).
     pub fn total_capacity(&self) -> usize {
         self.floor_capacities.iter().sum()
     }

--- a/crates/pixtuoid-core/src/state/reducer/mod.rs
+++ b/crates/pixtuoid-core/src/state/reducer/mod.rs
@@ -237,6 +237,9 @@ struct TaskTracking {
     handled_by_task_start: bool,
 }
 
+/// The event coordinator: folds `AgentEvent`s into `SceneState`, owning the
+/// cross-slot correlation maps, the Active→Idle debounce, and the stale/exit
+/// sweeps.
 #[derive(Debug, Default)]
 pub struct Reducer {
     /// The seven cross-slot correlation maps + their TTL pruning — see
@@ -257,6 +260,7 @@ pub struct Reducer {
 }
 
 impl Reducer {
+    /// A reducer with empty correlation state.
     pub fn new() -> Self {
         Self::default()
     }
@@ -319,6 +323,9 @@ impl Reducer {
         }
     }
 
+    /// Fold one `AgentEvent` into the scene at `now`, tagged with the
+    /// `Transport` it arrived on (load-bearing for hook-wins dedup). Runs the
+    /// GC + exit/idle sweeps first, then dispatches on the event.
     pub fn apply(
         &mut self,
         scene: &mut SceneState,

--- a/crates/pixtuoid-core/src/walkable.rs
+++ b/crates/pixtuoid-core/src/walkable.rs
@@ -82,22 +82,27 @@ pub struct OccupancyOverlay {
 }
 
 impl OccupancyOverlay {
+    /// An empty overlay — no rects blocked.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Drop every blocked rect, ready to rebuild for the next frame.
     pub fn clear(&mut self) {
         self.rects.clear();
     }
 
+    /// Block the rect at `(x, y)` of size `w × h`.
     pub fn add(&mut self, x: u16, y: u16, w: u16, h: u16) {
         self.rects.push((x, y, w, h));
     }
 
+    /// The number of blocked rects.
     pub fn len(&self) -> usize {
         self.rects.len()
     }
 
+    /// True when no rect is blocked.
     pub fn is_empty(&self) -> bool {
         self.rects.is_empty()
     }

--- a/crates/pixtuoid-scene/src/chitchat.rs
+++ b/crates/pixtuoid-scene/src/chitchat.rs
@@ -89,22 +89,38 @@ pub const CHITCHAT_LINES: &[&str] = &[
 /// every other social waypoint is its own `Waypoint` venue.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum VenueKey {
-    Room { floor_idx: usize, room_id: usize },
-    Waypoint { floor_idx: usize, wp_idx: usize },
+    /// A whole meeting room's group conversation (all its slots share one venue).
+    Room {
+        /// Index of the floor the room is on.
+        floor_idx: usize,
+        /// The room's id (index into `layout.meeting_rooms`).
+        room_id: usize,
+    },
+    /// A single social waypoint's conversation (pantry, couch, vending, printer).
+    Waypoint {
+        /// Index of the floor the waypoint is on.
+        floor_idx: usize,
+        /// Index of the waypoint in `layout.waypoints`.
+        wp_idx: usize,
+    },
 }
 
 /// A live conversation among the agents currently at a venue.
 pub struct ActiveChitchat {
+    /// The venue this conversation belongs to.
     pub venue: VenueKey,
     /// Current attendees, sorted ascending by raw id for a stable speaker
     /// rotation. Refreshed each frame so agents joining/leaving the venue are
     /// folded into / out of the rotation.
     pub participants: Vec<AgentId>,
+    /// When the conversation began — the turn/expiry clock.
     pub started_at: SystemTime,
     seed: u64,
 }
 
 impl ActiveChitchat {
+    /// Starts a conversation at `venue` among `participants`, seeded from the
+    /// sorted attendee set plus the start time.
     pub fn new(venue: VenueKey, participants: Vec<AgentId>, now: SystemTime) -> Self {
         // Direct call to the model-layer `anim::elapsed_ms` (NOT the render-layer
         // `pixel_painter::epoch_ms` forwarder — chitchat is a model module and
@@ -138,6 +154,7 @@ impl ActiveChitchat {
         self.participants = participants;
     }
 
+    /// Whether the exchange has run its full `CHITCHAT_TOTAL_MS`.
     pub fn is_expired(&self, now: SystemTime) -> bool {
         self.elapsed_ms(now) >= CHITCHAT_TOTAL_MS
     }
@@ -223,13 +240,14 @@ pub fn venue_wp_idx(
 }
 
 /// Whether agents at this waypoint kind can start a chitchat — any venue but
-/// [`ChitchatVenue::None`].
+/// `ChitchatVenue::None`.
 pub fn supports_chitchat(kind: WaypointKind) -> bool {
     chitchat_venue(kind) != ChitchatVenue::None
 }
 
 /// A single speech bubble ready for the widget layer to render.
 pub struct ChitchatBubble {
+    /// The quip to render.
     pub text: &'static str,
     /// Pixel coords of the speaking agent's anchor.
     pub anchor: Point,
@@ -241,9 +259,13 @@ pub struct ChitchatBubble {
 /// and consumer can't transpose the two `usize`-ish fields.
 #[derive(Debug, Clone, Copy)]
 pub struct Visitor {
+    /// The visitor's waypoint slot index.
     pub wp_idx: usize,
+    /// The visiting agent.
     pub agent_id: AgentId,
+    /// The agent's pixel anchor (bubble placement).
     pub anchor: Point,
+    /// `Some(room_id)` for meeting slots, `None` for single-point waypoints.
     pub room_id: Option<usize>,
 }
 

--- a/crates/pixtuoid-scene/src/embedded_pack.rs
+++ b/crates/pixtuoid-scene/src/embedded_pack.rs
@@ -88,6 +88,8 @@ fn warn_pack_validation_gaps(pack: &Pack, origin: &str) -> ValidationReport {
     report
 }
 
+/// Load the character sprite pack: the compiled-in default pack, with an
+/// optional `--pack-dir` custom pack merged over it.
 pub fn load_sprite_pack(pack_dir: Option<PathBuf>) -> Result<Pack> {
     let base = load_embedded_pack()?;
 

--- a/crates/pixtuoid-scene/src/floor/mod.rs
+++ b/crates/pixtuoid-scene/src/floor/mod.rs
@@ -55,14 +55,19 @@ pub fn floor_capacity(buf_w: u16, buf_h: u16, floor_seed: u64) -> usize {
         .unwrap_or(0)
 }
 
+/// Per-floor identity + look: index, altitude, and derived layout seed.
 #[derive(Debug, Clone, Copy)]
 pub struct FloorMeta {
+    /// Zero-based floor index.
     pub floor_idx: usize,
+    /// Height fraction: 0.0 (ground) → 1.0 (top floor); drives skyline depth in the windows.
     pub altitude: f32,
+    /// This floor's layout seed (`floor_seed(floor_idx)`).
     pub floor_seed: u64,
 }
 
 impl FloorMeta {
+    /// Metadata for floor `floor_idx` of `total_floors` — altitude spreads 0.0 (ground) → 1.0 (top).
     pub fn for_floor(floor_idx: usize, total_floors: usize) -> Self {
         let altitude = if total_floors <= 1 {
             0.0
@@ -80,6 +85,7 @@ impl FloorMeta {
         }
     }
 
+    /// The lone floor of a single-floor office (index 0, altitude 0.0).
     pub fn ground() -> Self {
         Self::for_floor(0, 1)
     }
@@ -89,10 +95,15 @@ impl FloorMeta {
 /// occupancy overlay, pose history, recolored-frame cache, lighting
 /// fade state, and motion map so floors are fully independent.
 pub struct FloorCtx {
+    /// This floor's A\* pathfinder.
     pub router: AStarRouter,
+    /// Per-tick walkable-cell occupancy (routing steers around occupied cells).
     pub overlay: OccupancyOverlay,
+    /// Per-agent pose history for the routed pose derivation.
     pub history: PoseHistory,
+    /// Per-agent recolored-sprite cache.
     pub cache: FrameCache,
+    /// This floor's indoor-lighting fade state.
     pub light: LightingState,
     /// Per-agent walk-timing state (physics profiles for entry/exit/wander).
     /// Evicted alongside `history` and `cache` in [`FloorCtx::evict_missing`]
@@ -123,6 +134,7 @@ impl Default for FloorCtx {
 }
 
 impl FloorCtx {
+    /// Fresh per-floor state — empty router, overlay, history, cache, and lighting.
     pub fn new() -> Self {
         Self {
             router: AStarRouter::new(),
@@ -242,6 +254,7 @@ impl CoffeeState {
     /// both read it, so the paint and the bookkeeping can't drift.
     pub const STEAM_WINDOW_SECS: u64 = 120;
 
+    /// Empty coffee state — no cups held.
     pub fn new() -> Self {
         Self::default()
     }
@@ -347,14 +360,23 @@ pub fn frame_epilogue(
 /// `split_at_mut`, so they can't fold into one bundle. `buf_w`/`buf_h` fold into
 /// [`Size`].
 pub struct FrameInputs<'a> {
+    /// The scene to render (the full live scene, or a projected single-floor one).
     pub scene: &'a SceneState,
+    /// The character sprite pack.
     pub pack: &'a Pack,
+    /// The active color theme.
     pub theme: &'static Theme,
+    /// This frame's wall-clock time.
     pub now: SystemTime,
+    /// Target pixel-buffer size.
     pub size: Size,
+    /// This floor's index, altitude, and layout seed.
     pub floor_meta: FloorMeta,
+    /// The pet's live interaction state, if a pet is present.
     pub active_pet: Option<&'a PetState>,
+    /// This floor's configured pet, if any.
     pub floor_pet: Option<&'a Pet>,
+    /// Composite the walkable / approach / route debug layer (the `w` toggle).
     pub debug_walkable: bool,
 }
 
@@ -364,10 +386,19 @@ pub struct FrameInputs<'a> {
 /// pass, the appliance audio-cue feed a windowed painter can't otherwise
 /// reach (#633; the TUI reads the same set off its `DrawCtx` out-param).
 pub struct FloorFrame {
+    /// The frame's computed layout (callers cache it for overlays / hit-testing).
     pub layout: Arc<crate::layout::Layout>,
+    /// The occupied-waypoint indices this frame — the appliance audio-cue feed.
     pub occupied_waypoints: std::collections::HashSet<usize>,
 }
 
+/// THE shared headless frame seam: scene → `RgbBuffer`, one floor, one frame —
+/// prologue (buffer sizing, layout, router zone) → the pixel pass → the coffee +
+/// door-anim [`frame_epilogue`], single-sourced so the epilogue can't drift across
+/// painters (#423). Returns the [`FloorFrame`] (layout + occupancy), or `None` when
+/// the size can't lay out (buffer left cleared, no panic). Per-agent eviction stays
+/// caller-side — [`FloorSession`] owns it for the single-floor painters; a
+/// projected-scene consumer (the TUI floor slide) must never evict in here.
 pub fn render_floor(
     fctx: &mut FloorCtx,
     buf: &mut RgbBuffer,
@@ -419,11 +450,14 @@ pub fn render_floor(
 /// into. A multi-floor painter composes `Vec<PerFloor>` (the TUI); the
 /// single-floor painters hold one inside a [`FloorSession`].
 pub struct PerFloor {
+    /// This floor's sim/paint stores.
     pub ctx: FloorCtx,
+    /// The reused pixel buffer this floor renders into.
     pub buf: RgbBuffer,
 }
 
 impl PerFloor {
+    /// Fresh floor stores + an empty (zero-sized) pixel buffer.
     pub fn new() -> Self {
         Self {
             ctx: FloorCtx::new(),
@@ -482,6 +516,7 @@ pub struct AudioObserver {
 }
 
 impl AudioObserver {
+    /// A fresh observer, primed for no floor yet.
     pub fn new() -> Self {
         Self::default()
     }
@@ -544,7 +579,9 @@ impl AudioObserver {
 /// cue edges stay warm (the observer reprimes on a switch).
 #[derive(Default)]
 pub struct PerOffice {
+    /// Every agent's desk cup + fetch time — survives floor navigation.
     pub coffee: CoffeeState,
+    /// Active speech bubbles keyed by venue (the `VenueKey` carries `floor_idx`).
     pub chitchat: HashMap<VenueKey, ActiveChitchat>,
     /// The office-wide audio observer (the sound twin of `coffee`): one cue
     /// tracker + reprime latch, shared across floors, so every painter composes
@@ -553,6 +590,7 @@ pub struct PerOffice {
 }
 
 impl PerOffice {
+    /// Empty office state.
     pub fn new() -> Self {
         Self::default()
     }
@@ -575,7 +613,9 @@ impl PerOffice {
 /// TUI) composes `Vec<`[`PerFloor`]`>` + one [`PerOffice`] and drives
 /// [`render_floor`] / `draw_scene` itself.
 pub struct FloorSession {
+    /// This session's single floor — its sim/paint stores + pixel buffer.
     pub floor: PerFloor,
+    /// The office-wide cross-frame state (coffee, chitchat, audio) shared across floors.
     pub office: PerOffice,
     /// The layout the last `render` laid out — [`FloorSession::overlay`] builds
     /// labels against IT (not a caller-supplied one), so a painter can't pass a
@@ -589,6 +629,7 @@ pub struct FloorSession {
 }
 
 impl FloorSession {
+    /// An empty session — fresh floor + office state, nothing laid out yet.
     pub fn new() -> Self {
         Self {
             floor: PerFloor::new(),
@@ -800,14 +841,18 @@ impl Default for LightingState {
 }
 
 impl LightingState {
+    /// Floor of the smoothed lit level — an empty floor dims to here, never to black.
     pub const MIN_LEVEL: f32 = 0.10;
+    /// How long an emptied floor holds full light before it starts fading (ms).
     pub const EMPTY_DEBOUNCE_MS: u64 = 5_000;
+    /// Time constant of the exponential lit-level ease (ms).
     pub const FADE_TAU_MS: u64 = 800;
     /// Multiplier applied to the time-of-day floor-darken overlay when
     /// the floor is fully empty. Tunes "how dark" empty looks; the only
     /// knob to reach for if empty floors read as too dark / too bright.
     pub const EMPTY_FLOOR_DIM_BOOST: f32 = 2.4;
 
+    /// A fully-lit floor (level 1.0), no fade in progress.
     pub fn new() -> Self {
         Self {
             level: 1.0,
@@ -859,15 +904,20 @@ impl LightingState {
 
 /// Animated floor-switch transition.
 pub struct FloorTransition {
+    /// The floor being slid away FROM.
     pub from_floor: usize,
+    /// The floor being slid TO.
     pub to_floor: usize,
+    /// When the slide began.
     pub started_at: SystemTime,
+    /// Slide duration (ms).
     pub duration_ms: u64,
 }
 
 const TRANSITION_DURATION_MS: u64 = 900;
 
 impl FloorTransition {
+    /// Start a slide from floor `from` to floor `to` at `now`.
     pub fn new(from: usize, to: usize, now: SystemTime) -> Self {
         Self {
             from_floor: from,
@@ -887,6 +937,7 @@ impl FloorTransition {
         )
     }
 
+    /// Whether the slide has finished (or a backward clock step past its duration ends it).
     pub fn is_done(&self, now: SystemTime) -> bool {
         // Backward-clock escape: `t` saturates to 0 while `now < started_at`
         // (eased_progress), so a wall-clock step to before the transition
@@ -927,7 +978,9 @@ pub fn num_floors(scene: &SceneState) -> usize {
 /// back into `AgentSlot.desk_index`, keeps that field's GLOBAL type honest
 /// until [`project_floor_scene`] re-hosts the slot.
 pub struct ProjectedSlot {
+    /// The projected agent — its `desk_index` still the ORIGINAL global allocation.
     pub slot: AgentSlot,
+    /// The agent's desk remapped into this floor's local `[0..capacity)` space.
     pub desk: FloorLocalDeskIndex,
 }
 

--- a/crates/pixtuoid-scene/src/layout/decor.rs
+++ b/crates/pixtuoid-scene/src/layout/decor.rs
@@ -43,10 +43,15 @@ pub enum WaypointKind {
 /// wander destination).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DwellWindow {
+    /// Baseline dwell time at the spot, in milliseconds.
     pub base_ms: u64,
+    /// Extra randomized dwell added on top of `base_ms`, in milliseconds
+    /// (`0` marks the [`Self::DECOR`] non-destination sentinel).
     pub range_ms: u64,
 }
 impl DwellWindow {
+    /// The decor sentinel — scenery, not a wander destination
+    /// (`base_ms == range_ms == 0`).
     pub const DECOR: DwellWindow = DwellWindow {
         base_ms: 0,
         range_ms: 0,
@@ -70,9 +75,13 @@ pub(crate) const PLANT_FOOTPRINT: Size = Size { w: 6, h: 3 };
 /// the canonical absolute sides (north = −y).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ApproachSides {
+    /// Approachable from the north (−y) in the canonical frame?
     pub n: bool,
+    /// Approachable from the south (+y, the canonical front)?
     pub s: bool,
+    /// Approachable from the east (+x)?
     pub e: bool,
+    /// Approachable from the west (−x)?
     pub w: bool,
 }
 
@@ -313,32 +322,55 @@ impl WaypointKind {
 /// [`desk_furniture_def`] accessor.)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Furniture {
+    /// The lounge / cubicle-top viewing couch (3 seats).
     Couch,
+    /// The pantry counter (kitchen + coffee).
     Pantry,
+    /// An aisle phone booth.
     PhoneBooth,
+    /// An aisle standing desk (alternate workstation).
     StandingDesk,
+    /// A corridor vending machine.
     VendingMachine,
+    /// A corridor printer.
     Printer,
+    /// A meeting-room sofa SEAT (its body is [`Furniture::MeetingSofaBody`]).
     MeetingSofa,
+    /// A meeting-room standing spot beside the table.
     MeetingChair,
+    /// A potted ficus (6px pot, overhanging canopy).
     PlantFicus,
+    /// A tall potted plant (shares the ficus pot footprint).
     PlantTall,
+    /// A small flowering plant (2×2 pot).
     PlantFlower,
+    /// A low succulent (3×2 pot).
     PlantSucculent,
+    /// A rolling whiteboard (aisle filler or wall decor).
     Whiteboard,
+    /// A wall-mounted TV.
     Tv,
+    /// A bookshelf.
     Bookshelf,
+    /// A cork bulletin board.
     BulletinBoard,
+    /// An exit sign.
     ExitSign,
+    /// A meeting-room presentation screen.
     MeetingScreen,
     // Singleton / per-room furniture (not keyed by a role enum — placed
     // directly in the layout). The meeting sofa/table BODIES are distinct from
     // the `MeetingSofa`/`MeetingChair` SEAT rows above (3 seats sit on 1 body):
     // the seat rows carry `None` footprint, these carry the obstacle the mask
     // stamps once per room.
+    /// The meeting-sofa BODY — the obstacle the mask stamps once per room
+    /// (its seats are the [`Furniture::MeetingSofa`] rows).
     MeetingSofaBody,
+    /// The meeting-room table body.
     MeetingTable,
+    /// The lounge floor lamp.
     FloorLamp,
+    /// The lounge side table (wood surface + magazine).
     LoungeSideTable,
     /// Kitchen-island BODY (the big center counter) — the obstacle the mask
     /// stamps once; the `IslandStand` rows are the stand slots around it
@@ -980,9 +1012,13 @@ pub fn seated_foot_cell(kind: Furniture, pos: Point) -> Option<Point> {
 /// face the table at the room centre.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Facing {
+    /// Facing north (−y, toward the far wall) — a back view.
     North,
+    /// Facing south (+y, toward the viewer) — a front view.
     South,
+    /// Facing east (+x, right).
     East,
+    /// Facing west (−x, left).
     West,
 }
 
@@ -991,9 +1027,13 @@ pub enum Facing {
 /// cubicle row to reach the back wall.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum WallDecor {
+    /// A bookshelf against the back wall.
     Bookshelf,
+    /// A wall-mounted whiteboard.
     Whiteboard,
+    /// A cork bulletin board.
     BulletinBoard,
+    /// An exit sign.
     ExitSign,
     /// Wall-mounted meeting-room display — paints above the meeting
     /// room interior so participants can pretend they're presenting.
@@ -1033,9 +1073,13 @@ impl WallDecor {
 /// these around the lounge so it doesn't feel like one ficus repeated.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum PlantKind {
+    /// A leafy ficus in a 6px pot.
     Ficus,
+    /// A tall plant (shares the ficus pot footprint).
     Tall,
+    /// A small flowering plant (2×2 pot).
     Flower,
+    /// A low succulent (3×2 pot).
     Succulent,
 }
 
@@ -1068,10 +1112,15 @@ impl PlantKind {
 /// but stable across renders. Each variant maps to a distinct sprite.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum PodDecor {
+    /// A tall plant filling the aisle.
     PlantTall,
+    /// A rolling whiteboard in the aisle.
     Whiteboard,
+    /// A wheeled TV cart.
     Tv,
+    /// A phone booth.
     PhoneBooth,
+    /// A standing desk.
     StandingDesk,
 }
 

--- a/crates/pixtuoid-scene/src/layout/mod.rs
+++ b/crates/pixtuoid-scene/src/layout/mod.rs
@@ -62,15 +62,23 @@ use pixtuoid_core::walkable::WalkableMask;
 /// for the ratatui dep in core.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Bounds {
+    /// Left edge x, in buffer pixels.
     pub x: u16,
+    /// Top edge y, in buffer pixels.
     pub y: u16,
+    /// Width in pixels.
     pub width: u16,
+    /// Height in pixels.
     pub height: u16,
 }
 
+/// A position in buffer-pixel space (screen-space: east = +x, south = +y,
+/// north = −y = the buffer top).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Point {
+    /// Pixel column (east-positive).
     pub x: u16,
+    /// Pixel row (south-positive; north is the buffer top).
     pub y: u16,
 }
 
@@ -78,7 +86,9 @@ pub struct Point {
 /// silently transposed. Distinct from Point (a position).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Size {
+    /// Width in pixels.
     pub w: u16,
+    /// Height in pixels.
     pub h: u16,
 }
 
@@ -87,7 +97,9 @@ pub struct Size {
 /// tuple.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WallSegment {
+    /// One endpoint of the straight wall run (pixel-space).
     pub start: Point,
+    /// The other endpoint (pixel-space).
     pub end: Point,
 }
 
@@ -95,7 +107,9 @@ pub struct WallSegment {
 /// `(PlantKind, Point)` tuple in `SceneLayout::plants`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PlantItem {
+    /// Which plant species/sprite.
     pub kind: PlantKind,
+    /// Centre position in buffer pixels.
     pub pos: Point,
 }
 
@@ -103,7 +117,9 @@ pub struct PlantItem {
 /// `(WallDecor, Point)` tuple in `SceneLayout::wall_decor`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WallDecorItem {
+    /// Which wall decoration.
     pub kind: WallDecor,
+    /// Position in buffer pixels.
     pub pos: Point,
 }
 
@@ -111,13 +127,19 @@ pub struct WallDecorItem {
 /// Names what was a `(PodDecor, Point)` tuple in `SceneLayout::pod_decor`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PodDecorItem {
+    /// Which aisle/pod decoration.
     pub kind: PodDecor,
+    /// Centre position in buffer pixels.
     pub pos: Point,
 }
 
+/// A named stop an agent can walk to and occupy — a lounge seat, appliance,
+/// or meeting-room slot.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Waypoint {
+    /// Where the occupant stands or sits (pixel-space).
     pub pos: Point,
+    /// What kind of stop this is (seat, appliance, meeting slot, …).
     pub kind: WaypointKind,
     /// Direction the occupant faces while at this waypoint. `South` for
     /// all the legacy single-point waypoints (facing-neutral); set toward
@@ -152,10 +174,16 @@ pub struct Lounge {
     pub fish_tank: Option<Point>,
 }
 
+/// The computed office geometry for one floor — quadrant bounds, per-agent
+/// desks, waypoints, decor, walls, and the walkability mask. Built once per
+/// `(buf_w, buf_h, num_agents)` via [`Self::compute`].
 #[derive(Debug, Clone)]
 pub struct SceneLayout {
+    /// Buffer width in pixels this layout was computed for.
     pub buf_w: u16,
+    /// Buffer height in pixels this layout was computed for.
     pub buf_h: u16,
+    /// The desk-pod quadrant — the bounds enclosing the cubicle grid.
     pub cubicle_band: Bounds,
     /// The cubicle-band-width horizontal aisle at the bottom of the desk pods
     /// (x = the cubicle columns' extent). This is the appliance-placement region
@@ -163,9 +191,14 @@ pub struct SceneLayout {
     /// to the whole buffer) is the A\* router's preferred zone + the pet/mascot
     /// path. Keep the two distinct: same y/height, different x-extent.
     pub cubicle_aisle: Bounds,
+    /// Per-agent home-desk anchor positions, indexed floor-locally (read via
+    /// [`Self::home_desk`]).
     pub home_desks: Vec<Point>,
+    /// Named stops (lounge seats, appliances, meeting slots) agents walk to.
     pub waypoints: Vec<Waypoint>,
+    /// Placed potted plants.
     pub plants: Vec<PlantItem>,
+    /// Decorations mounted on the walls (whiteboards, TVs, exit signs).
     pub wall_decor: Vec<WallDecorItem>,
     /// Decor items placed in the aisles between 2×2 desk pods. Each
     /// item paints its sprite centred on `pos` and marks it as an obstacle
@@ -179,7 +212,9 @@ pub struct SceneLayout {
     /// [`MeetingRoom`]/[`PantryRoom`]: one aggregate per area, the co-presence
     /// invariant typed instead of four parallel `Option<Point>`.
     pub lounge: Option<Lounge>,
+    /// The office entry-door position, or `None` if none fits.
     pub door: Option<Point>,
+    /// The walkable cell just inside the door — the entry/exit waypoint.
     pub door_threshold: Option<Point>,
     /// Meeting rooms in floor order — index IS the `room_id` every waypoint
     /// and painter joins on (room 1 exists only on the dual-meeting Dense
@@ -190,14 +225,21 @@ pub struct SceneLayout {
     /// The pantry aggregate (bounds + counter footprint + island) — `None`
     /// on floors without a pantry (Dense dual-meeting).
     pub pantry: Option<PantryRoom>,
+    /// Interior room-wall segments the painter draws and the mask blocks.
     pub room_walls: Vec<WallSegment>,
     /// The openings the wall resolver cut into `room_walls` — the painter
     /// draws door frames from these instead of re-inferring gaps from
     /// segment adjacency (the resolver is the one place that knows every
     /// door; see `rooms/walls.rs`).
     pub doorways: Vec<Doorway>,
+    /// Top offset in px reserved above the floor for the north wall+window
+    /// band (and its carpet apron).
     pub top_margin: u16,
+    /// The full-width horizontal corridor below the desk pods — the A\* router's
+    /// preferred zone and the pet/mascot path; `None` when it doesn't fit.
     pub corridor: Option<Bounds>,
+    /// Per-pixel walkability mask — the ground footprint every obstacle stamps,
+    /// the surface routing runs over.
     pub walkable: WalkableMask,
     /// Coarse-cell reachable component (the walkable area an agent can A\*-route
     /// to). Computed once from a known in-component seed; consumed by
@@ -253,11 +295,13 @@ pub const PANTRY_FOOTPRINT_DEPTH: u16 = 3;
 /// The desk BODY size in SLOT units — the grid-pitch pricing (pod stride,
 /// intra-pod gaps) counts `DESK_W`×`DESK_H`, and the sprite/visual is
 /// `DESK_W+4` wide × `DESK_H+2` tall. SLOT ≠ GROUND: the desk's blocked
-/// GROUND is the full `DESK_W+4`-px sprite width ([`decor::DESK_GROUND_W`],
+/// GROUND is the full `DESK_W+4`-px sprite width (`decor::DESK_GROUND_W`,
 /// side cabinets included) — the +4 overhang rides the aisle, so every
 /// band-EDGE clamp reads `DESK_GROUND_W`, not `DESK_W` (the #549 2px-overflow
 /// drift).
 pub const DESK_W: u16 = 10;
+/// Desk body height in SLOT units — the N-S pod pitch. The sprite paints
+/// `DESK_H+2` tall; the blocked ground is only `DESK_FOOT_H` deep.
 pub const DESK_H: u16 = 5;
 /// The desk's ground-CONTACT depth (rows) — only the front edge / legs touch
 /// the floor; the surface + monitor OVERHANG north (`ground_y: End`), so a
@@ -291,6 +335,8 @@ pub const CHARACTER_SPRITE_H_CELLS: u16 = 6;
 /// layout (`compute`) and the renderer (`pixel_painter` / `background`) read
 /// these so the door footprint can't drift between them.
 pub const ELEVATOR_W: u16 = 16;
+/// Elevator-door sprite height in buffer px — the door's z-sort anchor row
+/// (paired with `ELEVATOR_W`; see it for the shared-source rationale).
 pub const ELEVATOR_H: u16 = 14;
 /// NOT a cap anymore — production layouts fill the buffer's physical space
 /// (`compute_with_seed(.., max_desks: None, ..)`), so desk count scales with
@@ -306,8 +352,13 @@ pub const CLASSIC_OFFICE_DESKS: usize = 16;
 /// (Published as `MAX_VISIBLE_DESKS` through 0.11.x; that deprecated alias was
 /// dropped at 0.12.0 exactly as its own comment scheduled — don't re-add it.)
 pub const TEST_DEFAULT_DESKS: usize = CLASSIC_OFFICE_DESKS;
+/// Minimum horizontal gap (px) flanking the desk grid — sizes `MIN_LAYOUT_W`
+/// (`DESK_W` plus one gap on each side).
 pub const DESK_GAP_X: u16 = 11;
+/// The N-S counterpart to [`DESK_GAP_X`] — the desk-grid vertical gap unit (px).
 pub const DESK_GAP_Y: u16 = 14;
+/// Floor (px) for the layout's `top_margin` — the north wall band never
+/// shrinks below this (`top_margin = max(30% of buffer height, this)`).
 pub const MIN_TOP_MARGIN: u16 = 20;
 const MIN_DUAL_MEETING_H: u16 = 80;
 
@@ -318,6 +369,8 @@ pub const POD_SIDE: u16 = 2;
 /// a merged blob. 12 px ≈ a full desk width of empty floor between
 /// pod-mates.
 pub const INTRA_POD_GAP_X: u16 = 12;
+/// N-S gap between the two desks stacked in one pod (vertical counterpart to
+/// [`INTRA_POD_GAP_X`]); sets the pod's inner height.
 pub const INTRA_POD_GAP_Y: u16 = 12;
 /// Horizontal (E-W) gap between adjacent pod COLUMNS — wider than the
 /// intra-pod gap so the pod boundary stays visually distinct, while hosting
@@ -357,6 +410,8 @@ impl SceneLayout {
         compute::compute_with_seed(buf_w, buf_h, max_desks, floor_seed)
     }
 
+    /// Is buffer pixel `(x, y)` walkable? Delegates to this layout's `walkable`
+    /// mask.
     pub fn is_walkable(&self, x: u16, y: u16) -> bool {
         self.walkable.is_walkable(x, y)
     }
@@ -411,7 +466,7 @@ impl SceneLayout {
         self.lounge.as_ref().and_then(|l| l.fish_tank)
     }
 
-    /// The pantry counter's footprint, or the [`rooms::pantry::COMPACT_COUNTER`]
+    /// The pantry counter's footprint, or the `rooms::pantry::COMPACT_COUNTER`
     /// fallback when no pantry exists — the shape every consumer of the old
     /// always-present `pantry_counter_size` field expects (the runtime-sized
     /// counter must resolve to SOME size for `approach_point`'s signature
@@ -426,7 +481,7 @@ impl SceneLayout {
     /// nearest `origin` facing `facing`. This layout's `walkable`/`reachable`/
     /// `pantry_counter_size` are supplied internally, so a caller passes only
     /// the trip's own facts (not three mutually-consistent layout internals).
-    /// The deep interface over the free [`stand_point`].
+    /// The deep interface over the free `stand_point`.
     pub fn stand_point(
         &self,
         kind: WaypointKind,
@@ -448,7 +503,7 @@ impl SceneLayout {
     /// A\*'s goal cell when an agent at `origin` visits furniture `kind` at
     /// `pos` facing `facing` — this layout's `walkable`/`reachable`/
     /// `pantry_counter_size` supplied internally (the deep interface over the
-    /// free [`approach_point`]). Callers MUST still honor its `== pos` "no valid
+    /// free `approach_point`). Callers MUST still honor its `== pos` "no valid
     /// approach" sentinel (skip the furniture this cycle rather than route to it).
     pub fn approach_point(
         &self,

--- a/crates/pixtuoid-scene/src/layout/mod.rs
+++ b/crates/pixtuoid-scene/src/layout/mod.rs
@@ -1,5 +1,5 @@
 //! Zone-based scene layout for the top-down office — primitive geometry
-//! only, no terminal deps. Computed once per (buf_w, buf_h, num_agents)
+//! only, no terminal deps. Computed once per (buf_w, buf_h, max_desks)
 //! triple; serializable / wire-shippable (no out-of-process consumer today).
 //!
 //! Splits a buf-pixel rectangle into quadrants (meeting / pantry /
@@ -176,7 +176,7 @@ pub struct Lounge {
 
 /// The computed office geometry for one floor — quadrant bounds, per-agent
 /// desks, waypoints, decor, walls, and the walkability mask. Built once per
-/// `(buf_w, buf_h, num_agents)` via [`Self::compute`].
+/// `(buf_w, buf_h, max_desks)` via [`Self::compute`].
 #[derive(Debug, Clone)]
 pub struct SceneLayout {
     /// Buffer width in pixels this layout was computed for.

--- a/crates/pixtuoid-scene/src/layout/rooms/meeting.rs
+++ b/crates/pixtuoid-scene/src/layout/rooms/meeting.rs
@@ -10,7 +10,9 @@ use crate::layout::{furniture_def, pct, Bounds, Furniture, Point, OBSTACLE_PAD_P
 /// `compute::room_furniture`), so the fixed-size array encodes that invariant.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct MeetingTrio {
+    /// The two sofa centres: `[0]` north, `[1]` south (pixel-space).
     pub sofas: [Point; 2],
+    /// The table centre, midway between the two sofas (pixel-space).
     pub table: Point,
 }
 
@@ -25,7 +27,10 @@ pub struct MeetingTrio {
 /// keeping bounds and trio in ONE element makes that class unrepresentable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct MeetingRoom {
+    /// The room's interior rectangle (buffer pixels).
     pub bounds: Bounds,
+    /// The sofa/table trio, or `None` when the room is too small to fit it
+    /// (bare floor — the room still exists to hold its `room_id`).
     pub trio: Option<MeetingTrio>,
 }
 

--- a/crates/pixtuoid-scene/src/layout/rooms/pantry.rs
+++ b/crates/pixtuoid-scene/src/layout/rooms/pantry.rs
@@ -14,7 +14,7 @@ use crate::layout::{
 pub(crate) const COMPACT_COUNTER: Size = Size { w: 20, h: 8 };
 
 /// The pantry room: its bounds plus what it owns — the counter's chosen
-/// footprint (large detailed kitchen vs [`COMPACT_COUNTER`], a width-only
+/// footprint (large detailed kitchen vs `COMPACT_COUNTER`, a width-only
 /// decision) and the kitchen-island body centre (`None` when the room can't
 /// host it clear of walls + the counter — refuse-don't-force). The island's
 /// 4 `WaypointKind::Island` stand slots and the counter/snack-shelf
@@ -22,10 +22,11 @@ pub(crate) const COMPACT_COUNTER: Size = Size { w: 20, h: 8 };
 /// topic, different identity).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct PantryRoom {
+    /// The pantry room's interior rectangle (buffer pixels).
     pub bounds: Bounds,
     /// Footprint (width, height) of the pantry counter sprite. (32, 10)
     /// when the pantry is wide enough for the detailed kitchen run;
-    /// [`COMPACT_COUNTER`] for narrow terminals where the wide sprite
+    /// `COMPACT_COUNTER` for narrow terminals where the wide sprite
     /// wouldn't fit. The renderer reads this to pick which sprite to paint
     /// (`pantry` vs `pantry_small`).
     pub counter_size: Size,

--- a/crates/pixtuoid-scene/src/layout/rooms/walls.rs
+++ b/crates/pixtuoid-scene/src/layout/rooms/walls.rs
@@ -252,7 +252,10 @@ pub(crate) fn wall_segment_rect(
 /// doorway (the span is in y), else horizontal (span in x).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Doorway {
+    /// One endpoint of the opening (pixel-space).
     pub start: Point,
+    /// The other endpoint (pixel-space; the span axis is implicit — see the
+    /// type doc).
     pub end: Point,
 }
 

--- a/crates/pixtuoid-scene/src/lib.rs
+++ b/crates/pixtuoid-scene/src/lib.rs
@@ -5,6 +5,21 @@
 //! chitchat, and the embedded sprite pack. It has **no** terminal or window
 //! dependency — `tui` (ratatui half-block) and `floating` (winit/softbuffer)
 //! are thin painters layered on top, and neither depends on the other.
+//!
+//! ```
+//! use pixtuoid_scene::layout::SceneLayout;
+//! use pixtuoid_scene::theme::theme_by_name;
+//!
+//! // Themes are bundled and resolved by name (normal, cyberpunk, dracula, …).
+//! let theme = theme_by_name("dracula").expect("bundled theme");
+//! assert_eq!(theme.name, "dracula");
+//!
+//! // Lay out an office for a 192×64 pixel viewport — pure geometry, no window.
+//! // `None` fills the buffer with as many desk pods as physically fit.
+//! let office = SceneLayout::compute_with_seed(192, 64, None, 0)
+//!     .expect("viewport is large enough for an office");
+//! assert!(!office.home_desks.is_empty());
+//! ```
 
 // Terminal- and window-free (invariant #1, crate-boundary enforced). The dep
 // boundary can't see a raw `println!` (std, no dep); this restriction lint does
@@ -16,6 +31,11 @@
 // Grid/RgbBuffer seams). Lives here, not in Cargo.toml: `[lints] workspace =
 // true` cannot be combined with a per-crate `[lints.rust]` table.
 #![forbid(unsafe_code)]
+// Public-API doc gate. Scoped to this PUBLISHED crate (not `[workspace.lints]`)
+// because the binary crates' `pub` items aren't a semver surface — the same
+// two-crate scope as the semver-checks + api-surface gates. `-D warnings`
+// (`just clippy`) promotes it to a hard gate; `#[doc(hidden)] pub` is exempt.
+#![warn(missing_docs)]
 
 // Easing curves for the binary's floor-slide/popup animations — in-workspace
 // painter plumbing, not a stable engine API.
@@ -51,10 +71,12 @@ pub mod motion;
 #[doc(hidden)]
 pub mod overlay;
 pub mod pathfind;
+/// Office pets — the `Pet`/`PetKind` model and per-floor selection.
 pub mod pet;
 pub mod physics;
 pub mod pixel_painter;
 pub mod pose;
+/// The color-theme MODEL: the `Theme` role palette and the bundled themes.
 pub mod theme;
 pub mod token_meter;
 

--- a/crates/pixtuoid-scene/src/motion/mod.rs
+++ b/crates/pixtuoid-scene/src/motion/mod.rs
@@ -36,8 +36,11 @@ use crate::pose::{
 /// agents that step into its path mid-leg (rare, cosmetic, legs are seconds).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WalkPathSnapshot {
+    /// Leg start point.
     pub from: Point,
+    /// Leg end point.
     pub to: Point,
+    /// The frozen A* polyline from `from` to `to`.
     pub path: Vec<Point>,
 }
 
@@ -86,8 +89,11 @@ pub struct WanderFrame {
 /// of what was a `(SystemTime, WalkProfile, Point)` tuple.
 #[derive(Debug, Clone)]
 pub struct WalkLeg {
+    /// Wall-clock instant the leg armed.
     pub started_at: SystemTime,
+    /// Frozen physics profile for the leg.
     pub profile: WalkProfile,
+    /// Frozen leg origin, recorded at arm-time so the leg doesn't drift.
     pub from: Point,
 }
 
@@ -101,6 +107,7 @@ pub struct WalkLeg {
 pub struct WanderTarget {
     /// Destination pixel of the current trip (the walkable approach/amble cell).
     pub dest: Point,
+    /// Whether `dest` is a named waypoint (with optional seat) or an aimless amble.
     pub kind: WanderKind,
 }
 
@@ -113,8 +120,11 @@ pub enum WanderKind {
     /// way back) so arrival/departure don't pop; `seat = None` for obstacles
     /// (the agent stands AT `dest`).
     Named {
+        /// Index into `layout.waypoints`.
         wp_idx: usize,
+        /// Kind of the target waypoint.
         kind: WaypointKind,
+        /// Seat foot cell to settle onto; `None` for a stand-at obstacle.
         seat: Option<Point>,
     },
     /// An aimless amble to a random walkable point (no named waypoint, no seat).
@@ -193,6 +203,7 @@ pub struct WanderState {
 /// lazily on the first relevant walk-start frame.
 #[derive(Debug, Clone)]
 pub struct MotionState {
+    /// The agent this motion state belongs to.
     pub agent_id: AgentId,
 
     // --- entry / exit / snap-back one-shot walks ---

--- a/crates/pixtuoid-scene/src/pathfind/mod.rs
+++ b/crates/pixtuoid-scene/src/pathfind/mod.rs
@@ -91,14 +91,17 @@ pub struct AStarRouter {
 }
 
 impl AStarRouter {
+    /// Construct an empty router — no cached paths, no preferred zone.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Number of cached `(from, to)` routes currently held.
     pub fn len(&self) -> usize {
         self.paths.len()
     }
 
+    /// Whether the path cache holds no routes.
     pub fn is_empty(&self) -> bool {
         self.paths.is_empty()
     }

--- a/crates/pixtuoid-scene/src/pet.rs
+++ b/crates/pixtuoid-scene/src/pet.rs
@@ -9,13 +9,18 @@ pub const PET_DURATION_MS: u64 = 2000;
 /// (render-side only) — petting is a local visual effect, not a data
 /// model concern. Same pattern as `mouse_pos`.
 pub struct PetState {
+    /// When the pet was last clicked — anchors the `PET_DURATION_MS` freeze.
     pub petted_at: SystemTime,
+    /// Buffer-pixel position of the petted animal (hearts anchor).
     pub pet_pos: Point,
+    /// Which pet was petted.
     pub kind: PetKind,
+    /// Index of the floor the petted animal is on.
     pub floor_idx: usize,
 }
 
 impl PetState {
+    /// Whether the freeze/hearts effect is still playing at `now` (within `PET_DURATION_MS`).
     pub fn is_active(&self, now: SystemTime) -> bool {
         now.duration_since(self.petted_at)
             .map(|d| d.as_millis() as u64)
@@ -23,6 +28,7 @@ impl PetState {
             < PET_DURATION_MS
     }
 
+    /// Milliseconds since the pet was clicked, saturating to 0 on a backward clock.
     pub fn elapsed_ms(&self, now: SystemTime) -> u64 {
         // Delegate to the crate's saturate-to-0 helper (byte-identical). `is_active`
         // above keeps its own form: its backward-clock fallback is `PET_DURATION_MS+1`
@@ -35,20 +41,28 @@ impl PetState {
 /// produced by the pixel pass and consumed by the renderer/tooltip/hit-test.
 #[derive(Clone, Copy)]
 pub struct PetFrame {
+    /// Buffer-pixel position of the pet this tick.
     pub pos: Point,
+    /// Resolved sprite/animation name (walk/sit/sleep).
     pub anim: &'static str,
+    /// Which pet this frame renders.
     pub kind: PetKind,
 }
 
+/// The kind of office pet — selects sprites, hitbox, and idle-sleep behavior.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum PetKind {
+    /// The office cat.
     Cat,
+    /// The office dog.
     Dog,
 }
 
 impl PetKind {
+    /// Every pet kind.
     pub const ALL: &'static [PetKind] = &[PetKind::Cat, PetKind::Dog];
 
+    /// Parses a `[[pets]]` `kind` string ("cat"/"dog") into a `PetKind`; `None` if unknown.
     pub fn from_config_name(s: &str) -> Option<Self> {
         match s {
             "cat" => Some(PetKind::Cat),
@@ -57,6 +71,7 @@ impl PetKind {
         }
     }
 
+    /// Sprite name for the walking pose.
     pub fn walk_anim(self) -> &'static str {
         match self {
             PetKind::Cat => "cat_walk",
@@ -64,6 +79,7 @@ impl PetKind {
         }
     }
 
+    /// Sprite name for the sitting/resting pose.
     pub fn sit_anim(self) -> &'static str {
         match self {
             PetKind::Cat => "cat_sit",
@@ -71,6 +87,7 @@ impl PetKind {
         }
     }
 
+    /// Sprite name for the sleeping pose.
     pub fn sleep_anim(self) -> &'static str {
         match self {
             PetKind::Cat => "cat_sleep",
@@ -88,6 +105,7 @@ impl PetKind {
         }
     }
 
+    /// Whether this kind curls up to sleep near idle agents (cat yes, dog no).
     pub fn sleeps_near_idle(self) -> bool {
         match self {
             PetKind::Cat => true,
@@ -95,6 +113,7 @@ impl PetKind {
         }
     }
 
+    /// Click hit-test box for the given anim name (walk widest, sleep shortest).
     pub fn hitbox(self, anim_name: &str) -> Size {
         if anim_name == self.walk_anim() {
             Size { w: 8, h: 6 }
@@ -114,7 +133,9 @@ impl PetKind {
 /// pet has a name" true by construction.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Pet {
+    /// Which animal.
     pub kind: PetKind,
+    /// Display name shown in the hover tooltip.
     pub name: String,
 }
 
@@ -128,6 +149,8 @@ impl Pet {
     }
 }
 
+/// Picks the one pet for a floor from the office's pets (`floor_seed`-indexed);
+/// `None` when none are configured.
 pub fn select_pet_for_floor(floor_seed: u64, pets: &[Pet]) -> Option<&Pet> {
     if pets.is_empty() {
         return None;

--- a/crates/pixtuoid-scene/src/physics.rs
+++ b/crates/pixtuoid-scene/src/physics.rs
@@ -173,6 +173,9 @@ impl WalkKinematics {
     }
 }
 
+/// Freeze a [`WalkProfile`] for one walk leg: trapezoidal/triangular kinematics
+/// over `path_len_octile`, with cruise speed picked by `intent` and per-agent
+/// speed/pause personality seeded from `agent_id`.
 pub fn walk_profile(path_len_octile: u32, intent: WalkIntent, agent_id: AgentId) -> WalkProfile {
     let v_base = match intent {
         WalkIntent::SnapBack => V_CRUISE_SNAPBACK,

--- a/crates/pixtuoid-scene/src/pixel_painter/mod.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/mod.rs
@@ -46,10 +46,12 @@ pub(super) fn epoch_ms(now: SystemTime) -> u64 {
 /// and agent ids that were seen carrying coffee this frame (so the
 /// caller can persist them into its `CoffeeState`).
 pub struct PixelPassResult {
+    /// The office pet's resolved frame this tick (for hit-testing), if present.
     pub pet_pos: Option<PetFrame>,
     /// The gateway mascot's resolved frame this tick (for hover identity).
     /// `None` when no gateway is present.
     pub mascot_pos: Option<MascotFrame>,
+    /// Active speech bubbles this frame, for the caller's widget pass.
     pub chitchat_bubbles: Vec<ChitchatBubble>,
     /// Agent ids observed in `Walking { carrying_coffee: true }` this
     /// frame. The caller inserts them into the persistent
@@ -66,11 +68,13 @@ pub struct PixelPassResult {
 /// this is recaptured each render like `PetFrame`.
 #[derive(Clone, Copy)]
 pub struct MascotFrame {
+    /// The mascot's top-left screen position this tick.
     pub pos: Point,
     /// The painted sprite's pixel size (from the pack's real frame) — so the
     /// binary's `hit_test_mascot` click box derives from what's drawn, not a
     /// hardcoded constant.
     pub w: u16,
+    /// The painted sprite's pixel height (paired with `w`).
     pub h: u16,
     /// Human-readable gateway name (e.g. "OpenClaw").
     pub name: &'static str,
@@ -81,6 +85,7 @@ pub struct MascotFrame {
     /// Gateway up but its model backend is failing every run (#317) — the tooltip
     /// reads "model error" and the lobster renders sickly red.
     pub degraded: bool,
+    /// Number of sessions the gateway currently holds (tooltip detail).
     pub active_sessions: u32,
 }
 
@@ -122,6 +127,8 @@ pub use sim::{CharacterGlow, CharacterPlacement, SimFrame};
 /// from the painted art / steam anchor when the sprite is re-tuned. Pinned to the
 /// steam anchor by `steam_anchor_sits_within_the_coffee_machine_columns`.
 pub const PANTRY_COFFEE_COLS_LARGE: (u16, u16) = (11, 18);
+/// Coffee-machine column range for the 20-wide `pantry_small` sprite (see
+/// [`PANTRY_COFFEE_COLS_LARGE`]).
 pub const PANTRY_COFFEE_COLS_SMALL: (u16, u16) = (9, 12);
 
 /// The neon wall-sign panel geometry, in PIXELS: origin `(X, Y)` and OUTER size
@@ -139,6 +146,7 @@ pub const PANTRY_COFFEE_COLS_SMALL: (u16, u16) = (9, 12);
 /// cross-crate consumer (`pub(crate)`, don't widen the semver surface).
 pub(crate) const NEON_PANEL_X: u16 = 1;
 pub(crate) const NEON_PANEL_Y: u16 = 1;
+/// The neon panel's OUTER width in pixels (frame included) — see the panel-geometry doc above.
 pub const NEON_PANEL_W: u16 = 30;
 pub(crate) const NEON_PANEL_H: u16 = 8;
 /// The frame thickness `paint_neon_panel` lights on every side (it reads THIS, so
@@ -277,13 +285,21 @@ pub struct PixelCtx<'a> {
     /// field: it is a sibling of the `FloorCtx` on a `PerFloor`, borrowed
     /// disjointly by a multi-floor painter's `split_at_mut`.
     pub store: &'a mut crate::floor::FloorCtx,
+    /// The RGB pixel buffer this pass paints into.
     pub buf: &'a mut RgbBuffer,
+    /// The live scene state to render.
     pub scene: &'a SceneState,
+    /// The computed office geometry for this frame.
     pub layout: &'a Layout,
+    /// The character/furniture sprite pack.
     pub pack: &'a Pack,
+    /// The current time (the engine never reads the clock itself — it's a parameter).
     pub now: SystemTime,
+    /// The active color theme.
     pub theme: &'a crate::theme::Theme,
+    /// Which floor of the office this pass renders.
     pub floor: crate::floor::FloorMeta,
+    /// The pet-interaction (heart-anim) state, if a pet is being petted.
     pub active_pet: Option<&'a crate::pet::PetState>,
     /// The pet on this floor (kind drives the sprite; name is unused here — the
     /// pixel pass doesn't render the name, the tooltip does).
@@ -291,6 +307,7 @@ pub struct PixelCtx<'a> {
     /// Carrier → fetch-time view of [`crate::floor::CoffeeState`] (one map:
     /// key present = has a desk cup, value = steam-window anchor).
     pub coffee: &'a HashMap<pixtuoid_core::AgentId, SystemTime>,
+    /// Per-venue active speech-bubble state, advanced across frames.
     pub chitchat_state: &'a mut HashMap<crate::chitchat::VenueKey, ActiveChitchat>,
     /// When set, composite the walkable / approach / route debug layer over the
     /// finished scene (the live `w` toggle). Off by default; transient.
@@ -319,6 +336,10 @@ struct PaintCtx<'a> {
     debug_walkable: bool,
 }
 
+/// Render `ctx`'s scene into its buffer — the SHARED world render, TWO phases:
+/// `sim_step` advances the world (no pixels) into a [`SimFrame`], then the paint
+/// pass consumes it, mutating only the buffer + recolor cache. Returns the frame's
+/// [`PixelPassResult`] (pet/mascot frames, chitchat bubbles, coffee carriers, occupancy).
 pub fn render_to_rgb_buffer(ctx: &mut PixelCtx<'_>) -> PixelPassResult {
     // Phase 1 — SIM: advance the world (motion/poses/lighting/chitchat),
     // producing no pixels. See `sim::sim_step`.

--- a/crates/pixtuoid-scene/src/pixel_painter/sim.rs
+++ b/crates/pixtuoid-scene/src/pixel_painter/sim.rs
@@ -58,6 +58,7 @@ pub(crate) struct SimStores<'a> {
 /// colors are presentation and must not leak into the sim layer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CharacterGlow {
+    /// No glow.
     None,
     /// `SeatedThinking` — paint uses the theme's default tool-glow color.
     Thinking,
@@ -70,17 +71,26 @@ pub enum CharacterGlow {
 /// `agent_idx` indexes [`SimFrame::agents`].
 #[derive(Debug, Clone, Copy)]
 pub struct CharacterPlacement {
+    /// Index into [`SimFrame::agents`] for this character.
     pub agent_idx: usize,
     /// Y-sort key (breath-independent — see the arm comments in
     /// `resolve_characters`).
     pub anchor_y: u16,
+    /// The sprite animation to blit (e.g. `"seated"`, `"walk"`).
     pub anim_name: &'static str,
+    /// The frame within `anim_name` to draw this tick.
     pub frame_idx: usize,
+    /// Top-left screen position to blit the sprite at.
     pub anchor: Point,
+    /// Whether to mirror the sprite horizontally (facing west).
     pub flip_x: bool,
+    /// The glow decision for this character (paint maps it to a color).
     pub glow: CharacterGlow,
+    /// `Some(seed)` drives the sleeping "z" particles; `None` when awake.
     pub sleep_z_seed: Option<u64>,
+    /// Whether to draw the waiting/permission bubble over this character.
     pub waiting_bubble: bool,
+    /// `Some(frame)` draws the walking dust puff; `None` when standing still.
     pub walking_dust_frame: Option<usize>,
 }
 

--- a/crates/pixtuoid-scene/src/pose/mod.rs
+++ b/crates/pixtuoid-scene/src/pose/mod.rs
@@ -44,9 +44,13 @@ use crate::pathfind::Router;
 /// separate args (frame inputs, not engine state). `overlay` is shared (&) —
 /// none of these fns mutate it; router/history/motion are &mut.
 pub struct RouteCtx<'a> {
+    /// The A* router for this frame.
     pub router: &'a mut dyn Router,
+    /// Live occupancy overlay (shared, read-only here).
     pub overlay: &'a OccupancyOverlay,
+    /// Per-agent rendered-position cache.
     pub history: &'a mut PoseHistory,
+    /// Per-agent walk-timing state, keyed by `AgentId`.
     pub motion: &'a mut HashMap<AgentId, MotionState>,
 }
 
@@ -60,6 +64,7 @@ pub struct PoseHistory {
 }
 
 impl PoseHistory {
+    /// A new, empty history.
     pub fn new() -> Self {
         Self::default()
     }

--- a/crates/pixtuoid-scene/src/pose/pure.rs
+++ b/crates/pixtuoid-scene/src/pose/pure.rs
@@ -51,12 +51,16 @@ pub const STALE_RESUME_GAP_RANGE_MS: u64 = 6_000;
 /// are physics-timed only in the routed motion path — and #62's frozen leg paths make
 /// approximate overlay timing safe (a new leg's shape is snapshotted once).
 pub const WANDER_WALK_EST_MS: u64 = 3_500;
+/// Companion estimate: the at-waypoint dwell beat (paired with `WANDER_WALK_EST_MS`).
 pub const WANDER_DWELL_EST_MS: u64 = 18_000;
 
 /// Frame-cycle period for animated poses.
 pub const TYPING_FRAME_MS: u64 = 140;
+/// Per-frame duration of the walking animation.
 pub const WALKING_FRAME_MS: u64 = 220;
+/// Frame count of the typing animation loop.
 pub const TYPING_FRAMES: usize = 2;
+/// Frame count of the walking animation loop.
 pub const WALKING_FRAMES: usize = 2;
 
 /// The walking sprite's frame index at `elapsed_ms` into the walk — the one
@@ -140,6 +144,7 @@ pub struct Personality {
 const TRIP_CHANCE_SPAN_PCT: u64 = 36;
 const AIMLESS_PREF_SPAN_PCT: u64 = 51;
 
+/// Derives an agent's wander `Personality` from its id hash.
 pub fn personality_for(agent_id: AgentId) -> Personality {
     let h = agent_id.raw();
     Personality {
@@ -176,34 +181,48 @@ pub fn waypoint_index_for_cycle(agent_id: AgentId, cycle_n: u64, num_waypoints: 
     ((agent_id.raw() ^ cycle_n) as usize) % num_waypoints
 }
 
+/// The pose an agent renders this frame — the output of pose derivation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Pose {
+    /// Seated at the desk, idle.
     SeatedIdle,
     /// Seated at desk, awake but not typing. Used when the agent
     /// recently finished a tool call and the LLM is likely thinking.
     SeatedThinking,
+    /// Seated at the desk, typing.
     SeatedTyping {
+        /// Typing animation frame index (`0..TYPING_FRAMES`).
         frame: usize,
     },
+    /// Standing at the desk.
     StandingAtDesk,
     /// At a lounge waypoint. Concrete render depends on the kind:
     ///   Couch    → sit on couch sprite
     ///   Coffee   → standing + holding-coffee sprite
     ///   Others   → plain standing
     AtWaypoint {
+        /// Index of the target waypoint.
         wp: usize,
+        /// Kind of the target waypoint (selects the concrete sprite).
         kind: WaypointKind,
     },
+    /// Walking along the current leg between two points.
     Walking {
+        /// Leg start point (buffer pixels).
         from: Point,
+        /// Leg end point (buffer pixels).
         to: Point,
+        /// Progress along the leg, 0..=1000 (thousandths).
         t_x1000: u16,
+        /// Walking animation frame index (`0..WALKING_FRAMES`).
         frame: usize,
+        /// Whether the agent renders holding a coffee on this leg.
         carrying_coffee: bool,
     },
     /// Standing at a random cubicle_aisle point (not at any waypoint). The dest field
     /// is the buf-pixel target the agent walked to. Used by aimless wander.
     AimlessAt {
+        /// Buffer-pixel point the agent ambled to.
         dest: Point,
     },
 }

--- a/crates/pixtuoid-scene/src/theme/cyberpunk.rs
+++ b/crates/pixtuoid-scene/src/theme/cyberpunk.rs
@@ -2,6 +2,7 @@ use pixtuoid_core::sprite::Rgb;
 
 use super::*;
 
+/// The `cyberpunk` dark theme.
 pub static CYBERPUNK: Theme = Theme {
     name: "cyberpunk",
     kind: ThemeKind::Dark,

--- a/crates/pixtuoid-scene/src/theme/dracula.rs
+++ b/crates/pixtuoid-scene/src/theme/dracula.rs
@@ -2,6 +2,7 @@ use pixtuoid_core::sprite::Rgb;
 
 use super::*;
 
+/// The `dracula` dark theme.
 pub static DRACULA: Theme = Theme {
     name: "dracula",
     kind: ThemeKind::Dark,

--- a/crates/pixtuoid-scene/src/theme/mod.rs
+++ b/crates/pixtuoid-scene/src/theme/mod.rs
@@ -19,67 +19,117 @@ pub use tokyo_night::TOKYO_NIGHT;
 /// but as dirt smears on light themes).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ThemeKind {
+    /// A light-background theme.
     Light,
+    /// A dark-background theme.
     Dark,
 }
 
+/// A complete office color palette: nine role groups plus name/kind.
 #[derive(Debug, Clone)]
 pub struct Theme {
+    /// Theme id — the `--theme` value and the registry lookup key.
     pub name: &'static str,
+    /// Light vs dark classification.
     pub kind: ThemeKind,
+    /// Room-shell colors (walls, carpet, window frame).
     pub surface: SurfaceColors,
+    /// Office-fixture colors (cubicles, runner, skyline, clock, shadow).
     pub office: OfficeColors,
+    /// Sky, sun/moon, and interior-light colors.
     pub lighting: LightingColors,
+    /// Furniture colors (desks, rugs, aquarium, token-meter paper).
     pub furniture: FurnitureColors,
+    /// Transient-effect cue colors (glow, sleep z, steam, dust, bubble).
     pub effects: EffectColors,
+    /// Name-badge, tooltip, and neon-brand UI colors.
     pub ui: UiColors,
+    /// Per-tool monitor-glow hues.
     pub tool_glow: ToolGlowColors,
+    /// Corridor-appliance colors (vending, printer, coat rack).
     pub appliance: ApplianceColors,
+    /// Per-CLI agent-badge hues.
     pub source: SourceColors,
 }
 
+/// The room shell: perimeter walls, carpet, and window frame.
 #[derive(Debug, Clone)]
 pub struct SurfaceColors {
+    /// Perimeter wall fill.
     pub wall: Rgb,
+    /// Perimeter wall base/top trim line.
     pub wall_trim: Rgb,
+    /// Carpet base fill.
     pub carpet_base: Rgb,
+    /// Lighter carpet speckle.
     pub carpet_light: Rgb,
+    /// Darker carpet speckle.
     pub carpet_dark: Rgb,
+    /// Floor-to-ceiling window frame / mullions.
     pub window_frame: Rgb,
+    /// Base buffer fill behind the whole scene.
     pub bg_fallback: Rgb,
 }
 
+/// Office fixtures: cubicles, corridor runner, city skyline, clock, shadow.
 #[derive(Debug, Clone)]
 pub struct OfficeColors {
+    /// Frosted-glass room-divider highlight / gradient base.
     pub room_wall_trim_light: Rgb,
+    /// Room-divider door jambs + dark trim (also the aquarium frame).
     pub room_wall_trim_dark: Rgb,
+    /// Cubicle pod-divider wall.
     pub cubicle_divider: Rgb,
+    /// Corridor runner-rug base.
     pub runner_base: Rgb,
+    /// Corridor runner-rug stripe.
     pub runner_stripe: Rgb,
+    /// Corridor runner-rug edge border.
     pub runner_edge: Rgb,
+    /// Neon wall-board panel background.
     pub neon_panel_bg: Rgb,
+    /// Neon wall-board pulsing-border base color.
     pub neon_frame_base: Rgb,
+    /// City-skyline building, shaded side.
     pub building_dark: Rgb,
+    /// City-skyline building, lit side.
     pub building_light: Rgb,
+    /// The three lit city-skyline window hues.
     pub city_lit_windows: [Rgb; 3],
+    /// Unlit city-skyline window.
     pub city_dark_window: Rgb,
+    /// Wall-clock rim.
     pub clock_rim: Rgb,
+    /// Wall-clock face.
     pub clock_face: Rgb,
+    /// Wall-clock hands.
     pub clock_hand: Rgb,
+    /// Drop-shadow tint under sprites and furniture.
     pub shadow: Rgb,
 }
 
+/// Sky gradients, sun/moon disc, light spill, and night tint.
 #[derive(Debug, Clone)]
 pub struct LightingColors {
+    /// Daytime window-sky gradient near the horizon.
     pub day_sky_a: Rgb,
+    /// Daytime window-sky gradient near the top.
     pub day_sky_b: Rgb,
+    /// Night window-sky gradient near the horizon.
     pub night_sky_a: Rgb,
+    /// Night window-sky gradient near the top.
     pub night_sky_b: Rgb,
+    /// Twilight (dawn/dusk) warm-shift near the horizon.
     pub twilight_a: Rgb,
+    /// Twilight (dawn/dusk) warm-shift near the top.
     pub twilight_b: Rgb,
+    /// Warm sunlight spill on the floor and walls.
     pub sun_spill: Rgb,
+    /// Soft overhead ceiling light-pool tint.
     pub ceiling_pool: Rgb,
+    /// Lounge floor-lamp glow halo.
     pub floor_lamp_halo: Rgb,
+    /// Night-time interior darkening tint.
     pub night_tint: Rgb,
     /// The sun disc's core color (window-wall celestial body, `pixel_painter::background::celestial::compute_disc`).
     /// The soft halo ring reuses this SAME hue at lower alpha (no separate glow color) — must read
@@ -90,61 +140,100 @@ pub struct LightingColors {
     pub moon_core: Rgb,
 }
 
+/// Desk, rug, aquarium, and token-meter furniture colors.
 #[derive(Debug, Clone)]
 pub struct FurnitureColors {
+    /// Desk/table wood surface.
     pub wood_top: Rgb,
+    /// Desk/table wood edge trim (darker).
     pub wood_trim: Rgb,
+    /// Lounge area-rug field (main fill).
     pub rug_field: Rgb,
+    /// Lounge area-rug border trim.
     pub rug_trim: Rgb,
+    /// Lounge area-rug accent detail.
     pub rug_accent: Rgb,
+    /// Coffee-table magazine cover.
     pub magazine: Rgb,
+    /// Coffee-table magazine spine/trim.
     pub magazine_trim: Rgb,
+    /// Chair wood trim.
     pub chair_trim: Rgb,
+    /// Desk coffee-cup body.
     pub coffee_cup: Rgb,
+    /// Desk coffee-cup shaded side.
     pub coffee_cup_shadow: Rgb,
     /// Aquarium water body (deep) + its lit surface row.
     pub tank_water: Rgb,
+    /// Aquarium surface highlight line; also the water-cooler glug bubble.
     pub tank_water_line: Rgb,
     /// The two fish (frame/cabinet reuse `room_wall_trim_dark` / `wood_*`).
     pub tank_fish: Rgb,
+    /// The second aquarium fish (kept off the lobster's carapace reds).
     pub tank_fish_alt: Rgb,
+    /// Aquarium plant.
     pub tank_plant: Rgb,
     /// Token-meter paper tower (#632): the sheet face + the every-other-row
     /// ream shading that makes the block read as STACKED PAPER, not a slab.
     pub paper: Rgb,
+    /// Token-meter paper ream-shading (the every-other-row band).
     pub paper_shade: Rgb,
 }
 
+/// Transient effect cues (glow, sleep z, steam, dust, bubble).
 #[derive(Debug, Clone)]
 pub struct EffectColors {
+    /// Lit monitor bezel on an active screen.
     pub monitor_frame_lit: Rgb,
+    /// Floating "z" of a sleeping agent.
     pub sleep_z: Rgb,
+    /// Steam wisp off a fresh coffee cup.
     pub coffee_steam: Rgb,
+    /// Dust puff kicked up while walking.
     pub walking_dust: Rgb,
+    /// Overhead bubble on a waiting agent.
     pub waiting_bubble: Rgb,
 }
 
+/// Per-tool monitor-glow hues (the screen glow while a tool runs).
 #[derive(Debug, Clone)]
 pub struct ToolGlowColors {
+    /// Glow while an Edit/Write tool runs.
     pub edit: Rgb,
+    /// Glow while a Read tool runs.
     pub read: Rgb,
+    /// Glow while a Bash tool runs.
     pub bash: Rgb,
+    /// Glow while an Agent/subagent tool runs.
     pub agent: Rgb,
+    /// Glow while a Grep/search tool runs.
     pub grep: Rgb,
+    /// Glow for any other tool.
     pub default: Rgb,
 }
 
+/// Name-badge, tooltip, and neon-brand UI colors.
 #[derive(Debug, Clone)]
 pub struct UiColors {
+    /// Name-badge tone for an active agent.
     pub label_active: Rgb,
+    /// Name-badge tone for a waiting agent.
     pub label_waiting: Rgb,
+    /// Name-badge tone for an idle agent.
     pub label_idle: Rgb,
+    /// Name-badge tone for an exiting agent.
     pub label_exiting: Rgb,
+    /// Tooltip / popup background fill.
     pub tooltip_bg: Rgb,
+    /// Tooltip title text.
     pub tooltip_title: Rgb,
+    /// Tooltip body text.
     pub tooltip_text: Rgb,
+    /// Tooltip dimmed/secondary text.
     pub tooltip_dim: Rgb,
+    /// Neon wall-board brand text (and the theme-picker swatch).
     pub neon_brand: Rgb,
+    /// Neon wall-board ★ star-CTA accent.
     pub neon_star: Rgb,
 }
 
@@ -187,18 +276,31 @@ pub struct ApplianceColors {
 /// (guarded by `source_badges_legible_for_every_theme`).
 #[derive(Debug, Clone)]
 pub struct SourceColors {
+    /// Claude Code badge hue.
     pub claude_code: Rgb,
+    /// Codex badge hue.
     pub codex: Rgb,
+    /// Reasonix badge hue.
     pub reasonix: Rgb,
+    /// Antigravity badge hue.
     pub antigravity: Rgb,
+    /// CodeWhale badge hue.
     pub codewhale: Rgb,
+    /// OpenCode badge hue.
     pub opencode: Rgb,
+    /// Copilot badge hue.
     pub copilot: Rgb,
+    /// Cursor badge hue.
     pub cursor: Rgb,
+    /// OpenClaw daemon badge hue.
     pub openclaw: Rgb,
+    /// Hermes badge hue.
     pub hermes: Rgb,
+    /// omp badge hue.
     pub omp: Rgb,
+    /// Grok badge hue.
     pub grok: Rgb,
+    /// Kimi badge hue.
     pub kimi: Rgb,
 }
 
@@ -251,6 +353,7 @@ impl SourceColors {
     }
 }
 
+/// Every built-in theme, in picker order — the slice `theme_by_name` searches.
 pub static ALL_THEMES: &[&Theme] = &[
     &NORMAL,
     &CYBERPUNK,
@@ -260,6 +363,7 @@ pub static ALL_THEMES: &[&Theme] = &[
     &GRUVBOX,
 ];
 
+/// Resolve a theme by its `name` (the `--theme` value), or `None` if unknown.
 pub fn theme_by_name(name: &str) -> Option<&'static Theme> {
     ALL_THEMES.iter().find(|t| t.name == name).copied()
 }

--- a/crates/pixtuoid-scene/src/theme/normal.rs
+++ b/crates/pixtuoid-scene/src/theme/normal.rs
@@ -2,6 +2,7 @@ use pixtuoid_core::sprite::Rgb;
 
 use super::*;
 
+/// The default `normal` theme — the only light-mode palette.
 pub static NORMAL: Theme = Theme {
     name: "normal",
     kind: ThemeKind::Light,

--- a/crates/pixtuoid-scene/src/theme/tokyo_night.rs
+++ b/crates/pixtuoid-scene/src/theme/tokyo_night.rs
@@ -2,6 +2,7 @@ use pixtuoid_core::sprite::Rgb;
 
 use super::*;
 
+/// The `tokyo-night` dark theme.
 pub static TOKYO_NIGHT: Theme = Theme {
     name: "tokyo-night",
     kind: ThemeKind::Dark,

--- a/justfile
+++ b/justfile
@@ -15,6 +15,21 @@
 # single-sourced cross-platform (CI never writes inline commands).
 set windows-shell := ["bash", "-cu"]
 
+# ── variables ─────────────────────────────────────────────────────
+# just evaluates these globally regardless of position; kept at the top (the
+# idiom) so the file's config lives in one place.
+
+# The published semver surface: the ONLY two crates whose public API is a
+# contract (the binary lib target is not). Single-sourced here so the three
+# gates over it — semver / api-surface / api-surface-check — can't drift; a
+# newly-published crate is added in ONE place.
+PUBLISHED_CRATES := "pixtuoid-core pixtuoid-scene"
+
+# The nightly the api-surface goldens are pinned to (rustdoc JSON is
+# nightly-only). Self-installed by `_api-nightly`; CI + setup-tools pin
+# cargo-public-api 0.52.0 to match. Bump both together or the golden churns.
+API_NIGHTLY := "nightly-2026-07-22"
+
 # List available recipes.
 default:
     @just --list
@@ -195,27 +210,30 @@ msrv:
 [group('rust')]
 [doc('SemVer-check pixtuoid-core + pixtuoid-scene against their crates.io baselines (CI-only)')]
 semver:
-    cargo semver-checks --package pixtuoid-core --package pixtuoid-scene
+    cargo semver-checks $(printf -- '--package %s ' {{PUBLISHED_CRATES}})
 
-# Public-API surface snapshot for the two PUBLISHED libraries (pixtuoid-core +
-# pixtuoid-scene). COMPLEMENTS `just semver`: the semver gate answers
-# "major/minor bump?", this shows *what* changed as a reviewable golden diff.
-# Goldens live in `api/<crate>.txt` — `cargo public-api -s` output (`-s` omits
-# blanket-impl noise like `Into`/`Receiver`; auto-derived `Clone`/`Serialize`/…
-# STAY, since adding/removing a derive IS a public-API change). rustdoc JSON is
-# nightly-only, so both recipes PIN {{API_NIGHTLY}} (self-installed on first use)
-# — the golden is reproducible local↔CI. CI + setup-tools pin cargo-public-api
-# 0.52.0 to match; regenerate with those exact two versions or the golden churns.
-# CI-only in practice (like semver) — run `just api-surface` + commit the golden
-# whenever either crate's public surface changes.
-API_NIGHTLY := "nightly-2026-07-22"
-
+# Public-API surface snapshot for the PUBLISHED libraries. COMPLEMENTS
+# `just semver`: the semver gate answers "major/minor bump?", this shows *what*
+# changed as a reviewable golden diff. Goldens live in `api/<crate>.txt` —
+# `cargo public-api -s` output (`-s` omits blanket-impl noise like
+# `Into`/`Receiver`; auto-derived `Clone`/`Serialize`/… STAY, since
+# adding/removing a derive IS a public-API change). cargo-public-api takes one
+# crate per call, so a golden file is regenerated per crate. rustdoc JSON is
+# nightly-only, so both recipes PIN {{API_NIGHTLY}}. CI-only in practice (like
+# semver) — run `just api-surface` + commit the golden whenever either crate's
+# public surface changes.
 [group('rust')]
 [doc('Regenerate the api/<crate>.txt public-API goldens (cargo-public-api + pinned nightly)')]
 api-surface: _api-nightly
     #!/usr/bin/env bash
     set -euo pipefail
-    for crate in pixtuoid-core pixtuoid-scene; do
+    # cargo-public-api only honors RUSTUP_TOOLCHAIN when the invoked `cargo` is
+    # the rustup PROXY. A Homebrew/system cargo ahead of it on PATH ignores the
+    # env, so cargo-public-api falls back to rust-toolchain.toml's STABLE pin and
+    # dies on `-Z` (nightly-only). Prepend the rustup bin so the proxy wins (a
+    # no-op on CI, where it's already first).
+    export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:$PATH"
+    for crate in {{PUBLISHED_CRATES}}; do
         RUSTUP_TOOLCHAIN={{API_NIGHTLY}} cargo public-api -p "$crate" -s > "api/$crate.txt"
     done
 
@@ -224,10 +242,12 @@ api-surface: _api-nightly
 api-surface-check: _api-nightly
     #!/usr/bin/env bash
     set -euo pipefail
+    # See `api-surface`: force the rustup proxy cargo so RUSTUP_TOOLCHAIN is honored.
+    export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:$PATH"
     tmp="$(mktemp -d)"
     trap 'rm -rf "$tmp"' EXIT
     fail=0
-    for crate in pixtuoid-core pixtuoid-scene; do
+    for crate in {{PUBLISHED_CRATES}}; do
         RUSTUP_TOOLCHAIN={{API_NIGHTLY}} cargo public-api -p "$crate" -s > "$tmp/$crate.txt"
         if ! diff -u "api/$crate.txt" "$tmp/$crate.txt"; then
             echo "error: public API of $crate drifted from api/$crate.txt — run 'just api-surface' and commit the update" >&2

--- a/justfile
+++ b/justfile
@@ -197,6 +197,58 @@ msrv:
 semver:
     cargo semver-checks --package pixtuoid-core --package pixtuoid-scene
 
+# Public-API surface snapshot for the two PUBLISHED libraries (pixtuoid-core +
+# pixtuoid-scene). COMPLEMENTS `just semver`: the semver gate answers
+# "major/minor bump?", this shows *what* changed as a reviewable golden diff.
+# Goldens live in `api/<crate>.txt` — `cargo public-api -s` output (`-s` omits
+# blanket-impl noise like `Into`/`Receiver`; auto-derived `Clone`/`Serialize`/…
+# STAY, since adding/removing a derive IS a public-API change). rustdoc JSON is
+# nightly-only, so both recipes PIN {{API_NIGHTLY}} (self-installed on first use)
+# — the golden is reproducible local↔CI. CI + setup-tools pin cargo-public-api
+# 0.52.0 to match; regenerate with those exact two versions or the golden churns.
+# CI-only in practice (like semver) — run `just api-surface` + commit the golden
+# whenever either crate's public surface changes.
+API_NIGHTLY := "nightly-2026-07-22"
+
+[group('rust')]
+[doc('Regenerate the api/<crate>.txt public-API goldens (cargo-public-api + pinned nightly)')]
+api-surface: _api-nightly
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for crate in pixtuoid-core pixtuoid-scene; do
+        RUSTUP_TOOLCHAIN={{API_NIGHTLY}} cargo public-api -p "$crate" -s > "api/$crate.txt"
+    done
+
+[group('rust')]
+[doc("Fail if a published crate's public API drifted from the api/ goldens (CI-only)")]
+api-surface-check: _api-nightly
+    #!/usr/bin/env bash
+    set -euo pipefail
+    tmp="$(mktemp -d)"
+    trap 'rm -rf "$tmp"' EXIT
+    fail=0
+    for crate in pixtuoid-core pixtuoid-scene; do
+        RUSTUP_TOOLCHAIN={{API_NIGHTLY}} cargo public-api -p "$crate" -s > "$tmp/$crate.txt"
+        if ! diff -u "api/$crate.txt" "$tmp/$crate.txt"; then
+            echo "error: public API of $crate drifted from api/$crate.txt — run 'just api-surface' and commit the update" >&2
+            fail=1
+        fi
+    done
+    exit "$fail"
+
+# Self-provision the api-surface pinned nightly (rustdoc JSON is nightly-only) if
+# it isn't already installed — the same idempotent posture as setup-tools. The
+# minimal profile carries rustdoc (bundled with rustc), all cargo-public-api
+# needs to build the crate's rustdoc JSON.
+[private]
+_api-nightly:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    command -v rustup >/dev/null || { echo "rustup not found — install {{API_NIGHTLY}} manually for api-surface" >&2; exit 1; }
+    rustup toolchain list | grep -q '{{API_NIGHTLY}}' && exit 0
+    echo "installing {{API_NIGHTLY}} (api-surface needs nightly rustdoc JSON)…" >&2
+    rustup toolchain install {{API_NIGHTLY}} --profile minimal
+
 # Coverage + JUnit XML in one run — the exact command ci.yml's coverage job uses.
 # CI-only in practice: needs cargo-llvm-cov + cargo-nextest + the `ci` nextest
 # profile. Writes lcov.info + target/nextest/ci/junit.xml.
@@ -717,7 +769,9 @@ verify: preflight site-check gen-check
 setup-tools:
     #!/usr/bin/env bash
     set -euo pipefail
-    tools=(cargo-nextest cargo-machete cargo-deny cargo-hack cargo-semver-checks cargo-edit cargo-insta lychee)
+    # cargo-public-api is PINNED (the `just api-surface` goldens are reproducible
+    # only against an exact tool + nightly pair — see the api-surface recipe).
+    tools=(cargo-nextest cargo-machete cargo-deny cargo-hack cargo-semver-checks cargo-edit cargo-insta lychee cargo-public-api@0.52.0)
     if command -v cargo-binstall &>/dev/null; then
         cargo binstall -y "${tools[@]}"
     else


### PR DESCRIPTION
Oracle-plan **Step 4** (#749) — instrument the published semver surface
(`pixtuoid-core` + `pixtuoid-scene`; the binary lib target is not a semver
surface) with doc-coverage and a reviewable public-API snapshot.

## What

**api-surface snapshot** — the reviewable-diff twin of `just semver`
- Committed goldens `api/pixtuoid-core.txt` + `api/pixtuoid-scene.txt`
  (`cargo public-api -s` — `-s` omits blanket-impl noise but KEEPS auto-derives,
  since adding/removing a derive *is* a public-API change).
- `just api-surface` (regenerate) + `just api-surface-check` (diff-gate, CI-only
  like semver) + a CI job; `cargo-public-api@0.52.0` pinned in `setup-tools`.
- rustdoc JSON is nightly-only, so the recipes pin a dated `nightly-2026-07-22`
  (justfile `API_NIGHTLY`, self-installed by `_api-nightly`) → goldens reproduce
  local↔CI. No `cfg(target_os)`-gated **public** items in either crate, so the
  golden is platform-stable (macOS↔Linux).

**missing_docs** — the backlog was **542**, not the ~87 the issue estimated
(core 187 / scene 355; scene's `#[doc(hidden)]` modules were already exempt, so
355 is real API). Documented every public item and enabled the lint via
`#![warn(missing_docs)]` in each crate's `lib.rs` — scoped to the two published
crates exactly like the semver/api-surface gates, **not** `[workspace.lints]`
(workspace-wide would force docs on ~190 non-API binary internals). `-D warnings`
(`just clippy`) makes it a hard gate.

**doctests** — first compiled crate-root examples (0 before): a `pixtuoid-core`
`Reducer` round-trip and a `pixtuoid-scene` layout + theme lookup, so
`cargo test --doc` has teeth on the public entry points.

Docs-currency: `CLAUDE.md` CI-gates list + a `missing_docs` conventions bullet.

## Gates (local)
`just clippy` 0 · `missing_docs` 0 on both crates · `cargo test --doc` 2/2 ·
`just api-surface-check` pass (+ negative-control verified) · full suite
**2662 passed / 0 failed** · fmt · arch · actionlint clean. Pre-push preflight green.

## ⚠️ Before merge
The **`api-surface` CI job is new and non-required** — confirm its first run is
green on the Linux runner (the golden was generated on macOS; it should reproduce
byte-for-byte under the same pinned nightly, but this is its first CI execution)
**before** merging, then close #749 by hand. Same discipline as #747's new jobs.

Refs #749

🤖 Generated with [Claude Code](https://claude.com/claude-code)