### PR TITLE
fix(site): drive the hero reveal roll by painted frames, not the clock

### DIFF
--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -173,6 +173,28 @@ display-line authority (`starText`), unit-tested on its null-stars arm since
   wrong-time still — the day/night flip is gone by construction; the splash in
   turn HOLDS on `window.__pixEngineReady` (Level-2 gate) so it lifts straight into
   the roll. Any failure / no-JS / no-wasm / reduced-motion keeps the still poster).
+  **SHARP EDGE — the reveal roll is FRAME-driven, never clock-driven.** Right
+  after a first visit settles, Safari blocks the page's ENTIRE main thread for
+  ~1.3-1.5s inside its own tab-snapshot IPC: `WebPage::TakeSnapshot` →
+  `RemoteImageBufferProxy::flushDrawingContext()` → `IPC::Semaphore::waitFor` →
+  `semaphore_timedwait_trap`, while the GPU process sits in
+  `CA::CG::ContextDelegate::operation_`'s `dispatch_sync` (captured with `sample`
+  on both processes, Safari 27). NEITHER side is computing — it is a
+  CoreAnimation queue-ownership wait, which is why the duration is near-constant
+  and why no JS callback ever exceeds 4ms. It fires on the same "page settled"
+  signal the splash's Level-2 `__pixEngineReady` gate waits for, so it lands ON
+  the roll whenever it fires. A wall-clock ramp
+  (`(nowMs - revealStartSim) / REVEAL_MS`) kept advancing while nothing painted,
+  so the roll froze on a half-drawn frame and SNAPPED to the settled office — the
+  reveal was never seen. So `paint()` accumulates `revealElapsed` from
+  `Math.min(step, REVEAL_MAX_STEP_MS)` per PAINTED frame, and holds the start
+  until `REVEAL_READY_FRAMES` consecutive on-budget frames land (putting the
+  stall on the flat bg tone instead of a broken frame) — bounded by
+  `REVEAL_READY_MAX_WAIT` so a device that never meets the budget still gets its
+  office. Don't "simplify" any of the three back to a clock. The stall itself is
+  Safari's and cannot be prevented; it does NOT reproduce in Playwright's WebKit
+  or Chromium (no tab UI to snapshot), and it is INTERMITTENT — a single-shot A/B
+  against it will lie, so pin changes here with repeated interleaved trials.
   Never hand-edit
   (prettier/eslint/knip all ignore it); regenerate from the crate.
   The hero renders at `BUF_H=130`, `SEED=0` (a deliberately closer camera than

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -173,28 +173,6 @@ display-line authority (`starText`), unit-tested on its null-stars arm since
   wrong-time still — the day/night flip is gone by construction; the splash in
   turn HOLDS on `window.__pixEngineReady` (Level-2 gate) so it lifts straight into
   the roll. Any failure / no-JS / no-wasm / reduced-motion keeps the still poster).
