### PR TITLE
fix(ci): restart the Claude review bots and close the gate gaps behind them

### DIFF
--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -163,7 +163,25 @@ given change/tree, say so, don't skip it.
   branches [`duplicate_root_session_start_..._resurrect` + `parent_waiting_..._ends_a_tool` fixed both]);
   isolation & flakiness (real-state writes, wall-clock/order nondeterminism,
   `TEST_ENV_LOCK`, snapshot determinism); CI/build (gate coverage, path-filter
-  holes, toolchain skew); gate-teeth & gate liveness (can this check actually
+  holes, toolchain skew); **gate rules need BOTH directions** — a new check
+  wants a fires-on-violation test AND a stays-silent-on-a-legitimate-variant
+  test, because "can it fire?" and "does it only fire when it should?" are
+  independent failure modes and the second is the one nobody writes. #788 shipped
+  three of them in one PR: the `--json-schema` rule silently required the schema
+  to be the LAST flag (a valid payload with any argument after it was rejected);
+  and prefix-matching `./.github/workflows/` dropped a cross-repo `uses:` out of
+  the group set, whereupon the membership rule instructed the maintainer to
+  REMOVE a group from the ONLY required status check protecting main — a
+  confident wrong instruction carrying a gate's authority, worse than silence.
+  Mutation testing proves only the first direction; `deny_coverage_test.sh`
+  mechanically enforces that a deny message is asserted somewhere, and the
+  legitimate-variant half stays this factor's job; **the message is half the
+  rule** — a deny/error/panic string is the ONLY part of a check a future
+  maintainer reads, so it must name the actual requirement and the remedy, not a
+  plausible-sounding neighbour: #788's OIDC rule denied with "only the tests call
+  uploads via OIDC" while `release.yml` uses `id-token` for provenance, so the
+  sentence was false and pointed the reader nowhere. Review the string with the
+  same care as the condition; gate-teeth & gate liveness (can this check actually
   FAIL, and is it alive: a checker that exits 0 on its own internal error is
   fail-open; an exit code read through a pipe / `; echo $?` is eaten; a check
   never wired into a required workflow gates nothing — the `.harness` fail-open

--- a/.github/prompts/review-schema.json
+++ b/.github/prompts/review-schema.json
@@ -1,0 +1,52 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "summary": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 8000
+    },
+    "findings": {
+      "type": "array",
+      "maxItems": 5,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "severity": {
+            "type": "string",
+            "enum": [
+              "HIGH",
+              "MEDIUM"
+            ]
+          },
+          "path": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 512
+          },
+          "line": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "body": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4000
+          }
+        },
+        "required": [
+          "severity",
+          "path",
+          "line",
+          "body"
+        ]
+      }
+    }
+  },
+  "required": [
+    "summary",
+    "findings"
+  ]
+}

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -100,6 +100,7 @@ jobs:
       - run: just shfmt-check
       - run: just shellcheck
       - run: just actionlint
+      - run: just actionlint-composites
       - run: just zizmor
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -87,7 +87,13 @@ jobs:
           go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
           go install github.com/mikefarah/yq/v4@v4.53.3
           CGO_ENABLED=0 go install github.com/open-policy-agent/conftest@v0.68.2
+          # conftest embeds OPA but exposes neither `check` nor test coverage, so
+          # the OPA binary owns both; regal is the OPA project's Rego linter.
+          go install github.com/open-policy-agent/opa@v1.18.2
+          go install github.com/open-policy-agent/regal@v0.42.0
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+      - name: Install the JSON Schema validator
+        run: pipx install check-jsonschema==0.37.4
       - uses: taiki-e/install-action@v2
         with:
           tool: lychee@0.24.2,zizmor@1.28.0
@@ -105,6 +111,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
       - run: just ci-observability
+      - run: just json-schemas
       - run: just links
 
   msrv:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -163,6 +163,10 @@ jobs:
 
   snapshots:
     name: snapshot hygiene
+    # Declared, not inherited: an omitted block would take the caller's
+    # id-token: write and hand this job a repo-scoped OIDC minting capability.
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -182,6 +186,8 @@ jobs:
   # Mutation testing remains in its separate on-demand mutants.yml workflow.
   smoke:
     name: smoke
+    permissions:
+      contents: read
     # Independent of lint jobs: parallel execution lowers green-path latency.
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -249,6 +255,8 @@ jobs:
 
   required:
     name: required-test-jobs
+    permissions:
+      contents: read
     # Explicit membership keeps a deleted or renamed nested job from letting the
     # single protected ci-gate silently lose coverage.
     if: ${{ always() }}

--- a/.github/workflows/claude-readonly-review.yml
+++ b/.github/workflows/claude-readonly-review.yml
@@ -134,7 +134,7 @@ jobs:
             --permission-mode dontAsk
             --allowedTools "Read,Glob,Grep"
             --json-schema
-            '{"type":"object","additionalProperties":false,"properties":{"summary":{"type":"string","minLength":1,"maxLength":8000},"findings":{"type":"array","maxItems":5,"items":{"type":"object","additionalProperties":false,"properties":{"severity":{"type":"string","enum":["HIGH","MEDIUM"]},"path":{"type":"string","minLength":1,"maxLength":512},"line":{"type":"integer","minimum":1},"body":{"type":"string","minLength":1,"maxLength":4000}},"required":["severity","path","line","body"]}},"required":["summary","findings"]}'
+            '{"type":"object","additionalProperties":false,"properties":{"summary":{"type":"string","minLength":1,"maxLength":8000},"findings":{"type":"array","maxItems":5,"items":{"type":"object","additionalProperties":false,"properties":{"severity":{"type":"string","enum":["HIGH","MEDIUM"]},"path":{"type":"string","minLength":1,"maxLength":512},"line":{"type":"integer","minimum":1},"body":{"type":"string","minLength":1,"maxLength":4000}},"required":["severity","path","line","body"]}}},"required":["summary","findings"]}'
 
       - name: Require a valid structured review
         if: steps.pr.outputs.reviewable == 'true'

--- a/.github/workflows/claude-readonly-review.yml
+++ b/.github/workflows/claude-readonly-review.yml
@@ -105,6 +105,23 @@ jobs:
             echo "Head: $HEAD_SHA"
           } > .claude-review/review-context.md
 
+      # The schema lives in a committed .json so every tool can read it — the
+      # inline literal was invisible to actionlint and zizmor, and an unbalanced
+      # brace in it took both review bots down for 31h. `check-jsonschema
+      # --check-metaschema` gates the file in `just lint`. The CLI has no
+      # --json-schema-file and rejects a path, so it must round-trip through a
+      # step output; shlex.quote does the shell quoting, which (unlike a
+      # hand-written '...' wrapper) survives a payload containing an apostrophe.
+      - name: Load the review schema
+        if: steps.pr.outputs.reviewable == 'true'
+        id: schema
+        run: |
+          set -euo pipefail
+          printf 'json=%s\n' \
+            "$(jq -c . .github/prompts/review-schema.json |
+              python3 -c 'import shlex,sys; sys.stdout.write(shlex.quote(sys.stdin.read().strip()))')" \
+            >>"$GITHUB_OUTPUT"
+
       - name: Run read-only Claude review
         if: steps.pr.outputs.reviewable == 'true'
         id: claude
@@ -133,8 +150,7 @@ jobs:
             --max-budget-usd ${{ inputs.max_budget_usd }}
             --permission-mode dontAsk
             --allowedTools "Read,Glob,Grep"
-            --json-schema
-            '{"type":"object","additionalProperties":false,"properties":{"summary":{"type":"string","minLength":1,"maxLength":8000},"findings":{"type":"array","maxItems":5,"items":{"type":"object","additionalProperties":false,"properties":{"severity":{"type":"string","enum":["HIGH","MEDIUM"]},"path":{"type":"string","minLength":1,"maxLength":512},"line":{"type":"integer","minimum":1},"body":{"type":"string","minLength":1,"maxLength":4000}},"required":["severity","path","line","body"]}}},"required":["summary","findings"]}'
+            --json-schema ${{ steps.schema.outputs.json }}
 
       - name: Require a valid structured review
         if: steps.pr.outputs.reviewable == 'true'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -81,6 +81,13 @@ jobs:
         uses: github/codeql-action/analyze@v4
         with:
           category: /language:${{ matrix.language }}
+          # Rust defers its upload until the extraction-health gate below has
+          # passed. A degraded extraction yields FEWER alerts, so uploading first
+          # publishes a security tab that looks CLEANER than reality — the job
+          # goes red, but the dashboard says fine. Only Rust defers: upstream
+          # notes `never` complicates debugging, and no other language here has a
+          # health gate to wait for.
+          upload: ${{ matrix.language == 'rust' && 'never' || 'always' }}
 
       # The action can remain green when extractor diagnostics affect most
       # files. Read CodeQL's own SARIF metrics and enforce this repository's
@@ -130,3 +137,13 @@ jobs:
             echo "::error title=Unhealthy Rust CodeQL database::$with_diagnostics files have extraction diagnostics; only $without_diagnostics are clean."
             exit 1
           fi
+
+      # Only now — the SARIF the gate above just vouched for. If that gate failed
+      # this never runs, which is the point: no analysis reaches the security tab
+      # unless it was healthy enough to be worth trusting.
+      - name: Upload Rust analysis
+        if: ${{ matrix.language == 'rust' }}
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: ${{ steps.analyze.outputs.sarif-output }}
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -26,6 +26,11 @@ jobs:
           fetch-depth: 0 # `--in-diff` needs the merge base in history
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
+      # cargo-mutants builds a baseline with DEFAULT features, which pull
+      # rodio -> cpal -> ALSA headers. Without these the on-demand audit dies
+      # in its baseline build before testing a single mutant.
+      - name: Install ALSA headers
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: v1-rust # match setup-cargo-just's default cache namespace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
         # Linux artifacts build WITHOUT the audio feature: musl can't link
         # ALSA statically and the aarch64 cross image has no ALSA headers.
         # Prebuilt Linux = silent; from-source Linux gets audio (#633).
-        run: just build-target ${{ matrix.target }} ${{ matrix.cross }} "${{ contains(matrix.target, 'linux') && '--no-default-features' || '' }}"
+        run: just build-target ${{ matrix.target }} "${{ matrix.cross || 'false' }}" "${{ contains(matrix.target, 'linux') && '--no-default-features' || '' }}"
 
       - name: Package (Unix)
         if: runner.os != 'Windows'
@@ -208,7 +208,7 @@ jobs:
         # Linux artifacts build WITHOUT the audio feature: musl can't link
         # ALSA statically and the aarch64 cross image has no ALSA headers.
         # Prebuilt Linux = silent; from-source Linux gets audio (#633).
-        run: just build-target ${{ matrix.target }} ${{ matrix.cross }} "${{ contains(matrix.target, 'linux') && '--no-default-features' || '' }}"
+        run: just build-target ${{ matrix.target }} "${{ matrix.cross || 'false' }}" "${{ contains(matrix.target, 'linux') && '--no-default-features' || '' }}"
 
       - name: Build .deb packages
         run: just deb ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Install musl-tools
         if: contains(matrix.target, 'musl')
-        run: sudo apt-get install -y musl-tools
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
 
       - name: Build
         # Linux artifacts build WITHOUT the audio feature: musl can't link
@@ -296,6 +296,13 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
+      # `cargo publish` BUILDS each crate to verify it, and pixtuoid's default
+      # features pull rodio -> cpal -> ALSA headers. Without these the loop
+      # publishes pixtuoid-core, pixtuoid-scene and pixtuoid-hook — irreversibly
+      # — and only then fails to compile pixtuoid, stranding the release
+      # half-published at a version that can never be reused.
+      - name: Install ALSA headers
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
       - uses: Swatinem/rust-cache@v2 # zizmor: ignore[cache-poisoning] PR caches are merge-ref scoped; stable tags are ancestry-gated to main
         with:
           prefix-key: v1-rust

--- a/.github/workflows/risk-radar.yml
+++ b/.github/workflows/risk-radar.yml
@@ -35,7 +35,12 @@ jobs:
         run: just risk-radar-test
 
       # continue-on-error: a transient `gh pr diff` hiccup must not redden an
-      # advisory, non-required job. The step summary is the durable floor.
+      # advisory, non-required job. The step summary is the durable floor, so it
+      # is written on BOTH paths — but the two must not look alike. Without
+      # pipefail the pipeline reported python3's status, so a failed diff read as
+      # success on empty input and printed the same confident "no seams touched"
+      # as a genuinely clean diff. Pipefail separates them; the explicit else
+      # keeps the floor that a bare `set -e` would have removed entirely.
       - name: Compute risk radar
         id: compute
         continue-on-error: true
@@ -43,15 +48,21 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
         run: |
