### PR TITLE
fix(raycast): bump the top-level brace-expansion off the DoS advisory

### DIFF
--- a/integrations/raycast/package-lock.json
+++ b/integrations/raycast/package-lock.json
@@ -1676,15 +1676,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/chardet": {


### PR DESCRIPTION
GHSA-mh99-v99m-4gvg (high) — unbounded expansion length crashes the process out
of memory. Vulnerable `<= 5.0.7`, patched in `5.0.8`.

## What this fixes

The top-level copy, consumed by `minimatch@10.2.5` at `^5.0.5`. `5.0.8`
satisfies that, so it is a four-line lockfile change. `npm run lint` exits 0
(2 pre-existing warnings in `src/manage-sources.tsx`, untouched by this diff).

## What it does NOT fix, and why that is not laziness

`npm audit` still reports 11 high. That is **one root cause**, not eleven
problems:

```
brace-expansion ≤5.0.7 → minimatch → filelist → jake → ejs → @oclif/core → @raycast/api
```

A second copy sits at `filelist/node_modules/brace-expansion@2.1.2`, held there
by `minimatch@5.1.9` requiring `^2.0.1`. The advisory's range is `<= 5.0.7` with
the **only** patch at `5.0.8` — every 1.x–4.x line is unpatched.

**The obvious fix breaks the extension.** I tried
`overrides: { "brace-expansion": "^5.0.8" }`:

- `npm audit` → **0 vulnerabilities**
- the code → **`expand is not a function`**

5.x changed the export from a function to an object
(`{EXPANSION_MAX, EXPANSION_MAX_LENGTH, expand}`), while `minimatch.js:19` does
`const expand = require('brace-expansion')` and calls `expand(pattern)` at
`:119`. Reproduced directly. A green audit over broken code is strictly worse
than the advisory, so the override is not taken.

`npm audit fix` without `--force` cannot resolve it; `--force` proposes breaking
changes to `@raycast/api` itself.

## Reachability

The extension's own source never references `minimatch`, `brace-expansion`,
`ejs` or `glob` — the vulnerable path is a build-tool glob library inside a
bundled extension. Clearing it needs `@oclif/core` (or `ejs`) to move off the
2.x line upstream, same shape as #440.

## Separately

The 10 open CodeQL alerts (`rust/cleartext-logging`) were each verified to sit
inside a `#[cfg(test)]` module — the interpolated values are hardcoded fixtures.
Dismissed as `used in tests`. Rust keeps unit tests inline, so `paths-ignore`
could not exclude them without dropping the production code too.
