### PR TITLE
fix(site): docs callout invisible in the default day theme, +5 a11y/link defects

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Press `s` to open the **Sources** panel and connect your agent CLI (Claude Code,
 | [Claude Code](https://code.claude.com) | macOS · Linux · Windows\* |
 | [Codex CLI](https://github.com/openai/codex) | macOS · Linux · Windows\* |
 
-_Also supported: [Antigravity CLI](https://github.com/antiGravity-AI/antigravity-cli), [DeepSeek-Reasonix](https://github.com/esengine/DeepSeek-Reasonix), [CodeWhale](https://github.com/Hmbown/CodeWhale), [Copilot CLI](https://github.com/github/copilot-cli), [opencode](https://github.com/anomalyco/opencode), [Cursor CLI](https://cursor.com/cli), [Hermes Agent](https://hermes-agent.nousresearch.com), [Oh My Pi](https://omp.sh), [OpenClaw](https://github.com/openclaw/openclaw), [Grok Build](https://github.com/xai-org/grok-build), [Kimi Code CLI](https://github.com/MoonshotAI/kimi-code)._
+_Also supported: [Antigravity CLI](https://github.com/google-antigravity/antigravity-cli), [DeepSeek-Reasonix](https://github.com/esengine/DeepSeek-Reasonix), [CodeWhale](https://github.com/Hmbown/CodeWhale), [Copilot CLI](https://github.com/github/copilot-cli), [opencode](https://github.com/anomalyco/opencode), [Cursor CLI](https://cursor.com/cli), [Hermes Agent](https://hermes-agent.nousresearch.com), [Oh My Pi](https://omp.sh), [OpenClaw](https://github.com/openclaw/openclaw), [Grok Build](https://github.com/xai-org/grok-build), [Kimi Code CLI](https://github.com/MoonshotAI/kimi-code)._
 
 **→ [Full tool × OS support matrix on the site](https://pixtuoid.dev/#tools)**
 

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -278,7 +278,16 @@ display-line authority (`starText`), unit-tested on its null-stars arm since
   dial. `--led` itself is a HARDWARE hue (global.css: "HARDWARE components …
   are `.hw-panel` … dark `--screen` ground"); the dial is the one place it is
   used with no `--screen` under it, hence its own token rather than a fourth
-  bare `--led` site.
+  bare `--led` site. Text on the page's OPAQUE DOM plates is a third population
+  with a third sweep, "opaque-plate text clears WCAG AA in every theme" — and
+  that one runs **dracula** too. Dracula is visitor-reachable (`?theme=dracula`
+  via `VALID_THEMES`, plus `Base.astro`'s keydown egg) but nothing measured it:
+  the office sweep is day+night on purpose (dracula's `--bg` darkens the same
+  way night's does, so it piggybacks) and Lighthouse only ever scores the
+  default theme. Its own palette steps much further from `--bg` to `--surface-2`
+  than day/night do, which is why its `--fg-muted` and upstream Dracula Purple
+  needed their own tuning against its own plates rather than inheriting the
+  assumption that "dark theme ⇒ fine".
   Pinned by `smoke.spec.ts` ("crisp AA captions
   overlay the live office" — incl. the 3-span split with a colored prefix —
   + the reduced-motion hide twin). This layer is part

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -276,12 +276,20 @@ display-line authority (`starText`), unit-tested on its null-stars arm since
   its sweep is `smoke.spec.ts`'s "bare hero text clears WCAG AA at the real
   office composite": it scrolls each selector on screen, reads the office
   canvas under its box, composites the live dimmer and grades the element's
-  real ink. **SHARP EDGE — that sweep only measures anything for an element
+  real ink. **SHARP EDGE — an office grade only means anything for an element
   that is ON SCREEN**: the canvas is a viewport-fixed backdrop with a tiny
   buffer, so an unscrolled below-fold selector indexes past it and
   `getImageData` returns zeroed pixels — the sweep then silently grades
-  "dimmer over black" instead of the office, which is how the studio dial's
-  `--led` accents passed while rendering at 1.13:1. Day and night pull the ink
+  "dimmer over black" instead of the office. `officeGrounds` therefore both
+  scrolls the element in first AND asserts the read landed on painted canvas,
+  so that failure is now a loud one rather than a wrong number. (It is NOT what
+  hid the studio dial's `--led` accents — two independent holes were fused into
+  one story here once, so: those accents were never in the selector list at
+  all, scoped away by the rest row's `:not([aria-pressed='true'])`, and the
+  zeroed-pixel grade would have failed them anyway. Measured by restoring the
+  raw `--led` on the pressed number: 1.02:1 against "dimmer over black", ~1.15:1
+  against the real day composite — both an order of magnitude under the floor,
+  so no scroll fix would have caught what was never swept.) Day and night pull the ink
   in OPPOSITE directions (day's dimmer lightens the composite toward `--paper`,
   night's darkens it toward `--bg`), so any hue that lands here needs a
   theme-aware token measured against the REAL composite — `--office-ink` /
@@ -289,13 +297,35 @@ display-line authority (`starText`), unit-tested on its null-stars arm since
   dial. `--led` itself is a HARDWARE hue (global.css: "HARDWARE components …
   are `.hw-panel` … dark `--screen` ground"); the dial is the one place it is
   used with no `--screen` under it, hence its own token rather than a fourth
-  bare `--led` site. Text on the page's OPAQUE DOM plates is a third population
-  with a third sweep, "opaque-plate text clears WCAG AA in every theme" — and
-  that one runs **dracula** too. Dracula is visitor-reachable (`?theme=dracula`
+  bare `--led` site. Its `--led-glow` text-shadow deliberately stays the
+  theme-independent lime: a shadow the GLYPH paints is decoration, not the
+  ground it is graded against (WCAG 1.4.3 and axe both read ink vs
+  background), and at 0.55 alpha over day's light composite it leaves no lit
+  ring — in a 3× render of the day dial the most green-biased pixel in the row
+  IS the glyph. Measured worst case against the real office composite: 5.28:1
+  for the pressed number, 5.55:1 for `live`.
+  Text on the page's DOM plates is swept by "plate and chip
+  text clears WCAG AA in every theme" — and that one runs **dracula** too.
+  There are FOUR populations, not three: bare-over-office (above); the OPAQUE
+  plates (terminal chrome bar, stage OSD chips / caption / sky ticks, docs
+  pager, prose code chips); the TRANSLUCENT `--screen` chips, whose ground is
+  the office seen THROUGH the chip (the footer line, the nav version tag) — the
+  population the plate sweep's own introducing change had just repaired
+  (`.footer__coffee`) and still left unpinned, with `.nav__version` sitting at
+  2.34:1; and the docs callout window (its own sweep, below §6).
+  `paintedContrast` grades all four the same way — composite every ancestor
+  background down, seed the ground from the office canvas when no ancestor
+  plate is opaque, and **FOLD ancestor `opacity` into the ink**: an
+  `opacity: .7` group shows 30% of its ground through the glyph, so a raw
+  `getComputedStyle().color` read reports a ratio nobody sees (`.vibing__ticks`
+  graded 5.77:1 while rendering 3.06:1 until the fold landed). The corollary,
+  which `.boot__hint` had already reached: on any of these surfaces
+  de-emphasis comes from SIZE, never from a sub-AA ink or an `opacity`
+  multiplier. Dracula is visitor-reachable (`?theme=dracula`
   via `VALID_THEMES`, plus `Base.astro`'s keydown egg) but nothing measured it:
   the office sweep is day+night on purpose (dracula's `--bg` darkens the same
   way night's does, so it piggybacks) and Lighthouse only ever scores the
-  default theme. Its own palette steps much further from `--bg` to `--surface-2`
+  pinned theme. Its own palette steps much further from `--bg` to `--surface-2`
   than day/night do, which is why its `--fg-muted` and upstream Dracula Purple
   needed their own tuning against its own plates rather than inheriting the
   assumption that "dark theme ⇒ fine".

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -84,12 +84,23 @@ callout window is a `--screen` panel dropped inside `.prose`, so every
 DIRECTLY (`.prose p`, `.prose li`, `.prose a`, `.prose :not(pre) > code`)
 always beats the `--chip-ink` the `.callout__body` blockquote hands DOWN —
 inheritance loses to any match, whatever the specificity. `Docs.astro`
-therefore reclaims each of them at `.docs :global(.callout__body <tag>)`
-(0,2,1), winning by WEIGHT not source order. `p`/`li` were missed when `a`
+therefore reclaims each of them at `.docs :global(.callout__body <tag>)`,
+which Astro's attribute scoping compiles to
+`.docs[data-astro-cid-…] .callout__body <tag>` = **(0,3,1)** — three
+class-level components plus one type, beating `.prose <tag>` (0,1,1) by
+WEIGHT. `p`/`li` were missed when `a`
 and `code` were first noticed, which shipped day's body copy as `--fg` ink on
 the near-black screen (1.16:1, three published pages) until the smoke suite's
 callout AA sweep pinned it. Add a `.prose` colour rule ⇒ add its callout
-twin, and let that sweep prove it. Elsewhere in the
+twin, and let that sweep prove it — but COUNT the twin: a theme-prefixed
+global rule (`:root[data-theme='night'] .prose a`) is ALSO (0,3,1), an exact
+TIE that the twin wins only on source order (Astro emits component styles
+after `global.css`), and one carrying a second type selector
+(`… .prose a > code`, (0,3,2)) OUTWEIGHS a plain twin outright — which is how
+dracula's link-wrapped code chip briefly wore `--surface` beside its
+`--hw-hover` siblings inside the terminal window. That twin therefore lifts to
+`.docs :global(.callout .callout__body a > code)` (0,4,2) and wins on weight.
+Elsewhere in the
 same arc: `src/faq.json` is a NEW single-sourced content manifest (the pantry
 chitchat FAQ copy, every answer citing a repo contract, e.g. the hook-shim
 200ms/exit-0 invariant); the lobby tenant-directory board restyle kept

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -535,14 +535,24 @@ one audit.** `color-contrast` weighs 7 of the accessibility category's 195
 points, so a TOTAL contrast failure costs 3.6% against a `minScore: 0.9` floor:
 the landing page really did score 0.93 with `color-contrast` at 0 and a hard AA
 failure in the footer, green. `lighthouserc.json` therefore asserts
-`"color-contrast": ["error", { "minScore": 1 }]` alongside the category — a
-category score is a budget, not a contract, so anything that must NEVER regress
-needs its own per-audit assertion. Second surprise: Lighthouse does **not** run
-a fixed theme. `Base.astro`'s init picks night off the 7/19 wall clock, so which
-palette gets audited depends on what time CI runs — every theme a visitor can
-land in has to clear the audit, not just day. (The per-theme WCAG sweeps live in
-`smoke.spec.ts`, which drives day/night/dracula explicitly; Lighthouse is the
-rendered-DOM axe backstop, not the theme matrix.)
+`"color-contrast": ["error", { "minScore": 1, "aggregationMethod":
+"pessimistic" }]` alongside the category — a category score is a budget, not a
+contract, so anything that must NEVER regress needs its own per-audit
+assertion, and a CONTRACT audit needs every run to clear it. The
+`aggregationMethod` is not decoration: LHCI defaults to `optimistic`
+(`@lhci/utils/src/assertions.js`), which for a `minScore` assertion takes
+`Math.max` over the three runs — so ONE passing run would green a binary 0/1
+axe audit. Second surprise: Lighthouse does **not** pick a theme of its own.
+`Base.astro`'s init falls back to night off the 7/19 wall clock, so an
+unqualified URL audits whatever palette the runner's clock happens to hold —
+half of all CI runs on one palette, half on the other, and a hard per-audit
+assertion on top of that is a coin flip. The collect URLs therefore carry
+`?theme=day` (the `Base.astro` override, ahead of storage/clock/system): ONE
+deterministic palette, the default one, and the one whose light ground the
+`--screen`-chip inks are hardest on. **Lighthouse is the rendered-DOM axe
+backstop on the pinned theme, not the theme matrix** — the theme matrix is
+`smoke.spec.ts`, which drives day/night/dracula explicitly; adding a
+theme-dependent surface means adding it THERE, not doubling the collect list.
 `src/styles/fonts.css` uses Fontsource's own WOFF2 assets
 with `font-display: optional`, while `Base.astro` preloads the regular faces.
 Do not replace those declarations with Fontsource's default `swap` CSS: an

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -261,6 +261,24 @@ display-line authority (`starText`), unit-tested on its null-stars arm since
   dark text-shadow) by design — raw label/badge hues are deliberately not
   WCAG-gated against the office pixels (the idle/exiting grays never were;
   the flat chips elsewhere on the page are the raw-contrast surfaces).
+  **The DOM chrome that sits bare over the office is the opposite case**, and
+  its sweep is `smoke.spec.ts`'s "bare hero text clears WCAG AA at the real
+  office composite": it scrolls each selector on screen, reads the office
+  canvas under its box, composites the live dimmer and grades the element's
+  real ink. **SHARP EDGE — that sweep only measures anything for an element
+  that is ON SCREEN**: the canvas is a viewport-fixed backdrop with a tiny
+  buffer, so an unscrolled below-fold selector indexes past it and
+  `getImageData` returns zeroed pixels — the sweep then silently grades
+  "dimmer over black" instead of the office, which is how the studio dial's
+  `--led` accents passed while rendering at 1.13:1. Day and night pull the ink
+  in OPPOSITE directions (day's dimmer lightens the composite toward `--paper`,
+  night's darkens it toward `--bg`), so any hue that lands here needs a
+  theme-aware token measured against the REAL composite — `--office-ink` /
+  `--office-ink-accent` for body/eyebrow copy, `--led-ink` for the 5F studio
+  dial. `--led` itself is a HARDWARE hue (global.css: "HARDWARE components …
+  are `.hw-panel` … dark `--screen` ground"); the dial is the one place it is
+  used with no `--screen` under it, hence its own token rather than a fourth
+  bare `--led` site.
   Pinned by `smoke.spec.ts` ("crisp AA captions
   overlay the live office" — incl. the 3-span split with a colored prefix —
   + the reduced-motion hide twin). This layer is part

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -489,7 +489,20 @@ the Rust `ci.yml`).
 
 Lighthouse runs every route three times and gates volatile lab metrics by their
 median; the one first-visit reveal timing stays pessimistic because all three
-visits must clear it. `src/styles/fonts.css` uses Fontsource's own WOFF2 assets
+visits must clear it. **SHARP EDGE — a `categories:*` assertion cannot fail on
+one audit.** `color-contrast` weighs 7 of the accessibility category's 195
+points, so a TOTAL contrast failure costs 3.6% against a `minScore: 0.9` floor:
+the landing page really did score 0.93 with `color-contrast` at 0 and a hard AA
+failure in the footer, green. `lighthouserc.json` therefore asserts
+`"color-contrast": ["error", { "minScore": 1 }]` alongside the category — a
+category score is a budget, not a contract, so anything that must NEVER regress
+needs its own per-audit assertion. Second surprise: Lighthouse does **not** run
+a fixed theme. `Base.astro`'s init picks night off the 7/19 wall clock, so which
+palette gets audited depends on what time CI runs — every theme a visitor can
+land in has to clear the audit, not just day. (The per-theme WCAG sweeps live in
+`smoke.spec.ts`, which drives day/night/dracula explicitly; Lighthouse is the
+rendered-DOM axe backstop, not the theme matrix.)
+`src/styles/fonts.css` uses Fontsource's own WOFF2 assets
 with `font-display: optional`, while `Base.astro` preloads the regular faces.
 Do not replace those declarations with Fontsource's default `swap` CSS: an
 Ubuntu cold visit lacks the metric-matched Georgia fallback and reflows long doc

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -78,7 +78,18 @@ terminal-window callout via [`config/rehype-callouts.mjs`](config/rehype-callout
 processor AFTER `rehypeRepoLinks` (order matters: it walks the final tree).
 Note its smartypants quirk: Astro's remark-smartypants has already turned a
 straight `'` into a curly U+2019 by the time the transform runs, so the
-imperative-warning sniff normalizes back before matching. Elsewhere in the
+imperative-warning sniff normalizes back before matching. **SHARP EDGE — the
+callout window is a `--screen` panel dropped inside `.prose`, so every
+`.prose <tag>` colour rule is a cascade trap**: a rule that matches the tag
+DIRECTLY (`.prose p`, `.prose li`, `.prose a`, `.prose :not(pre) > code`)
+always beats the `--chip-ink` the `.callout__body` blockquote hands DOWN —
+inheritance loses to any match, whatever the specificity. `Docs.astro`
+therefore reclaims each of them at `.docs :global(.callout__body <tag>)`
+(0,2,1), winning by WEIGHT not source order. `p`/`li` were missed when `a`
+and `code` were first noticed, which shipped day's body copy as `--fg` ink on
+the near-black screen (1.16:1, three published pages) until the smoke suite's
+callout AA sweep pinned it. Add a `.prose` colour rule ⇒ add its callout
+twin, and let that sweep prove it. Elsewhere in the
 same arc: `src/faq.json` is a NEW single-sourced content manifest (the pantry
 chitchat FAQ copy, every answer citing a repo contract, e.g. the hook-shim
 200ms/exit-0 invariant); the lobby tenant-directory board restyle kept

--- a/site/lighthouserc.json
+++ b/site/lighthouserc.json
@@ -6,18 +6,18 @@
       "startServerReadyTimeout": 20000,
       "numberOfRuns": 3,
       "url": [
-        "http://localhost:4321/",
-        "http://localhost:4321/architecture/",
-        "http://localhost:4321/config/",
-        "http://localhost:4321/contributing/",
-        "http://localhost:4321/knowledge-base/",
-        "http://localhost:4321/parallel-delivery/"
+        "http://localhost:4321/?theme=day",
+        "http://localhost:4321/architecture/?theme=day",
+        "http://localhost:4321/config/?theme=day",
+        "http://localhost:4321/contributing/?theme=day",
+        "http://localhost:4321/knowledge-base/?theme=day",
+        "http://localhost:4321/parallel-delivery/?theme=day"
       ]
     },
     "assert": {
       "assertions": {
         "categories:accessibility": ["error", { "minScore": 0.9 }],
-        "color-contrast": ["error", { "minScore": 1 }],
+        "color-contrast": ["error", { "minScore": 1, "aggregationMethod": "pessimistic" }],
         "categories:seo": ["error", { "minScore": 0.9 }],
         "categories:best-practices": ["error", { "minScore": 0.9 }],
         "categories:performance": ["error", { "minScore": 0.7, "aggregationMethod": "median" }],

--- a/site/lighthouserc.json
+++ b/site/lighthouserc.json
@@ -17,6 +17,7 @@
     "assert": {
       "assertions": {
         "categories:accessibility": ["error", { "minScore": 0.9 }],
+        "color-contrast": ["error", { "minScore": 1 }],
         "categories:seo": ["error", { "minScore": 0.9 }],
         "categories:best-practices": ["error", { "minScore": 0.9 }],
         "categories:performance": ["error", { "minScore": 0.7, "aggregationMethod": "median" }],

--- a/site/src/components/ChannelStage.astro
+++ b/site/src/components/ChannelStage.astro
@@ -351,9 +351,8 @@ function defaultVariant(g: EnrichedVariantGroup): ShowcaseVariant | undefined {
     letter-spacing: 0.08em;
     /* de-emphasis comes from the 0.6rem size alone — the same call `.boot__hint`
        already made (global.css). The `opacity: .7` this used to carry showed 30%
-       of the --surface plate through the glyph, rendering --fg-muted at 3.06:1
-       day / 4.08 night / 3.93 dracula against the 4.5:1 floor; the raw token
-       clears at 5.77 / 6.89 / 6.13. */
+       of the --surface plate through the glyph, dropping --fg-muted under the
+       4.5:1 floor in every theme. */
     color: var(--fg-muted);
   }
   .vibing__clock {

--- a/site/src/components/ChannelStage.astro
+++ b/site/src/components/ChannelStage.astro
@@ -349,8 +349,12 @@ function defaultVariant(g: EnrichedVariantGroup): ShowcaseVariant | undefined {
     font-family: var(--font-mono);
     font-size: 0.6rem;
     letter-spacing: 0.08em;
+    /* de-emphasis comes from the 0.6rem size alone — the same call `.boot__hint`
+       already made (global.css). The `opacity: .7` this used to carry showed 30%
+       of the --surface plate through the glyph, rendering --fg-muted at 3.06:1
+       day / 4.08 night / 3.93 dracula against the 4.5:1 floor; the raw token
+       clears at 5.77 / 6.89 / 6.13. */
     color: var(--fg-muted);
-    opacity: 0.7;
   }
   .vibing__clock {
     min-width: 4.1em;

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -48,7 +48,11 @@ import { REPO, CRATES, SPONSOR, asset } from '../consts';
   }
   /* The line floats over the released dimmer (office fully lit) at page end,
      so it rides the same --screen chip as every other over-office caption —
-     theme-independent inks, never --fg-muted (invisible on the day office). */
+     theme-independent inks, never --fg-muted (invisible on the day office).
+     --chip-ink is the ink for EVERYTHING in the line, `.footer__sep` included:
+     the dimmer --chip-dim wants an OPAQUE --screen (5.34:1), and --chip-bg is
+     only 82% of it over the office, which drops --chip-dim to 4.13:1 in day
+     (9.69:1 inherited). The dots' de-emphasis is the "·" glyph itself. */
   .footer__line {
     display: flex;
     flex-wrap: wrap;
@@ -79,10 +83,6 @@ import { REPO, CRATES, SPONSOR, asset } from '../consts';
     width: 16px;
     image-rendering: pixelated;
   }
-  /* The separators inherit `.footer__line`'s --chip-ink rather than carrying
-     --chip-dim: the dim tone wants an OPAQUE --screen (5.34:1), and this line's
-     --chip-bg is 82% of it over the page-end office, which drops --chip-dim to
-     4.13:1 in day (9.69:1 inherited). Their de-emphasis is the "·" glyph. */
   /* Groups a "·" with the item it introduces into ONE flex item, so
      flex-wrap can only break BETWEEN groups — never leave a separator
      stranded alone at the start of a wrapped line (#U8: a bare .footer__sep
@@ -116,8 +116,9 @@ import { REPO, CRATES, SPONSOR, asset } from '../consts';
      a colour-mix toward white rather than Nav's deep→full token swap. Rests on
      --chip-accent, NOT --coral: this line's whole point is theme-independent ink
      on the --screen chip (see .footer__line above), and the theme token broke
-     that — it measured 3.70:1 in day and 4.26:1 in night against the chip, the
-     one node Lighthouse's colour-contrast audit failed. Mixing toward white only
+     that — it measured 3.70:1 in day and 4.26:1 in night against the chip, one
+     of the two nodes Lighthouse's colour-contrast audit failed (`.nav__version`
+     was the other, on the doc routes). Mixing toward white only
      GAINS contrast (AA-safe). Keep this rest rule AFTER `.footer__line a:hover`:
      on a pre-color-mix engine the hover value drops and the two tie at equal
      specificity, so source order is what holds the fallback at the accent (no

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -79,9 +79,10 @@ import { REPO, CRATES, SPONSOR, asset } from '../consts';
     width: 16px;
     image-rendering: pixelated;
   }
-  .footer__sep {
-    color: var(--chip-dim);
-  }
+  /* The separators inherit `.footer__line`'s --chip-ink rather than carrying
+     --chip-dim: the dim tone wants an OPAQUE --screen (5.34:1), and this line's
+     --chip-bg is 82% of it over the page-end office, which drops --chip-dim to
+     4.13:1 in day (9.69:1 inherited). Their de-emphasis is the "·" glyph. */
   /* Groups a "·" with the item it introduces into ONE flex item, so
      flex-wrap can only break BETWEEN groups — never leave a separator
      stranded alone at the start of a wrapped line (#U8: a bare .footer__sep

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -112,19 +112,20 @@ import { REPO, CRATES, SPONSOR, asset } from '../consts';
     color: #fff;
   }
   /* support CTA — the same brighten-on-hover IDEA as Nav's coffee (#686), but via
-     a colour-mix toward white rather than Nav's deep→full token swap (footer
-     coffee already rests at full --coral). The compound selector outranks
-     `.footer__line a`(:hover), so the old `!important` hack is gone. Rest --coral
-     is light on the dark chip, so mixing toward white only GAINS contrast
-     (AA-safe), and mixing FROM var(--coral) keeps the hover riding a gallery
-     retint accent. Keep this rest rule AFTER `.footer__line a:hover`: on a
-     pre-color-mix engine the hover value drops and the two tie at equal
-     specificity, so source order is what holds the fallback at coral (no #fff flash). */
+     a colour-mix toward white rather than Nav's deep→full token swap. Rests on
+     --chip-accent, NOT --coral: this line's whole point is theme-independent ink
+     on the --screen chip (see .footer__line above), and the theme token broke
+     that — it measured 3.70:1 in day and 4.26:1 in night against the chip, the
+     one node Lighthouse's colour-contrast audit failed. Mixing toward white only
+     GAINS contrast (AA-safe). Keep this rest rule AFTER `.footer__line a:hover`:
+     on a pre-color-mix engine the hover value drops and the two tie at equal
+     specificity, so source order is what holds the fallback at the accent (no
+     #fff flash). */
   .footer__line a.footer__coffee {
-    color: var(--coral);
+    color: var(--chip-accent);
   }
   .footer__line a.footer__coffee:hover {
-    color: color-mix(in srgb, var(--coral) 72%, #fff);
+    color: color-mix(in srgb, var(--chip-accent) 72%, #fff);
   }
   /* the brand mark wants the brighter --chip-bright (its `.footer__logo` rule
      declared it, but `.footer__line a` swallowed it — the same specificity trap

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -189,7 +189,14 @@ const { floating = false } = Astro.props;
   .nav__version {
     font-family: var(--font-mono);
     font-size: 0.75rem;
-    color: var(--chip-dim);
+    /* --chip-ink, not --chip-dim: the dim tone is tuned for an OPAQUE --screen
+       (5.34:1 — see SupportedTools' board note) and this chip is only 72% of
+       it, so day's light ground shows through into a mid gray in BOTH nav
+       variants — --chip-dim measured 2.85:1 floating over the office and 2.34:1
+       on the sticky docs bar (axe's own colour-contrast violation on all five
+       doc routes). --chip-ink clears at 6.13:1 / 5.54:1; the version tag's
+       de-emphasis comes from its 0.75rem size, the `.boot__hint` call. */
+    color: var(--chip-ink);
     background: color-mix(in srgb, var(--screen) 72%, transparent);
     padding: 0.15rem 0.45rem;
     margin-left: -0.4rem;

--- a/site/src/components/Showcase.astro
+++ b/site/src/components/Showcase.astro
@@ -643,7 +643,9 @@ const countWord = COUNT_WORDS[channels.length] ?? String(channels.length);
     color: var(--fg);
   }
   .dial__ch[aria-pressed='true'] .dial__num {
-    color: var(--led);
+    /* --led-ink, not --led: the dial is the one LED surface with no --screen
+       under it (see the token's note in global.css). */
+    color: var(--led-ink);
     text-shadow: 0 0 6px var(--led-glow);
   }
   .dial__num {
@@ -663,7 +665,7 @@ const countWord = COUNT_WORDS[channels.length] ?? String(channels.length);
     letter-spacing: 0.08em;
   }
   .dial__live {
-    color: var(--led);
+    color: var(--led-ink);
     text-shadow: 0 0 6px var(--led-glow);
   }
   /* the ONE accordion slot for the picked demo's feature desc — sits in the

--- a/site/src/layouts/Docs.astro
+++ b/site/src/layouts/Docs.astro
@@ -312,9 +312,15 @@ const toc = raw.map((h) => ({ ...h, text: h.text.replace(/\s*\([^)]*\)\s*$/, '')
   /* global.css's `.prose p, .prose li {color: var(--fg)}` matches these
      elements DIRECTLY, and a direct match always beats the --chip-ink their
      .callout__body ancestor hands down — which pinned day's body copy to
-     dark ink on the dark --screen (1.16:1). Reclaim inheritance at (0,2,1),
-     the same beats-by-weight-not-source-order lift the a/code rules below
-     use; `inherit` keeps ONE definition of the window's ink. */
+     dark ink on the dark --screen (1.16:1). Reclaim inheritance here; Astro
+     compiles `.docs :global(.callout__body p)` to
+     `.docs[data-astro-cid-…] .callout__body p` = (0,3,1), which beats
+     `.prose p` (0,1,1) by WEIGHT; `inherit` keeps ONE definition of the ink.
+     CAVEAT for the a/code twins below: a THEME-prefixed global rule
+     (`:root[data-theme='night'] .prose a`) is ALSO (0,3,1), an exact tie those
+     twins win only because Astro emits component styles after global.css. A
+     new `.prose <tag>` rule that must be beaten on weight needs the twin
+     lifted past (0,3,1) — the `a > code` rule below is the worked example. */
   .docs :global(.callout__body p),
   .docs :global(.callout__body li) {
     color: inherit;
@@ -324,6 +330,15 @@ const toc = raw.map((h) => ({ ...h, text: h.text.replace(/\s*\([^)]*\)\s*$/, '')
   }
   .docs :global(.callout__body code) {
     color: var(--chip-bright);
+    background: var(--hw-hover);
+  }
+  /* The twin for global.css's dracula `.prose a > code` plate swap, which is
+     (0,3,2) — it OUTWEIGHS the (0,3,1) rule above, so without this the one
+     link-wrapped chip in a callout wore --surface next to its --hw-hover
+     siblings (measured rgb(52,55,70) vs rgb(28,25,22) on /architecture). The
+     extra `.callout` takes this to (0,4,2) so it wins on weight, not order:
+     the global rule it must beat is same-weight, so a plain twin would tie. */
+  .docs :global(.callout .callout__body a > code) {
     background: var(--hw-hover);
   }
   /* scrollspy state (#257) — same affordance family as the sidebar's current

--- a/site/src/layouts/Docs.astro
+++ b/site/src/layouts/Docs.astro
@@ -309,6 +309,16 @@ const toc = raw.map((h) => ({ ...h, text: h.text.replace(/\s*\([^)]*\)\s*$/, '')
     border: 0;
     color: var(--chip-ink);
   }
+  /* global.css's `.prose p, .prose li {color: var(--fg)}` matches these
+     elements DIRECTLY, and a direct match always beats the --chip-ink their
+     .callout__body ancestor hands down — which pinned day's body copy to
+     dark ink on the dark --screen (1.16:1). Reclaim inheritance at (0,2,1),
+     the same beats-by-weight-not-source-order lift the a/code rules below
+     use; `inherit` keeps ONE definition of the window's ink. */
+  .docs :global(.callout__body p),
+  .docs :global(.callout__body li) {
+    color: inherit;
+  }
   .docs :global(.callout__body a) {
     color: var(--chip-bright);
   }

--- a/site/src/sources.json
+++ b/site/src/sources.json
@@ -34,7 +34,7 @@
     "badge": "ag·",
     "badge_color": "#2e9e4a",
     "name": "Antigravity CLI",
-    "url": "https://github.com/antiGravity-AI/antigravity-cli",
+    "url": "https://github.com/google-antigravity/antigravity-cli",
     "status": "supported",
     "featured": false,
     "transport": "session transcripts",
@@ -97,7 +97,7 @@
     "url": "https://github.com/anomalyco/opencode",
     "status": "supported",
     "featured": false,
-    "transport": "hooks (TS plugin → ~/.config/opencode/plugin/, session-id-keyed)",
+    "transport": "hooks (TS plugin → ~/.config/opencode/plugins/, session-id-keyed)",
     "platforms": {
       "macos": "yes",
       "linux": "yes",
@@ -157,7 +157,7 @@
     "url": "https://github.com/openclaw/openclaw",
     "status": "supported",
     "featured": false,
-    "transport": "hooks (TS plugin → openclaw gateway; a wandering gateway mascot, not a desk agent)",
+    "transport": "hooks (JS plugin → openclaw gateway; a wandering gateway mascot, not a desk agent)",
     "platforms": {
       "macos": "yes",
       "linux": "yes",

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -58,14 +58,13 @@
      --bg per theme. Near-opaque (not the old 90%/72%) so the office pixels
      underneath stop showing through as mud — the crisp terminal-panel idiom
      (`.text-scrim` below) reads as an intentional card, not a translucent
-     smudge. Worst case (scrimmed --fg-muted subcopy over the hero's darkest
-     office pixel, dimmer capped at data-lit-max 0.74), measured via computed
-     styles in a real render, not estimated: day 4.88:1 (was ~4.76:1 at the
-     old 90%, the pinned e2e's floor is 4.5:1), night 7.50:1 (~unchanged —
-     already far past the floor), dracula 4.74:1 (was ~4.85:1 at the old
-     72% — a denser scrim leans slightly on the underlying --screen pixel
-     less, which happens to cost dracula's light-on-dark pairing a hair of
-     margin; still clears AA with the same headroom day's old 90% had). */
+     smudge. Worst case (the scrimmed --fg-muted `.install__note`, over the
+     office pixel + this section's dimmer), measured via computed styles in a
+     real render, not estimated: day 5.18:1, night 7.35:1, dracula 7.23:1 —
+     floor 4.5:1. Which office pixel is the worst one FLIPS with the theme: for
+     day's dark-on-light pairing it is the DARKEST underlying pixel, for
+     night/dracula's light-on-dark pairing the BRIGHTEST, so both extremes get
+     measured rather than assuming day's. */
   --scrim: rgba(244, 238, 226, 0.95);
 
   /* Semantic tokens — DAY (warm cream) */
@@ -74,7 +73,10 @@
   --surface: #fdf9ef;
   --surface-2: #ece1cd;
   --fg: var(--ink);
-  --fg-muted: #6f6453;
+  /* Tuned against --surface-2, the TIGHTEST opaque plate muted text lands on
+     (the terminal chrome bar) — not --bg: the old #6f6453 cleared the page at
+     5.02:1 but only reached 4.476:1 on the bar. 4.69:1 there, 5.25:1 on --bg. */
+  --fg-muted: #6c614f;
   --border: color-mix(in srgb, var(--ink) 12%, transparent);
   --border-strong: color-mix(in srgb, var(--ink) 20%, transparent);
   --shadow: 0 1px 2px rgba(36, 28, 20, 0.05), 0 8px 24px rgba(36, 28, 20, 0.09);
@@ -824,7 +826,14 @@ code {
   --surface: #343746;
   --surface-2: #44475a;
   --fg: #f8f8f2;
-  --fg-muted: #8b92bd;
+  /* Dracula's own palette steps much further from --bg (#282a36) to --surface-2
+     (#44475a, upstream "Current Line") than day/night do, so the muted ink has
+     to climb to match: the old #8b92bd measured 3.03:1 on the terminal bar and
+     3.90:1 on --surface (the OSD chips, the stage caption, the sky ticks, the
+     docs pager). 4.75:1 / 6.13:1 here. Lightening the INK, not darkening the
+     plate — no ink clears 4.5:1 on #44475a from below #8b92bd's luminance, and
+     the plate hexes are upstream Dracula. */
+  --fg-muted: #b2b9e0;
   --border: color-mix(in srgb, #f8f8f2 13%, transparent);
   --border-strong: color-mix(in srgb, #f8f8f2 24%, transparent);
   --shadow: 0 1px 2px rgba(0, 0, 0, 0.35), 0 10px 30px rgba(0, 0, 0, 0.45);
@@ -936,6 +945,16 @@ code {
 :root[data-theme='night'] .prose a,
 :root[data-theme='dracula'] .prose a {
   color: var(--coral);
+}
+/* An inline code chip inside a prose LINK wears the link's accent hue on the
+   chip's --surface-2 plate. Dracula's accent is upstream Dracula Purple
+   (#bd93f9) and its --surface-2 is upstream Current Line (#44475a) — a pairing
+   that measures 3.79:1, and both hexes are palette fidelity, not ours to
+   retune. Dropping this one chip to the calmer --surface plate buys 4.89:1.
+   Day (4.65:1) and night (5.30:1) already clear the floor on --surface-2, so
+   they keep the shared chip shade. */
+:root[data-theme='dracula'] .prose a > code {
+  background: var(--surface);
 }
 .prose ul {
   padding-left: 1.3rem;

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -44,6 +44,14 @@
   --led: #8de069;
   --led-glow: rgba(141, 224, 105, 0.55);
   --led-off: #6f675a; /* an unlit LED (also the statusline idle dot) */
+  /* The LED hue for the one place it is NOT on --screen: the 5F studio dial,
+     whose active channel number + "live" tag sit BARE over the office. --led is
+     tuned for the always-dark hardware ground, so day's light office composite
+     dropped it to 1.13:1 (measured, worst office pixel + dimmer). This is the
+     --office-ink move applied to the LED: dark for day, unchanged where the
+     office is already dark. Day's #33601e measures 5.12:1 worst-case against the
+     real dial composite (#3f6b28 only reached 4.33). */
+  --led-ink: #33601e;
   /* opaque-theme --bg at 95% (day) / 94% (night, dracula) — plain rgba() on
      purpose: the scrim is load-bearing legibility, so it must not depend on
      color-mix() support (see the @supports fallback note below). Mirrors
@@ -152,6 +160,9 @@
      neutral warm gray. */
   --office-ink: var(--chip-ink);
   --office-ink-accent: #f5c9a0;
+  /* the office composite is already dark here, so the raw LED is the legible
+     one (9.34:1 measured) — day's darkening would invert the problem. */
+  --led-ink: var(--led);
 }
 
 /* color-mix() landed in Safari 16.2 (Dec 2022). On an older engine an invalid
@@ -826,6 +837,8 @@ code {
      own existing --coral-deep rather than day's dark accent. */
   --office-ink: var(--chip-ink);
   --office-ink-accent: var(--coral-deep);
+  /* dark office composite, same as night — raw LED stays legible (7.52:1). */
+  --led-ink: var(--led);
 }
 
 /* ---------- boot intro overlay ---------- */

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -114,6 +114,14 @@
   --chip-line: #3a332a;
   --chip-bg: color-mix(in srgb, var(--screen) 82%, transparent);
   --chrome-halo: none;
+  /* The chip family's ACCENT ink — one branded hue for a chip-borne CTA (the
+     footer's ☕ link). Theme-independent and a LITERAL for the same reason
+     --focus-ring is: on the dark chip, day's --coral measures 3.70:1 and
+     night's 4.26:1, and a gallery retint can move --coral anywhere, so an
+     accent that inherits the theme token cannot hold the 4.5:1 floor. 5.53:1
+     on --chip-bg — the same lightened coral a dark ground wants, which is why
+     it is night's --coral-deep value rather than a fourth invented orange. */
+  --chip-accent: #f0a07f;
 
   /* Bare-over-office ink (no plate/scrim behind it) — the hero subcopy/eyebrow/
      platform-line and the 4F intro paragraph read directly against the live

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -75,7 +75,7 @@
   --fg: var(--ink);
   /* Tuned against --surface-2, the TIGHTEST opaque plate muted text lands on
      (the terminal chrome bar) — not --bg: the old #6f6453 cleared the page at
-     5.02:1 but only reached 4.476:1 on the bar. 4.69:1 there, 5.25:1 on --bg. */
+     5.02:1 but only reached 4.476:1 on the bar. */
   --fg-muted: #6c614f;
   --border: color-mix(in srgb, var(--ink) 12%, transparent);
   --border-strong: color-mix(in srgb, var(--ink) 20%, transparent);
@@ -838,9 +838,9 @@ code {
      (#44475a, upstream "Current Line") than day/night do, so the muted ink has
      to climb to match: the old #8b92bd measured 3.03:1 on the terminal bar and
      3.90:1 on --surface (the OSD chips, the stage caption, the sky ticks, the
-     docs pager). 4.75:1 / 6.13:1 here. Lightening the INK, not darkening the
-     plate — no ink clears 4.5:1 on #44475a from below #8b92bd's luminance, and
-     the plate hexes are upstream Dracula. */
+     docs pager). Lightening the INK, not darkening the plate — no ink clears
+     4.5:1 on #44475a from below #8b92bd's luminance, and the plate hexes are
+     upstream Dracula. */
   --fg-muted: #b2b9e0;
   --border: color-mix(in srgb, #f8f8f2 13%, transparent);
   --border-strong: color-mix(in srgb, #f8f8f2 24%, transparent);

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -1817,8 +1817,20 @@ test('bare hero text clears WCAG AA at the real office composite (day + night)',
   // the true worst case can be either extreme depending on theme), composites
   // each with the live dimmer, and checks both against the element's real
   // computed ink color.
+  // Settle window after scrolling a selector on screen: the dimmer controller
+  // is IntersectionObserver-driven, so its target opacity lands a frame or two
+  // after the scroll (the canvas itself is under the dimmer, so any painted
+  // frame is a valid sample).
+  const SCROLL_SETTLE_MS = 300;
+  // The office canvas is a VIEWPORT-fixed backdrop (a small buffer stretched
+  // over the viewport), so an element's canvas coordinates are only real once it
+  // is on screen — unscrolled, every below-fold selector indexed past the buffer
+  // and getImageData handed back zeroed pixels, i.e. the sweep graded them
+  // against "dimmer over black" instead of the office it claims to measure.
   async function worstCaseRatio(selector: string): Promise<{ ratio: number; theme: string }> {
     const theme = await page.evaluate(() => document.documentElement.dataset.theme || 'day');
+    await page.locator(selector).first().scrollIntoViewIfNeeded();
+    await page.waitForTimeout(SCROLL_SETTLE_MS);
     const measured = await page.evaluate((sel) => {
       const canvas = document.getElementById('office-live') as HTMLCanvasElement;
       const el = document.querySelector(sel)!;
@@ -1907,6 +1919,12 @@ test('bare hero text clears WCAG AA at the real office composite (day + night)',
       // over the office too (were --fg-muted, sub-AA — audit finding A1).
       ".dial__ch:not([aria-pressed='true'])",
       '.dial__desc',
+      // …and so are the dial's two LED accents. The `:not()` above deliberately
+      // scoped the rest row, but the PRESSED row overrides its number's colour
+      // and `live` is the only marker for the one interactive demo — both were
+      // bare `--led`, an on-`--screen` hardware hue with no screen under it.
+      ".dial__ch[aria-pressed='true'] .dial__num",
+      '.dial__live',
       '#how .eyebrow',
       '#tools .section-head .lead',
       '#install .section-head .lead',

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -20,9 +20,10 @@ const supportedSources = (sourcesData as SourceRow[]).filter((s) => s.status ===
 
 /**
  * WCAG 2.1 relative luminance + contrast ratio (per the spec's definitions),
- * plus the minimal alpha-compositing needed to pin `.text-scrim`'s worst case:
- * the scrim is painted over the dimmer, which is itself translucent over the
- * live office. Kept fn-local (used by one test) rather than a shared util.
+ * plus the alpha-compositing every contrast pin here needs: nothing on this
+ * page sits on a flat colour — a scrim over a dimmer over the live office, a
+ * `--screen` chip over that office, an `opacity` group over a plate.
+ * {@link paintedContrast} is the one place that walk lives.
  */
 function relLuminance([r, g, b]: [number, number, number]): number {
   const lin = (c: number) => {
@@ -59,6 +60,180 @@ function parseRgb(css: string): [number, number, number, number] {
     return [r! * 255, g! * 255, b! * 255, a ?? 1];
   }
   throw new Error(`unparseable color: ${css}`);
+}
+
+// Settle window after scrolling a selector on screen: the dimmer controller is
+// IntersectionObserver-driven, so its target opacity lands a frame or two after
+// the scroll (the canvas itself is under the dimmer, so any painted frame is a
+// valid sample).
+const SCROLL_SETTLE_MS = 300;
+
+/**
+ * Put every reveal-on-scroll section in its RESTED state before grading.
+ *
+ * `.reveal` starts at `opacity: 0` and the IntersectionObserver adds `.in` once
+ * (then unobserves — Base.astro), so `.in` IS the settled state, not a shortcut.
+ * It matters because {@link paintedContrast} folds ancestor opacity into the
+ * ink: an unrevealed section would grade at alpha 0 and a mid-entrance one at
+ * some transient alpha, neither of which is what a visitor reads.
+ */
+async function settleReveals(page: Page): Promise<void> {
+  await page.evaluate(() =>
+    document.querySelectorAll('.reveal').forEach((el) => el.classList.add('in'))
+  );
+  await page.waitForFunction(() =>
+    [...document.querySelectorAll('.reveal')].every(
+      (el) => parseFloat(getComputedStyle(el).opacity) === 1
+    )
+  );
+}
+
+/**
+ * The office grounds under an element's box — the canvas's BRIGHTEST and
+ * DARKEST pixel there, each composited with the live dimmer. `null` on a route
+ * with no live office (the doc pages), where the ground is pure DOM.
+ *
+ * Day's dimmer LIGHTENS the composite toward `--paper` and night's DARKENS it
+ * toward `--bg`, so the true worst case is either extreme depending on theme —
+ * hence both, never an average.
+ *
+ * SHARP EDGE this both scrolls for and then GUARDS: the canvas is a
+ * viewport-fixed backdrop with a tiny buffer, so an element's canvas
+ * coordinates are only real once it is on screen. An unscrolled below-fold
+ * selector indexes past the buffer and `getImageData` hands back ZEROED pixels
+ * — a silent "dimmer over black" grade instead of the office. The assertion
+ * below turns that into a loud failure instead of a wrong number.
+ */
+async function officeGrounds(
+  page: Page,
+  selector: string,
+  nth = 0
+): Promise<[number, number, number][] | null> {
+  if ((await page.locator('#office-live').count()) === 0) return null;
+  await page.locator(selector).nth(nth).scrollIntoViewIfNeeded();
+  await page.waitForTimeout(SCROLL_SETTLE_MS);
+  const sampled = await page.evaluate(
+    ([sel, i]) => {
+      const canvas = document.getElementById('office-live') as HTMLCanvasElement | null;
+      if (!canvas || parseFloat(getComputedStyle(canvas).opacity) === 0) return null;
+      const el = document.querySelectorAll(sel)[i as number];
+      const r = el.getBoundingClientRect();
+      const cr = canvas.getBoundingClientRect();
+      const sx = canvas.width / cr.width;
+      const sy = canvas.height / cr.height;
+      const ctx = canvas.getContext('2d', { willReadFrequently: true })!;
+      const x0 = Math.min(canvas.width - 1, Math.max(0, Math.floor((r.left - cr.left) * sx)));
+      const y0 = Math.min(canvas.height - 1, Math.max(0, Math.floor((r.top - cr.top) * sy)));
+      const w = Math.min(Math.max(1, Math.ceil(r.width * sx)), canvas.width - x0);
+      const h = Math.min(Math.max(1, Math.ceil(r.height * sy)), canvas.height - y0);
+      const data = ctx.getImageData(x0, y0, w, h).data;
+      const relLum = ([rr, gg, bb]: number[]) => {
+        const lin = (c: number) => {
+          const s = c / 255;
+          return s <= 0.04045 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+        };
+        return 0.2126 * lin(rr) + 0.7152 * lin(gg) + 0.0722 * lin(bb);
+      };
+      let maxLum = -1,
+        maxPx = [0, 0, 0],
+        minLum = 2,
+        minPx = [0, 0, 0],
+        painted = 0;
+      for (let k = 0; k < data.length; k += 4) {
+        if (data[k + 3] === 0) continue;
+        painted++;
+        const px = [data[k], data[k + 1], data[k + 2]];
+        const lum = relLum(px);
+        if (lum > maxLum) {
+          maxLum = lum;
+          maxPx = px;
+        }
+        if (lum < minLum) {
+          minLum = lum;
+          minPx = px;
+        }
+      }
+      const dimmer = document.getElementById('dimmer') as HTMLElement;
+      return {
+        maxPx,
+        minPx,
+        painted,
+        total: data.length / 4,
+        dimmerBg: getComputedStyle(dimmer).backgroundColor,
+        dimmerOpacity: parseFloat(dimmer.style.opacity || '0'),
+      };
+    },
+    [selector, nth] as const
+  );
+  if (!sampled) return null;
+  expect(
+    sampled.painted,
+    `${selector}[${nth}]: sampled ${sampled.total} office pixels, none painted — the box indexed past the canvas buffer, so the grade below would be "dimmer over black", not the office`
+  ).toBeGreaterThan(0);
+  const dim = [
+    ...(parseRgb(sampled.dimmerBg).slice(0, 3) as [number, number, number]),
+    sampled.dimmerOpacity,
+  ] as [number, number, number, number];
+  return [
+    compositeOver(dim, sampled.maxPx as [number, number, number]),
+    compositeOver(dim, sampled.minPx as [number, number, number]),
+  ];
+}
+
+/**
+ * The worst contrast ratio the element's text ACTUALLY renders at: every
+ * ancestor background composited down (translucent chips included), every
+ * ancestor `opacity` folded into the ink, over the office composite where a
+ * live office is the ground and over the page's own opaque plate where it is
+ * not.
+ *
+ * Folding `opacity` is the difference between graded and rendered: a group at
+ * `opacity: .7` shows 30% of its ground through the glyph, so grading the raw
+ * `getComputedStyle().color` reports a ratio the visitor never sees.
+ */
+async function paintedContrast(page: Page, selector: string, nth = 0): Promise<number> {
+  const { ink, chain } = await page.evaluate(
+    ([sel, i]) => {
+      const el = document.querySelectorAll(sel)[i as number];
+      const chain: { bg: string; opacity: number; isPageRoot: boolean }[] = [];
+      for (let n: Element | null = el; n; n = n.parentElement) {
+        const cs = getComputedStyle(n);
+        chain.push({
+          bg: cs.backgroundColor,
+          opacity: parseFloat(cs.opacity),
+          isPageRoot: n === document.body || n === document.documentElement,
+        });
+      }
+      return { ink: getComputedStyle(el).color, chain };
+    },
+    [selector, nth] as const
+  );
+  const inkRgb = parseRgb(ink).slice(0, 3) as [number, number, number];
+  // An ancestor's `opacity` fades ITS OWN background and everything inside it,
+  // never an ancestor's — so the group factor accumulates from the ROOT DOWN,
+  // and the ink carries the whole chain's product.
+  const inkAlpha = chain.reduce((p, c) => p * c.opacity, 1);
+  const groupAt = chain.map((_, k) =>
+    chain.slice(k).reduce((p, c) => p * c.opacity, 1)
+  ) as number[];
+  // An opaque plate anywhere in the chain makes whatever is under the page
+  // immaterial — only a chain that stays translucent all the way out needs the
+  // office sampled (and only that case pays its scroll + settle).
+  const plated = chain.some((c, k) => !c.isPageRoot && parseRgb(c.bg)[3] * groupAt[k] >= 1);
+  const grounds = plated ? null : await officeGrounds(page, selector, nth);
+  const seeds: [number, number, number][] = grounds ?? [[255, 255, 255]];
+  let worst = Infinity;
+  for (const seed of seeds) {
+    let ground = seed;
+    for (let k = chain.length - 1; k >= 0; k--) {
+      // the office backdrop is a fixed sibling painting OVER the page background
+      if (grounds && chain[k].isPageRoot) continue;
+      const [r, g, b, a] = parseRgb(chain[k].bg);
+      if (a * groupAt[k] > 0) ground = compositeOver([r, g, b, a * groupAt[k]], ground);
+    }
+    worst = Math.min(worst, contrastRatio(compositeOver([...inkRgb, inkAlpha], ground), ground));
+  }
+  return worst;
 }
 /**
  * Fail the calling test if the page logs an uncaught error or console.error.
@@ -1809,94 +1984,10 @@ test('bare hero text clears WCAG AA at the real office composite (day + night)',
   // 5F band — see the .text-scrim test above — so the bare-ink-token
   // legibility path no longer applies to them). Legibility now depends
   // entirely on the ink token clearing contrast against whatever the office
-  // ACTUALLY renders behind it, so this samples the REAL canvas pixels (not a --screen proxy
-  // — with no opaque plate the underlying office pixel is no longer
-  // "immaterial") across the sampled element's bounding box, finds the
-  // brightest AND darkest pixel in it (day's dimmer LIGHTENS the composite
-  // toward --paper, night's DARKENS it toward --bg — opposite directions, so
-  // the true worst case can be either extreme depending on theme), composites
-  // each with the live dimmer, and checks both against the element's real
-  // computed ink color.
-  // Settle window after scrolling a selector on screen: the dimmer controller
-  // is IntersectionObserver-driven, so its target opacity lands a frame or two
-  // after the scroll (the canvas itself is under the dimmer, so any painted
-  // frame is a valid sample).
-  const SCROLL_SETTLE_MS = 300;
-  // The office canvas is a VIEWPORT-fixed backdrop (a small buffer stretched
-  // over the viewport), so an element's canvas coordinates are only real once it
-  // is on screen — unscrolled, every below-fold selector indexed past the buffer
-  // and getImageData handed back zeroed pixels, i.e. the sweep graded them
-  // against "dimmer over black" instead of the office it claims to measure.
-  async function worstCaseRatio(selector: string): Promise<{ ratio: number; theme: string }> {
-    const theme = await page.evaluate(() => document.documentElement.dataset.theme || 'day');
-    await page.locator(selector).first().scrollIntoViewIfNeeded();
-    await page.waitForTimeout(SCROLL_SETTLE_MS);
-    const measured = await page.evaluate((sel) => {
-      const canvas = document.getElementById('office-live') as HTMLCanvasElement;
-      const el = document.querySelector(sel)!;
-      const r = el.getBoundingClientRect();
-      const cr = canvas.getBoundingClientRect();
-      const sx = canvas.width / cr.width;
-      const sy = canvas.height / cr.height;
-      const ctx = canvas.getContext('2d', { willReadFrequently: true })!;
-      const x0 = Math.max(0, Math.floor((r.left - cr.left) * sx));
-      const y0 = Math.max(0, Math.floor((r.top - cr.top) * sy));
-      const w = Math.max(1, Math.ceil(r.width * sx));
-      const h = Math.max(1, Math.ceil(r.height * sy));
-      const data = ctx.getImageData(
-        x0,
-        y0,
-        Math.min(w, canvas.width - x0),
-        Math.min(h, canvas.height - y0)
-      ).data;
-      let maxLum = -1,
-        maxPx = [0, 0, 0];
-      let minLum = 2,
-        minPx = [0, 0, 0];
-      const relLum = ([rr, gg, bb]: number[]) => {
-        const lin = (c: number) => {
-          const s = c / 255;
-          return s <= 0.04045 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
-        };
-        return 0.2126 * lin(rr) + 0.7152 * lin(gg) + 0.0722 * lin(bb);
-      };
-      for (let i = 0; i < data.length; i += 4) {
-        const px = [data[i], data[i + 1], data[i + 2]];
-        const lum = relLum(px);
-        if (lum > maxLum) {
-          maxLum = lum;
-          maxPx = px;
-        }
-        if (lum < minLum) {
-          minLum = lum;
-          minPx = px;
-        }
-      }
-      return {
-        maxPx,
-        minPx,
-        dimmerBg: getComputedStyle(document.getElementById('dimmer')!).backgroundColor,
-        dimmerOpacity: parseFloat(
-          (document.getElementById('dimmer') as HTMLElement).style.opacity || '0'
-        ),
-        textColor: getComputedStyle(el).color,
-      };
-    }, selector);
-
-    const dim = parseRgb(measured.dimmerBg).slice(0, 3) as [number, number, number];
-    const textRgb = parseRgb(measured.textColor).slice(0, 3) as [number, number, number];
-    const afterMax = compositeOver(
-      [...dim, measured.dimmerOpacity] as [number, number, number, number],
-      measured.maxPx as [number, number, number]
-    );
-    const afterMin = compositeOver(
-      [...dim, measured.dimmerOpacity] as [number, number, number, number],
-      measured.minPx as [number, number, number]
-    );
-    const ratio = Math.min(contrastRatio(textRgb, afterMax), contrastRatio(textRgb, afterMin));
-    return { ratio, theme };
-  }
-
+  // ACTUALLY renders behind it, so this grades through `paintedContrast` — the
+  // REAL canvas pixels under the box (not a --screen proxy: with no opaque
+  // plate the underlying office pixel is no longer "immaterial"), both
+  // luminance extremes, composited with the live dimmer.
   for (const theme of ['day', 'night'] as const) {
     await page.addInitScript((t) => {
       sessionStorage.setItem('pix-booted', '1');
@@ -1904,6 +1995,7 @@ test('bare hero text clears WCAG AA at the real office composite (day + night)',
     }, theme);
     await page.goto('./');
     await expect(page.locator('html')).toHaveAttribute('data-theme', theme);
+    await settleReveals(page);
 
     // Every BARE muted-text surface over the office, not just the hero's
     // (lens B measured #showcase's lead + roster body at 3.79-3.96:1 day —
@@ -1931,7 +2023,7 @@ test('bare hero text clears WCAG AA at the real office composite (day + night)',
       '#amenities .eyebrow',
       '.pantry__cite',
     ]) {
-      const { ratio } = await worstCaseRatio(selector);
+      const ratio = await paintedContrast(page, selector);
       expect(
         ratio,
         `${theme} ${selector}: WCAG AA floor is 4.5:1; measured ${ratio.toFixed(2)}:1`
@@ -1940,46 +2032,35 @@ test('bare hero text clears WCAG AA at the real office composite (day + night)',
   }
 });
 
-test('opaque-plate text clears WCAG AA in every theme (day + night + dracula)', async ({
+test('plate and chip text clears WCAG AA in every theme (day + night + dracula)', async ({
   page,
 }) => {
-  // The sweep above grades text painted over the office CANVAS. This one grades
-  // the page's opaque DOM plates — the terminal chrome bar (--surface-2), the
-  // stage OSD chips / caption / sky ticks and the docs pager (--surface), and
-  // the inline code chip inside a prose link (the accent hue on --surface-2).
+  // The sweep above grades BARE text over the office canvas. This one grades
+  // the two DOM-plate populations: the page's OPAQUE plates — the terminal
+  // chrome bar (--surface-2), the stage OSD chips / caption / sky ticks and the
+  // docs pager (--surface), the inline code chip inside a prose link — and the
+  // TRANSLUCENT --screen chips, which are neither bare nor opaque: the footer
+  // line and the nav's version tag composite --chip-bg over the LIVE office, so
+  // their ground is the office pixel seen through the chip. `paintedContrast`
+  // grades all three the same way; only the populations differ.
   // DRACULA is the point: it is visitor-reachable (`?theme=dracula`, validated
   // by VALID_THEMES, plus Base.astro's keydown egg) but it is the one theme
   // NOTHING measured — the office sweep runs day+night by design (dracula's
   // --bg darkens the same way night's does) and Lighthouse only ever scores the
-  // default theme, so dracula's own --fg-muted/--coral had never been checked
+  // pinned theme, so dracula's own --fg-muted/--coral had never been checked
   // against dracula's own plates.
   const PLATE_SURFACES: Record<string, string[]> = {
-    './': ['.terminal__title', '.osd__chip', '.stage__caption', '.vibing__ticks span'],
+    './': [
+      '.terminal__title',
+      '.osd__chip',
+      '.stage__caption',
+      '.vibing__ticks span',
+      '.footer__line a.footer__coffee',
+      '.footer__sep',
+      '.nav__version',
+    ],
     './404': ['.terminal__title'],
     './architecture': ['.prose :not(pre) > code', '.prose a > code', '.docs__pager-dir'],
-  };
-  // Every plate here is an opaque DOM background, so the ground is the first
-  // fully-opaque ancestor with the translucent layers below it composited back
-  // down — no canvas sampling (that is the office sweep's job).
-  const effectiveBg = async (selector: string, nth: number): Promise<[number, number, number]> => {
-    const chain = await page.evaluate(
-      ([sel, i]) => {
-        const out: string[] = [];
-        let node: Element | null = document.querySelectorAll(sel)[i as number];
-        while (node) {
-          const bg = getComputedStyle(node).backgroundColor;
-          out.push(bg);
-          if (!/,\s*0(\.\d+)?\)\s*$/.test(bg) && !/\/\s*0(\.\d+)?\)/.test(bg)) break;
-          node = node.parentElement;
-        }
-        return out;
-      },
-      [selector, nth] as const
-    );
-    const layers = chain.map(parseRgb).filter(([, , , a]) => a > 0);
-    let ground: [number, number, number] = [255, 255, 255];
-    for (let i = layers.length - 1; i >= 0; i--) ground = compositeOver(layers[i], ground);
-    return ground;
   };
 
   for (const theme of ['day', 'night', 'dracula'] as const) {
@@ -1991,18 +2072,12 @@ test('opaque-plate text clears WCAG AA in every theme (day + night + dracula)', 
     for (const [route, selectors] of Object.entries(PLATE_SURFACES)) {
       await page.goto(route);
       await expect(page.locator('html')).toHaveAttribute('data-theme', theme);
+      await settleReveals(page);
       for (const selector of selectors) {
         const count = await page.locator(selector).count();
         expect(count, `${theme} ${route}: no ${selector} to sweep`).toBeGreaterThan(0);
         for (let i = 0; i < count; i++) {
-          const ink = await page
-            .locator(selector)
-            .nth(i)
-            .evaluate((el) => getComputedStyle(el).color);
-          const ratio = contrastRatio(
-            parseRgb(ink).slice(0, 3) as [number, number, number],
-            await effectiveBg(selector, i)
-          );
+          const ratio = await paintedContrast(page, selector, i);
           expect(
             ratio,
             `${theme} ${route} ${selector}[${i}]: WCAG AA floor is 4.5:1; measured ${ratio.toFixed(2)}:1`

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -1940,6 +1940,81 @@ test('bare hero text clears WCAG AA at the real office composite (day + night)',
   }
 });
 
+test('opaque-plate text clears WCAG AA in every theme (day + night + dracula)', async ({
+  page,
+}) => {
+  // The sweep above grades text painted over the office CANVAS. This one grades
+  // the page's opaque DOM plates — the terminal chrome bar (--surface-2), the
+  // stage OSD chips / caption / sky ticks and the docs pager (--surface), and
+  // the inline code chip inside a prose link (the accent hue on --surface-2).
+  // DRACULA is the point: it is visitor-reachable (`?theme=dracula`, validated
+  // by VALID_THEMES, plus Base.astro's keydown egg) but it is the one theme
+  // NOTHING measured — the office sweep runs day+night by design (dracula's
+  // --bg darkens the same way night's does) and Lighthouse only ever scores the
+  // default theme, so dracula's own --fg-muted/--coral had never been checked
+  // against dracula's own plates.
+  const PLATE_SURFACES: Record<string, string[]> = {
+    './': ['.terminal__title', '.osd__chip', '.stage__caption', '.vibing__ticks span'],
+    './404': ['.terminal__title'],
+    './architecture': ['.prose :not(pre) > code', '.prose a > code', '.docs__pager-dir'],
+  };
+  // Every plate here is an opaque DOM background, so the ground is the first
+  // fully-opaque ancestor with the translucent layers below it composited back
+  // down — no canvas sampling (that is the office sweep's job).
+  const effectiveBg = async (selector: string, nth: number): Promise<[number, number, number]> => {
+    const chain = await page.evaluate(
+      ([sel, i]) => {
+        const out: string[] = [];
+        let node: Element | null = document.querySelectorAll(sel)[i as number];
+        while (node) {
+          const bg = getComputedStyle(node).backgroundColor;
+          out.push(bg);
+          if (!/,\s*0(\.\d+)?\)\s*$/.test(bg) && !/\/\s*0(\.\d+)?\)/.test(bg)) break;
+          node = node.parentElement;
+        }
+        return out;
+      },
+      [selector, nth] as const
+    );
+    const layers = chain.map(parseRgb).filter(([, , , a]) => a > 0);
+    let ground: [number, number, number] = [255, 255, 255];
+    for (let i = layers.length - 1; i >= 0; i--) ground = compositeOver(layers[i], ground);
+    return ground;
+  };
+
+  for (const theme of ['day', 'night', 'dracula'] as const) {
+    await page.addInitScript((t) => {
+      sessionStorage.setItem('pix-booted', '1');
+      localStorage.setItem('pix-theme', t);
+    }, theme);
+    let swept = 0;
+    for (const [route, selectors] of Object.entries(PLATE_SURFACES)) {
+      await page.goto(route);
+      await expect(page.locator('html')).toHaveAttribute('data-theme', theme);
+      for (const selector of selectors) {
+        const count = await page.locator(selector).count();
+        expect(count, `${theme} ${route}: no ${selector} to sweep`).toBeGreaterThan(0);
+        for (let i = 0; i < count; i++) {
+          const ink = await page
+            .locator(selector)
+            .nth(i)
+            .evaluate((el) => getComputedStyle(el).color);
+          const ratio = contrastRatio(
+            parseRgb(ink).slice(0, 3) as [number, number, number],
+            await effectiveBg(selector, i)
+          );
+          expect(
+            ratio,
+            `${theme} ${route} ${selector}[${i}]: WCAG AA floor is 4.5:1; measured ${ratio.toFixed(2)}:1`
+          ).toBeGreaterThanOrEqual(4.5);
+          swept++;
+        }
+      }
+    }
+    expect(swept, `${theme}: swept nothing`).toBeGreaterThan(0);
+  }
+});
+
 test('hero badge row: one chip per registered source, matching the tools-table row count', async ({
   page,
 }) => {

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -2214,6 +2214,69 @@ test('pantry chitchat bubble text clears WCAG AA against its own dark ground (da
   }
 });
 
+test('docs callout body copy clears WCAG AA against the callout screen (day + night + dracula)', async ({
+  page,
+}) => {
+  // A markdown callout is a terminal window on the theme-independent --screen,
+  // so ALL of its ink must come from the chip palette. `.prose p`/`.prose li`
+  // match the callout's own <p>/<li> DIRECTLY, and a direct match always beats
+  // the --chip-ink the .callout__body blockquote hands DOWN — the sibling `a`
+  // and `code` overrides exist for exactly that reason. This sweeps every
+  // text-bearing tag markdown can put in the window (not just the two that
+  // were noticed), across every doc route and every theme, so the next
+  // .prose rule to land can't silently re-darken the body copy.
+  const TEXT_TAGS = 'p, li, strong, em, a, code';
+  for (const theme of ['day', 'night', 'dracula'] as const) {
+    await page.addInitScript((t) => localStorage.setItem('pix-theme', t), theme);
+    await page.goto('./config');
+    await expect(page.locator('html')).toHaveAttribute('data-theme', theme);
+    // the doc routes come off the rendered sidebar (itself stamped from the one
+    // DOCS manifest) so a new/renamed doc joins the sweep without an edit here
+    const routes = await page.evaluate(() =>
+      [...document.querySelectorAll('.docs__sidebar .docs__list:not(.docs__list--building) a')].map(
+        (a) => (a as HTMLAnchorElement).getAttribute('href')!
+      )
+    );
+    expect(routes.length, `${theme}: no doc routes in the sidebar`).toBeGreaterThan(0);
+
+    let swept = 0;
+    for (const route of routes) {
+      await page.goto(`.${route}`);
+      const rows = await page.evaluate((tags) => {
+        const transparent = (c: string) => /,\s*0\)\s*$/.test(c);
+        return [...document.querySelectorAll('.callout__body')].flatMap((body) => {
+          const screen = getComputedStyle(body.closest('.callout')!).backgroundColor;
+          return [...body.querySelectorAll(tags)].map((el) => {
+            const cs = getComputedStyle(el);
+            return {
+              tag: el.tagName.toLowerCase(),
+              color: cs.color,
+              bg: transparent(cs.backgroundColor) ? screen : cs.backgroundColor,
+              text: (el.textContent || '').trim().slice(0, 48),
+            };
+          });
+        });
+      }, TEXT_TAGS);
+      for (const { tag, color, bg, text } of rows) {
+        const ratio = contrastRatio(
+          parseRgb(color).slice(0, 3) as [number, number, number],
+          parseRgb(bg).slice(0, 3) as [number, number, number]
+        );
+        expect(
+          ratio,
+          `${theme} ${route} <${tag}> "${text}": WCAG AA floor is 4.5:1; ${color} on ${bg} measured ${ratio.toFixed(2)}:1`
+        ).toBeGreaterThanOrEqual(4.5);
+      }
+      swept += rows.length;
+    }
+    // teeth: a docs tree that stopped emitting callouts would pass vacuously
+    expect(
+      swept,
+      `${theme}: no .callout__body text swept across ${routes.length} doc routes`
+    ).toBeGreaterThan(0);
+  }
+});
+
 test('the statusline feed ellipsizes on the wrapping text span, not the flex row', async ({
   page,
 }) => {

--- a/site/tests/e2e/smoke.spec.ts
+++ b/site/tests/e2e/smoke.spec.ts
@@ -209,16 +209,12 @@ async function paintedContrast(page: Page, selector: string, nth = 0): Promise<n
     [selector, nth] as const
   );
   const inkRgb = parseRgb(ink).slice(0, 3) as [number, number, number];
-  // An ancestor's `opacity` fades ITS OWN background and everything inside it,
-  // never an ancestor's — so the group factor accumulates from the ROOT DOWN,
-  // and the ink carries the whole chain's product.
+  // `opacity` fades a node's OWN background and everything inside it, never an
+  // ancestor's — so a layer's group factor is the product from the ROOT down.
   const inkAlpha = chain.reduce((p, c) => p * c.opacity, 1);
-  const groupAt = chain.map((_, k) =>
-    chain.slice(k).reduce((p, c) => p * c.opacity, 1)
-  ) as number[];
-  // An opaque plate anywhere in the chain makes whatever is under the page
-  // immaterial — only a chain that stays translucent all the way out needs the
-  // office sampled (and only that case pays its scroll + settle).
+  const groupAt = chain.map((_, k) => chain.slice(k).reduce((p, c) => p * c.opacity, 1));
+  // An opaque plate makes whatever is under the page immaterial, so only a
+  // chain translucent all the way out pays for the office sample's scroll.
   const plated = chain.some((c, k) => !c.isPageRoot && parseRgb(c.bg)[3] * groupAt[k] >= 1);
   const grounds = plated ? null : await officeGrounds(page, selector, nth);
   const seeds: [number, number, number][] = grounds ?? [[255, 255, 255]];


### PR DESCRIPTION

Also: the studio-dial LED accents (1.13:1 measured), dracula `--fg-muted` below AA on its own plates, a Lighthouse a11y gate structurally unable to fail on contrast, a 404'ing Antigravity URL, and opencode's plugin dir named singular.

**Measured against the compiled build, never the source** — this repo has a documented CSS cascade-swallow class. Day went 1.16:1 → 12.58:1. The new sweep folds element `opacity` into the graded ink (a raw-color sweep graded `.vibing__ticks` at 5.77:1 while it rendered 3.06:1) and asserts painted canvas pixels, so the zeroed-canvas failure mode is now loud.

### Commits

- `092d2e6d` style(site): apply the redundancy-within comment test to the new WHY
- `010a4fd9` fix(site): re-home the footer-ink note and correct "the one node" claim
- `727b4f8a` fix(site): make the colour-contrast assertion deterministic, not a coin flip
- `2737dbe7` fix(site): grade the ink that RENDERS — fold opacity, sweep the chip population
- `d09bf713` fix(site): count the callout cascade correctly and give dracula's a>code a twin
- `f4793352` fix(site): give the Lighthouse a11y gate a colour-contrast assertion it can fail
- `6c4e98ca` fix(site): measure the muted ink against the plates it actually lands on
- `9e596a41` fix(site): give the studio dial's LED accents an over-office ink
- `eeb410f9` fix(site): point the Antigravity row at the real repo and name opencode's real plugin dir
- `01459ffc` fix(site): reclaim callout body ink from the .prose cascade

---

### Provenance

Part of a whole-codebase audit (13 branches, 136 commits). Pipeline: 11 subsystem
finders + 8 whole-tree specialist sweeps + loop-until-dry security/concurrency
hunts → 312 raw findings → adversarial skeptics (default REFUTE, 3 differentiated
lenses on HIGH/security/concurrency) → **108 distinct confirmed defects** (35%
refutation rate, stable across two rounds) → fixes → a two-lens merge review per
branch plus trigger-driven escalation lenses → a fix round on that review's
findings.

Every defect has exactly one terminal state: **181 FIXED · 8 REFUTED-with-citation
· 12 ISSUE-NEEDED** (filed: #799 #800 #802 #803 #804).

### Composition verified

All 13 branches were merged together in a throwaway worktree and gated as one tree
— the step no per-branch review can perform:

- `just preflight` → **exit 0** (13 lint sub-gates → clippy → hack → **2,795 tests passed**)
- `just site-check` · `just site-e2e` (96) · `just ci-observability` (107 Rego + 108 conftest) → all exit 0

That pass found **5 genuine cross-branch contradictions** in prose that merged
cleanly — e.g. one branch documenting a sweep as "per-frame" while another had
memoized it. Resolved against the merged code, not mechanically.

### Merge order

Measured, not inferred: `site → ci-tooling → tui → bin-runtime → scene-painter →
core → scene-sim → ci-policy → bin-install → docs → scripts` (+ `hook-docs`,
`consumer-gaps`, independent). Each branch is individually clean against `main`;
later ones may need a rebase once earlier ones land. Known collision points:
`crates/pixtuoid/CLAUDE.md` (5 branches), `crates/pixtuoid-core/CLAUDE.md` (4),
`policy/ci-observability/main.rego` (2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