-          # Without pipefail the pipeline reports python3's status, so a failed
-          # `gh pr diff` reads as success on empty input and the guard below
-          # publishes a confident "no seams touched" verdict for an unread diff.
-          set -euo pipefail
-          gh pr diff "$PR" --name-only | python3 scripts/risk-radar.py >radar.md
-          {
-            echo "## Risk radar"
-            if [ -s radar.md ]; then cat radar.md; else echo "_No high-blast-radius seams touched._"; fi
-          } >>"$GITHUB_STEP_SUMMARY"
+          set -uo pipefail
+          if gh pr diff "$PR" --name-only | python3 scripts/risk-radar.py >radar.md; then
+            {
+              echo "## Risk radar"
+              if [ -s radar.md ]; then cat radar.md; else echo "_No high-blast-radius seams touched._"; fi
+            } >>"$GITHUB_STEP_SUMMARY"
+          else
+            # Not a verdict: discard the partial file so nothing downstream reads it.
+            rm -f radar.md
+            {
+              echo "## Risk radar"
+              echo "_Could not read the pull-request diff — radar not computed._"
+            } >>"$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
 
       # Only upsert when the radar was actually computed (else radar.md is
       # untrustworthy and the empty-body branch would wrongly delete the

--- a/.github/workflows/risk-radar.yml
+++ b/.github/workflows/risk-radar.yml
@@ -43,6 +43,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
         run: |
+          # Without pipefail the pipeline reports python3's status, so a failed
+          # `gh pr diff` reads as success on empty input and the guard below
+          # publishes a confident "no seams touched" verdict for an unread diff.
+          set -euo pipefail
           gh pr diff "$PR" --name-only | python3 scripts/risk-radar.py >radar.md
           {
             echo "## Risk radar"

--- a/.regal/config.yaml
+++ b/.regal/config.yaml
@@ -1,0 +1,46 @@
+# Regal (the OPA project's Rego linter) over policy/ci-observability.
+# Every disabled rule below is a deliberate, evidence-backed disagreement — not
+# a convenience. Anything not listed here is ON and gated by `just regal`.
+rules:
+  idiomatic:
+    # `superfluous-object-get` rewrites `object.get(o, "k", default)` into a bare
+    # `o.k`. Those are NOT equivalent for policy: on a MISSING key the bare ref is
+    # undefined, so the rule body is never true and the check silently passes.
+    # Demonstrated with `opa eval` on a two-rule fixture — with the key absent,
+    # only the object.get form fires. This repo already shipped 11 CodeQL rules
+    # that were fail-open for exactly that reason; taking this lint's advice
+    # would have manufactured 32 more. The default is load-bearing, not noise.
+    superfluous-object-get:
+      level: ignore
+    # Conftest evaluates the `deny` set directly and has no entrypoint concept.
+    no-defined-entrypoint:
+      level: ignore
+    # Conftest requires the policy to live in the `main` namespace regardless of
+    # directory (`conftest test --policy policy/ci-observability`).
+    directory-package-mismatch:
+      level: ignore
+  testing:
+    # Conftest's documented layout is `x.rego` + `x_test.rego` in the SAME
+    # package — `conftest verify` discovers tests there. A separate _test package
+    # would break the tool that actually runs them.
+    test-outside-test-package:
+      level: ignore
+  style:
+    # Default is max-allowed: 2. Exactly one helper needs three —
+    # `pinned_npm_setup_steps` reads `documents` (the single input index this
+    # whole policy is built on) plus two package constants. The rule targets
+    # hidden dependencies on mutable state; threading the input index and two
+    # consts through every helper's signature would add noise, not safety.
+    # Raised by one rather than disabled, so a fourth reference still trips it.
+    external-reference:
+      max-allowed: 3
+    # The policy's WHY comments and sprintf messages are deliberately long-form;
+    # the repo's house style favours a complete sentence over a wrapped one.
+    line-length:
+      level: ignore
+    # main.rego is one cross-file CI contract by design — splitting it would put
+    # rules that share constants into separate files.
+    file-length:
+      level: ignore
+    rule-length:
+      level: ignore

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ component — `rust-toolchain.toml` pins only `rustfmt`+`clippy`, so without it 
 editor / AI-agent LSP silently degrades to grep).
 
 ```
-just preflight    # full pre-push gate: lint (fmt+machete+deny+arch+shfmt+shellcheck+actionlint+actionlint-composites+zizmor+ci-observability+links) → clippy → hack → test
+just preflight    # full pre-push gate: lint (fmt+machete+deny+arch+shfmt+shellcheck+actionlint+actionlint-composites+zizmor+ci-observability+json-schemas+links) → clippy → hack → test
 just fmt          # auto-format
 git config core.hooksPath .githooks   # activate hooks once per clone
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ component — `rust-toolchain.toml` pins only `rustfmt`+`clippy`, so without it 
 editor / AI-agent LSP silently degrades to grep).
 
 ```
-just preflight    # full pre-push gate: lint (fmt+machete+deny+arch+shfmt+shellcheck+actionlint+ci-observability+links) → clippy → hack → test
+just preflight    # full pre-push gate: lint (fmt+machete+deny+arch+shfmt+shellcheck+actionlint+actionlint-composites+zizmor+ci-observability+links) → clippy → hack → test
 just fmt          # auto-format
 git config core.hooksPath .githooks   # activate hooks once per clone
 ```

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -19,7 +19,7 @@ git hooks call the same recipes.
 
 ```bash
 just              # list recipes
-just preflight    # full pre-push gate: lint (fmt + machete + deny + arch + shfmt + shellcheck + actionlint + actionlint-composites + zizmor + ci-observability + links) → clippy → hack → test
+just preflight    # full pre-push gate: lint (fmt + machete + deny + arch + shfmt + shellcheck + actionlint + actionlint-composites + zizmor + ci-observability + json-schemas + links) → clippy → hack → test
 just fmt          # auto-format
 just test         # the whole suite (cargo-nextest if installed, else cargo test)
 ```

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -19,7 +19,7 @@ git hooks call the same recipes.
 
 ```bash
 just              # list recipes
