### PR TITLE
fix(ci): stop Dependabot rewriting floating action majors into stale pins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,18 @@ updates:
       actions:
         patterns: ["*"]
     open-pull-requests-limit: 5
+    ignore:
+      # This repo pins actions to a FLOATING major (`@v4`), which .github/zizmor.yml
+      # records as deliberate policy — the tag already tracks the newest release, so
+      # patch/minor updates arrive without a PR. Dependabot reads `@v4` as "version
+      # 4" and, filtered by the cooldown below, offers the newest version that is a
+      # week OLD — rewriting the self-updating ref into a stale exact pin. #786 did
+      # exactly that: `@v1` (then v1.0.183) -> v1.0.178, `@v4` (then v4.37.3) ->
+      # v4.37.1. Both downgrades. Only a MAJOR bump needs a human, so only majors
+      # should open a PR.
+      - dependency-name: "*"
+        update-types:
+          ["version-update:semver-patch", "version-update:semver-minor"]
     cooldown:
       default-days: 7
 

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -117,9 +117,32 @@ uses_entries := [entry |
 	}
 ]
 
+# Dependabot pins a floating major to an exact release (`@v4` -> `@v4.37.1`),
+# which is a STRICTER pin and exactly what this repo's ref-pin policy wants. The
+# rules used to compare the literal string, so that improvement was rejected
+# with "must analyze with CodeQL v4 exactly once" — of a step that WAS v4.
+# Compare the action path and the pinned major, and accept any more precise ref
+# beneath it; a real major bump (v4 -> v5) still fails, which is the point.
+split_action(value) := parts if {
+	parts := split(value, "@")
+	count(parts) == 2
+}
+
+action_matches(uses, expected) if {
+	uses == expected
+}
+
+action_matches(uses, expected) if {
+	uses != expected
+	actual := split_action(uses)
+	wanted := split_action(expected)
+	actual[0] == wanted[0]
+	startswith(actual[1], sprintf("%s.", [wanted[1]]))
+}
+
 entries_using(action) := [entry |
 	some entry in uses_entries
-	entry.uses == action
+	action_matches(entry.uses, action)
 ]
 
 codecov_action_reference(value) if {
@@ -136,13 +159,13 @@ rogue_codecov_entries := [entry |
 
 canonical_codecov_entry(entry) if {
 	entry.path == codecov_authority_path
-	entry.uses == codecov_action
+	action_matches(entry.uses, codecov_action)
 }
 
 authority_uploads := [entry |
 	some entry in uses_entries
 	entry.path == codecov_authority_path
-	entry.uses == codecov_action
+	action_matches(entry.uses, codecov_action)
 ]
 
 authority_objects := [entry |
@@ -210,7 +233,7 @@ pinned_npm_setup_steps(path, job_name) := [step |
 
 codecov_uploads := [entry |
 	some entry in uses_entries
-	entry.uses == codecov_wrapper
+	action_matches(entry.uses, codecov_wrapper)
 ]
 
 codecov_route(entry) := route if {
@@ -246,7 +269,11 @@ indexed_steps_matching(steps, field, expected) := [entry |
 	entry := {"index": index, "value": step}
 ]
 
-codeql_steps_using(action) := indexed_steps_matching(codeql_steps, "uses", action)
+codeql_steps_using(action) := [entry |
+	some index, step in codeql_steps
+	action_matches(object.get(step, "uses", ""), action)
+	entry := {"index": index, "value": step}
+]
 
 codeql_named_steps(name) := indexed_steps_matching(codeql_steps, "name", name)
 
@@ -280,7 +307,11 @@ claude_publish_job := object.get(claude_reusable_jobs, "publish", {})
 claude_analyze_steps := object.get(claude_analyze_job, "steps", [])
 claude_publish_steps := object.get(claude_publish_job, "steps", [])
 
-claude_analyze_steps_using(action) := indexed_steps_matching(claude_analyze_steps, "uses", action)
+claude_analyze_steps_using(action) := [entry |
+	some index, step in claude_analyze_steps
+	action_matches(object.get(step, "uses", ""), action)
+	entry := {"index": index, "value": step}
+]
 
 claude_analyze_named_steps(name) := indexed_steps_matching(claude_analyze_steps, "name", name)
 
@@ -862,7 +893,7 @@ deny contains msg if {
 
 deny contains msg if {
 	some entry in uses_entries
-	entry.uses == codecov_wrapper
+	action_matches(entry.uses, codecov_wrapper)
 	params := object.get(entry.value, "with", {})
 	object.get(params, "report-type", null) != null
 	msg := sprintf("%s must use report_type, not report-type", [entry.path])

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -269,11 +269,16 @@ indexed_steps_matching(steps, field, expected) := [entry |
 	entry := {"index": index, "value": step}
 ]
 
-codeql_steps_using(action) := [entry |
-	some index, step in codeql_steps
+# The `uses` twin of indexed_steps_matching: same indexed-entry shape, but the
+# comparison is version-tolerant rather than literal. Shared so a future change
+# to the matching contract cannot land on one call site and miss the other.
+steps_using_action(steps, action) := [entry |
+	some index, step in steps
 	action_matches(object.get(step, "uses", ""), action)
 	entry := {"index": index, "value": step}
 ]
+
+codeql_steps_using(action) := steps_using_action(codeql_steps, action)
 
 codeql_named_steps(name) := indexed_steps_matching(codeql_steps, "name", name)
 
@@ -307,11 +312,7 @@ claude_publish_job := object.get(claude_reusable_jobs, "publish", {})
 claude_analyze_steps := object.get(claude_analyze_job, "steps", [])
 claude_publish_steps := object.get(claude_publish_job, "steps", [])
 
-claude_analyze_steps_using(action) := [entry |
-	some index, step in claude_analyze_steps
-	action_matches(object.get(step, "uses", ""), action)
-	entry := {"index": index, "value": step}
-]
+claude_analyze_steps_using(action) := steps_using_action(claude_analyze_steps, action)
 
 claude_analyze_named_steps(name) := indexed_steps_matching(claude_analyze_steps, "name", name)
 

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -6,6 +6,7 @@ codecov_action := "codecov/codecov-action@v7"
 codecov_action_name := "codecov/codecov-action"
 codecov_authority_path := ".github/actions/upload-codecov/action.yml"
 codecov_wrapper := "./.github/actions/upload-codecov"
+upload_artifact_action := "actions/upload-artifact@v7"
 ci_workflow_path := ".github/workflows/ci.yml"
 codecov_workflow_path := ".github/workflows/ci-tests.yml"
 codecov_input_file := "${{ inputs.file }}"
@@ -914,7 +915,7 @@ deny contains msg if {
 	uploads := [entry |
 		some entry in uses_entries
 		entry.path == lighthouse_workflow_path
-		entry.uses == "actions/upload-artifact@v7"
+		action_matches(entry.uses, upload_artifact_action)
 		params := object.get(entry.value, "with", {})
 		object.get(params, "path", "") == "site/.lighthouseci/"
 	]
@@ -926,7 +927,7 @@ deny contains msg if {
 	msg := sprintf("%s Lighthouse upload must run under !cancelled()", [lighthouse_workflow_path])
 	some entry in uses_entries
 	entry.path == lighthouse_workflow_path
-	entry.uses == "actions/upload-artifact@v7"
+	action_matches(entry.uses, upload_artifact_action)
 	params := object.get(entry.value, "with", {})
 	object.get(params, "path", "") == "site/.lighthouseci/"
 	object.get(entry.value, "if", "") != "${{ !cancelled() }}"
@@ -936,7 +937,7 @@ deny contains msg if {
 	msg := sprintf("%s Lighthouse upload must include hidden files", [lighthouse_workflow_path])
 	some entry in uses_entries
 	entry.path == lighthouse_workflow_path
-	entry.uses == "actions/upload-artifact@v7"
+	action_matches(entry.uses, upload_artifact_action)
 	params := object.get(entry.value, "with", {})
 	object.get(params, "path", "") == "site/.lighthouseci/"
 	object.get(params, "include-hidden-files", false) != true
@@ -946,7 +947,7 @@ deny contains msg if {
 	msg := sprintf("%s Lighthouse upload must fail when reports are absent", [lighthouse_workflow_path])
 	some entry in uses_entries
 	entry.path == lighthouse_workflow_path
-	entry.uses == "actions/upload-artifact@v7"
+	action_matches(entry.uses, upload_artifact_action)
 	params := object.get(entry.value, "with", {})
 	object.get(params, "path", "") == "site/.lighthouseci/"
 	object.get(params, "if-no-files-found", "") != "error"

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -993,3 +993,32 @@ test_unrelated_action_does_not_match if {
 test_prefix_lookalike_does_not_match if {
 	not action_matches("github/codeql-action/analyze@v40.1.0", "github/codeql-action/analyze@v4")
 }
+
+# The Lighthouse rules matched `actions/upload-artifact@v7` literally, so an
+# exact pin would have emptied their entry list and spuriously fired all four
+# "must upload site/.lighthouseci/" denials — #786's failure, relocated.
+test_lighthouse_rules_tolerate_an_exact_upload_artifact_pin if {
+	fixture := {"documents": [{
+		"path": lighthouse_workflow_path,
+		"contents": {"jobs": {"lighthouse": {"steps": [{
+			"uses": "actions/upload-artifact@v7.1.2",
+			"if": "${{ !cancelled() }}",
+			"with": {
+				"path": "site/.lighthouseci/",
+				"include-hidden-files": true,
+				"if-no-files-found": "error",
+			},
+		}]}}},
+	}]}
+	violations := deny with input as fixture
+	every message in {
+		"must upload site/.lighthouseci/ exactly once",
+		"Lighthouse upload must run under !cancelled()",
+		"Lighthouse upload must include hidden files",
+		"Lighthouse upload must fail when reports are absent",
+	} {
+		every violation in violations {
+			not contains(violation, message)
+		}
+	}
+}

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -967,3 +967,29 @@ test_codeql_health_gate_before_upload_is_accepted if {
 	violations := deny with input as fixture
 	not sprintf("%s must verify Rust extraction health before uploading the SARIF", [codeql_workflow_path]) in violations
 }
+
+# Dependabot pins a floating major to an exact release. That is a STRICTER pin
+# and must not be rejected — #786 failed with "must analyze with CodeQL v4
+# exactly once" against a step that was v4.37.1.
+test_exact_release_pin_matches_the_major if {
+	action_matches("github/codeql-action/analyze@v4.37.1", "github/codeql-action/analyze@v4")
+	action_matches("anthropics/claude-code-action@v1.0.178", claude_action)
+	action_matches("codecov/codecov-action@v7.1.2", codecov_action)
+}
+
+# A real major bump must STILL fail — that is what the pin is for.
+test_major_bump_does_not_match if {
+	not action_matches("github/codeql-action/analyze@v5.0.0", "github/codeql-action/analyze@v4")
+	not action_matches("anthropics/claude-code-action@v2", claude_action)
+}
+
+# A different action that merely shares a version must not match.
+test_unrelated_action_does_not_match if {
+	not action_matches("evil/codeql-action/analyze@v4.37.1", "github/codeql-action/analyze@v4")
+	not action_matches("github/codeql-action/init@v4.37.1", "github/codeql-action/analyze@v4")
+}
+
+# A ref that only PREFIXES the major is not beneath it (v40 is not v4.x).
+test_prefix_lookalike_does_not_match if {
+	not action_matches("github/codeql-action/analyze@v40.1.0", "github/codeql-action/analyze@v4")
+}


### PR DESCRIPTION
Found by #786's red `hygiene` job — the first thing post-merge CI caught.

## #786 is a downgrade

| ref | resolves to | #786 proposes | |
|---|---|---|---|
| `anthropics/claude-code-action@v1` | `v1.0.183` | `v1.0.178` | ⬇ |
| `github/codeql-action@v4` | `v4.37.3` | `v4.37.1` | ⬇ |

The floating major tags **do** track the newest release. Dependabot reads `@v4`
as "version 4", and the `cooldown: default-days: 7` added in #785 filters that
to the newest release already a week old — so it offers last week's version
*and* rewrites a self-updating ref into a fixed one, losing both the currency
and the auto-update.

That also contradicts `.github/zizmor.yml`, which records symbolic refs as
deliberate repository policy.

**Fix:** github-actions opens PRs for MAJOR bumps only — the case that actually
needs a human. `ignore` + `update-types` syntax verified against GitHub's
options reference.

**Recommend closing #786 rather than merging it.**

## The policy rejected a legitimate pin

Separately, and the reason #786 went red rather than just being wrong: the
policy compared the literal `uses` string, so *any* exact pin failed —

```
FAIL .github/workflows/codeql.yml must analyze with CodeQL v4 exactly once
```

…against a step that **was** v4, just `v4.37.1`. Action matching now compares
the action path and the pinned major, accepting a more precise ref beneath it.

Kept even though the config change makes such PRs rare: a hand-written exact
pin is legitimate and must not be rejected with a false message.

Still correctly rejected, each with a test:
- a real major bump (`v4` → `v5.0.0`)
- a lookalike major (`v40.1.0` is not `v4.x`)
- a different action at the same version (`evil/codeql-action@v4.37.1`)

## Verification

Applied #786's actual pins to a worktree and ran the real gate: 103 document
checks pass where they previously produced 3 failures. `just lint` 12/12, 69
Rego unit tests.

## Note

This is the third spurious-firing defect in this policy in two days — a rule
whose condition was defensible and which blocked legitimate work with a
misleading message. Worth weighing against the value of pinning incidental
detail at all.
