### PR TITLE
chore: add Codex development environment

### DIFF
--- a/.agents/skills/add-source
+++ b/.agents/skills/add-source
@@ -1,0 +1,1 @@
+../../.claude/skills/add-source

--- a/.agents/skills/add-theme
+++ b/.agents/skills/add-theme
@@ -1,0 +1,1 @@
+../../.claude/skills/add-theme

--- a/.agents/skills/beautify-decoration
+++ b/.agents/skills/beautify-decoration
@@ -1,0 +1,1 @@
+../../.claude/skills/beautify-decoration

--- a/.agents/skills/procedural-lofi
+++ b/.agents/skills/procedural-lofi
@@ -1,0 +1,1 @@
+../../.claude/skills/procedural-lofi

--- a/.agents/skills/two-lens-review
+++ b/.agents/skills/two-lens-review
@@ -1,0 +1,1 @@
+../../.claude/skills/two-lens-review

--- a/.claude/skills/beautify-decoration/SKILL.md
+++ b/.claude/skills/beautify-decoration/SKILL.md
@@ -78,7 +78,7 @@ crop = crop.resize((crop.width*2, crop.height*2), Image.NEAREST)
 crop.save('/tmp/crop.png')
 ```
 
-Then `Read` the cropped PNG — you (Claude) can see PNG content via the Read tool.
+Then inspect the cropped PNG with the agent's image-viewing tool.
 
 PIL is available system-wide (installed via `pip3 install --user --break-system-packages Pillow`). If a fresh environment misses it, install once.
 

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,2 @@
+# Applicable root+nested AGENTS.md chains exceed Codex's 32 KiB default.
+project_doc_max_bytes = 262144

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,12 +232,13 @@ repo-committed and won't exist on a fresh checkout or in a non-Claude tool.
 9. **Wrap** — retro; record durable lessons.
 
 **Skills.** Repo skills live in [`.claude/skills/`](.claude/skills/) (committed,
-so they travel with the repo): `two-lens-review` (the merge gate),
+so they travel with the repo); [`.agents/skills/`](.agents/skills/) aliases them
+for Codex. The skills are `two-lens-review` (the merge gate),
 `beautify-decoration` (the visual mock loop), `add-source` / `add-theme`
 (scaffold + test-teeth for a new CLI / palette), `procedural-lofi` (synthesize
 a new ambient sound — the reference-fingerprint → freeze pipeline). Claude Code
-auto-surfaces them by description; other tools read this file (`AGENTS.md`) and
-run the loop above as prose.
+and Codex auto-surface them by description; other tools read this file
+(`AGENTS.md`) and run the loop above as prose.
 
 **Bootstrap on a fresh machine / other tool.** `git clone` gives you the repo
 skills + all `just` gates immediately. The day-to-day *loop* skills

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,13 +232,14 @@ repo-committed and won't exist on a fresh checkout or in a non-Claude tool.
 9. **Wrap** — retro; record durable lessons.
 
 **Skills.** Repo skills live in [`.claude/skills/`](.claude/skills/) (committed,
-so they travel with the repo); [`.agents/skills/`](.agents/skills/) aliases them
-for Codex. The skills are `two-lens-review` (the merge gate),
+so they travel with the repo). On symlink-capable checkouts,
+[`.agents/skills/`](.agents/skills/) aliases the same directories for Codex.
+The skills are `two-lens-review` (the merge gate),
 `beautify-decoration` (the visual mock loop), `add-source` / `add-theme`
 (scaffold + test-teeth for a new CLI / palette), `procedural-lofi` (synthesize
 a new ambient sound — the reference-fingerprint → freeze pipeline). Claude Code
-and Codex auto-surface them by description; other tools read this file
-(`AGENTS.md`) and run the loop above as prose.
+auto-surfaces them by description; Codex does the same through the aliases.
+Other tools read this file (`AGENTS.md`) and run the loop above as prose.
 
 **Bootstrap on a fresh machine / other tool.** `git clone` gives you the repo
 skills + all `just` gates immediately. The day-to-day *loop* skills


### PR DESCRIPTION
## Summary

- Keep `.claude/skills/` as the canonical repo skill source and expose the same directories to Codex through `.agents/skills/` symlinks on symlink-capable checkouts.
- Add project-scoped Codex configuration so the repo's root and nested `AGENTS.md` instruction chains are not truncated.
- Make the visual-verification skill wording tool-neutral and document the shared Claude Code/Codex layout.

## Related issue

n/a

## Type of change

- [x] Refactor / chore

## How I tested it

- `just preflight` (2,662 tests passed)
- `just lint`
- `codex -C . --strict-config --version`
- Live Codex prompt inspection discovered all five repo skills and resolved them to the canonical `.claude/skills/*/SKILL.md` files.
- Verified every alias is Git mode `120000`, targets the matching canonical directory, resolves to `SKILL.md`, and shares the canonical bytes.
- Two-lens local review (correctness/grounding and design/blast-radius): both passed with no remaining findings.

## Visual verification

- [x] Not a visual change.

## Checklist

- [x] I read the relevant root `CLAUDE.md`.
- [x] No production Rust behavior or public API changed.
- [x] Documentation was updated with the development-environment change.
- [x] `just preflight` passes locally.

## AI assistance

- [x] This PR was written/heavily-assisted by an AI agent.