-just preflight    # full pre-push gate: lint (fmt + machete + deny + arch + shfmt + shellcheck + actionlint + ci-observability + links) → clippy → hack → test
+just preflight    # full pre-push gate: lint (fmt + machete + deny + arch + shfmt + shellcheck + actionlint + actionlint-composites + zizmor + ci-observability + links) → clippy → hack → test
 just fmt          # auto-format
 just test         # the whole suite (cargo-nextest if installed, else cargo test)
 ```

--- a/justfile
+++ b/justfile
@@ -79,6 +79,43 @@ shellcheck:
 actionlint:
     actionlint
 
+# The blind spot the recipe above cannot cover: actionlint models WORKFLOWS, so
+# it discovers only .github/workflows and rejects an action.yml outright
+# ("jobs section is missing"). Shell that moves from a workflow into a composite
+# action therefore loses its shellcheck coverage silently — which is exactly
+# what happened to the homebrew-core contract asserts in packaging-build. Pull
+# each `run:` out ourselves and check it with the same linter.
+[group('rust')]
+[doc('Shellcheck every run: block inside the composite actions (actionlint cannot parse action.yml)')]
+actionlint-composites:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    shopt -s nullglob
+    actions=(.github/actions/*/action.yml)
+    ((${#actions[@]})) || { echo "error: no composite actions found" >&2; exit 1; }
+    work="$(mktemp -d)"
+    trap 'rm -rf "$work"' EXIT
+    checked=0
+    for action in "${actions[@]}"; do
+        count="$(yq '[.runs.steps[] | select(has("run"))] | length' "$action")"
+        ((count)) || continue # a pure `uses:` composite has no shell to check
+        for i in $(seq 0 $((count - 1))); do
+            # Default to bash: composite steps must name a shell, and actionlint
+            # treats bash as the default elsewhere. sh gets the stricter dialect.
+            shell="$(yq -r ".runs.steps | map(select(has(\"run\"))) | .[$i].shell // \"bash\"" "$action")"
+            case "$shell" in
+            bash | sh) ;;
+            *) continue ;; # pwsh/python are not shellcheck's to judge
+            esac
+            script="$work/$(echo "$action" | tr /. __)-$i.$shell"
+            { echo "#!/usr/bin/env $shell"; yq -r ".runs.steps | map(select(has(\"run\"))) | .[$i].run" "$action"; } >"$script"
+            shellcheck -s "$shell" "$script" || { echo "  ^ from $action step $i" >&2; exit 1; }
+            checked=$((checked + 1))
+        done
+    done
+    ((checked > 0)) || { echo "error: no composite run: blocks were checked" >&2; exit 1; }
+    echo "$checked composite run: blocks shellchecked"
+
 # Security audit for workflows/actions/Dependabot. zizmor owns the parser and
 # audit catalog; .github/zizmor.yml records the repository's deliberate
 # ref-or-SHA pin policy and every accepted finding is suppressed at its exact
@@ -199,6 +236,7 @@ lint:
     run shfmt   just shfmt-check         & pids+=($!)
     run shell   just shellcheck           & pids+=($!)
     run actions just actionlint          & pids+=($!)
+    run composites just actionlint-composites & pids+=($!)
     run zizmor  just zizmor              & pids+=($!)
     run ci-obs  just ci-observability     & pids+=($!)
     run links   just links               & pids+=($!)
@@ -469,6 +507,17 @@ build-target target cross="false" flags="":
     #!/usr/bin/env bash
     set -euo pipefail
     use_cross="{{ cross }}"
+    # An unquoted, unset matrix.cross in release.yml used to expand to nothing and
+    # slide `flags` into this slot, so the LINUX artifacts silently built WITHOUT
+    # --no-default-features. Anything but the two legal words is a caller bug, so
+    # fail loudly here rather than infer "not true, so cargo".
+    case "$use_cross" in
+    true | false) ;;
+    *)
+        echo "error: cross must be 'true' or 'false', got '$use_cross' (positional args shifted?)" >&2
+        exit 1
+        ;;
+    esac
     # flags: extra cargo flags — release.yml passes --no-default-features for
     # every LINUX artifact (musl can't link ALSA statically; the aarch64 cross
     # image has no ALSA headers), so prebuilt Linux binaries ship SILENT and

--- a/justfile
+++ b/justfile
@@ -100,6 +100,7 @@ actionlint-composites:
     work="$(mktemp -d)"
     trap 'rm -rf "$work"' EXIT
     checked=0
+    skipped=()
     for action in "${actions[@]}"; do
         count="$(yq '[.runs.steps[] | select(has("run"))] | length' "$action")"
         ((count)) || continue # a pure `uses:` composite has no shell to check
@@ -109,7 +110,12 @@ actionlint-composites:
             shell="$(yq -r ".runs.steps | map(select(has(\"run\"))) | .[$i].shell // \"bash\"" "$action")"
             case "$shell" in
             bash | sh) ;;
-            *) continue ;; # pwsh/python are not shellcheck's to judge
+            # pwsh/python are not shellcheck's to judge, but a bounded gate that
+            # does not name what it dropped reads as full coverage.
+            *)
+                skipped+=("$action step $i ($shell)")
+                continue
+                ;;
             esac
             script="$work/$(echo "$action" | tr /. __)-$i.$shell"
             { echo "#!/usr/bin/env $shell"; yq -r ".runs.steps | map(select(has(\"run\"))) | .[$i].run" "$action"; } >"$script"
@@ -119,6 +125,8 @@ actionlint-composites:
     done
     ((checked > 0)) || { echo "error: no composite run: blocks were checked" >&2; exit 1; }
     echo "$checked composite run: blocks shellchecked"
+    ((${#skipped[@]})) && printf '  skipped (not a shellcheck dialect): %s\n' "${skipped[@]}"
+    exit 0
 
 # Security audit for workflows/actions/Dependabot. zizmor owns the parser and
 # audit catalog; .github/zizmor.yml records the repository's deliberate

--- a/justfile
+++ b/justfile
@@ -156,6 +156,14 @@ ci-observability:
     trap 'rm -f "$combined" "$policy_test_results"' EXIT
     yq eval-all -o=json '[{"path": filename, "contents": .}] | {"documents": .}' "${files[@]}" >"$combined"
     conftest fmt --check policy/ci-observability
+    # conftest embeds OPA but exposes neither `check` nor coverage, so the OPA
+    # binary owns both. `--strict` catches compile-level slop conftest accepts
+    # (an unused argument shipped here undetected); the coverage threshold is a
+    # RATCHET on #789 — an uncovered rule head means "the body was never true",
+    # i.e. no test makes that rule fire, which is how two vacuous rules reached
+    # main. Raise the number as rules gain tests; never lower it.
+    opa check --strict policy/ci-observability
+    opa test --coverage --threshold 94 policy/ci-observability >/dev/null
     if ! conftest verify --policy policy/ci-observability --output json >"$policy_test_results"; then
         yq -P '.' "$policy_test_results" >&2
         exit 1
@@ -166,6 +174,27 @@ ci-observability:
     conftest test --parser json --policy policy/ci-observability "$combined"
     bash policy/ci-observability/action_behavior_test.sh
     iconv -f US-ASCII -t US-ASCII codecov.yml >/dev/null
+    # Regal is the OPA project's own Rego linter; .regal/config.yaml records
+    # every deliberate disagreement with a WHY. LAST on purpose: it judges style,
+    # and under `set -e` an earlier position would abort the recipe before the
+    # correctness checks above ever evaluated the documents.
+    regal lint policy/ci-observability
+
+# Every committed JSON Schema, held to the metaschema. These are contracts a
+# consumer reads at runtime — the review schema reaches the Claude CLI, the
+# raycast ones pin the `--json` shape — and nothing else parses them: a broken
+# one is invisible until the consumer refuses to start, which is exactly how the
+# review bots died for 31h.
+[group('rust')]
+[doc('Validate every committed JSON Schema against the metaschema (check-jsonschema)')]
+json-schemas:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    shopt -s nullglob
+    schemas=(.github/prompts/review-schema.json integrations/raycast/contract/*.schema.json)
+    ((${#schemas[@]})) || { echo "error: no committed JSON Schemas found" >&2; exit 1; }
+    check-jsonschema --check-metaschema "${schemas[@]}"
+    echo "${#schemas[@]} JSON Schemas validated"
 
 # Offline link + anchor check (lychee) over the repo's OWN markdown: every
 # relative cross-link between the nested CLAUDE.md/AGENTS.md guides + docs/ must
@@ -230,7 +259,7 @@ lint:
     # Fail fast with an actionable message when a lint tool is missing, instead
     # of a bare `command not found` (exit 127) buried in a parallel job's log.
     missing=()
-    for t in shfmt shellcheck actionlint zizmor conftest yq jq iconv cargo-machete cargo-deny lychee; do
+    for t in shfmt shellcheck actionlint zizmor conftest opa regal check-jsonschema yq jq iconv cargo-machete cargo-deny lychee; do
         command -v "$t" &>/dev/null || missing+=("$t")
     done
     if (( ${#missing[@]} )); then
@@ -251,6 +280,7 @@ lint:
     run composites just actionlint-composites & pids+=($!)
     run zizmor  just zizmor              & pids+=($!)
     run ci-obs  just ci-observability     & pids+=($!)
+    run schemas just json-schemas         & pids+=($!)
     run links   just links               & pids+=($!)
     for p in "${pids[@]}"; do wait "$p" || fail=1; done
     [[ $fail -eq 0 ]]
@@ -961,7 +991,7 @@ setup-tools:
     # ast-grep backs the `comment-lint` advisory (structural Rust lint rules in
     # .ast-grep/rules/); shfmt/actionlint/shellcheck/zizmor back workflow
     # linting, while yq + jq + Conftest/OPA evaluate repository-specific policy.
-    for t in shfmt actionlint shellcheck zizmor ast-grep yq jq conftest; do
+    for t in shfmt actionlint shellcheck zizmor ast-grep yq jq conftest opa regal check-jsonschema; do
         command -v "$t" &>/dev/null && continue
         if command -v brew &>/dev/null; then
             brew install "$t" || true
@@ -972,7 +1002,7 @@ setup-tools:
     # caught here — not silently pass as a successful setup (the #283-class silent
     # no-op this recipe is meant to prevent).
     missing=()
-    for t in shfmt actionlint shellcheck zizmor yq jq conftest iconv; do
+    for t in shfmt actionlint shellcheck zizmor yq jq conftest opa regal check-jsonschema iconv; do
         command -v "$t" &>/dev/null || missing+=("$t")
     done
     if (( ${#missing[@]} )); then

--- a/justfile
+++ b/justfile
@@ -25,7 +25,11 @@ set windows-shell := ["bash", "-cu"]
 # newly-published crate is added in ONE place.
 PUBLISHED_CRATES := "pixtuoid-core pixtuoid-scene"
 
-# Shell sources share one authority so formatting and lint coverage cannot drift.
+# Standalone shell FILES share one authority so formatting and lint coverage
+# cannot drift. Shell embedded in YAML is a second population this cannot cover:
+# workflow `run:` blocks go to actionlint, composite-action ones to
+# `actionlint-composites`. Both are shellcheck-only — shfmt cannot rewrite a
+# scalar in place — so adding a file here is not enough for embedded shell.
 SHELL_SOURCES := "scripts/*.sh .githooks/* policy/ci-observability/*.sh"
 
 # The nightly the api-surface goldens are pinned to (rustdoc JSON is

--- a/justfile
+++ b/justfile
@@ -91,7 +91,7 @@ actionlint-composites:
     #!/usr/bin/env bash
     set -euo pipefail
     shopt -s nullglob
-    actions=(.github/actions/*/action.yml)
+    actions=(.github/actions/*/action.y*ml) # GitHub accepts action.yaml too
     ((${#actions[@]})) || { echo "error: no composite actions found" >&2; exit 1; }
     work="$(mktemp -d)"
     trap 'rm -rf "$work"' EXIT

--- a/justfile
+++ b/justfile
@@ -100,8 +100,8 @@ actionlint-composites:
         count="$(yq '[.runs.steps[] | select(has("run"))] | length' "$action")"
         ((count)) || continue # a pure `uses:` composite has no shell to check
         for i in $(seq 0 $((count - 1))); do
-            # Default to bash: composite steps must name a shell, and actionlint
-            # treats bash as the default elsewhere. sh gets the stricter dialect.
+            # The default should never fire — a composite run step must name a
+            # shell — but bash is what actionlint assumes for a workflow step.
             shell="$(yq -r ".runs.steps | map(select(has(\"run\"))) | .[$i].shell // \"bash\"" "$action")"
             case "$shell" in
             bash | sh) ;;
@@ -500,17 +500,18 @@ build *args:
 
 # Cross-compile a release build for ONE target triple (release.yml's build
 # matrix). Pass `true` for targets that need the Docker-backed `cross` toolchain
-# (CI installs it via taiki-e/install-action@cross).
+# (CI installs it via taiki-e/install-action@cross). `cross` is validated rather
+# than defaulted because callers pass it POSITIONALLY: an unquoted, unset
+# matrix.cross expands to nothing, and the collapse slid `flags` into this slot
+# on both Linux legs that omit the key — pinned by the arg-shift case below.
 [group('rust')]
 [doc('Cross-compile a release for ONE target triple (release.yml build matrix)')]
 build-target target cross="false" flags="":
     #!/usr/bin/env bash
     set -euo pipefail
     use_cross="{{ cross }}"
-    # An unquoted, unset matrix.cross in release.yml used to expand to nothing and
-    # slide `flags` into this slot, so the LINUX artifacts silently built WITHOUT
-    # --no-default-features. Anything but the two legal words is a caller bug, so
-    # fail loudly here rather than infer "not true, so cargo".
+    # Anything but the two legal words means the caller's positional args
+    # shifted, so fail loudly rather than infer "not true, so cargo".
     case "$use_cross" in
     true | false) ;;
     *)

--- a/justfile
+++ b/justfile
@@ -163,7 +163,7 @@ ci-observability:
     # i.e. no test makes that rule fire, which is how two vacuous rules reached
     # main. Raise the number as rules gain tests; never lower it.
     opa check --strict policy/ci-observability
-    opa test --coverage --threshold 94 policy/ci-observability >/dev/null
+    opa test --coverage --threshold 95 policy/ci-observability >/dev/null
     if ! conftest verify --policy policy/ci-observability --output json >"$policy_test_results"; then
         yq -P '.' "$policy_test_results" >&2
         exit 1

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -91,13 +91,15 @@ codecov_oidc_job_names := {
 	"coverage-macos",
 }
 
-documents := {document.path: document.contents |
+documents[path] := contents if {
 	some document in input.documents
+	path := document.path
+	contents := document.contents
 }
 
 objects := [entry |
 	some document in input.documents
-	some _, value in walk(document.contents)
+	some value in walk(document.contents)
 	is_object(value)
 	entry := {"path": document.path, "value": value}
 ]
@@ -163,7 +165,8 @@ warning_steps := [entry |
 	object.get(entry.value, "if", "") == "${{ steps.upload.outcome == 'failure' }}"
 ]
 
-effective_working_directory(job, step) := directory if {
+# The step's own working-directory wins, so this arm never consults the job.
+effective_working_directory(_, step) := directory if {
 	directory := object.get(step, "working-directory", null)
 	directory != null
 }
@@ -220,8 +223,9 @@ codecov_route(entry) := route if {
 	}
 }
 
-actual_codecov_routes := {codecov_route(entry) |
+actual_codecov_routes contains route if {
 	some entry in codecov_uploads
+	route := codecov_route(entry)
 }
 
 ci_workflow := object.get(documents, ci_workflow_path, {})
@@ -281,7 +285,7 @@ claude_publish_named_steps(name) := indexed_steps_matching(claude_publish_steps,
 claude_caller_jobs(path) := [job |
 	workflow := documents[path]
 	jobs := object.get(workflow, "jobs", {})
-	some _, job in jobs
+	some job in jobs
 	object.get(job, "uses", "") == claude_reusable_reference
 ]
 
@@ -328,14 +332,12 @@ claude_model_is_read_only(step) if {
 	not contains(args, "mcp__github")
 }
 
-# `--json-schema` smuggles a JSON document through a YAML string, so nothing
-# else in the gate stack reads it: actionlint and zizmor see an opaque scalar,
-# and the read-only rule above is satisfied by the flag NAME alone. An
-# unbalanced brace therefore survives every local check and only surfaces on the
-# runner, where the CLI refuses to start and every review run dies with
-# "--json-schema is not valid JSON" — a gate that can never pass. Parse the
-# payload here instead, and hold it to being a well-formed JSON *Schema* rather
-# than merely well-formed JSON, so `--json-schema '123'` fails too.
+# The schema is no longer a literal here: it lives in a committed .json that
+# check-jsonschema gates, and reaches the CLI through a step output. Pin the
+# reference exactly so an inline payload — the shape whose unbalanced brace took
+# both bots down — cannot creep back in and become unreadable to every linter.
+review_schema_reference := "--json-schema ${{ steps.schema.outputs.json }}"
+
 claude_args_schema_entries := [entry |
 	some candidate in objects
 	args := object.get(candidate.value, "claude_args", null)
@@ -343,24 +345,6 @@ claude_args_schema_entries := [entry |
 	contains(args, json_schema_flag)
 	entry := {"path": candidate.path, "args": args}
 ]
-
-claude_json_schema_is_wellformed(args) if {
-	parts := split(args, sprintf("%s '", [json_schema_flag]))
-
-	# Exactly one occurrence; a second copy makes the effective payload ambiguous.
-	count(parts) == 2
-
-	# Cut at the CLOSING quote, not at the end of the string: the schema is not
-	# required to be the final flag, and an earlier draft that trimmed a trailing
-	# quote rejected every valid payload with an argument after it.
-	payload := split(parts[1], "'")[0]
-
-	# split returns the whole remainder when the separator is absent, so this
-	# proves a closing quote exists rather than the payload running off the end.
-	payload != parts[1]
-	json.is_valid(payload)
-	json.verify_schema(json.unmarshal(payload))[0]
-}
 
 claude_model_auth_is_scoped(step) if {
 	params := object.get(step, "with", {})
@@ -411,6 +395,47 @@ has_weekly_codeql_schedule if {
 	some schedule in codeql.on.schedule
 	schedule.cron == "29 11 * * 3"
 }
+
+# A job in a CALLED workflow that omits `permissions:` runs with exactly the set
+# the caller handed down, and ci.yml grants this workflow id-token:write for the
+# Codecov OIDC upload. So an omitted block is not "no permissions" — it IS the
+# grant, and a rule that only inspects the declared block cannot see the very
+# jobs that are exposed. Require every non-Codecov job to declare its own scope.
+codecov_job_scope_is_self_declared(job) if {
+	permissions := object.get(job, "permissions", null)
+	is_object(permissions)
+	object.get(permissions, "id-token", "") != "write"
+}
+
+# `ci-gate` is the ONLY context in branch protection, so its `needs` list plus
+# the results it reads ARE the merge gate. Each reusable workflow already pins
+# its own nested job membership; nothing pinned the level above, where adding a
+# group and forgetting to gate it leaves the single required check green while
+# that group is free to fail. `supplemental` is advisory by design.
+
+# A job-level `uses:` IS a reusable-workflow call — a job cannot carry both
+# `uses:` and `steps:`. Matching on the `./.github/workflows/` prefix instead
+# would drop a cross-repo call out of the group set, and the membership rule
+# would then instruct the maintainer to REMOVE that group from the merge gate.
+calls_a_reusable_workflow(job) if {
+	uses := object.get(job, "uses", "")
+	is_string(uses)
+	uses != ""
+}
+
+ci_gate_job_key := "gate"
+
+ci_advisory_job_keys := {"supplemental"}
+
+ci_gate_job := object.get(ci_jobs, ci_gate_job_key, {})
+
+ci_group_job_keys contains name if {
+	some name, job in ci_jobs
+	calls_a_reusable_workflow(job)
+	not name in ci_advisory_job_keys
+}
+
+ci_gate_needs := {name | some name in object.get(ci_gate_job, "needs", [])}
 
 deny contains msg if {
 	some path in claude_trigger_workflow_paths
@@ -507,15 +532,15 @@ deny contains msg if {
 	msg := sprintf("%s Claude step must use WIF-first authentication with the scoped job token", [claude_reusable_workflow_path])
 }
 
-# Deliberately walks every document rather than the reusable workflow alone: the
-# payload is unreadable to actionlint wherever it appears, so any future caller
-# that grows its own `--json-schema` inherits the same silent-red failure mode.
+# Walks every document, not just the reusable workflow: any future caller that
+# grows its own `--json-schema` inherits the same "invisible to every linter"
+# problem, so it must use the committed file too.
 deny contains msg if {
 	some entry in claude_args_schema_entries
-	not claude_json_schema_is_wellformed(entry.args)
+	not contains(entry.args, review_schema_reference)
 	msg := sprintf(
-		"%s %s must carry exactly one single-quoted, well-formed JSON Schema payload",
-		[entry.path, json_schema_flag],
+		"%s must pass %s via the committed schema file (%s), not an inline literal",
+		[entry.path, json_schema_flag, review_schema_reference],
 	)
 }
 
@@ -531,9 +556,9 @@ deny contains msg if {
 
 deny contains msg if {
 	_ := documents[claude_reusable_workflow_path]
+	msg := sprintf("%s publish job must have comment-only permissions and no checkout", [claude_reusable_workflow_path])
 	some step in claude_publish_steps
 	object.get(step, "uses", "") != ""
-	msg := sprintf("%s publish job must have comment-only permissions and no checkout", [claude_reusable_workflow_path])
 }
 
 deny contains msg if {
@@ -690,25 +715,14 @@ deny contains msg if {
 
 deny contains msg if {
 	_ := documents[codecov_workflow_path]
-	some name in codecov_oidc_job_names
-	job := object.get(codecov_jobs, name, {})
 	expected := {
 		"contents": "read",
 		"id-token": "write",
 	}
+	some name in codecov_oidc_job_names
+	job := object.get(codecov_jobs, name, {})
 	object.get(job, "permissions", {}) != expected
 	msg := sprintf("%s job %s must receive the Codecov OIDC permission", [codecov_workflow_path, name])
-}
-
-# A job in a CALLED workflow that omits `permissions:` runs with exactly the set
-# the caller handed down, and ci.yml grants this workflow id-token:write for the
-# Codecov OIDC upload. So an omitted block is not "no permissions" — it IS the
-# grant, and a rule that only inspects the declared block cannot see the very
-# jobs that are exposed. Require every non-Codecov job to declare its own scope.
-codecov_job_scope_is_self_declared(job) if {
-	permissions := object.get(job, "permissions", null)
-	is_object(permissions)
-	object.get(permissions, "id-token", "") != "write"
 }
 
 deny contains msg if {
@@ -720,40 +734,11 @@ deny contains msg if {
 }
 
 deny contains msg if {
-	path := {ci_workflow_path, codecov_workflow_path, codecov_authority_path}[_]
+	some path in {ci_workflow_path, codecov_workflow_path, codecov_authority_path}
 	document := documents[path]
 	contains(json.marshal(document), "CODECOV_TOKEN")
 	msg := sprintf("%s must not reference the retired CODECOV_TOKEN secret", [path])
 }
-
-# `ci-gate` is the ONLY context in branch protection, so its `needs` list plus
-# the results it reads ARE the merge gate. Each reusable workflow already pins
-# its own nested job membership; nothing pinned the level above, where adding a
-# group and forgetting to gate it leaves the single required check green while
-# that group is free to fail. `supplemental` is advisory by design.
-# A job-level `uses:` IS a reusable-workflow call — a job cannot carry both
-# `uses:` and `steps:`. Matching on the `./.github/workflows/` prefix instead
-# would drop a cross-repo call out of the group set, and the membership rule
-# would then instruct the maintainer to REMOVE that group from the merge gate.
-calls_a_reusable_workflow(job) if {
-	uses := object.get(job, "uses", "")
-	is_string(uses)
-	uses != ""
-}
-
-ci_gate_job_key := "gate"
-
-ci_advisory_job_keys := {"supplemental"}
-
-ci_gate_job := object.get(ci_jobs, ci_gate_job_key, {})
-
-ci_group_job_keys := {name |
-	some name, job in ci_jobs
-	calls_a_reusable_workflow(job)
-	not name in ci_advisory_job_keys
-}
-
-ci_gate_needs := {name | some name in object.get(ci_gate_job, "needs", [])}
 
 deny contains msg if {
 	_ := documents[ci_workflow_path]
@@ -849,33 +834,33 @@ deny contains msg if {
 }
 
 deny contains msg if {
+	msg := sprintf("%s Lighthouse upload must run under !cancelled()", [lighthouse_workflow_path])
 	some entry in uses_entries
 	entry.path == lighthouse_workflow_path
 	entry.uses == "actions/upload-artifact@v7"
 	params := object.get(entry.value, "with", {})
 	object.get(params, "path", "") == "site/.lighthouseci/"
 	object.get(entry.value, "if", "") != "${{ !cancelled() }}"
-	msg := sprintf("%s Lighthouse upload must run under !cancelled()", [lighthouse_workflow_path])
 }
 
 deny contains msg if {
+	msg := sprintf("%s Lighthouse upload must include hidden files", [lighthouse_workflow_path])
 	some entry in uses_entries
 	entry.path == lighthouse_workflow_path
 	entry.uses == "actions/upload-artifact@v7"
 	params := object.get(entry.value, "with", {})
 	object.get(params, "path", "") == "site/.lighthouseci/"
 	object.get(params, "include-hidden-files", false) != true
-	msg := sprintf("%s Lighthouse upload must include hidden files", [lighthouse_workflow_path])
 }
 
 deny contains msg if {
+	msg := sprintf("%s Lighthouse upload must fail when reports are absent", [lighthouse_workflow_path])
 	some entry in uses_entries
 	entry.path == lighthouse_workflow_path
 	entry.uses == "actions/upload-artifact@v7"
 	params := object.get(entry.value, "with", {})
 	object.get(params, "path", "") == "site/.lighthouseci/"
 	object.get(params, "if-no-files-found", "") != "error"
-	msg := sprintf("%s Lighthouse upload must fail when reports are absent", [lighthouse_workflow_path])
 }
 
 deny contains msg if {
@@ -946,7 +931,7 @@ deny contains msg if {
 }
 
 deny contains msg if {
-	codeql.on.push.branches != ["main"]
+	object.get(codeql, ["on", "push", "branches"], null) != ["main"]
 	msg := sprintf("%s must run on pushes to main", [codeql_workflow_path])
 }
 
@@ -966,52 +951,52 @@ deny contains msg if {
 }
 
 deny contains msg if {
-	codeql.permissions.actions != "read"
+	object.get(codeql, ["permissions", "actions"], null) != "read"
 	msg := sprintf("%s must grant actions: read", [codeql_workflow_path])
 }
 
 deny contains msg if {
-	codeql.permissions.contents != "read"
+	object.get(codeql, ["permissions", "contents"], null) != "read"
 	msg := sprintf("%s must grant contents: read", [codeql_workflow_path])
 }
 
 deny contains msg if {
-	codeql.permissions.packages != "read"
+	object.get(codeql, ["permissions", "packages"], null) != "read"
 	msg := sprintf("%s must grant packages: read", [codeql_workflow_path])
 }
 
 deny contains msg if {
-	codeql.permissions["security-events"] != "write"
+	object.get(codeql, ["permissions", "security-events"], null) != "write"
 	msg := sprintf("%s must grant security-events: write", [codeql_workflow_path])
 }
 
 deny contains msg if {
-	codeql.concurrency.group != "codeql-${{ github.ref }}"
+	object.get(codeql, ["concurrency", "group"], null) != "codeql-${{ github.ref }}"
 	msg := sprintf("%s must group concurrency by ref", [codeql_workflow_path])
 }
 
 deny contains msg if {
-	codeql.concurrency["cancel-in-progress"] != "${{ github.event_name == 'pull_request' }}"
+	object.get(codeql, ["concurrency", "cancel-in-progress"], null) != "${{ github.event_name == 'pull_request' }}"
 	msg := sprintf("%s must cancel only superseded pull-request runs", [codeql_workflow_path])
 }
 
 deny contains msg if {
-	codeql_job["runs-on"] != "ubuntu-latest"
+	object.get(codeql_job, "runs-on", null) != "ubuntu-latest"
 	msg := sprintf("%s analyze job must use ubuntu-latest", [codeql_workflow_path])
 }
 
 deny contains msg if {
-	codeql_job["timeout-minutes"] != 30
+	object.get(codeql_job, "timeout-minutes", null) != 30
 	msg := sprintf("%s analyze job must keep timeout-minutes: 30", [codeql_workflow_path])
 }
 
 deny contains msg if {
-	codeql_job.strategy["fail-fast"] != false
+	object.get(codeql_job, ["strategy", "fail-fast"], null) != false
 	msg := sprintf("%s analyze matrix must keep fail-fast: false", [codeql_workflow_path])
 }
 
 deny contains msg if {
-	codeql_job.strategy.matrix.language != ["actions", "javascript-typescript", "python", "rust"]
+	object.get(codeql_job, ["strategy", "matrix", "language"], null) != ["actions", "javascript-typescript", "python", "rust"]
 	msg := sprintf("%s must analyze actions, JavaScript/TypeScript, Python, and Rust", [codeql_workflow_path])
 }
 
@@ -1168,16 +1153,16 @@ deny contains msg if {
 
 deny contains msg if {
 	checkout_steps := codeql_steps_using("actions/checkout@v7")
-	init_steps := codeql_steps_using("github/codeql-action/init@v4")
 	count(checkout_steps) == 1
+	init_steps := codeql_steps_using("github/codeql-action/init@v4")
 	count(init_steps) == 1
 	checkout_steps[0].index >= init_steps[0].index
 	msg := sprintf("%s must check out before CodeQL init", [codeql_workflow_path])
 }
 
 deny contains msg if {
-	init_steps := codeql_steps_using("github/codeql-action/init@v4")
 	count(rust_setup_steps) == 1
+	init_steps := codeql_steps_using("github/codeql-action/init@v4")
 	count(init_steps) == 1
 	rust_setup_steps[0].index >= init_steps[0].index
 	msg := sprintf("%s must prepare Rust before CodeQL init", [codeql_workflow_path])

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -677,13 +677,23 @@ deny contains msg if {
 	msg := sprintf("%s job %s must receive the Codecov OIDC permission", [codecov_workflow_path, name])
 }
 
+# A job in a CALLED workflow that omits `permissions:` runs with exactly the set
+# the caller handed down, and ci.yml grants this workflow id-token:write for the
+# Codecov OIDC upload. So an omitted block is not "no permissions" — it IS the
+# grant, and a rule that only inspects the declared block cannot see the very
+# jobs that are exposed. Require every non-Codecov job to declare its own scope.
+codecov_job_scope_is_self_declared(job) if {
+	permissions := object.get(job, "permissions", null)
+	is_object(permissions)
+	object.get(permissions, "id-token", "") != "write"
+}
+
 deny contains msg if {
 	_ := documents[codecov_workflow_path]
 	some name, job in codecov_jobs
 	not name in codecov_oidc_job_names
-	permissions := object.get(job, "permissions", {})
-	object.get(permissions, "id-token", "") == "write"
-	msg := sprintf("%s job %s must not receive the Codecov OIDC permission", [codecov_workflow_path, name])
+	not codecov_job_scope_is_self_declared(job)
+	msg := sprintf("%s job %s must declare its own permissions and must not receive the Codecov OIDC permission", [codecov_workflow_path, name])
 }
 
 deny contains msg if {
@@ -691,6 +701,45 @@ deny contains msg if {
 	document := documents[path]
 	contains(json.marshal(document), "CODECOV_TOKEN")
 	msg := sprintf("%s must not reference the retired CODECOV_TOKEN secret", [path])
+}
+
+# `ci-gate` is the ONLY context in branch protection, so its `needs` list plus
+# the results it reads ARE the merge gate. Each reusable workflow already pins
+# its own nested job membership; nothing pinned the level above, where adding a
+# group and forgetting to gate it leaves the single required check green while
+# that group is free to fail. `supplemental` is advisory by design.
+ci_gate_job_key := "gate"
+
+ci_advisory_job_keys := {"supplemental"}
+
+ci_jobs := object.get(ci_workflow, "jobs", {})
+
+ci_gate_job := object.get(ci_jobs, ci_gate_job_key, {})
+
+ci_group_job_keys := {name |
+	some name, job in ci_jobs
+	startswith(object.get(job, "uses", ""), "./.github/workflows/")
+	not name in ci_advisory_job_keys
+}
+
+ci_gate_needs := {name | some name in object.get(ci_gate_job, "needs", [])}
+
+deny contains msg if {
+	_ := documents[ci_workflow_path]
+	ci_gate_needs != ci_group_job_keys
+	msg := sprintf(
+		"%s %s must gate exactly the non-advisory group jobs %v, not %v",
+		[ci_workflow_path, ci_gate_job_key, ci_group_job_keys, ci_gate_needs],
+	)
+}
+
+# Membership alone is not enough: a job can sit in `needs` and still be ignored
+# by the shell that decides the verdict.
+deny contains msg if {
+	_ := documents[ci_workflow_path]
+	some name in ci_group_job_keys
+	not contains(json.marshal(ci_gate_job), sprintf("needs.%s.result", [name]))
+	msg := sprintf("%s %s must read needs.%s.result", [ci_workflow_path, ci_gate_job_key, name])
 }
 
 deny contains msg if {

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -349,12 +349,15 @@ claude_json_schema_is_wellformed(args) if {
 
 	# Exactly one occurrence; a second copy makes the effective payload ambiguous.
 	count(parts) == 2
-	quoted := trim_space(parts[1])
-	payload := trim_suffix(quoted, "'")
 
-	# trim_suffix is a no-op when the suffix is absent, so this proves the
-	# closing quote was actually there and the payload is not truncated.
-	payload != quoted
+	# Cut at the CLOSING quote, not at the end of the string: the schema is not
+	# required to be the final flag, and an earlier draft that trimmed a trailing
+	# quote rejected every valid payload with an argument after it.
+	payload := split(parts[1], "'")[0]
+
+	# split returns the whole remainder when the separator is absent, so this
+	# proves a closing quote exists rather than the payload running off the end.
+	payload != parts[1]
 	json.is_valid(payload)
 	json.verify_schema(json.unmarshal(payload))[0]
 }
@@ -665,6 +668,20 @@ deny contains msg if {
 	msg := sprintf("%s tests call must grant only contents:read and id-token:write", [ci_workflow_path])
 }
 
+# The callee-side rule above pins ci-tests.yml's own jobs, but only the `tests`
+# call is supposed to carry OIDC at all. The other group calls fan out to ~19
+# jobs that legitimately declare no `permissions:` of their own, so granting
+# id-token here would hand every one of them a repo-scoped token in a single
+# edit, with nothing downstream to notice.
+deny contains msg if {
+	_ := documents[ci_workflow_path]
+	some name, job in ci_jobs
+	name != "tests"
+	startswith(object.get(job, "uses", ""), "./.github/workflows/")
+	object.get(object.get(job, "permissions", {}), "id-token", "") == "write"
+	msg := sprintf("%s %s call must not grant id-token: write — only the tests call uploads via OIDC", [ci_workflow_path, name])
+}
+
 deny contains msg if {
 	_ := documents[codecov_workflow_path]
 	some name in codecov_oidc_job_names
@@ -711,8 +728,6 @@ deny contains msg if {
 ci_gate_job_key := "gate"
 
 ci_advisory_job_keys := {"supplemental"}
-
-ci_jobs := object.get(ci_workflow, "jobs", {})
 
 ci_gate_job := object.get(ci_jobs, ci_gate_job_key, {})
 

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -24,6 +24,7 @@ actionlint_release_queue_ignore := "unexpected key \"queue\" for \"concurrency\"
 zizmor_config_path := ".github/zizmor.yml"
 cache_cleanup_workflow_path := ".github/workflows/cache-cleanup.yml"
 claude_action := "anthropics/claude-code-action@v1"
+json_schema_flag := "--json-schema"
 claude_review_workflow_path := ".github/workflows/claude-review.yml"
 claude_security_workflow_path := ".github/workflows/claude-security-review.yml"
 claude_reusable_workflow_path := ".github/workflows/claude-readonly-review.yml"
@@ -322,9 +323,40 @@ claude_model_is_read_only(step) if {
 	params := object.get(step, "with", {})
 	args := object.get(params, "claude_args", "")
 	contains(args, "--allowedTools \"Read,Glob,Grep\"")
-	contains(args, "--json-schema")
+	contains(args, json_schema_flag)
 	not contains(args, "Bash")
 	not contains(args, "mcp__github")
+}
+
+# `--json-schema` smuggles a JSON document through a YAML string, so nothing
+# else in the gate stack reads it: actionlint and zizmor see an opaque scalar,
+# and the read-only rule above is satisfied by the flag NAME alone. An
+# unbalanced brace therefore survives every local check and only surfaces on the
+# runner, where the CLI refuses to start and every review run dies with
+# "--json-schema is not valid JSON" — a gate that can never pass. Parse the
+# payload here instead, and hold it to being a well-formed JSON *Schema* rather
+# than merely well-formed JSON, so `--json-schema '123'` fails too.
+claude_args_schema_entries := [entry |
+	some candidate in objects
+	args := object.get(candidate.value, "claude_args", null)
+	is_string(args)
+	contains(args, json_schema_flag)
+	entry := {"path": candidate.path, "args": args}
+]
+
+claude_json_schema_is_wellformed(args) if {
+	parts := split(args, sprintf("%s '", [json_schema_flag]))
+
+	# Exactly one occurrence; a second copy makes the effective payload ambiguous.
+	count(parts) == 2
+	quoted := trim_space(parts[1])
+	payload := trim_suffix(quoted, "'")
+
+	# trim_suffix is a no-op when the suffix is absent, so this proves the
+	# closing quote was actually there and the payload is not truncated.
+	payload != quoted
+	json.is_valid(payload)
+	json.verify_schema(json.unmarshal(payload))[0]
 }
 
 claude_model_auth_is_scoped(step) if {
@@ -470,6 +502,18 @@ deny contains msg if {
 	count(model_steps) == 1
 	not claude_model_auth_is_scoped(model_steps[0].value)
 	msg := sprintf("%s Claude step must use WIF-first authentication with the scoped job token", [claude_reusable_workflow_path])
+}
+
+# Deliberately walks every document rather than the reusable workflow alone: the
+# payload is unreadable to actionlint wherever it appears, so any future caller
+# that grows its own `--json-schema` inherits the same silent-red failure mode.
+deny contains msg if {
+	some entry in claude_args_schema_entries
+	not claude_json_schema_is_wellformed(entry.args)
+	msg := sprintf(
+		"%s %s must carry exactly one single-quoted, well-formed JSON Schema payload",
+		[entry.path, json_schema_flag],
+	)
 }
 
 deny contains msg if {

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -668,18 +668,24 @@ deny contains msg if {
 	msg := sprintf("%s tests call must grant only contents:read and id-token:write", [ci_workflow_path])
 }
 
-# The callee-side rule above pins ci-tests.yml's own jobs, but only the `tests`
-# call is supposed to carry OIDC at all. The other group calls fan out to ~19
-# jobs that legitimately declare no `permissions:` of their own, so granting
-# id-token here would hand every one of them a repo-scoped token in a single
-# edit, with nothing downstream to notice.
+# The callee-side rule above pins ci-tests.yml's own jobs. This is its caller
+# half: the other group calls fan out to ~19 jobs that declare no `permissions:`
+# of their own, so granting id-token here hands every one of them a repo-scoped
+# token in a single edit with nothing downstream to notice. A future group that
+# genuinely needs OIDC (provenance attestation also uses it, not just Codecov)
+# is not blocked forever — it first gives its own jobs explicit scopes, the way
+# ci-tests.yml does, and the message says so rather than claiming OIDC belongs
+# to `tests` alone.
 deny contains msg if {
 	_ := documents[ci_workflow_path]
 	some name, job in ci_jobs
 	name != "tests"
 	startswith(object.get(job, "uses", ""), "./.github/workflows/")
 	object.get(object.get(job, "permissions", {}), "id-token", "") == "write"
-	msg := sprintf("%s %s call must not grant id-token: write — only the tests call uploads via OIDC", [ci_workflow_path, name])
+	msg := sprintf(
+		"%s %s call must not pass id-token: write down to jobs that declare no permissions of their own",
+		[ci_workflow_path, name],
+	)
 }
 
 deny contains msg if {

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -680,7 +680,7 @@ deny contains msg if {
 	_ := documents[ci_workflow_path]
 	some name, job in ci_jobs
 	name != "tests"
-	startswith(object.get(job, "uses", ""), "./.github/workflows/")
+	calls_a_reusable_workflow(job)
 	object.get(object.get(job, "permissions", {}), "id-token", "") == "write"
 	msg := sprintf(
 		"%s %s call must not pass id-token: write down to jobs that declare no permissions of their own",
@@ -731,6 +731,16 @@ deny contains msg if {
 # its own nested job membership; nothing pinned the level above, where adding a
 # group and forgetting to gate it leaves the single required check green while
 # that group is free to fail. `supplemental` is advisory by design.
+# A job-level `uses:` IS a reusable-workflow call — a job cannot carry both
+# `uses:` and `steps:`. Matching on the `./.github/workflows/` prefix instead
+# would drop a cross-repo call out of the group set, and the membership rule
+# would then instruct the maintainer to REMOVE that group from the merge gate.
+calls_a_reusable_workflow(job) if {
+	uses := object.get(job, "uses", "")
+	is_string(uses)
+	uses != ""
+}
+
 ci_gate_job_key := "gate"
 
 ci_advisory_job_keys := {"supplemental"}
@@ -739,7 +749,7 @@ ci_gate_job := object.get(ci_jobs, ci_gate_job_key, {})
 
 ci_group_job_keys := {name |
 	some name, job in ci_jobs
-	startswith(object.get(job, "uses", ""), "./.github/workflows/")
+	calls_a_reusable_workflow(job)
 	not name in ci_advisory_job_keys
 }
 

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -407,6 +407,30 @@ codecov_job_scope_is_self_declared(job) if {
 	object.get(permissions, "id-token", "") != "write"
 }
 
+# Each reusable group workflow ends in a `required` job whose `needs` is the
+# manifest that keeps a deleted or renamed nested job from silently shrinking
+# ci-gate. Nothing pinned the manifests themselves, so ADDING a job and
+# forgetting to list it left that job outside the merge gate — the same hole
+# ci-gate had one level up, and invisible for the same reason.
+required_manifest_workflows := {
+	".github/workflows/ci-lint.yml",
+	".github/workflows/ci-builds.yml",
+	".github/workflows/ci-tests.yml",
+}
+
+required_manifest_job_key := "required"
+
+nested_jobs(path) := object.get(documents[path], "jobs", {})
+
+nested_gated_job_keys(path) := {name |
+	some name, _ in nested_jobs(path)
+	name != required_manifest_job_key
+}
+
+nested_manifest_needs(path) := {name |
+	some name in object.get(object.get(nested_jobs(path), required_manifest_job_key, {}), "needs", [])
+}
+
 # `ci-gate` is the ONLY context in branch protection, so its `needs` list plus
 # the results it reads ARE the merge gate. Each reusable workflow already pins
 # its own nested job membership; nothing pinned the level above, where adding a
@@ -436,6 +460,16 @@ ci_group_job_keys contains name if {
 }
 
 ci_gate_needs := {name | some name in object.get(ci_gate_job, "needs", [])}
+
+deny contains msg if {
+	some path in required_manifest_workflows
+	_ := documents[path]
+	nested_manifest_needs(path) != nested_gated_job_keys(path)
+	msg := sprintf(
+		"%s %s job must need exactly %v, not %v",
+		[path, required_manifest_job_key, nested_gated_job_keys(path), nested_manifest_needs(path)],
+	)
+}
 
 deny contains msg if {
 	some path in claude_trigger_workflow_paths

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -469,6 +469,21 @@ ci_gate_needs := {name | some name in object.get(ci_gate_job, "needs", [])}
 # health gate publishes a security tab that reads cleaner than reality. Pin both
 # halves: analyze must defer Rust's upload, and the deferred upload must exist —
 # either alone silently restores the old ordering.
+# The ordering that matters is health BEFORE upload, not analyze before health:
+# putting the gate ahead of analyze fails loudly on its own (SARIF_DIR resolves
+# empty, the glob matches nothing, `set -euo pipefail` kills the step) and
+# actionlint rejects the undefined step reference outright. Moving the gate
+# BELOW the upload is the silent one — it was green on both gates until this.
+deny contains msg if {
+	_ := documents[codeql_workflow_path]
+	health := codeql_named_steps(rust_health_step_name)
+	count(health) == 1
+	upload := codeql_named_steps(codeql_upload_step_name)
+	count(upload) == 1
+	health[0].index >= upload[0].index
+	msg := sprintf("%s must verify Rust extraction health before uploading the SARIF", [codeql_workflow_path])
+}
+
 deny contains msg if {
 	_ := documents[codeql_workflow_path]
 	steps := codeql_steps_using("github/codeql-action/analyze@v4")
@@ -826,20 +841,6 @@ deny contains msg if {
 
 deny contains msg if {
 	count(warning_steps) == 1
-	run := object.get(warning_steps[0].value, "run", "")
-	not contains(run, "::warning")
-	msg := sprintf("%s failure step must emit a workflow warning", [codecov_authority_path])
-}
-
-deny contains msg if {
-	count(warning_steps) == 1
-	run := object.get(warning_steps[0].value, "run", "")
-	not contains(run, "GITHUB_STEP_SUMMARY")
-	msg := sprintf("%s failure step must write the job summary", [codecov_authority_path])
-}
-
-deny contains msg if {
-	count(warning_steps) == 1
 	env := object.get(warning_steps[0].value, "env", {})
 	object.get(env, "REPORT_FILE", "") != codecov_input_file
 	msg := sprintf("%s failure step must identify inputs.file", [codecov_authority_path])
@@ -997,11 +998,6 @@ deny contains msg if {
 }
 
 deny contains msg if {
-	object.get(codeql.on, "workflow_dispatch", "missing") != null
-	msg := sprintf("%s must support manual dispatch", [codeql_workflow_path])
-}
-
-deny contains msg if {
 	not has_weekly_codeql_schedule
 	msg := sprintf("%s must retain its weekly schedule", [codeql_workflow_path])
 }
@@ -1148,26 +1144,11 @@ deny contains msg if {
 }
 
 deny contains msg if {
-	init_steps := codeql_steps_using("github/codeql-action/init@v4")
-	count(init_steps) == 1
-	params := object.get(init_steps[0].value, "with", {})
-	object.get(params, "build-mode", "") != "none"
-	msg := sprintf("%s CodeQL init must use build-mode: none", [codeql_workflow_path])
-}
-
-deny contains msg if {
 	analyze_steps := codeql_steps_using("github/codeql-action/analyze@v4")
 	count(analyze_steps) == 1
 	params := object.get(analyze_steps[0].value, "with", {})
 	object.get(params, "category", "") != "/language:${{ matrix.language }}"
 	msg := sprintf("%s CodeQL analyze must use a per-language category", [codeql_workflow_path])
-}
-
-deny contains msg if {
-	analyze_steps := codeql_steps_using("github/codeql-action/analyze@v4")
-	count(analyze_steps) == 1
-	object.get(analyze_steps[0].value, "id", "") != codeql_analyze_step_id
-	msg := sprintf("%s CodeQL analyze step must have id: %s", [codeql_workflow_path, codeql_analyze_step_id])
 }
 
 deny contains msg if {
@@ -1222,12 +1203,4 @@ deny contains msg if {
 	count(init_steps) == 1
 	rust_setup_steps[0].index >= init_steps[0].index
 	msg := sprintf("%s must prepare Rust before CodeQL init", [codeql_workflow_path])
-}
-
-deny contains msg if {
-	analyze_steps := codeql_steps_using("github/codeql-action/analyze@v4")
-	count(analyze_steps) == 1
-	count(rust_health_steps) == 1
-	analyze_steps[0].index >= rust_health_steps[0].index
-	msg := sprintf("%s must verify Rust extraction health after CodeQL analyze", [codeql_workflow_path])
 }

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -46,6 +46,8 @@ rust_health_step_name := "Verify Rust extraction health"
 rust_matrix_condition := "${{ matrix.language == 'rust' }}"
 codeql_analyze_step_id := "analyze"
 codeql_sarif_output := "${{ steps.analyze.outputs.sarif-output }}"
+codeql_rust_upload_gate := "${{ matrix.language == 'rust' && 'never' || 'always' }}"
+codeql_upload_step_name := "Upload Rust analysis"
 rust_diagnostics_metric := "rust/summary/number-of-files-extracted-with-errors"
 rust_clean_metric := "rust/summary/number-of-successfully-extracted-files"
 lighthouse_workflow_path := ".github/workflows/site.yml"
@@ -245,6 +247,8 @@ indexed_steps_matching(steps, field, expected) := [entry |
 ]
 
 codeql_steps_using(action) := indexed_steps_matching(codeql_steps, "uses", action)
+
+codeql_named_steps(name) := indexed_steps_matching(codeql_steps, "name", name)
 
 rust_setup_steps := [entry |
 	some index, step in codeql_steps
@@ -460,6 +464,24 @@ ci_group_job_keys contains name if {
 }
 
 ci_gate_needs := {name | some name in object.get(ci_gate_job, "needs", [])}
+
+# A degraded Rust extraction produces FEWER alerts, so uploading before the
+# health gate publishes a security tab that reads cleaner than reality. Pin both
+# halves: analyze must defer Rust's upload, and the deferred upload must exist —
+# either alone silently restores the old ordering.
+deny contains msg if {
+	_ := documents[codeql_workflow_path]
+	steps := codeql_steps_using("github/codeql-action/analyze@v4")
+	count(steps) == 1
+	object.get(object.get(steps[0].value, "with", {}), "upload", "") != codeql_rust_upload_gate
+	msg := sprintf("%s analyze must defer the Rust upload until extraction health passes", [codeql_workflow_path])
+}
+
+deny contains msg if {
+	_ := documents[codeql_workflow_path]
+	count(codeql_named_steps(codeql_upload_step_name)) != 1
+	msg := sprintf("%s must upload the Rust SARIF after the extraction-health gate", [codeql_workflow_path])
+}
 
 deny contains msg if {
 	some path in required_manifest_workflows

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -735,7 +735,7 @@ test_balanced_json_schema_payload_is_accepted if {
 # still satisfying the flag-name-only presence check.
 test_unreadable_json_schema_payloads_are_denied if {
 	every args in {
-		# Not single-quoted, so shell-quote hands the CLI a bare `{`.
+		# Unquoted, so quote-removal mangles the payload before the CLI sees it.
 		`--json-schema {"type":"object"}`,
 		# Opening quote with no closing quote.
 		`--json-schema '{"type":"object"}`,

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -924,3 +924,29 @@ test_nested_manifest_needing_a_deleted_job_is_denied if {
 	violations := deny with input as nested_manifest_fixture(jobs)
 	nested_manifest_message(".github/workflows/ci-lint.yml", {"fmt"}, {"clippy", "fmt"}) in violations
 }
+
+# Uploading before the health gate publishes a security tab that reads cleaner
+# than reality, because a degraded extraction yields fewer alerts.
+test_codeql_analyze_uploading_rust_inline_is_denied if {
+	fixture := {"documents": [{
+		"path": codeql_workflow_path,
+		"contents": {"jobs": {"analyze": {"steps": [{
+			"uses": "github/codeql-action/analyze@v4",
+			"with": {"category": "/language:${{ matrix.language }}"},
+		}]}}},
+	}]}
+	violations := deny with input as fixture
+	sprintf("%s analyze must defer the Rust upload until extraction health passes", [codeql_workflow_path]) in violations
+}
+
+test_codeql_missing_deferred_upload_is_denied if {
+	fixture := {"documents": [{
+		"path": codeql_workflow_path,
+		"contents": {"jobs": {"analyze": {"steps": [{
+			"uses": "github/codeql-action/analyze@v4",
+			"with": {"upload": codeql_rust_upload_gate},
+		}]}}},
+	}]}
+	violations := deny with input as fixture
+	sprintf("%s must upload the Rust SARIF after the extraction-health gate", [codeql_workflow_path]) in violations
+}

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -851,7 +851,7 @@ test_json_schema_unterminated_before_another_flag_is_denied if {
 }
 
 ci_oidc_call_message(name) := sprintf(
-	"%s %s call must not grant id-token: write — only the tests call uploads via OIDC",
+	"%s %s call must not pass id-token: write down to jobs that declare no permissions of their own",
 	[ci_workflow_path, name],
 )
 

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -396,6 +396,11 @@ test_codecov_oidc_replaces_the_repository_token if {
 	sprintf("%s must not declare or forward a Codecov upload token", [codecov_authority_path]) in violations
 }
 
+codecov_scope_message(name) := sprintf(
+	"%s job %s must declare its own permissions and must not receive the Codecov OIDC permission",
+	[codecov_workflow_path, name],
+)
+
 test_codecov_oidc_permission_is_job_scoped if {
 	fixture := {"documents": [{
 		"path": codecov_workflow_path,
@@ -406,7 +411,28 @@ test_codecov_oidc_permission_is_job_scoped if {
 	}]}
 	violations := deny with input as fixture
 	sprintf("%s job coverage must receive the Codecov OIDC permission", [codecov_workflow_path]) in violations
-	sprintf("%s job snapshots must not receive the Codecov OIDC permission", [codecov_workflow_path]) in violations
+	codecov_scope_message("snapshots") in violations
+}
+
+# The regression that shipped: snapshots/smoke/required carried no `permissions:`
+# block at all, so they silently inherited the caller's id-token:write while the
+# old rule — which only read the declared block — stayed quiet.
+test_codecov_job_omitting_permissions_is_denied if {
+	fixture := {"documents": [{
+		"path": codecov_workflow_path,
+		"contents": {"jobs": {"snapshots": {"runs-on": "ubuntu-latest"}}},
+	}]}
+	violations := deny with input as fixture
+	codecov_scope_message("snapshots") in violations
+}
+
+test_codecov_job_declaring_its_own_scope_is_accepted if {
+	fixture := {"documents": [{
+		"path": codecov_workflow_path,
+		"contents": {"jobs": {"snapshots": {"permissions": {"contents": "read"}}}},
+	}]}
+	violations := deny with input as fixture
+	not codecov_scope_message("snapshots") in violations
 }
 
 test_release_concurrency_must_serialize_different_tags if {
@@ -730,4 +756,81 @@ test_unreadable_json_schema_payloads_are_denied if {
 test_claude_args_without_a_schema_flag_is_not_denied if {
 	violations := deny with input as json_schema_fixture(`--max-turns 60 --allowedTools "Read,Glob,Grep"`)
 	not malformed_json_schema_message in violations
+}
+
+ci_gate_fixture(jobs) := {"documents": [{"path": ci_workflow_path, "contents": {"jobs": jobs}}]}
+
+ci_gate_shipped_jobs := {
+	"lint": {"uses": "./.github/workflows/ci-lint.yml"},
+	"builds": {"uses": "./.github/workflows/ci-builds.yml"},
+	"tests": {"uses": "./.github/workflows/ci-tests.yml"},
+	"supplemental": {"uses": "./.github/workflows/ci-supplemental.yml"},
+	"gate": {
+		"needs": ["lint", "builds", "tests"],
+		"steps": [{"env": {
+			"LINT_RESULT": "${{ needs.lint.result }}",
+			"BUILDS_RESULT": "${{ needs.builds.result }}",
+			"TESTS_RESULT": "${{ needs.tests.result }}",
+		}}],
+	},
+}
+
+ci_gate_membership_violations(jobs) := [msg |
+	some msg in deny with input as ci_gate_fixture(jobs)
+	contains(msg, "must gate exactly the non-advisory group jobs")
+]
+
+ci_gate_unread_violations(jobs) := [msg |
+	some msg in deny with input as ci_gate_fixture(jobs)
+	contains(msg, "must read needs.")
+]
+
+test_ci_gate_covering_every_group_is_accepted if {
+	count(ci_gate_membership_violations(ci_gate_shipped_jobs)) == 0
+	count(ci_gate_unread_violations(ci_gate_shipped_jobs)) == 0
+}
+
+# The gap: a fifth reusable group lands and nobody adds it to the gate, so the
+# single protected context stays green while that whole group can fail.
+test_ci_gate_missing_a_new_group_is_denied if {
+	jobs := object.union(ci_gate_shipped_jobs, {"security": {"uses": "./.github/workflows/ci-security.yml"}})
+	count(ci_gate_membership_violations(jobs)) == 1
+}
+
+# Consistently dropping a group — from `needs` AND from the env the shell reads —
+# is the edit actionlint cannot catch, because nothing dangles.
+test_ci_gate_dropping_a_group_entirely_is_denied if {
+	jobs := object.union(ci_gate_shipped_jobs, {"gate": {
+		"needs": ["lint", "tests"],
+		"steps": [{"env": {
+			"LINT_RESULT": "${{ needs.lint.result }}",
+			"TESTS_RESULT": "${{ needs.tests.result }}",
+		}}],
+	}})
+	count(ci_gate_membership_violations(jobs)) == 1
+	sprintf("%s %s must read needs.builds.result", [ci_workflow_path, ci_gate_job_key]) in deny with input as ci_gate_fixture(jobs)
+}
+
+# In `needs` but never consulted by the verdict shell.
+test_ci_gate_listing_a_group_it_never_reads_is_denied if {
+	jobs := object.union(ci_gate_shipped_jobs, {"gate": {
+		"needs": ["lint", "builds", "tests"],
+		"steps": [{"env": {
+			"LINT_RESULT": "${{ needs.lint.result }}",
+			"TESTS_RESULT": "${{ needs.tests.result }}",
+		}}],
+	}})
+	sprintf("%s %s must read needs.builds.result", [ci_workflow_path, ci_gate_job_key]) in deny with input as ci_gate_fixture(jobs)
+}
+
+test_ci_gate_need_on_the_advisory_group_is_denied if {
+	jobs := object.union(ci_gate_shipped_jobs, {"gate": {
+		"needs": ["lint", "builds", "tests", "supplemental"],
+		"steps": [{"env": {
+			"LINT_RESULT": "${{ needs.lint.result }}",
+			"BUILDS_RESULT": "${{ needs.builds.result }}",
+			"TESTS_RESULT": "${{ needs.tests.result }}",
+		}}],
+	}})
+	count(ci_gate_membership_violations(jobs)) == 1
 }

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -872,3 +872,35 @@ test_tests_call_granting_oidc_is_accepted if {
 	violations := deny with input as ci_gate_fixture(jobs)
 	not ci_oidc_call_message("tests") in violations
 }
+
+# A group converted to a cross-repo reusable workflow must stay in the gate set.
+# Prefix-matching `./.github/workflows/` dropped it instead, and the membership
+# rule then told the maintainer to REMOVE that group from the merge gate.
+test_cross_repo_group_call_still_counts_as_a_group if {
+	jobs := object.union(ci_gate_shipped_jobs, {"builds": {"uses": "someorg/shared/.github/workflows/ci-builds.yml@v1"}})
+	count(ci_gate_membership_violations(jobs)) == 0
+	count(ci_gate_unread_violations(jobs)) == 0
+}
+
+test_cross_repo_group_call_ungated_is_denied if {
+	jobs := object.union(ci_gate_shipped_jobs, {
+		"builds": {"uses": "someorg/shared/.github/workflows/ci-builds.yml@v1"},
+		"gate": {
+			"needs": ["lint", "tests"],
+			"steps": [{"env": {
+				"LINT_RESULT": "${{ needs.lint.result }}",
+				"TESTS_RESULT": "${{ needs.tests.result }}",
+			}}],
+		},
+	})
+	count(ci_gate_membership_violations(jobs)) == 1
+}
+
+test_cross_repo_group_call_granting_oidc_is_denied if {
+	jobs := object.union(ci_gate_shipped_jobs, {"builds": {
+		"uses": "someorg/shared/.github/workflows/ci-builds.yml@v1",
+		"permissions": {"contents": "read", "id-token": "write"},
+	}})
+	violations := deny with input as ci_gate_fixture(jobs)
+	ci_oidc_call_message("builds") in violations
+}

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -18,12 +18,12 @@ test_unrelated_action_is_not_codecov if {
 }
 
 test_case_variants_cannot_bypass_centralization if {
+	path := ".github/workflows/rogue.yml"
 	every value in {
 		"Codecov/codecov-action@v7",
 		"CODECOV/CODECOV-ACTION@v7",
 		"codecov/Codecov-Action@v7",
 	} {
-		path := ".github/workflows/rogue.yml"
 		fixture := {"documents": [{
 			"path": path,
 			"contents": {"jobs": {"test": {"steps": [{"uses": value}]}}},
@@ -77,10 +77,10 @@ test_codeql_step_selection_preserves_order if {
 		{"uses": "github/codeql-action/analyze@v4"},
 	]
 	checkout := codeql_steps_using("actions/checkout@v7") with codeql_steps as steps
-	initialize := codeql_steps_using("github/codeql-action/init@v4") with codeql_steps as steps
-	analyze := codeql_steps_using("github/codeql-action/analyze@v4") with codeql_steps as steps
 	checkout[0].index == 0
+	initialize := codeql_steps_using("github/codeql-action/init@v4") with codeql_steps as steps
 	initialize[0].index == 1
+	analyze := codeql_steps_using("github/codeql-action/analyze@v4") with codeql_steps as steps
 	analyze[0].index == 2
 }
 
@@ -701,12 +701,10 @@ test_codeql_health_metrics_must_be_visible_in_the_job_summary if {
 	sprintf("%s Rust extraction-health gate must write a quantified job summary", [codeql_workflow_path]) in violations
 }
 
-# The exact payload that shipped in #785: the root "properties" object is never
-# closed (10 `{` against 9 `}`), so every `claude review` and
-# `claude security review` run aborted with "--json-schema is not valid JSON".
-broken_json_schema_args := `--max-turns 60 --allowedTools "Read,Glob,Grep" --json-schema '{"type":"object","properties":{"summary":{"type":"string"}},"required":["summary"]'`
-
-fixed_json_schema_args := `--max-turns 60 --allowedTools "Read,Glob,Grep" --json-schema '{"type":"object","properties":{"summary":{"type":"string"}},"required":["summary"]}'`
+schema_reference_message := sprintf(
+	"%s must pass %s via the committed schema file (%s), not an inline literal",
+	[claude_reusable_workflow_path, json_schema_flag, review_schema_reference],
+)
 
 json_schema_fixture(args) := {"documents": [{
 	"path": claude_reusable_workflow_path,
@@ -716,46 +714,31 @@ json_schema_fixture(args) := {"documents": [{
 	}]}}},
 }]}
 
-malformed_json_schema_message := sprintf(
-	"%s %s must carry exactly one single-quoted, well-formed JSON Schema payload",
-	[claude_reusable_workflow_path, json_schema_flag],
-)
-
-test_unbalanced_json_schema_payload_is_denied if {
-	violations := deny with input as json_schema_fixture(broken_json_schema_args)
-	malformed_json_schema_message in violations
+test_committed_schema_reference_is_accepted if {
+	args := sprintf("--max-turns 60 %s", [review_schema_reference])
+	violations := deny with input as json_schema_fixture(args)
+	not schema_reference_message in violations
 }
 
-test_balanced_json_schema_payload_is_accepted if {
-	violations := deny with input as json_schema_fixture(fixed_json_schema_args)
-	not malformed_json_schema_message in violations
-}
-
-# Each variant is a distinct way the payload can be unreadable to the CLI while
-# still satisfying the flag-name-only presence check.
-test_unreadable_json_schema_payloads_are_denied if {
+# The regression that took both bots down for 31h: an inline literal is opaque
+# to actionlint and zizmor, so a single unbalanced brace reached the runner.
+# Any inline payload is now refused outright, balanced or not.
+test_inline_schema_payloads_are_denied if {
 	every args in {
-		# Unquoted, so quote-removal mangles the payload before the CLI sees it.
+		# The exact malformed payload from #785 — ten `{` against nine `}`.
+		`--json-schema '{"type":"object","properties":{"summary":{"type":"string"}},"required":["summary"]'`,
+		# Balanced, and still refused: inline is the shape being retired.
+		`--json-schema '{"type":"object"}'`,
 		`--json-schema {"type":"object"}`,
-		# Opening quote with no closing quote.
-		`--json-schema '{"type":"object"}`,
-		# Valid JSON, but a scalar is not a schema.
-		`--json-schema '123'`,
-		# Well-formed JSON that is not a well-formed JSON Schema.
-		`--json-schema '{"type":"not-a-type"}'`,
-		# Two payloads make the effective schema ambiguous.
-		`--json-schema '{"type":"object"}' --json-schema '{"type":"array"}'`,
-		# Empty payload.
-		`--json-schema ''`,
 	} {
 		violations := deny with input as json_schema_fixture(args)
-		malformed_json_schema_message in violations
+		schema_reference_message in violations
 	}
 }
 
 test_claude_args_without_a_schema_flag_is_not_denied if {
 	violations := deny with input as json_schema_fixture(`--max-turns 60 --allowedTools "Read,Glob,Grep"`)
-	not malformed_json_schema_message in violations
+	not schema_reference_message in violations
 }
 
 ci_gate_fixture(jobs) := {"documents": [{"path": ci_workflow_path, "contents": {"jobs": jobs}}]}
@@ -775,26 +758,28 @@ ci_gate_shipped_jobs := {
 	},
 }
 
-ci_gate_membership_violations(jobs) := [msg |
-	some msg in deny with input as ci_gate_fixture(jobs)
+ci_gate_membership_violations(violations) := [msg |
+	some msg in violations
 	contains(msg, "must gate exactly the non-advisory group jobs")
 ]
 
-ci_gate_unread_violations(jobs) := [msg |
-	some msg in deny with input as ci_gate_fixture(jobs)
+ci_gate_unread_violations(violations) := [msg |
+	some msg in violations
 	contains(msg, "must read needs.")
 ]
 
 test_ci_gate_covering_every_group_is_accepted if {
-	count(ci_gate_membership_violations(ci_gate_shipped_jobs)) == 0
-	count(ci_gate_unread_violations(ci_gate_shipped_jobs)) == 0
+	shipped_violations := deny with input as ci_gate_fixture(ci_gate_shipped_jobs)
+	count(ci_gate_membership_violations(shipped_violations)) == 0
+	count(ci_gate_unread_violations(shipped_violations)) == 0
 }
 
 # The gap: a fifth reusable group lands and nobody adds it to the gate, so the
 # single protected context stays green while that whole group can fail.
 test_ci_gate_missing_a_new_group_is_denied if {
 	jobs := object.union(ci_gate_shipped_jobs, {"security": {"uses": "./.github/workflows/ci-security.yml"}})
-	count(ci_gate_membership_violations(jobs)) == 1
+	violations := deny with input as ci_gate_fixture(jobs)
+	count(ci_gate_membership_violations(violations)) == 1
 }
 
 # Consistently dropping a group — from `needs` AND from the env the shell reads —
@@ -807,7 +792,8 @@ test_ci_gate_dropping_a_group_entirely_is_denied if {
 			"TESTS_RESULT": "${{ needs.tests.result }}",
 		}}],
 	}})
-	count(ci_gate_membership_violations(jobs)) == 1
+	violations := deny with input as ci_gate_fixture(jobs)
+	count(ci_gate_membership_violations(violations)) == 1
 	sprintf("%s %s must read needs.builds.result", [ci_workflow_path, ci_gate_job_key]) in deny with input as ci_gate_fixture(jobs)
 }
 
@@ -832,22 +818,8 @@ test_ci_gate_need_on_the_advisory_group_is_denied if {
 			"TESTS_RESULT": "${{ needs.tests.result }}",
 		}}],
 	}})