-  **SHARP EDGE — the reveal roll is FRAME-driven, never clock-driven.** Right
-  after a first visit settles, Safari blocks the page's ENTIRE main thread for
-  ~1.3-1.5s inside its own tab-snapshot IPC: `WebPage::TakeSnapshot` →
-  `RemoteImageBufferProxy::flushDrawingContext()` → `IPC::Semaphore::waitFor` →
-  `semaphore_timedwait_trap`, while the GPU process sits in
-  `CA::CG::ContextDelegate::operation_`'s `dispatch_sync` (captured with `sample`
-  on both processes, Safari 27). NEITHER side is computing — it is a
-  CoreAnimation queue-ownership wait, which is why the duration is near-constant
-  and why no JS callback ever exceeds 4ms. It fires on the same "page settled"
-  signal the splash's Level-2 `__pixEngineReady` gate waits for, so it lands ON
-  the roll whenever it fires. A wall-clock ramp
-  (`(nowMs - revealStartSim) / REVEAL_MS`) kept advancing while nothing painted,
-  so the roll froze on a half-drawn frame and SNAPPED to the settled office — the
-  reveal was never seen. So `paint()` accumulates `revealElapsed` from
-  `Math.min(step, REVEAL_MAX_STEP_MS)` per PAINTED frame, and holds the start
-  until `REVEAL_READY_FRAMES` consecutive on-budget frames land (putting the
-  stall on the flat bg tone instead of a broken frame) — bounded by
-  `REVEAL_READY_MAX_WAIT` so a device that never meets the budget still gets its
-  office. Don't "simplify" any of the three back to a clock. The stall itself is
-  Safari's and cannot be prevented; it does NOT reproduce in Playwright's WebKit
-  or Chromium (no tab UI to snapshot), and it is INTERMITTENT — a single-shot A/B
-  against it will lie, so pin changes here with repeated interleaved trials.
   Never hand-edit
   (prettier/eslint/knip all ignore it); regenerate from the crate.
   The hero renders at `BUF_H=130`, `SEED=0` (a deliberately closer camera than
@@ -204,6 +182,40 @@ display-line authority (`starText`), unit-tested on its null-stars arm since
   `hire()` easter egg is politely refused for lack of a free desk — graceful
   and owner-accepted, not a bug (pinned by pixtuoid-web's
   `a_phone_narrow_office_the_cast_fills_refuses_hires_outright`).
+- **SHARP EDGE — `OfficeBackdrop.astro`'s reveal roll is FRAME-driven, never
+  clock-driven.** Right after a first visit settles, Safari blocks the page's
+  ENTIRE main thread for ~1.3-1.5s inside its own tab-snapshot IPC:
+  `WebPage::TakeSnapshot` → `RemoteImageBufferProxy::flushDrawingContext()` →
+  `IPC::Semaphore::waitFor` → `semaphore_timedwait_trap`, while the GPU process
+  sits in `CA::CG::ContextDelegate::operation_`'s `dispatch_sync` (captured with
+  `sample` on BOTH processes, Safari 27). Neither side is computing — it is a
+  CoreAnimation queue-ownership wait, which is why the duration is near-constant
+  and why no JS callback in the profile exceeded ~4ms. It co-occurs with the
+  first live office frame — the same moment the splash's Level-2
+  `__pixEngineReady` gate lifts on — so when it fires it lands on the roll.
+  (Co-occurrence, not a known common trigger: a profile shows timing, not
+  WebKit's snapshot heuristic.) A wall-clock ramp
+  (`(nowMs - revealStartSim) / REVEAL_MS`) kept advancing while nothing painted,
+  so the roll froze on a half-drawn frame and SNAPPED to the settled office — the
+  reveal was never seen. So `paint()` accumulates `reveal.elapsed` from
+  `Math.min(step, REVEAL_MAX_STEP_MS)` per PAINTED frame, and holds the start
+  until `REVEAL_READY_FRAMES` consecutive on-budget frames land — which keeps the
+  stall on the flat bg tone rather than a faint chroma-split ghost of the
+  scrolling floors, and (the sturdier reason) defers `is-live`, the `pix:onair`
+  the statusline lights its ON-AIR readout from, and the ♩ button, so an office
+  about to freeze for 1.4s never announces itself live — bounded by
+  `REVEAL_READY_MAX_WAIT` so a device that never meets the budget still gets its
+  office. Don't "simplify" the accumulator, the step clamp, or the readiness gate
+  back to a clock. `REVEAL_MAX_STEP_MS` DERIVES from `FRAME_MS` on purpose: a
+  hardcoded twin silently disables the gate if `FRAME_MS` ever rises to meet it.
+  The four reveal fields live in ONE `reveal` object because they share a
+  LIFECYCLE — the reduced-motion arm's `live = false` must rewind ALL of them or
+  the un-reduce SNAPS (pinned by the un-reduce e2e test). The stall itself is
+  Safari's and cannot be prevented; it does NOT reproduce in Playwright's WebKit
+  or Chromium (no tab UI to snapshot), and it is INTERMITTENT — a single-shot A/B
+  against it will lie, so pin changes here with repeated interleaved trials.
+  This is also the SECOND bounded hold on a first visit: `Base.astro`'s
+  `MAX_ENGINE_WAITS` (~4s) runs first, and the two caps stack.
 - **The crisp AA caption layer (`#office-overlay`).** The canvas renders a
   ~130px buffer that CSS upscales with `image-rendering: pixelated`, so text
   BAKED into the office pixels blows up blocky. Instead the engine exports the

--- a/site/src/components/OfficeBackdrop.astro
+++ b/site/src/components/OfficeBackdrop.astro
@@ -412,10 +412,21 @@ const officeDriverUrl = asset('office-driver.js');
     const hasWasm = typeof WebAssembly !== 'undefined';
 
     // ── First-visit reveal (option A cover + Level-2 splash gate) ──────────────
-    let revealElapsed = 0; // roll progress, accumulated from PAINTED frames only
-    let revealLastSim = 0; // previous frame's sim clock, for the per-frame delta
-    let revealReady = 0; // consecutive on-budget frames seen before the roll starts
-    let revealWaited = 0; // total frames spent waiting, bounding that hold
+    // ONE object, not four flat lets: these don't all mutate together (ready /
+    // waited only while the gate holds, elapsed / lastSim only after it lifts)
+    // but they share one LIFECYCLE — every re-live restarts ALL of them, and a
+    // flat set lets a later edit reset three of four. `live = false` on the
+    // reduced-motion path is exactly that reset, and its un-reduce arm expects a
+    // FRESH roll ("rolls back in", below).
+    function freshReveal() {
+      return {
+        elapsed: 0, // roll progress, accumulated from PAINTED frames only
+        lastSim: 0, // previous frame's sim clock, for the per-frame delta
+        ready: 0, // consecutive on-budget frames seen before the roll starts
+        waited: 0, // total frames spent waiting, bounding that hold
+      };
+    }
+    let reveal = freshReveal();
     let splashCleared = !!window.__pixRevealed; // seeded/repeat visit: already lifted
     // Option A: on the boot path, cover the baked poster with the canvas's own bg
     // tone (CSS background: var(--bg)) from the first paint, so the office reveals
@@ -479,11 +490,22 @@ const officeDriverUrl = asset('office-driver.js');
     // per-frame step makes a hitch PAUSE the roll instead of skipping it, and
     // holding the start until frames flow puts the stall in the flat bg-tone
     // cover, where it reads as a beat rather than a broken frame.
-    const REVEAL_MAX_STEP_MS = 50; // a longer frame is a hitch, not motion
+    // DERIVED from the paint gate, never a second literal: `frame()` only paints
+    // once `t - last >= FRAME_MS`, so a step can never be below FRAME_MS, and the
+    // budget must clear that floor with headroom — one dropped frame is still
+    // motion, two is a hitch. Hardcoding 50 would silently break if FRAME_MS ever
+    // rose to meet it: EVERY frame would read over-budget, the readiness gate
+    // would never pass, and every reveal would take the MAX_WAIT fallback — green,
+    // with no test able to see it. (pixtuoid-scene's audio engine settled the same
+    // question with `MAX_DT_S`; deliberately NOT shared — different clock, different
+    // unit, wrong side of the wasm boundary.)
+    const REVEAL_MAX_STEP_MS = Math.round(FRAME_MS * 1.5); // 50ms at the 33ms cap
     const REVEAL_READY_FRAMES = 3; // consecutive on-budget frames before the roll starts
     // ...but a device that never sustains the budget must still get its office:
-    // the gate is a courtesy, never a precondition for going live.
-    const REVEAL_READY_MAX_WAIT = 30; // frames (~1s at the 33ms cap) before starting anyway
+    // the gate is a courtesy, never a precondition for going live. This is the
+    // SECOND bounded hold on a first visit — Base.astro's MAX_ENGINE_WAITS (~4s)
+    // runs first, and the two caps stack.
+    const REVEAL_READY_MAX_WAIT = Math.round(1000 / FRAME_MS); // ~1s of frames
 
     let office = null;
     let wasm = null;
@@ -670,30 +692,33 @@ const officeDriverUrl = asset('office-driver.js');
       // Hold on the bg-tone cover until the boot splash has lifted, so the roll is
       // never played hidden behind the overlay (the office keeps stepping meanwhile).
       if (!splashCleared) return;
+      // Per-frame delta off the SIM clock, so an explicit pause freezes the roll
+      // exactly as it freezes the office (pauseOffset already absorbs the gap).
+      const step = reveal.lastSim ? nowMs - reveal.lastSim : 0;
+      reveal.lastSim = nowMs;
+      const onBudget = step > 0 && step <= REVEAL_MAX_STEP_MS;
       // Under reduced motion the office is a poster-still: NO paint caller
       // may re-live it (the mq listener de-lives; a stray repaint — a
       // resize, a background tick — must not undo that). The un-reduce
       // path re-lives through boot()/start() as before.
-      // Per-frame delta off the SIM clock, so an explicit pause freezes the roll
-      // exactly as it freezes the office (pauseOffset already absorbs the gap).
-      const step = revealLastSim ? nowMs - revealLastSim : 0;
-      revealLastSim = nowMs;
-      const onBudget = step > 0 && step <= REVEAL_MAX_STEP_MS;
       if (!live && !mq.matches) {
-        // Hold on the bg-tone cover until frames are actually flowing, so a
-        // stall lands on the flat tone instead of a half-drawn reveal frame.
-        revealReady = onBudget ? revealReady + 1 : 0;
-        revealWaited++;
-        if (revealReady < REVEAL_READY_FRAMES && revealWaited < REVEAL_READY_MAX_WAIT) return;
+        // Frames must be flowing before the roll starts: that keeps a stall on
+        // the flat bg tone, and — the sturdier reason — defers `is-live`, the
+        // pix:onair the statusline lights its ON-AIR readout from, and the ♩
+        // button, so an office about to freeze never announces itself live.
+        reveal.ready = onBudget ? reveal.ready + 1 : 0;
+        reveal.waited++;
+        if (reveal.ready < REVEAL_READY_FRAMES && reveal.waited < REVEAL_READY_MAX_WAIT) return;
         live = true;
         wrap.classList.add('is-live');
         document.dispatchEvent(new CustomEvent('pix:onair', { detail: { live: true } }));
         showAudioBtn(); // a live office exists → offer the ♩ sound toggle
       }
       // A hitch contributes at most one frame of progress, so the roll pauses
-      // through it and resumes — it can never be skipped.
-      revealElapsed += Math.min(step, REVEAL_MAX_STEP_MS);
-      const rt = mq.matches ? 1 : revealElapsed / REVEAL_MS;
+      // through it and resumes — it can never be skipped. Date.now() is not
+      // monotonic, so a backward clock jump holds the roll rather than rewinding it.
+      reveal.elapsed += Math.max(0, Math.min(step, REVEAL_MAX_STEP_MS));
+      const rt = mq.matches ? 1 : reveal.elapsed / REVEAL_MS;
       if (rt < 1) {
         drawRevealFrame(view, rt < 0 ? 0 : rt);
       } else {
@@ -1391,6 +1416,11 @@ const officeDriverUrl = asset('office-driver.js');
           wrap.classList.remove('is-live');
           if (overlayEl) overlayEl.classList.remove('is-on');
           live = false;
+          // …and rewind the reveal with it: the un-reduce arm below re-covers
+          // and expects a FRESH roll. Without this the accumulated progress
+          // survives, rt is already >= 1, and the office SNAPS back in — the
+          // very failure this frame-driven roll exists to prevent.
+          reveal = freshReveal();
           document.dispatchEvent(new CustomEvent('pix:onair', { detail: { live: false } }));
           // Reduced motion stops the rAF loop, so the sound loops would drone
           // unfed behind the poster — suspend the context (the flag stays on, so

--- a/site/src/components/OfficeBackdrop.astro
+++ b/site/src/components/OfficeBackdrop.astro
@@ -412,7 +412,10 @@ const officeDriverUrl = asset('office-driver.js');
     const hasWasm = typeof WebAssembly !== 'undefined';
 
     // ── First-visit reveal (option A cover + Level-2 splash gate) ──────────────
-    let revealStartSim = 0; // sim-clock t0 of the roll (pause freezes it via nowMs)
+    let revealElapsed = 0; // roll progress, accumulated from PAINTED frames only
+    let revealLastSim = 0; // previous frame's sim clock, for the per-frame delta
+    let revealReady = 0; // consecutive on-budget frames seen before the roll starts
+    let revealWaited = 0; // total frames spent waiting, bounding that hold
     let splashCleared = !!window.__pixRevealed; // seeded/repeat visit: already lifted
     // Option A: on the boot path, cover the baked poster with the canvas's own bg
     // tone (CSS background: var(--bg)) from the first paint, so the office reveals
@@ -460,6 +463,27 @@ const officeDriverUrl = asset('office-driver.js');
     const REVEAL_MS = 1600;
     const FLOORS_PAST = 3.2;
     const CHROMA_SPLIT_PX = 3;
+    // The roll advances by PAINTED FRAMES, not by the wall clock, and only
+    // starts once frames are actually flowing. Right after a first visit
+    // settles, Safari blocks the page's whole main thread for ~1.3-1.5s inside
+    // its own tab-snapshot IPC (WebPage::TakeSnapshot ->
+    // RemoteImageBufferProxy::flushDrawingContext -> IPC::Semaphore::waitFor ->
+    // semaphore_timedwait_trap, with the GPU process parked in
+    // CA::CG::ContextDelegate::operation_'s dispatch_sync — profiled with
+    // `sample` on Safari 27; neither side is computing, it is a lock wait, hence
+    // the near-constant duration). The splash gates the reveal on
+    // __pixEngineReady and Safari snapshots on the same "page settled" signal,
+    // so the stall lands ON the roll every time it fires. A clock ramp keeps
+    // running while nothing paints, so the roll froze on a half-drawn frame and
+    // SNAPPED to the settled office — the reveal was never seen. Clamping the
+    // per-frame step makes a hitch PAUSE the roll instead of skipping it, and
+    // holding the start until frames flow puts the stall in the flat bg-tone
+    // cover, where it reads as a beat rather than a broken frame.
+    const REVEAL_MAX_STEP_MS = 50; // a longer frame is a hitch, not motion
+    const REVEAL_READY_FRAMES = 3; // consecutive on-budget frames before the roll starts
+    // ...but a device that never sustains the budget must still get its office:
+    // the gate is a courtesy, never a precondition for going live.
+    const REVEAL_READY_MAX_WAIT = 30; // frames (~1s at the 33ms cap) before starting anyway
 
     let office = null;
     let wasm = null;
@@ -650,14 +674,26 @@ const officeDriverUrl = asset('office-driver.js');
       // may re-live it (the mq listener de-lives; a stray repaint — a
       // resize, a background tick — must not undo that). The un-reduce
       // path re-lives through boot()/start() as before.
+      // Per-frame delta off the SIM clock, so an explicit pause freezes the roll
+      // exactly as it freezes the office (pauseOffset already absorbs the gap).
+      const step = revealLastSim ? nowMs - revealLastSim : 0;
+      revealLastSim = nowMs;
+      const onBudget = step > 0 && step <= REVEAL_MAX_STEP_MS;
       if (!live && !mq.matches) {
+        // Hold on the bg-tone cover until frames are actually flowing, so a
+        // stall lands on the flat tone instead of a half-drawn reveal frame.
+        revealReady = onBudget ? revealReady + 1 : 0;
+        revealWaited++;
+        if (revealReady < REVEAL_READY_FRAMES && revealWaited < REVEAL_READY_MAX_WAIT) return;
         live = true;
-        revealStartSim = nowMs; // sim-clock t0 → pause freezes the roll too
         wrap.classList.add('is-live');
         document.dispatchEvent(new CustomEvent('pix:onair', { detail: { live: true } }));
         showAudioBtn(); // a live office exists → offer the ♩ sound toggle
       }
-      const rt = mq.matches ? 1 : (nowMs - revealStartSim) / REVEAL_MS;
+      // A hitch contributes at most one frame of progress, so the roll pauses
+      // through it and resumes — it can never be skipped.
+      revealElapsed += Math.min(step, REVEAL_MAX_STEP_MS);
+      const rt = mq.matches ? 1 : revealElapsed / REVEAL_MS;
       if (rt < 1) {
         drawRevealFrame(view, rt < 0 ? 0 : rt);
       } else {

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -1118,6 +1118,72 @@ test('first visit: boot intro auto-runs, reveals the page, seeds the gate', asyn
   await expectSectionReveal(page, 'install');
 });
 
+test('the reveal roll survives a main-thread stall instead of snapping past it', async ({
+  page,
+}) => {
+  // Safari blocks the page's main thread for ~1.3-1.5s right after a first
+  // visit settles, inside its OWN tab-snapshot IPC: WebPage::TakeSnapshot ->
+  // RemoteImageBufferProxy::flushDrawingContext -> IPC::Semaphore::waitFor ->
+  // semaphore_timedwait_trap, while the GPU process sits blocked in
+  // CA::CG::ContextDelegate::operation_'s dispatch_sync (profiled with `sample`
+  // on Safari 27; neither process is doing work — it is a lock wait, which is
+  // why the duration is near-constant). Nothing here can stop that stall. What
+  // it MUST NOT do is eat the reveal: a wall-clock ramp keeps advancing while
+  // nothing paints, so the roll froze on a half-drawn frame and then snapped to
+  // the settled office — the animation never played (the reported bug).
+  // The roll is therefore driven by PAINTED frames, not by the clock.
+  const errors = watchErrors(page);
+  await page.goto('./'); // real first visit — the boot path is the only one that rolls
+  await expect(page.locator('.backdrop')).toHaveClass(/\bis-live\b/, { timeout: 15_000 });
+  const settled = () =>
+    page.evaluate(() => !!document.getElementById('office-overlay')?.classList.contains('is-on'));
+  expect(await settled()).toBe(false); // the roll is running
+  // Block the main thread for a full REVEAL_MS the way the snapshot IPC does.
+  await page.evaluate(() => {
+    const until = performance.now() + 1600;
+    while (performance.now() < until) {
+      /* synchronous stall — no frames can paint */
+    }
+  });
+  // A clock-driven ramp is now past REVEAL_MS: it would already have snapped to
+  // the settled office and switched the captions on. A frame-driven one has
+  // barely advanced, so the reveal still has its animation left to play.
+  expect(await settled()).toBe(false);
+  // ...and it must still finish on its own rather than hanging mid-roll.
+  await expect.poll(settled, { timeout: 10_000 }).toBe(true);
+  expect(errors()).toEqual([]);
+});
+
+test('the office still goes live on a device that never meets the frame budget', async ({
+  page,
+}) => {
+  // The roll waits for a few on-budget frames so a main-thread stall lands on
+  // the flat bg cover rather than a half-drawn frame. That wait is a COURTESY,
+  // never a precondition: a machine that cannot sustain the budget at all would
+  // otherwise sit on the cover forever and never get an office. Every frame
+  // here is deliberately pushed over budget, and the office must still come up.
+  const errors = watchErrors(page);
+  await page.addInitScript(() => {
+    // Push every frame past REVEAL_MAX_STEP_MS, but only ONCE the engine is up —
+    // starving the wasm boot itself would test a different thing (and never get
+    // as far as the readiness gate this pins).
+    const raf = window.requestAnimationFrame.bind(window);
+    window.requestAnimationFrame = (cb) =>
+      raf((t) => {
+        if ((window as unknown as { __pixEngineReady?: boolean }).__pixEngineReady) {
+          const until = performance.now() + 70;
+          while (performance.now() < until) {
+            /* every frame is a hitch */
+          }
+        }
+        cb(t);
+      });
+  });
+  await page.goto('./');
+  await expect(page.locator('.backdrop')).toHaveClass(/\bis-live\b/, { timeout: 20_000 });
+  expect(errors()).toEqual([]);
+});
+
 test('a keypress during the Level-2 engine hold force-settles the splash immediately', async ({
   page,
 }) => {

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -1154,6 +1154,34 @@ test('the reveal roll survives a main-thread stall instead of snapping past it',
   expect(errors()).toEqual([]);
 });
 
+test('un-reducing motion mid-session rolls the office in again, it does not snap', async ({
+  page,
+}) => {
+  // The reduced-motion arm sets `live = false`; its un-reduce arm re-covers and
+  // boots "so the office rolls back in". The roll's progress must rewind with
+  // it — frame-accumulated progress that SURVIVES the de-live leaves rt >= 1, so
+  // the office blits its settled frame and SNAPS: the exact failure the
+  // frame-driven roll exists to prevent, reintroduced on the neighbouring path.
+  // Nothing else in this suite un-reduces (every other test only reduces), so
+  // this is the sole guard on that direction.
+  const errors = watchErrors(page);
+  const captionsOn = () =>
+    page.evaluate(() => !!document.getElementById('office-overlay')?.classList.contains('is-on'));
+  await page.goto('./');
+  await expect(page.locator('.backdrop')).toHaveClass(/\bis-live\b/, { timeout: 15_000 });
+  // let the first roll finish, so accumulated progress is past REVEAL_MS
+  await expect.poll(captionsOn, { timeout: 15_000 }).toBe(true);
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  await expect(page.locator('.backdrop')).not.toHaveClass(/\bis-live\b/, { timeout: 5_000 });
+  await page.emulateMedia({ reducedMotion: 'no-preference' });
+  await expect(page.locator('.backdrop')).toHaveClass(/\bis-live\b/, { timeout: 15_000 });
+  // Live again — so the reveal must be REPLAYING, i.e. captions still off. A
+  // stale accumulator settles on the first frame and turns them straight on.
+  expect(await captionsOn()).toBe(false);
+  await expect.poll(captionsOn, { timeout: 15_000 }).toBe(true); // ...and it completes
+  expect(errors()).toEqual([]);
+});
+
 test('the office still goes live on a device that never meets the frame budget', async ({
   page,
 }) => {


### PR DESCRIPTION
## The bug

On a first visit the hero office reveal froze on a half-drawn frame for ~1.4s, then snapped straight to the settled office — the roll was never seen.

## Root cause

**Safari's own tab-snapshot IPC blocks the page's main thread.** Captured with macOS `sample` attached to Safari 27's real processes, on two independent stalls (1307ms, 1454ms):

```
web process   Messages::WebPage::TakeSnapshot          <- Safari asks for the tab thumbnail
              -> WebPage::takeSnapshot
                -> WebImage::createImageBufferBackendHandle
                  -> RemoteImageBufferProxy::flushDrawingContext()
                    -> IPC::Semaphore::waitFor(IPC::Timeout)
                      -> semaphore_timedwait_trap      <- blocked on the GPU process

GPU process   RemoteImageBufferSet::endPrepareForDisplay
              -> CA::CG::ContextDelegate::operation_
                -> _dispatch_sync_f_slow -> __DISPATCH_WAIT_FOR_QUEUE__ -> kevent_id
```

Neither side is computing: the GPU process's main thread is 2933/2935 samples idle in `mach_msg2_trap` and all 28 `RemoteRenderingBackend` threads are parked. It is a CoreAnimation queue-ownership wait — which is why the duration is near-constant rather than proportional to page weight, and why **no JS callback in the profile exceeded ~4ms**.

It lands on the reveal because it co-occurs with the first live office frame — the same moment the boot splash's Level-2 `__pixEngineReady` gate lifts on. (Co-occurrence, not a proven common trigger: a profile shows timing, not WebKit's snapshot heuristic.)

## Why this took several wrong turns first

The stall is **intermittent** (Safari does not snapshot every load) and does not reproduce in Playwright's WebKit or Chromium (no tab UI to snapshot). Single-shot A/B runs therefore produced clean-looking separations that were pure noise. Two hypotheses were raised and then **refuted by controls**:

- **the #705 audio prewarm worker** — refuted: an arm where `new Worker` was never constructed still stalled 1452ms.
- **the roll's per-pixel alpha / canvas compositing** — refuted: with both variants served from the SAME url (path and navigation order had been confounded with the variant), base stalled 6/7 and the "fix" 7/10.

The profiler settled it. Lesson recorded in the sharp edge: pin changes here with repeated interleaved trials, never one sample per arm.

## The fix

The stall is Safari's and cannot be prevented. What it must not do is **eat the reveal**: `rt = (nowMs - revealStartSim) / REVEAL_MS` was a wall-clock ramp, so it kept advancing while nothing painted.

The roll now accumulates from **painted frames**:

- `reveal.elapsed += Math.max(0, Math.min(step, REVEAL_MAX_STEP_MS))` — a hitch contributes one frame of progress, so the roll pauses through it and resumes rather than being skipped.
- the roll holds until `REVEAL_READY_FRAMES` consecutive on-budget frames land, so a stall sits on the flat bg-tone cover (reads as a beat) instead of a half-drawn frame.
- `REVEAL_READY_MAX_WAIT` bounds that hold — a device that never meets the budget must still get its office, so the gate is a courtesy, never a precondition.

The code is **cause-agnostic**: it depends on no WebKit internal, only on "a frame took too long". The internals appear in the sharp edge to explain why, not as a contract.

## Verification

**Real Safari, 24 alternating loads, fixed vs pre-fix, both served from the same url.** With a ~1.4s stall inside the roll:

| variant | stall in roll | roll wall-clock |
|---|---|---|
| pre-fix | 1455 ms | **1644 ms** — unchanged, so the animation was eaten |
| fixed | 1429 ms | **2971 ms** = 1590 + 1429 — paused, then played in full |

Unstalled rolls unchanged (fixed 1590-1621ms vs pre-fix 1619-1646ms). The readiness gate holds 126-165ms across all 12 fixed trials — 3-4 frames, never the fallback.

**Tests:** three pins in `smoke.spec.ts` (stall-survival, slow-device fallback, un-reduce replay), each red before its fix. Since the real stall cannot be reproduced headlessly, they inject a synthetic main-thread block instead. Negative-control caveat and final gate results are in the review section below.

## Docs

Sharp edge added to `site/CLAUDE.md`, including the intermittency warning and the "frame-driven, never clock-driven" invariant.

---

## Local review (two-lens gate)

Findings driven to terminal states:

| # | Finding | State |
|---|---|---|
| F1 | **Regression this PR introduced.** `revealElapsed` was never reset, so the reduced-motion un-reduce path (which expects a fresh roll) left `rt >= 1` and the office SNAPPED — the very failure this PR fixes, on the neighbouring path. | **FIXED** (`1c70eca9`) + new e2e pin |
| F2 | `REVEAL_MAX_STEP_MS` and `FRAME_MS` were independent literals; raising `FRAME_MS` to meet it would silently disable the readiness gate, green, untestable. | **FIXED** — derived, value byte-identical |
| F10 | `Date.now()` is not monotonic; a backward jump rewound the roll. | **FIXED** — clamped at 0 |
| F4 | The reduced-motion comment was detached from the `if` it explains. | **FIXED** |
| F3 | The sharp edge was inserted mid-bullet, orphaning `public/wasm/`'s "Never hand-edit … regenerate from the crate". | **FIXED** — own top-level bullet |
| F5 | Four doc overclaims (common-trigger vs co-occurrence; an absolute from one profile; "the three" with no antecedent; "broken frame"). | **FIXED** |
| F9 | `pixtuoid-scene`'s `MAX_DT_S` settled the same question for audio. | **REFUTED as shared code** (different clock, unit, side of the wasm boundary) — cited in the comment instead |
| F8 | This is the second bounded hold on a first visit; it stacks with `Base.astro`'s `MAX_ENGINE_WAITS`. | **FIXED** — documented |
| F7 | The 1 Hz hidden-tab audio tick is permanently off-budget. | **REFUTED** — self-healing on return, and the roll surviving the hide is the intended improvement |
| — | Bundling the four reveal fields into one object. | **FIXED** — F1 is the evidence they share a lifecycle |

### Review integrity, stated plainly

- The **rendered-runtime / motion lens has now run** (it initially died on a session limit) — see the PR comment below: the roll was watched frame-by-frame, clean and under two verified stall placements, 6/6 loads settled, zero console errors. **APPROVE.** Its first pass reported a false clean because an injected stall silently never fired; the run now self-verifies that the stall executed.
- Two lenses initially returned stubs; the design lens was re-run as a focused agent and is what caught F1. The correctness lens never returned — its checklist items were covered by the design lens and by my own verification, but it is not an independent second opinion.
- My earlier claim that the new pins were "negative-controlled" was **wrong**: mutating `dist/index.html` breaks the inline script's CSP hash, so the browser blocked the whole script and the tests failed for that reason. Both pins have since been re-controlled by mutating the **source** and rebuilding, and both now fail on the intended assertion.

## Gates

`just site-check` EXIT=0 · `just site-e2e` **94/94** EXIT=0

## Follow-up (not this PR)

`pixtuoid-scene audio::synth::tests::day_take_stems_match_the_ratified_fingerprints` takes 101s alone against nextest's 180s cap and times out under parallel load. Latent flake; will file separately.
