### PR TITLE
fix(ci): guards that could not fire on the worse shapes, +10 defects

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,14 @@
 version: 2
 updates:
   - package-ecosystem: cargo
+    # A RED cargo run does not mean the lane stopped: dependabot-core updates one
+    # package at a time, so a release that needs a LOCKSTEP SIBLING bump
+    # (serde -> serde_core/serde_derive; toml/toml_edit -> toml_writer) leaves the
+    # regenerated lock unchanged and `cargo/file_updater/lockfile_updater.rb:76`
+    # raises `unknown_error`. The group loop skips that dependency and still opens
+    # the PR for the rest — #624 and #761 were both cut from red runs. The remedy
+    # is a human `cargo update -p <crate>`; the advisory axis is covered
+    # independently by audit.yml's daily `cargo-deny check advisories`.
     directory: /
     schedule:
       interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,15 @@ updates:
       default-days: 7
 
   - package-ecosystem: github-actions
-    directory: /
+    # `directory: /` searches ONLY `.github/workflows` plus a root `action.yml`,
+    # so every third-party pin that #784/#785 moved into a composite left
+    # Dependabot's map. The second entry is the form dependabot-core#6704
+    # confirms works — `/.github/actions/*`, not `/.github/actions/*/action.yml`,
+    # which silently degrades back to workflows-only. `policy/ci-observability`
+    # denies a composite pin no declared directory covers.
+    directories:
+      - /
+      - /.github/actions/*
     schedule:
       interval: weekly
     groups:

--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -173,9 +173,12 @@ given change/tree, say so, don't skip it.
   the group set, whereupon the membership rule instructed the maintainer to
   REMOVE a group from the ONLY required status check protecting main — a
   confident wrong instruction carrying a gate's authority, worse than silence.
-  Mutation testing proves only the first direction; `deny_coverage_test.sh`
-  mechanically enforces that a deny message is asserted somewhere, and the
-  legitimate-variant half stays this factor's job; **the message is half the
+  Mutation testing proves only the first direction; the policy layer's
+  `opa test --coverage` ratchet (inside `just ci-observability`) is an
+  AGGREGATE line-coverage floor, not a per-rule assertion requirement — it is
+  what surfaced the Conftest `deny` heads whose bodies had never once been true
+  (#789), but a brand-new untested rule barely moves the number and still
+  passes, so BOTH directions stay this factor's job; **the message is half the
   rule** — a deny/error/panic string is the ONLY part of a check a future
   maintainer reads, so it must name the actual requirement and the remedy, not a
   plausible-sounding neighbour: #788's OIDC rule denied with "only the tests call

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -23,11 +23,17 @@ jobs:
     # this is the only contents:write job — fail CLOSED at the yaml layer too,
     # independent of the floating action tag. Each of the four event shapes needs
     # its OWN author_association field, or the owner's own trigger gets blocked.
+    # The two pull_request_review* arms need a SECOND guard: those events set
+    # GITHUB_REF to refs/pull/<n>/merge, so the ref-less checkout below lands
+    # fork-authored files — including a repo-root CLAUDE.md the agent auto-loads
+    # as instructions — in the workspace of the one job holding contents:write
+    # and the OAuth token. The issues/issue_comment arms check out the default
+    # branch and carry no pull_request object, so the guard is not theirs.
     if: >
       (github.event_name == 'issues' && contains(github.event.issue.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)) ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association))
+      (github.event_name == 'pull_request_review_comment' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     concurrency:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,8 +27,10 @@ jobs:
     # GITHUB_REF to refs/pull/<n>/merge, so the ref-less checkout below lands
     # fork-authored files — including a repo-root CLAUDE.md the agent auto-loads
     # as instructions — in the workspace of the one job holding contents:write
-    # and the OAuth token. The issues/issue_comment arms check out the default
-    # branch and carry no pull_request object, so the guard is not theirs.
+    # and the OAuth token. This does NOT make the rest safe: issues/issue_comment
+    # carry no pull_request object, so the guard is not expressible there, and
+    # claude-code-action checks the PR head out ITSELF (setupBranch, tag mode) —
+    # an @claude comment on a fork PR still stages fork files here. See #799.
     if: >
       (github.event_name == 'issues' && contains(github.event.issue.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)) ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,9 +213,13 @@ and emits schema-bound JSON; a separate no-checkout publisher revalidates the PR
 head before writing the review comment. The human-triggered `@claude` workflow
 (`claude.yml`, the only `contents: write` Claude job) checks out without a ref,
 so its two `pull_request_review*` arms — the events whose `GITHUB_REF` is the PR
-merge ref — additionally require the head to live in this repository; the
-`issues`/`issue_comment` arms get the default branch and carry no such guard.
-Anthropic WIF is preferred when its
+merge ref — additionally require the head to live in this repository, and the
+policy keys that requirement off the workflow's `on:` triggers rather than its
+surviving `if:` arms (a condition that never names an event SKIPS the job; a
+missing condition gates nothing). The `issues`/`issue_comment` arms carry no
+`pull_request` object, so the same guard is not expressible there — and
+claude-code-action checks the PR head out itself, which keeps `issue_comment`
+exposed on fork PRs (#799). Anthropic WIF is preferred when its
 repository variables are configured, with the existing OAuth secret as a
 compatibility fallback. Codecov uploads likewise use job-scoped GitHub OIDC
 (fork PRs remain Codecov's tokenless path), never a repository upload token.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,7 +207,12 @@ The two automatic Claude reviewers are thin trigger policies over
 `claude-readonly-review.yml`: the model job checks out only the trusted default
 branch, receives the exact PR diff as inert data, has read-only GitHub/tools,
 and emits schema-bound JSON; a separate no-checkout publisher revalidates the PR
-head before writing the review comment. Anthropic WIF is preferred when its
+head before writing the review comment. The human-triggered `@claude` workflow
+(`claude.yml`, the only `contents: write` Claude job) checks out without a ref,
+so its two `pull_request_review*` arms — the events whose `GITHUB_REF` is the PR
+merge ref — additionally require the head to live in this repository; the
+`issues`/`issue_comment` arms get the default branch and carry no such guard.
+Anthropic WIF is preferred when its
 repository variables are configured, with the existing OAuth secret as a
 compatibility fallback. Codecov uploads likewise use job-scoped GitHub OIDC
 (fork PRs remain Codecov's tokenless path), never a repository upload token.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,7 +202,10 @@ the repository deliberately requires a symbolic ref or SHA (not SHA-only),
 every checkout drops persisted credentials, and accepted analyzer findings use
 exact inline suppressions with their reason instead of disabled audit classes.
 Dependabot applies a seven-day update cooldown across every configured
-ecosystem.
+ecosystem, and its `github-actions` entry lists `/.github/actions/*` beside `/`
+— `directory: /` searches only `.github/workflows` plus a root `action.yml`, so
+a third-party pin extracted into a composite would leave update coverage
+entirely; the policy denies a composite pin no declared directory covers.
 The two automatic Claude reviewers are thin trigger policies over
 `claude-readonly-review.yml`: the model job checks out only the trusted default
 branch, receives the exact PR diff as inert data, has read-only GitHub/tools,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3101,9 +3101,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -3111,22 +3111,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3673,9 +3673,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -3697,9 +3697,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -3719,9 +3719,9 @@ dependencies = [
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tracing"

--- a/justfile
+++ b/justfile
@@ -149,8 +149,9 @@ ci-observability:
     ((${#files[@]})) || { echo "error: no GitHub Actions YAML files found" >&2; exit 1; }
     [[ -s .github/actionlint.yaml ]] || { echo "error: .github/actionlint.yaml is missing or empty" >&2; exit 1; }
     [[ -s .github/zizmor.yml ]] || { echo "error: .github/zizmor.yml is missing or empty" >&2; exit 1; }
+    [[ -s .github/dependabot.yml ]] || { echo "error: .github/dependabot.yml is missing or empty" >&2; exit 1; }
     [[ -s site/package.json ]] || { echo "error: site/package.json is missing or empty" >&2; exit 1; }
-    files+=(.github/actionlint.yaml .github/zizmor.yml site/package.json)
+    files+=(.github/actionlint.yaml .github/zizmor.yml .github/dependabot.yml site/package.json)
     combined="$(mktemp)"
     policy_test_results="$(mktemp)"
     trap 'rm -f "$combined" "$policy_test_results"' EXIT

--- a/justfile
+++ b/justfile
@@ -162,8 +162,9 @@ ci-observability:
     # (an unused argument shipped here undetected); the coverage threshold is a
     # RATCHET on #789 — an uncovered rule head means "the body was never true",
     # i.e. no test makes that rule fire, which is how two vacuous rules reached
-    # main. Raise the number as rules gain tests; never lower it. Every one of
-    # the 103 deny heads now fires in a test, so the remainder is helper lines.
+    # main. Raise the number as rules gain tests; never lower it. Every deny head
+    # now fires in a test, so the uncovered remainder is helper lines — a COUNT
+    # here would rot on the next rule, so don't reintroduce one.
     opa check --strict policy/ci-observability
     opa test --coverage --threshold 97 policy/ci-observability >/dev/null
     if ! conftest verify --policy policy/ci-observability --output json >"$policy_test_results"; then

--- a/justfile
+++ b/justfile
@@ -161,9 +161,10 @@ ci-observability:
     # (an unused argument shipped here undetected); the coverage threshold is a
     # RATCHET on #789 — an uncovered rule head means "the body was never true",
     # i.e. no test makes that rule fire, which is how two vacuous rules reached
-    # main. Raise the number as rules gain tests; never lower it.
+    # main. Raise the number as rules gain tests; never lower it. Every one of
+    # the 103 deny heads now fires in a test, so the remainder is helper lines.
     opa check --strict policy/ci-observability
-    opa test --coverage --threshold 95 policy/ci-observability >/dev/null
+    opa test --coverage --threshold 97 policy/ci-observability >/dev/null
     if ! conftest verify --policy policy/ci-observability --output json >"$policy_test_results"; then
         yq -P '.' "$policy_test_results" >&2
         exit 1

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -23,6 +23,9 @@ actionlint_config_path := ".github/actionlint.yaml"
 actionlint_claude_wif_ignore := "input \"anthropic_(federation_rule_id|organization_id|service_account_id)\" is not defined in action \"anthropics/claude-code-action@v1\""
 actionlint_release_queue_ignore := "unexpected key \"queue\" for \"concurrency\" section"
 zizmor_config_path := ".github/zizmor.yml"
+dependabot_config_path := ".github/dependabot.yml"
+composite_action_root := ".github/actions"
+github_actions_ecosystem := "github-actions"
 cache_cleanup_workflow_path := ".github/workflows/cache-cleanup.yml"
 claude_action := "anthropics/claude-code-action@v1"
 json_schema_flag := "--json-schema"
@@ -156,6 +159,34 @@ entries_using(action) := [entry |
 	some entry in uses_entries
 	action_matches(entry.uses, action)
 ]
+
+# `.github/actions/upload-codecov/action.yml` -> `/.github/actions/upload-codecov`,
+# the leading-slash directory form a Dependabot `directories` entry matches.
+dependabot_directory(path) := directory if {
+	segments := split(path, "/")
+	directory := sprintf("/%s", [concat("/", array.slice(segments, 0, count(segments) - 1))])
+}
+
+# Both spellings are legitimate: `directories` (globbable, one entry for all
+# composites) and the singular `directory` (the pre-2024 one-entry-per-composite
+# workaround). A `directories` entry is a glob, so match it as one.
+declared_actions_directories contains directory if {
+	some update in object.get(documents[dependabot_config_path], "updates", [])
+	object.get(update, "package-ecosystem", "") == github_actions_ecosystem
+	some directory in object.get(update, "directories", [])
+}
+
+declared_actions_directories contains directory if {
+	some update in object.get(documents[dependabot_config_path], "updates", [])
+	object.get(update, "package-ecosystem", "") == github_actions_ecosystem
+	directory := object.get(update, "directory", "")
+	directory != ""
+}
+
+dependabot_covers(directory) if {
+	some declared in declared_actions_directories
+	glob.match(declared, ["/"], directory)
+}
 
 codecov_action_reference(value) if {
 	parts := split(value, "@")
@@ -1043,6 +1074,22 @@ deny contains msg if {
 	config := documents[zizmor_config_path]
 	object.get(config, "rules", {}) != expected_zizmor_rules
 	msg := sprintf("%s must require every action to use a symbolic ref or SHA", [zizmor_config_path])
+}
+
+# The actions ignore rule below suppresses patch and minor, so MAJOR is the only
+# class that ever opens a PR — and zizmor accepts a symbolic ref regardless of
+# age. Dependabot is therefore the sole mechanism that reports a major bump, and
+# `directory: /` searches only `.github/workflows` plus a root `action.yml`: a
+# pin extracted into a composite silently leaves coverage, which is what
+# #784/#785 did to four of them. Keyed off the pins that EXIST, so a composite
+# holding nothing but sibling `./` references needs no entry.
+deny contains msg if {
+	some entry in uses_entries
+	startswith(entry.path, sprintf("%s/", [composite_action_root]))
+	not startswith(entry.uses, "./")
+	directory := dependabot_directory(entry.path)
+	not dependabot_covers(directory)
+	msg := sprintf("%s must list a github-actions directory covering %s: %s is otherwise invisible to Dependabot", [dependabot_config_path, directory, entry.uses])
 }
 
 deny contains msg if {

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -35,7 +35,18 @@ claude_manual_commands := {
 	claude_security_workflow_path: "/security-review",
 }
 
-claude_automatic_condition := `(github.event_name == 'pull_request_target' && github.actor != 'dependabot[bot]' && github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.ref == github.event.repository.default_branch)`
+claude_tag_workflow_path := ".github/workflows/claude.yml"
+claude_same_repo_head_condition := "github.event.pull_request.head.repo.full_name == github.repository"
+
+# The events whose GITHUB_REF is refs/pull/<n>/merge, so a ref-less checkout
+# stages fork-authored files; issues/issue_comment get the default branch.
+claude_pull_request_event_names := {"pull_request_review", "pull_request_review_comment"}
+
+claude_automatic_condition := sprintf(
+	`(github.event_name == 'pull_request_target' && github.actor != 'dependabot[bot]' && github.event.pull_request.draft == false && %s && github.event.pull_request.base.ref == github.event.repository.default_branch)`,
+	[claude_same_repo_head_condition],
+)
+
 claude_trusted_association_condition := `contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)`
 pr_resolution_step_name := "Resolve pull request"
 claude_model_step_name := "Run read-only Claude review"
@@ -306,6 +317,8 @@ claude_trigger_workflow_paths := {
 	claude_security_workflow_path,
 }
 
+claude_tag_job := object.get(documents, [claude_tag_workflow_path, "jobs", "claude"], {})
+
 claude_reusable := object.get(documents, claude_reusable_workflow_path, {})
 claude_reusable_jobs := object.get(claude_reusable, "jobs", {})
 claude_analyze_job := object.get(claude_reusable_jobs, "analyze", {})
@@ -570,6 +583,18 @@ deny contains msg if {
 	count(claude_caller_jobs(path)) == 1
 	not claude_caller_condition_is_trusted(path)
 	msg := sprintf("%s must preserve the trusted automatic and manual review guards", [path])
+}
+
+# claude.yml is the only contents:write Claude job and it checks out without a
+# ref, so on these events an unguarded arm stages fork-authored files — a
+# repo-root CLAUDE.md among them — as the agent's own instructions. Keyed off
+# the arms that EXIST: an absent arm cannot be triggered, so it is not exposure.
+deny contains msg if {
+	some event in claude_pull_request_event_names
+	some arm in split(normalized_claude_condition(object.get(claude_tag_job, "if", "")), " || ")
+	contains(arm, sprintf("github.event_name == '%s'", [event]))
+	not contains(arm, claude_same_repo_head_condition)
+	msg := sprintf("%s %s arm must require the pull request head to live in this repository", [claude_tag_workflow_path, event])
 }
 
 deny contains msg if {

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -167,16 +167,19 @@ dependabot_directory(path) := directory if {
 	directory := sprintf("/%s", [concat("/", array.slice(segments, 0, count(segments) - 1))])
 }
 
-# Both spellings are legitimate: `directories` (globbable, one entry for all
-# composites) and the singular `directory` (the pre-2024 one-entry-per-composite
-# workaround). A `directories` entry is a glob, so match it as one.
-declared_actions_directories contains directory if {
+# Both spellings are legitimate: `directories` (one entry for all composites)
+# and the singular `directory` (the pre-2024 one-entry-per-composite workaround).
+# They are NOT interchangeable — GitHub's options reference: "The `directories`
+# key supports globbing and the wildcard character `*`. These features are not
+# supported by the `directory` key." So copying the glob into the singular key
+# resolves nothing upstream, and must not read as coverage here.
+declared_actions_directory_globs contains directory if {
 	some update in object.get(documents[dependabot_config_path], "updates", [])
 	object.get(update, "package-ecosystem", "") == github_actions_ecosystem
 	some directory in object.get(update, "directories", [])
 }
 
-declared_actions_directories contains directory if {
+declared_actions_directory_literals contains directory if {
 	some update in object.get(documents[dependabot_config_path], "updates", [])
 	object.get(update, "package-ecosystem", "") == github_actions_ecosystem
 	directory := object.get(update, "directory", "")
@@ -184,8 +187,12 @@ declared_actions_directories contains directory if {
 }
 
 dependabot_covers(directory) if {
-	some declared in declared_actions_directories
+	some declared in declared_actions_directory_globs
 	glob.match(declared, ["/"], directory)
+}
+
+dependabot_covers(directory) if {
+	directory in declared_actions_directory_literals
 }
 
 codecov_action_reference(value) if {
@@ -348,7 +355,31 @@ claude_trigger_workflow_paths := {
 	claude_security_workflow_path,
 }
 
-claude_tag_job := object.get(documents, [claude_tag_workflow_path, "jobs", "claude"], {})
+# Identified by the action it runs, not by its job NAME: keying on the literal
+# name `claude` let a rename retire the head guard below in silence.
+claude_tag_jobs := [job |
+	some job in object.get(documents[claude_tag_workflow_path], "jobs", {})
+	some step in object.get(job, "steps", [])
+	action_matches(object.get(step, "uses", ""), claude_action)
+]
+
+claude_tag_condition := normalized_claude_condition(object.get(claude_tag_jobs[0], "if", ""))
+
+claude_tag_arms(event) := [arm |
+	some arm in split(claude_tag_condition, " || ")
+	contains(arm, sprintf("github.event_name == '%s'", [event]))
+]
+
+# Guarded means the event is REACHABLE only through guarded arms: at least one
+# arm names it (none at all = a missing condition, which gates nothing) and
+# every arm that names it carries the head check.
+claude_tag_event_is_guarded(event) if {
+	arms := claude_tag_arms(event)
+	count(arms) > 0
+	every arm in arms {
+		contains(arm, claude_same_repo_head_condition)
+	}
+}
 
 claude_reusable := object.get(documents, claude_reusable_workflow_path, {})
 claude_reusable_jobs := object.get(claude_reusable, "jobs", {})
@@ -619,13 +650,22 @@ deny contains msg if {
 # claude.yml is the only contents:write Claude job and it checks out without a
 # ref, so on these events an unguarded arm stages fork-authored files — a
 # repo-root CLAUDE.md among them — as the agent's own instructions. Keyed off
-# the arms that EXIST: an absent arm cannot be triggered, so it is not exposure.
+# the `on:` trigger set, not the `if:` arms — a condition that never mentions
+# the event is a SKIPPED job, but a MISSING condition is an ungated one, and
+# deleting the whole `if:` block is the cheapest way to lose the guard.
 deny contains msg if {
 	some event in claude_pull_request_event_names
-	some arm in split(normalized_claude_condition(object.get(claude_tag_job, "if", "")), " || ")
-	contains(arm, sprintf("github.event_name == '%s'", [event]))
-	not contains(arm, claude_same_repo_head_condition)
-	msg := sprintf("%s %s arm must require the pull request head to live in this repository", [claude_tag_workflow_path, event])
+	object.get(documents, [claude_tag_workflow_path, "on", event], "absent") != "absent"
+	not claude_tag_event_is_guarded(event)
+	msg := sprintf("%s %s arm must require `%s`", [claude_tag_workflow_path, event, claude_same_repo_head_condition])
+}
+
+# The existence half: the guard above resolves the job through its action step,
+# so a workflow where no job runs the action leaves nothing to check.
+deny contains msg if {
+	_ := documents[claude_tag_workflow_path]
+	count(claude_tag_jobs) != 1
+	msg := sprintf("%s must run `%s` in exactly one job — the fork-head guard is keyed to that job's condition", [claude_tag_workflow_path, claude_action])
 }
 
 deny contains msg if {

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -370,6 +370,17 @@ claude_tag_arms(event) := [arm |
 	contains(arm, sprintf("github.event_name == '%s'", [event]))
 ]
 
+# `on:` takes a mapping (each event carrying `types:`) OR a bare sequence of
+# event names; both reach the job, so both count as a trigger.
+claude_tag_triggers_event(event) if {
+	object.get(documents, [claude_tag_workflow_path, "on", event], "missing") != "missing"
+}
+
+claude_tag_triggers_event(event) if {
+	some declared in object.get(documents[claude_tag_workflow_path], "on", [])
+	declared == event
+}
+
 # Guarded means the event is REACHABLE only through guarded arms: at least one
 # arm names it (none at all = a missing condition, which gates nothing) and
 # every arm that names it carries the head check.
@@ -655,7 +666,7 @@ deny contains msg if {
 # deleting the whole `if:` block is the cheapest way to lose the guard.
 deny contains msg if {
 	some event in claude_pull_request_event_names
-	object.get(documents, [claude_tag_workflow_path, "on", event], "absent") != "absent"
+	claude_tag_triggers_event(event)
 	not claude_tag_event_is_guarded(event)
 	msg := sprintf("%s %s arm must require `%s`", [claude_tag_workflow_path, event, claude_same_repo_head_condition])
 }

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -1025,9 +1025,12 @@ deny contains msg if {
 	msg := sprintf("%s must run on pushes to main", [codeql_workflow_path])
 }
 
+# Only a bare `pull_request:` analyzes EVERY pull request; any filter (types,
+# branches, paths) lets some PR merge unanalyzed, so the pin is exact-null. The
+# path form keeps the rule defined — and firing — when `on:` itself is gone.
 deny contains msg if {
-	object.get(codeql.on, "pull_request", "missing") != null
-	msg := sprintf("%s must run on pull requests", [codeql_workflow_path])
+	object.get(codeql, ["on", "pull_request"], "missing") != null
+	msg := sprintf("%s must analyze every pull request: keep on.pull_request present and unfiltered", [codeql_workflow_path])
 }
 
 deny contains msg if {

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -1239,3 +1239,92 @@ test_lighthouse_rules_tolerate_an_exact_upload_artifact_pin if {
 		}
 	}
 }
+
+composite_pin_fixture(dependabot_contents) := {"documents": [
+	{
+		"path": codecov_authority_path,
+		"contents": {"runs": {"steps": [{"uses": codecov_action}]}},
+	},
+	{"path": dependabot_config_path, "contents": dependabot_contents},
+]}
+
+uncovered_composite_message := sprintf(
+	"%s must list a github-actions directory covering /%s/upload-codecov: %s is otherwise invisible to Dependabot",
+	[dependabot_config_path, composite_action_root, codecov_action],
+)
+
+# #784/#785 moved four third-party pins into composites; `directory: /` searches
+# only `.github/workflows` and a root `action.yml`, so all four left coverage.
+test_composite_pin_outside_dependabot_coverage_is_rejected if {
+	fixture := composite_pin_fixture({"updates": [{
+		"package-ecosystem": "github-actions",
+		"directory": "/",
+	}]})
+	violations := deny with input as fixture
+	uncovered_composite_message in violations
+}
+
+test_missing_dependabot_config_leaves_composite_pins_uncovered if {
+	fixture := {"documents": [{
+		"path": codecov_authority_path,
+		"contents": {"runs": {"steps": [{"uses": codecov_action}]}},
+	}]}
+	violations := deny with input as fixture
+	uncovered_composite_message in violations
+}
+
+# The glob form dependabot-core#6704 confirms works must stay silent.
+test_composite_directory_glob_covers_the_pin if {
+	fixture := composite_pin_fixture({"updates": [{
+		"package-ecosystem": "github-actions",
+		"directories": ["/", "/.github/actions/*"],
+	}]})
+	violations := deny with input as fixture
+	not uncovered_composite_message in violations
+}
+
+# So must the upstream one-entry-per-composite workaround, which predates
+# `directories` and uses the singular key.
+test_per_composite_directory_entry_covers_the_pin if {
+	fixture := composite_pin_fixture({"updates": [
+		{"package-ecosystem": "github-actions", "directory": "/"},
+		{
+			"package-ecosystem": "github-actions",
+			"directory": "/.github/actions/upload-codecov",
+		},
+	]})
+	violations := deny with input as fixture
+	not uncovered_composite_message in violations
+}
+
+# A composite that only calls sibling actions has nothing for Dependabot to
+# bump, so an uncovered directory is not a finding.
+test_local_composite_reference_needs_no_dependabot_coverage if {
+	fixture := {"documents": [
+		{
+			"path": ".github/actions/packaging-build/action.yml",
+			"contents": {"runs": {"steps": [{"uses": codecov_wrapper}]}},
+		},
+		{
+			"path": dependabot_config_path,
+			"contents": {"updates": [{
+				"package-ecosystem": "github-actions",
+				"directory": "/",
+			}]},
+		},
+	]}
+	violations := deny with input as fixture
+	every violation in violations {
+		not contains(violation, "invisible to Dependabot")
+	}
+}
+
+# A non-actions ecosystem's directory list must not launder the coverage.
+test_other_ecosystem_directories_do_not_cover_composites if {
+	fixture := composite_pin_fixture({"updates": [
+		{"package-ecosystem": "github-actions", "directory": "/"},
+		{"package-ecosystem": "npm", "directories": ["/.github/actions/*"]},
+	]})
+	violations := deny with input as fixture
+	uncovered_composite_message in violations
+}

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -334,6 +334,95 @@ test_codecov_token_forwarding_is_pinned if {
 	sprintf("%s must not declare or forward a Codecov upload token", [codecov_authority_path]) in violations
 }
 
+test_conditioned_codecov_upload_is_denied if {
+	fixture := {"documents": [{
+		"path": codecov_authority_path,
+		"contents": {"runs": {"steps": [{
+			"uses": codecov_action,
+			"if": post_test_condition,
+		}]}},
+	}]}
+	violations := deny with input as fixture
+	sprintf("%s Codecov step must remain unconditional", [codecov_authority_path]) in violations
+}
+
+# The authority action has its own token rule; this one covers every CALLER of
+# the wrapper, where a re-introduced token would otherwise pass unseen.
+test_wrapper_caller_forwarding_a_token_is_denied if {
+	path := ".github/workflows/extra.yml"
+	fixture := {"documents": [{
+		"path": path,
+		"contents": {"jobs": {"test": {"steps": [{
+			"uses": codecov_wrapper,
+			"with": {"token": "${{ secrets.UPLOAD_TOKEN }}"},
+		}]}}},
+	}]}
+	violations := deny with input as fixture
+	sprintf("%s must not forward a Codecov upload token", [path]) in violations
+}
+
+test_retired_codecov_token_secret_is_denied if {
+	every path in {ci_workflow_path, codecov_workflow_path, codecov_authority_path} {
+		fixture := {"documents": [{
+			"path": path,
+			"contents": {"jobs": {"test": {"env": {"TOKEN": "${{ secrets.CODECOV_TOKEN }}"}}}},
+		}]}
+		violations := deny with input as fixture
+		sprintf("%s must not reference the retired CODECOV_TOKEN secret", [path]) in violations
+	}
+}
+
+codecov_warning_step(env) := {
+	"path": codecov_authority_path,
+	"contents": {"runs": {"steps": [{
+		"name": upload_warning_step_name,
+		"if": "${{ steps.upload.outcome == 'failure' }}",
+		"env": env,
+		"run": "echo warning",
+	}]}},
+}
+
+# An advisory upload failure that does not name which report/flag/type failed is
+# a warning nobody can act on, so all three env pins are separate rules.
+test_codecov_warning_step_must_identify_the_failed_upload if {
+	fixture := {"documents": [codecov_warning_step({})]}
+	violations := deny with input as fixture
+	every message in {
+		"failure step must identify inputs.file",
+		"failure step must identify inputs.flag",
+		"failure step must identify inputs.report_type",
+	} {
+		sprintf("%s %s", [codecov_authority_path, message]) in violations
+	}
+}
+
+test_codecov_warning_step_naming_every_input_is_accepted if {
+	fixture := {"documents": [codecov_warning_step({
+		"REPORT_FILE": codecov_input_file,
+		"REPORT_FLAG": codecov_input_flag,
+		"REPORT_TYPE": codecov_input_report_type,
+	})]}
+	violations := deny with input as fixture
+	every message in {
+		"failure step must identify inputs.file",
+		"failure step must identify inputs.flag",
+		"failure step must identify inputs.report_type",
+	} {
+		not sprintf("%s %s", [codecov_authority_path, message]) in violations
+	}
+}
+
+# `queue` is a release-only compatibility field carried by an actionlint ignore;
+# anywhere else it is an unrecognized key that silently serializes nothing.
+test_release_queue_field_outside_release_is_denied if {
+	fixture := {"documents": [{
+		"path": ci_workflow_path,
+		"contents": {"concurrency": {"queue": true}},
+	}]}
+	violations := deny with input as fixture
+	sprintf("%s must not use the release-only queue compatibility field", [ci_workflow_path]) in violations
+}
+
 test_report_presence_check_reads_inputs_file if {
 	fixture := {"documents": [{
 		"path": codecov_authority_path,
@@ -966,6 +1055,56 @@ test_codeql_health_gate_before_upload_is_accepted if {
 	}]}
 	violations := deny with input as fixture
 	not sprintf("%s must verify Rust extraction health before uploading the SARIF", [codeql_workflow_path]) in violations
+}
+
+test_codeql_init_hardcoding_a_language_is_denied if {
+	fixture := {"documents": [{
+		"path": codeql_workflow_path,
+		"contents": {"jobs": {"analyze": {"steps": [{
+			"uses": "github/codeql-action/init@v4",
+			"with": {"languages": "rust"},
+		}]}}},
+	}]}
+	violations := deny with input as fixture
+	sprintf("%s CodeQL init must consume matrix.language", [codeql_workflow_path]) in violations
+}
+
+# init snapshots the workspace, so anything staged after it is invisible to the
+# extractor while the job still reports a successful analysis.
+test_codeql_init_before_its_inputs_is_denied if {
+	fixture := {"documents": [{
+		"path": codeql_workflow_path,
+		"contents": {"jobs": {"analyze": {"steps": [
+			{"uses": "github/codeql-action/init@v4"},
+			{"uses": "actions/checkout@v7"},
+			{
+				"name": rust_setup_step_name,
+				"if": rust_matrix_condition,
+				"run": "prepare",
+			},
+		]}}},
+	}]}
+	violations := deny with input as fixture
+	sprintf("%s must check out before CodeQL init", [codeql_workflow_path]) in violations
+	sprintf("%s must prepare Rust before CodeQL init", [codeql_workflow_path]) in violations
+}
+
+test_codeql_init_after_its_inputs_is_accepted if {
+	fixture := {"documents": [{
+		"path": codeql_workflow_path,
+		"contents": {"jobs": {"analyze": {"steps": [
+			{"uses": "actions/checkout@v7"},
+			{
+				"name": rust_setup_step_name,
+				"if": rust_matrix_condition,
+				"run": "prepare",
+			},
+			{"uses": "github/codeql-action/init@v4"},
+		]}}},
+	}]}
+	violations := deny with input as fixture
+	not sprintf("%s must check out before CodeQL init", [codeql_workflow_path]) in violations
+	not sprintf("%s must prepare Rust before CodeQL init", [codeql_workflow_path]) in violations
 }
 
 codeql_pull_request_message := sprintf("%s must analyze every pull request: keep on.pull_request present and unfiltered", [codeql_workflow_path])

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -968,6 +968,55 @@ test_codeql_health_gate_before_upload_is_accepted if {
 	not sprintf("%s must verify Rust extraction health before uploading the SARIF", [codeql_workflow_path]) in violations
 }
 
+codeql_pull_request_message := sprintf("%s must analyze every pull request: keep on.pull_request present and unfiltered", [codeql_workflow_path])
+
+test_codeql_dropping_the_pull_request_trigger_is_denied if {
+	fixture := {"documents": [{
+		"path": codeql_workflow_path,
+		"contents": {"on": {"push": {"branches": ["main"]}}},
+	}]}
+	violations := deny with input as fixture
+	codeql_pull_request_message in violations
+}
+
+# A filtered trigger still "runs on pull requests", so the old wording accused
+# the maintainer of the opposite of what they did. The requirement is that NO
+# pull request can skip analysis, which only a bare `pull_request:` guarantees.
+test_codeql_filtered_pull_request_trigger_is_denied if {
+	every trigger in {
+		{"types": ["opened", "synchronize", "reopened"]},
+		{"branches": ["main"]},
+		{"paths-ignore": ["docs/**"]},
+	} {
+		fixture := {"documents": [{
+			"path": codeql_workflow_path,
+			"contents": {"on": {"pull_request": trigger}},
+		}]}
+		violations := deny with input as fixture
+		codeql_pull_request_message in violations
+	}
+}
+
+test_bare_codeql_pull_request_trigger_is_accepted if {
+	fixture := {"documents": [{
+		"path": codeql_workflow_path,
+		"contents": {"on": {"pull_request": null}},
+	}]}
+	violations := deny with input as fixture
+	not codeql_pull_request_message in violations
+}
+
+# Reaching through `codeql.on` made the whole rule undefined — silently green —
+# when the trigger block itself was gone, the one shape that disables every arm.
+test_codeql_losing_its_trigger_block_is_denied if {
+	fixture := {"documents": [{
+		"path": codeql_workflow_path,
+		"contents": {"jobs": {"analyze": {"steps": []}}},
+	}]}
+	violations := deny with input as fixture
+	codeql_pull_request_message in violations
+}
+
 # Dependabot pins a floating major to an exact release. That is a STRICTER pin
 # and must not be rejected — #786 failed with "must analyze with CodeQL v4
 # exactly once" against a step that was v4.37.1.

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -1102,6 +1102,21 @@ test_claude_tag_job_without_a_condition_is_denied if {
 	}
 }
 
+# The sequence spelling of `on:` reaches the job just as the mapping does.
+test_claude_tag_sequence_trigger_form_is_denied if {
+	fixture := {"documents": [{
+		"path": claude_tag_workflow_path,
+		"contents": {
+			"on": ["issues", "pull_request_review", "pull_request_review_comment"],
+			"jobs": {"claude": {"steps": [{"uses": claude_action}]}},
+		},
+	}]}
+	violations := deny with input as fixture
+	every event in claude_pull_request_event_names {
+		claude_tag_head_guard_message(event) in violations
+	}
+}
+
 # Renaming the job away from `claude` used to silence the guard entirely.
 test_claude_tag_renamed_job_is_still_guarded if {
 	violations := deny with input as claude_tag_workflow("respond", {

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -1057,6 +1057,35 @@ test_codeql_health_gate_before_upload_is_accepted if {
 	not sprintf("%s must verify Rust extraction health before uploading the SARIF", [codeql_workflow_path]) in violations
 }
 
+claude_tag_head_guard_message(event) := sprintf("%s %s arm must require the pull request head to live in this repository", [claude_tag_workflow_path, event])
+
+claude_tag_fixture(review_arm_suffix) := {"documents": [{
+	"path": claude_tag_workflow_path,
+	"contents": {"jobs": {"claude": {"if": sprintf(
+		"(github.event_name == 'issues' && trusted) || (github.event_name == 'issue_comment' && trusted) || (github.event_name == 'pull_request_review'%s && trusted) || (github.event_name == 'pull_request_review_comment'%s && trusted)",
+		[review_arm_suffix, review_arm_suffix],
+	)}}},
+}]}
+
+test_claude_tag_pull_request_arms_without_the_head_guard_are_denied if {
+	violations := deny with input as claude_tag_fixture("")
+	every event in claude_pull_request_event_names {
+		claude_tag_head_guard_message(event) in violations
+	}
+}
+
+# The issues/issue_comment arms carry no pull_request object, so demanding the
+# guard of them would deny a workflow that is not exposed in the first place.
+test_claude_tag_guarded_pull_request_arms_are_accepted if {
+	violations := deny with input as claude_tag_fixture(sprintf(" && %s", [claude_same_repo_head_condition]))
+	every event in claude_pull_request_event_names {
+		not claude_tag_head_guard_message(event) in violations
+	}
+	every violation in violations {
+		not contains(violation, "arm must require the pull request head")
+	}
+}
+
 test_codeql_init_hardcoding_a_language_is_denied if {
 	fixture := {"documents": [{
 		"path": codeql_workflow_path,

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -1057,21 +1057,66 @@ test_codeql_health_gate_before_upload_is_accepted if {
 	not sprintf("%s must verify Rust extraction health before uploading the SARIF", [codeql_workflow_path]) in violations
 }
 
-claude_tag_head_guard_message(event) := sprintf("%s %s arm must require the pull request head to live in this repository", [claude_tag_workflow_path, event])
+claude_tag_head_guard_message(event) := sprintf("%s %s arm must require `%s`", [claude_tag_workflow_path, event, claude_same_repo_head_condition])
 
-claude_tag_fixture(review_arm_suffix) := {"documents": [{
+claude_tag_single_job_message := sprintf("%s must run `%s` in exactly one job — the fork-head guard is keyed to that job's condition", [claude_tag_workflow_path, claude_action])
+
+claude_tag_triggers := {
+	"issues": {"types": ["opened"]},
+	"issue_comment": {"types": ["created"]},
+	"pull_request_review": {"types": ["submitted"]},
+	"pull_request_review_comment": {"types": ["created"]},
+}
+
+claude_tag_workflow(job_name, job) := {"documents": [{
 	"path": claude_tag_workflow_path,
-	"contents": {"jobs": {"claude": {"if": sprintf(
-		"(github.event_name == 'issues' && trusted) || (github.event_name == 'issue_comment' && trusted) || (github.event_name == 'pull_request_review'%s && trusted) || (github.event_name == 'pull_request_review_comment'%s && trusted)",
-		[review_arm_suffix, review_arm_suffix],
-	)}}},
+	"contents": {
+		"on": claude_tag_triggers,
+		"jobs": {job_name: job},
+	},
 }]}
+
+claude_tag_condition_text(review_arm_suffix) := sprintf(
+	"(github.event_name == 'issues' && trusted) || (github.event_name == 'issue_comment' && trusted) || (github.event_name == 'pull_request_review'%s && trusted) || (github.event_name == 'pull_request_review_comment'%s && trusted)",
+	[review_arm_suffix, review_arm_suffix],
+)
+
+claude_tag_fixture(review_arm_suffix) := claude_tag_workflow("claude", {
+	"if": claude_tag_condition_text(review_arm_suffix),
+	"steps": [{"uses": claude_action}],
+})
 
 test_claude_tag_pull_request_arms_without_the_head_guard_are_denied if {
 	violations := deny with input as claude_tag_fixture("")
 	every event in claude_pull_request_event_names {
 		claude_tag_head_guard_message(event) in violations
 	}
+}
+
+# The worst shape, and the one an arm-keyed rule missed: with no condition at
+# all every arm is present-and-ungated, not absent.
+test_claude_tag_job_without_a_condition_is_denied if {
+	violations := deny with input as claude_tag_workflow("claude", {"steps": [{"uses": claude_action}]})
+	every event in claude_pull_request_event_names {
+		claude_tag_head_guard_message(event) in violations
+	}
+}
+
+# Renaming the job away from `claude` used to silence the guard entirely.
+test_claude_tag_renamed_job_is_still_guarded if {
+	violations := deny with input as claude_tag_workflow("respond", {
+		"if": claude_tag_condition_text(""),
+		"steps": [{"uses": claude_action}],
+	})
+	every event in claude_pull_request_event_names {
+		claude_tag_head_guard_message(event) in violations
+	}
+	not claude_tag_single_job_message in violations
+}
+
+test_claude_tag_workflow_without_the_action_is_denied if {
+	violations := deny with input as claude_tag_workflow("claude", {"steps": [{"uses": "actions/checkout@v7"}]})
+	claude_tag_single_job_message in violations
 }
 
 # The issues/issue_comment arms carry no pull_request object, so demanding the
@@ -1081,8 +1126,25 @@ test_claude_tag_guarded_pull_request_arms_are_accepted if {
 	every event in claude_pull_request_event_names {
 		not claude_tag_head_guard_message(event) in violations
 	}
+	not claude_tag_single_job_message in violations
+}
+
+# Dropping BOTH the arm and its `on:` entry retires the exposure, so the rule
+# keyed off `on:` must stay silent — the guard tracks reachability, not arms.
+test_claude_tag_dropping_a_pull_request_trigger_is_accepted if {
+	fixture := {"documents": [{
+		"path": claude_tag_workflow_path,
+		"contents": {
+			"on": {"issues": {"types": ["opened"]}},
+			"jobs": {"claude": {
+				"if": "(github.event_name == 'issues' && trusted)",
+				"steps": [{"uses": claude_action}],
+			}},
+		},
+	}]}
+	violations := deny with input as fixture
 	every violation in violations {
-		not contains(violation, "arm must require the pull request head")
+		not contains(violation, "arm must require")
 	}
 }
 
@@ -1269,6 +1331,17 @@ test_missing_dependabot_config_leaves_composite_pins_uncovered if {
 		"path": codecov_authority_path,
 		"contents": {"runs": {"steps": [{"uses": codecov_action}]}},
 	}]}
+	violations := deny with input as fixture
+	uncovered_composite_message in violations
+}
+
+# Copying the glob into the SINGULAR key is the likeliest way to get this wrong,
+# and GitHub does not glob `directory` — Dependabot would resolve nothing.
+test_globbed_singular_directory_does_not_cover_the_pin if {
+	fixture := composite_pin_fixture({"updates": [{
+		"package-ecosystem": "github-actions",
+		"directory": "/.github/actions/*",
+	}]})
 	violations := deny with input as fixture
 	uncovered_composite_message in violations
 }

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -1225,8 +1225,7 @@ test_codeql_dropping_the_pull_request_trigger_is_denied if {
 }
 
 # A filtered trigger still "runs on pull requests", so the old wording accused
-# the maintainer of the opposite of what they did. The requirement is that NO
-# pull request can skip analysis, which only a bare `pull_request:` guarantees.
+# the maintainer of the opposite of what they did.
 test_codeql_filtered_pull_request_trigger_is_denied if {
 	every trigger in {
 		{"types": ["opened", "synchronize", "reopened"]},


### PR DESCRIPTION
Fixes 11 confirmed audit defects in CI workflows and OPA policy — mostly **gates that did not gate**.

The fork-head guard keyed off the surviving `if:` arms, so it could not fire on the two strictly *worse* shapes: deleting the whole `if:` block, or renaming the job. A CodeQL rule denied with a message stating the **opposite** of what it enforced — a confident wrong instruction carrying a gate's authority. Dependabot never scanned `.github/actions/*/action.yml`, leaving four third-party pins uncovered, and its cargo ecosystem had failed every run since 2026-07-15.

Every deny rule now has a test proving it *can* fire; the harder half — that it **stays silent on a legitimate variant** — is the direction nobody writes and is exactly the class these defects came from.

### Commits

- `e9faf8df` style(policy): apply the redundancy-within comment test to the new WHY
- `839bb5d1` fix(policy): count the sequence spelling of `on:` as a trigger too
- `69014de8` docs(ci): stop the fork-head comment certifying the arm it does not cover
- `69c2a53f` fix(policy): key the fork-head guard off `on:`, not the surviving `if:` arms
- `cf95b2ca` docs(ci): drop the deny-head count that two new rules already stale
- `f8083ef4` chore(deps): bump the three crates Dependabot cannot move itself
- `f5fc84e0` fix(ci): put the composite actions back on Dependabot's map
- `fa08b483` docs(review): credit the gate that exists, at the strength it has
- `b9897727` fix(ci): keep fork heads out of the contents:write Claude workspace
- `582219f6` test(policy): give every deny rule a test that proves it can fire
- `7cad7ced` fix(policy): make the CodeQL PR-trigger rule say what it enforces

---

### Provenance

Part of a whole-codebase audit (13 branches, 136 commits). Pipeline: 11 subsystem
finders + 8 whole-tree specialist sweeps + loop-until-dry security/concurrency
hunts → 312 raw findings → adversarial skeptics (default REFUTE, 3 differentiated
lenses on HIGH/security/concurrency) → **108 distinct confirmed defects** (35%
refutation rate, stable across two rounds) → fixes → a two-lens merge review per
branch plus trigger-driven escalation lenses → a fix round on that review's
findings.

Every defect has exactly one terminal state: **181 FIXED · 8 REFUTED-with-citation
· 12 ISSUE-NEEDED** (filed: #799 #800 #802 #803 #804).

### Composition verified

All 13 branches were merged together in a throwaway worktree and gated as one tree
— the step no per-branch review can perform:

- `just preflight` → **exit 0** (13 lint sub-gates → clippy → hack → **2,795 tests passed**)
- `just site-check` · `just site-e2e` (96) · `just ci-observability` (107 Rego + 108 conftest) → all exit 0

That pass found **5 genuine cross-branch contradictions** in prose that merged
cleanly — e.g. one branch documenting a sweep as "per-frame" while another had
memoized it. Resolved against the merged code, not mechanically.

### Merge order

Measured, not inferred: `site → ci-tooling → tui → bin-runtime → scene-painter →
core → scene-sim → ci-policy → bin-install → docs → scripts` (+ `hook-docs`,
`consumer-gaps`, independent). Each branch is individually clean against `main`;
later ones may need a rebase once earlier ones land. Known collision points:
`crates/pixtuoid/CLAUDE.md` (5 branches), `crates/pixtuoid-core/CLAUDE.md` (4),
`policy/ci-observability/main.rego` (2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