-	count(ci_gate_membership_violations(jobs)) == 1
-}
-
-# The schema is not required to be the LAST flag in claude_args; an earlier
-# draft cut at the end of the string and rejected every valid payload followed
-# by another argument.
-test_json_schema_before_another_flag_is_accepted if {
-	args := sprintf("%s '{\"type\":\"object\"}' --max-turns 60", [json_schema_flag])
-	violations := deny with input as json_schema_fixture(args)
-	not malformed_json_schema_message in violations
-}
-
-test_json_schema_unterminated_before_another_flag_is_denied if {
-	args := sprintf("%s '{\"type\":\"object\"} --max-turns 60", [json_schema_flag])
-	violations := deny with input as json_schema_fixture(args)
-	malformed_json_schema_message in violations
+	violations := deny with input as ci_gate_fixture(jobs)
+	count(ci_gate_membership_violations(violations)) == 1
 }
 
 ci_oidc_call_message(name) := sprintf(
@@ -878,8 +850,9 @@ test_tests_call_granting_oidc_is_accepted if {
 # rule then told the maintainer to REMOVE that group from the merge gate.
 test_cross_repo_group_call_still_counts_as_a_group if {
 	jobs := object.union(ci_gate_shipped_jobs, {"builds": {"uses": "someorg/shared/.github/workflows/ci-builds.yml@v1"}})
-	count(ci_gate_membership_violations(jobs)) == 0
-	count(ci_gate_unread_violations(jobs)) == 0
+	violations := deny with input as ci_gate_fixture(jobs)
+	count(ci_gate_membership_violations(violations)) == 0
+	count(ci_gate_unread_violations(violations)) == 0
 }
 
 test_cross_repo_group_call_ungated_is_denied if {
@@ -893,7 +866,8 @@ test_cross_repo_group_call_ungated_is_denied if {
 			}}],
 		},
 	})
