### PR TITLE
ci: clean caches after pull requests close

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Delete closed PR caches
         run: |
           gh cache delete --all --ref "$PR_REF" --succeed-on-no-caches
-          echo "Deleted caches scoped to \`$PR_REF\`." >> "$GITHUB_STEP_SUMMARY"
+          echo "Cache cleanup completed for \`$PR_REF\` (no caches is a successful no-op)." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,30 @@
+name: cache cleanup
+
+# PR caches are scoped away from main and can evict useful main caches when the
+# repository reaches its 10 GB limit. Run in the base context so fork PRs can
+# clean up too, but never checkout or execute pull-request content here.
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  actions: write
+
+concurrency:
+  group: cache-cleanup-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  closed-pr:
+    name: closed PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      PR_REF: refs/pull/${{ github.event.pull_request.number }}/merge
+    steps:
+      - name: Delete closed PR caches
+        run: |
+          gh cache delete --all --ref "$PR_REF" --succeed-on-no-caches
+          echo "Deleted caches scoped to \`$PR_REF\`." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- delete caches scoped to a pull request when it closes
- support fork pull requests with `pull_request_target` without checking out or executing pull-request code
- keep the existing Rust cache keys and save behavior unchanged

Closes #779

## Design and security
- follows GitHub's documented recommendation to delete pull-request cache scopes after a PR closes
- grants only `actions: write`, which is required by the cache deletion API
- constructs the exact `refs/pull/<number>/merge` ref from GitHub's numeric PR event field
- never checks out the repository, invokes a local script, or executes pull-request content in the privileged workflow
- runs outside the required CI path, so cleanup cannot delay or fail `ci-gate`

References:
- https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manage-caches
- https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching
- https://docs.github.com/en/rest/actions/cache

## Measured impact
- repository cache policy: 10 GB limit, 7-day retention
- before cleanup: 55 caches / 10.620 GB
- closed-PR cache scopes: 12 caches / 2.626 GB
- after the one-time cleanup: 43 caches / 7.994 GB, all scoped to `main`
- restored headroom: 2.006 GB
- successful PR CI baseline: p50 515 s, p95 804 s
- first successful `main` run after #777: 516 s
- final #777 cache sample: 17 exact hits, 1 prefix restore, 0 misses

The measurements support retaining the current cache population strategy and removing only unreachable closed-PR scopes.

## Verification
- `just actionlint`
- `actionlint -verbose .github/workflows/cache-cleanup.yml`
- `just risk-radar-test`
- empty-scope cleanup command exercised without a checkout
- `just preflight`: 2,662 passed, 2 skipped
- pre-push `just preflight`: 2,662 passed, 2 skipped