-	count(ci_gate_membership_violations(jobs)) == 1
+	violations := deny with input as ci_gate_fixture(jobs)
+	count(ci_gate_membership_violations(violations)) == 1
 }
 
 test_cross_repo_group_call_granting_oidc_is_denied if {

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -878,3 +878,49 @@ test_cross_repo_group_call_granting_oidc_is_denied if {
 	violations := deny with input as ci_gate_fixture(jobs)
 	ci_oidc_call_message("builds") in violations
 }
+
+nested_manifest_message(path, expected, actual) := sprintf(
+	"%s %s job must need exactly %v, not %v",
+	[path, required_manifest_job_key, expected, actual],
+)
+
+nested_manifest_fixture(jobs) := {"documents": [{
+	"path": ".github/workflows/ci-lint.yml",
+	"contents": {"jobs": jobs},
+}]}
+
+test_nested_manifest_covering_every_job_is_accepted if {
+	jobs := {
+		"fmt": {},
+		"clippy": {},
+		"required": {"needs": ["fmt", "clippy"]},
+	}
+	violations := deny with input as nested_manifest_fixture(jobs)
+	not nested_manifest_message(".github/workflows/ci-lint.yml", {"clippy", "fmt"}, {"clippy", "fmt"}) in violations
+}
+
+# The gap: a job is added to the workflow but not to the manifest, so it sits
+# outside the single protected ci-gate with nothing to say so.
+test_nested_manifest_missing_a_new_job_is_denied if {
+	jobs := {
+		"fmt": {},
+		"clippy": {},
+		"newcheck": {},
+		"required": {"needs": ["fmt", "clippy"]},
+	}
+	violations := deny with input as nested_manifest_fixture(jobs)
+	nested_manifest_message(
+		".github/workflows/ci-lint.yml",
+		{"clippy", "fmt", "newcheck"},
+		{"clippy", "fmt"},
+	) in violations
+}
+
+test_nested_manifest_needing_a_deleted_job_is_denied if {
+	jobs := {
+		"fmt": {},
+		"required": {"needs": ["fmt", "clippy"]},
+	}
+	violations := deny with input as nested_manifest_fixture(jobs)
+	nested_manifest_message(".github/workflows/ci-lint.yml", {"fmt"}, {"clippy", "fmt"}) in violations
+}

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -121,15 +121,6 @@ test_codeql_extraction_health_cannot_be_masked_as_success if {
 	sprintf("%s Rust extraction-health gate must fail the job", [codeql_workflow_path]) in violations
 }
 
-test_codeql_analyze_must_expose_sarif_output if {
-	fixture := {"documents": [{
-		"path": codeql_workflow_path,
-		"contents": {"jobs": {"analyze": {"steps": [{"uses": "github/codeql-action/analyze@v4"}]}}},
-	}]}
-	violations := deny with input as fixture
-	sprintf("%s CodeQL analyze step must have id: analyze", [codeql_workflow_path]) in violations
-}
-
 test_report_presence_check_is_required if {
 	fixture := {"documents": [{
 		"path": codecov_authority_path,
@@ -949,4 +940,30 @@ test_codeql_missing_deferred_upload_is_denied if {
 	}]}
 	violations := deny with input as fixture
 	sprintf("%s must upload the Rust SARIF after the extraction-health gate", [codeql_workflow_path]) in violations
+}
+
+# Health BEFORE upload is the ordering that fails SILENTLY when broken — the
+# inverse (gate ahead of analyze) dies loudly on an empty SARIF_DIR.
+test_codeql_upload_before_health_gate_is_denied if {
+	fixture := {"documents": [{
+		"path": codeql_workflow_path,
+		"contents": {"jobs": {"analyze": {"steps": [
+			{"name": codeql_upload_step_name},
+			{"name": rust_health_step_name},
+		]}}},
+	}]}
+	violations := deny with input as fixture
+	sprintf("%s must verify Rust extraction health before uploading the SARIF", [codeql_workflow_path]) in violations
+}
+
+test_codeql_health_gate_before_upload_is_accepted if {
+	fixture := {"documents": [{
+		"path": codeql_workflow_path,
+		"contents": {"jobs": {"analyze": {"steps": [
+			{"name": rust_health_step_name},
+			{"name": codeql_upload_step_name},
+		]}}},
+	}]}
+	violations := deny with input as fixture
+	not sprintf("%s must verify Rust extraction health before uploading the SARIF", [codeql_workflow_path]) in violations
 }

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -834,3 +834,41 @@ test_ci_gate_need_on_the_advisory_group_is_denied if {
 	}})
 	count(ci_gate_membership_violations(jobs)) == 1
 }
+
+# The schema is not required to be the LAST flag in claude_args; an earlier
+# draft cut at the end of the string and rejected every valid payload followed
+# by another argument.
+test_json_schema_before_another_flag_is_accepted if {
+	args := sprintf("%s '{\"type\":\"object\"}' --max-turns 60", [json_schema_flag])
+	violations := deny with input as json_schema_fixture(args)
+	not malformed_json_schema_message in violations
+}
+
+test_json_schema_unterminated_before_another_flag_is_denied if {
+	args := sprintf("%s '{\"type\":\"object\"} --max-turns 60", [json_schema_flag])
+	violations := deny with input as json_schema_fixture(args)
+	malformed_json_schema_message in violations
+}
+
+ci_oidc_call_message(name) := sprintf(
+	"%s %s call must not grant id-token: write — only the tests call uploads via OIDC",
+	[ci_workflow_path, name],
+)
+
+test_non_tests_group_call_granting_oidc_is_denied if {
+	jobs := object.union(ci_gate_shipped_jobs, {"lint": {
+		"uses": "./.github/workflows/ci-lint.yml",
+		"permissions": {"contents": "read", "id-token": "write"},
+	}})
+	violations := deny with input as ci_gate_fixture(jobs)
+	ci_oidc_call_message("lint") in violations
+}
+
+test_tests_call_granting_oidc_is_accepted if {
+	jobs := object.union(ci_gate_shipped_jobs, {"tests": {
+		"uses": "./.github/workflows/ci-tests.yml",
+		"permissions": {"contents": "read", "id-token": "write"},
+	}})
+	violations := deny with input as ci_gate_fixture(jobs)
+	not ci_oidc_call_message("tests") in violations
+}

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -674,3 +674,60 @@ test_codeql_health_metrics_must_be_visible_in_the_job_summary if {
 	violations := deny with input as fixture
 	sprintf("%s Rust extraction-health gate must write a quantified job summary", [codeql_workflow_path]) in violations
 }
+
+# The exact payload that shipped in #785: the root "properties" object is never
+# closed (10 `{` against 9 `}`), so every `claude review` and
+# `claude security review` run aborted with "--json-schema is not valid JSON".
+broken_json_schema_args := `--max-turns 60 --allowedTools "Read,Glob,Grep" --json-schema '{"type":"object","properties":{"summary":{"type":"string"}},"required":["summary"]'`
+
+fixed_json_schema_args := `--max-turns 60 --allowedTools "Read,Glob,Grep" --json-schema '{"type":"object","properties":{"summary":{"type":"string"}},"required":["summary"]}'`
+
+json_schema_fixture(args) := {"documents": [{
+	"path": claude_reusable_workflow_path,
+	"contents": {"jobs": {"analyze": {"steps": [{
+		"uses": claude_action,
+		"with": {"claude_args": args},
+	}]}}},
+}]}
+
+malformed_json_schema_message := sprintf(
+	"%s %s must carry exactly one single-quoted, well-formed JSON Schema payload",
+	[claude_reusable_workflow_path, json_schema_flag],
+)
+
+test_unbalanced_json_schema_payload_is_denied if {
+	violations := deny with input as json_schema_fixture(broken_json_schema_args)
+	malformed_json_schema_message in violations
+}
+
+test_balanced_json_schema_payload_is_accepted if {
+	violations := deny with input as json_schema_fixture(fixed_json_schema_args)
+	not malformed_json_schema_message in violations
+}
+
+# Each variant is a distinct way the payload can be unreadable to the CLI while
+# still satisfying the flag-name-only presence check.
+test_unreadable_json_schema_payloads_are_denied if {
+	every args in {
+		# Not single-quoted, so shell-quote hands the CLI a bare `{`.
+		`--json-schema {"type":"object"}`,
+		# Opening quote with no closing quote.
+		`--json-schema '{"type":"object"}`,
+		# Valid JSON, but a scalar is not a schema.
+		`--json-schema '123'`,
+		# Well-formed JSON that is not a well-formed JSON Schema.
+		`--json-schema '{"type":"not-a-type"}'`,
+		# Two payloads make the effective schema ambiguous.
+		`--json-schema '{"type":"object"}' --json-schema '{"type":"array"}'`,
+		# Empty payload.
+		`--json-schema ''`,
+	} {
+		violations := deny with input as json_schema_fixture(args)
+		malformed_json_schema_message in violations
+	}
+}
+
+test_claude_args_without_a_schema_flag_is_not_denied if {
+	violations := deny with input as json_schema_fixture(`--max-turns 60 --allowedTools "Read,Glob,Grep"`)
+	not malformed_json_schema_message in violations
+}


### PR DESCRIPTION
Both review bots have been dead on every PR since `61d86778` (#785): the
`--json-schema` payload had ten `{` against nine `}`, and the CLI refuses to
start on an unparseable schema. Fixing that turned into an audit of the whole CI
surface.

Closes #789. Closes #790.

## What was broken

| Sev | | |
|---|---|---|
| **HIGH** | `release.yml` publish job had no ALSA headers | `cargo publish` builds to verify, so pixtuoid-core/scene/hook would publish **irreversibly** and only then would `pixtuoid` fail to compile — the release stranded at a version that can never be reused. Tag-only; no PR ever rehearses it |
| **HIGH** | `release.yml` arg shift | unset `matrix.cross` collapsed, sliding `flags` into the `cross` slot, so **both** Linux legs that omit the key built without `--no-default-features` |
| **MED** | 11 CodeQL rules were fail-open | bare refs — a missing key is undefined in Rego, so *deleting* the pinned block passed silently while a wrong value was caught |
| **MED** | `ci-tests.yml` inherited `id-token: write` | 3 jobs declared no permissions, so they took the caller's OIDC grant; the rule forbidding it was blind to exactly those jobs |
| **MED** | composite-action shell was unlinted | actionlint can't parse `action.yml`; that code is the homebrew-core contract oracle |
| **MED** | `risk-radar` swallowed a failed `gh pr diff` | no pipefail → published a confident "no seams touched" for a diff it never read |
| **LOW** | `ci-gate` + the three nested manifests unpinned | a group could sit outside the only required status check |
| **LOW** | CodeQL uploaded SARIF before the health gate | a degraded extraction yields fewer alerts → security tab reads cleaner than reality |

## Tooling — researched first, then adopted

The first attempt hand-rolled a "every deny rule must be tested" grep. It was
deleted: `opa test --coverage` already does it properly. What landed instead,
all installed and run against this tree:

- **`opa` 1.18.2** — `check --strict` (which *failed* on the committed policy)
  and `test --coverage`, ratcheted at 95%
- **Regal 0.42.0** — the OPA project's Rego linter
- **`check-jsonschema` 0.37.4** — gates all three committed schemas
- **`zizmor --fix`** — evaluated for SHA-pinning; **not adopted**, ref-pin stays

**Regal's `superfluous-object-get` is deliberately disabled.** It rewrites
`object.get(o,"k",default)` to a bare `o.k` — which is exactly the fail-open
pattern above. Proved with `opa eval`: with the key absent, only the object.get
form fires. Following that lint would have manufactured 32 more of the defect
this PR removes.

**`actionlint-composites` stays hand-rolled**, after searching: actionlint #46
(open since 2021) and #401 have no maintainer plan, zizmor never shellchecks,
and `yaml-shellcheck` is self-declared "passively maintained" *and* silently
skips `packaging-build/action.yml`.

## Deletion pass

All 107 deny rules were asked one question — *name the concrete failure this
prevents* — and every candidate went to an adversary whose job was to save it.
**20 of 26 were saved.** Six went: three redundant with a gate this repo already
runs (verified by breaking the behaviour and watching the *other* gate fail),
three guarding nothing. Coverage rose 94.35% → 95.33% as a result.

One of the six was pinning the wrong half: it required health *after analyze*
(which fails loudly anyway) while nothing pinned health *before upload* — the
silent one. Replaced.

## Verification

Every new rule is negative-controlled against the real tree, not fixtures:
re-break the contract, watch the gate go red with the new message. The schema
fix was reproduced against the real CLI in both directions.

`just lint` 12/12 · 65 Rego unit tests · 103 document checks · Regal clean ·
`opa check --strict` clean.

## Reviewer notes

- `pull_request_target` loads workflows from the **default branch**, so this
  PR's own bot checks fail against `main`'s broken copy. The fix can only prove
  itself after merge.
- Four review lenses were run; two produced no output. Their questions were
  answered by hand — that's weaker than an independent lens and is noted here
  rather than papered over.
- Five commits are self-corrections from those reviews. Three were the same
  mistake: a rule whose *condition* was right and whose *message* or *scope* was
  wrong. One told a maintainer to remove a group from the only check protecting
  `main`.
