### PR TITLE
fix(policy): a zizmor rule that false-fired and one that retired itself, +12 defects

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,8 +1,8 @@
 # cargo-mutants config (see `just mutants`). Mutation testing injects bugs and
 # checks the tests catch them — the "do your assertions have teeth?" dimension
 # that line/region coverage can't see. Use the project's runner (nextest) and
-# exclude paths where a surviving mutant is NOISE, not a real gap, so the
-# advisory signal stays high.
+# exclude the paths (`exclude_globs`) and FUNCTIONS (`exclude_re`) where a
+# surviving mutant is NOISE, not a real gap, so the advisory signal stays high.
 #
 # READ THIS BEFORE ACTING ON A `pixtuoid-core` / `pixtuoid-scene` SURVIVOR.
 # `test_workspace` is deliberately left at its default, which means "only the

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -29,18 +29,30 @@
 test_tool = "nextest"
 
 exclude_globs = [
-    # Untestable painter / async + winit glue — these six are the painter files
-    # codecov.yml ALSO ignores; no headless test can kill their mutants, so every
-    # one "survives" = noise. The two ignore lists OVERLAP, not subset: codecov
-    # also ignores crash/logging/sources_cli (pure helpers stay unit-tested —
-    # sources_cli via the cli_json e2e — so their mutants stay IN), and this file
-    # also excludes the pixtuoid-core probe files below. Edit shared entries together.
+    # Untestable painter / async + winit glue — no headless test can kill their
+    # mutants, so every one "survives" = noise. These four are a SUBSET of the
+    # painter files codecov.yml ignores; the lists overlap without either being
+    # a subset of the other, since codecov also ignores crash/logging/sources_cli
+    # (pure helpers stay unit-tested — sources_cli via the cli_json e2e — so
+    # their mutants stay IN), this file also excludes the pixtuoid-core probe
+    # files below, and tui/mod.rs + driver.rs are ignored THERE but mutated HERE
+    # (see the note under this list). Edit shared entries together.
     "crates/pixtuoid/src/main.rs",
-    "crates/pixtuoid/src/tui/mod.rs",
-    "crates/pixtuoid/src/runtime/driver.rs",
     "crates/pixtuoid/src/runtime/pipeline.rs",
     "crates/pixtuoid/src/floating/mod.rs",
     "crates/pixtuoid/src/floating/window.rs",
+    # NOT excluded, though codecov.yml ignores both: `tui/mod.rs` and
+    # `runtime/driver.rs` are line-uncoverable in BULK while still carrying a
+    # unit-tested pure decision layer, and per-FUNCTION mutants see that split
+    # where per-LINE coverage cannot. Measured, not assumed: 22 mutants across
+    # tui/mod.rs's `dispatch_key`/`toggle_intent`/`is_quit_chord`/
+    # `should_dispatch_key` = 19 caught, 1 unviable, and the only 2 missed are
+    # in `run_tui` itself; driver.rs's `build_source_set` mutant is caught by
+    # the registry-drift test written to close that gap. Excluding the files
+    # hid ~132 and ~9 mutants respectively — an exclusion that hides a killable
+    # mutant is worse than a noisy row (the same call as the `mascot_position`
+    # pair below). `run_tui`'s own ~44 mutants stay as documented known noise;
+    # `just mutants` is --in-diff, so they only surface when you edit `run_tui`.
     # Timing / FFI liveness probes: their tests assert wall-clock + OS behavior and
     # flake under mutation load — a "survivor" here is a flaked test, not a missing
     # assertion (this repo is flake-averse; #352-#354).

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -44,15 +44,27 @@ exclude_globs = [
     # NOT excluded, though codecov.yml ignores both: `tui/mod.rs` and
     # `runtime/driver.rs` are line-uncoverable in BULK while still carrying a
     # unit-tested pure decision layer, and per-FUNCTION mutants see that split
-    # where per-LINE coverage cannot. Measured, not assumed: 22 mutants across
-    # tui/mod.rs's `dispatch_key`/`toggle_intent`/`is_quit_chord`/
-    # `should_dispatch_key` = 19 caught, 1 unviable, and the only 2 missed are
-    # in `run_tui` itself; driver.rs's `build_source_set` mutant is caught by
-    # the registry-drift test written to close that gap. Excluding the files
-    # hid ~132 and ~9 mutants respectively — an exclusion that hides a killable
-    # mutant is worse than a noisy row (the same call as the `mascot_position`
-    # pair below). `run_tui`'s own ~44 mutants stay as documented known noise;
-    # `just mutants` is --in-diff, so they only surface when you edit `run_tui`.
+    # where per-LINE coverage cannot. Their untestable glue is pinned by
+    # FUNCTION in `exclude_re` below rather than hidden by file, so the decision
+    # layers stay in scope. The evidence behind that, and its exact limits:
+    # - tui/mod.rs carries 135 mutants (`cargo mutants --list --no-config
+    #   --package pixtuoid --file crates/pixtuoid/src/tui/mod.rs`), 72 of them in
+    #   `dispatch_key` alone. Exactly 22 have ever been RUN — those matching
+    #   `-F 'toggle_intent|is_quit_chord|should_dispatch_key'` — scoring 19
+    #   caught, 1 unviable, 2 missed (the `should_dispatch_key` match guards at
+    #   700:38, inside `run_tui`, now excluded by function). 14 of those 22 are
+    #   `is_quit_chord` guards INSIDE `dispatch_key`, so the run covered 22 of
+    #   the 78 mutants those four fns carry — NOT all of them. The other 113 are
+    #   UNMEASURED: a survivor there is unknown, not known noise, so measure it
+    #   before dismissing it.
+    # - driver.rs carries 9 mutants and none has been run under mutation. The 6
+    #   naming fns with zero test call sites are excluded below; the 3 left in
+    #   are the ones a test can reach (`build_source_set` x2 via the
+    #   registry-drift test, `headless_loop_with_signal` via the two signal-arm
+    #   tests).
+    # File-level exclusion was still the wrong tool: it hid all 135 and all 9,
+    # killable ones included, and an exclusion that hides a killable mutant is
+    # worse than a noisy row (the same call as the `mascot_position` pair below).
     # Timing / FFI liveness probes: their tests assert wall-clock + OS behavior and
     # flake under mutation load — a "survivor" here is a flaked test, not a missing
     # assertion (this repo is flake-averse; #352-#354).
@@ -121,4 +133,17 @@ exclude_re = [
     # single_pod_band + the boundary scan), so only the unobservable culprit-vs-
     # blanket distinction survives — an equivalent mutant within reach today.
     'compute\.rs.*plant_ground_in_bounds',
+    #
+    # A SECOND class, deliberately kept apart from the equivalent mutants above:
+    # untestable GLUE inside two files that are otherwise mutated. These are the
+    # function-granular replacement for the `tui/mod.rs` + `runtime/driver.rs`
+    # file exclusions dropped from `exclude_globs`, which is what lets the pure
+    # decision layers in the same files stay in scope. Every fn named here has
+    # ZERO test call sites — production callers only — so nothing exists that
+    # could kill a mutant in it. That is a call-graph fact (`--list` plus a grep
+    # for each name), NOT a claim that a mutation run scored them; re-derive both
+    # before adding a name, and delete a name the moment a test reaches it.
+    'tui/mod\.rs.*(run_tui|focus_clicked_agent|setup_terminal|teardown_terminal|resolve_version_popup)',
+    'runtime/driver\.rs.*replace (run|run_async|headless_loop|compute_boot_capacities) ->',
+    'runtime/driver\.rs.*replace reducer_task with',
 ]

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -20,3 +20,9 @@ jobs:
       - uses: EmbarkStudios/cargo-deny-action@v2.1.1 # explicit pin: the floating @v2 broke 2026-07-13 (v2.1.0 shift-5 ate the subcommand; v2.1.1 fixed same-day) — bump deliberately, not via the tag
         with:
           command: check advisories
+          # A `[advisories] ignore` entry whose crate has left the graph is dead
+          # config, and cargo-deny only WARNS on it ("advisory-not-detected") —
+          # so a shipped upstream fix leaves the ignore rotting behind a green
+          # daily run. Promote it to an error: this cron is the only thing that
+          # checks advisories, so it has to be what notices they went stale.
+          command-arguments: -D advisory-not-detected

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -19,10 +19,7 @@ jobs:
           persist-credentials: false
       - uses: EmbarkStudios/cargo-deny-action@v2.1.1 # explicit pin: the floating @v2 broke 2026-07-13 (v2.1.0 shift-5 ate the subcommand; v2.1.1 fixed same-day) — bump deliberately, not via the tag
         with:
+          # Stale-ignore detection is NOT a flag here: `[advisories]
+          # unused-ignored-advisory = "deny"` in deny.toml owns it, so it holds
+          # for any caller of `check advisories`, not just this cron.
           command: check advisories
-          # A `[advisories] ignore` entry whose crate has left the graph is dead
-          # config, and cargo-deny only WARNS on it ("advisory-not-detected") —
-          # so a shipped upstream fix leaves the ignore rotting behind a green
-          # daily run. Promote it to an error: this cron is the only thing that
-          # checks advisories, so it has to be what notices they went stale.
-          command-arguments: -D advisory-not-detected

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2669,9 +2669,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -4102,9 +4102,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.10"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
 dependencies = [
  "proc-macro2",
  "quick-xml",

--- a/codecov.yml
+++ b/codecov.yml
@@ -59,11 +59,14 @@ ignore:
   - "docs/"
   - "*.md"
   # Not coverable headlessly - exercising these needs a real TTY / OS / display.
-  # `.cargo/mutants.toml` also excludes the painter/glue files below (no headless
-  # test kills their mutants) but NOT crash/logging/sources_cli (pure helpers are
-  # unit-tested), and it additionally excludes some pixtuoid-core probe files not
-  # ignored here - so the two lists OVERLAP, neither is a subset. Keep the shared
-  # painter/glue entries in sync.
+  # `.cargo/mutants.toml` excludes MOST of the painter/glue files below (no
+  # headless test kills their mutants) but NOT crash/logging/sources_cli (pure
+  # helpers are unit-tested), and it additionally excludes some pixtuoid-core
+  # probe files not ignored here - so the two lists OVERLAP, neither is a subset.
+  # It also deliberately MUTATES tui/mod.rs + runtime/driver.rs, which stay
+  # ignored here: both are line-uncoverable in bulk yet carry a unit-tested pure
+  # decision layer, and per-function mutants see that split where per-line
+  # coverage cannot (measurements in that file). Keep the shared entries in sync.
   - "crates/pixtuoid/src/main.rs"               # binary entry: arg-parse + dispatch + terminal preflights
   - "crates/pixtuoid/src/crash.rs"              # panic hook: terminal restore + crash.log (was main.rs; its pure helpers stay unit-tested)
   - "crates/pixtuoid/src/logging.rs"            # global tracing-subscriber init (once per process; was main.rs; pure helpers unit-tested)

--- a/codecov.yml
+++ b/codecov.yml
@@ -63,10 +63,12 @@ ignore:
   # headless test kills their mutants) but NOT crash/logging/sources_cli (pure
   # helpers are unit-tested), and it additionally excludes some pixtuoid-core
   # probe files not ignored here - so the two lists OVERLAP, neither is a subset.
-  # It also deliberately MUTATES tui/mod.rs + runtime/driver.rs, which stay
-  # ignored here: both are line-uncoverable in bulk yet carry a unit-tested pure
-  # decision layer, and per-function mutants see that split where per-line
-  # coverage cannot (measurements in that file). Keep the shared entries in sync.
+  # It also deliberately MUTATES the unit-tested decision layers inside
+  # tui/mod.rs + runtime/driver.rs, which stay WHOLLY ignored here: both are
+  # line-uncoverable in bulk, and per-function mutants see that split where
+  # per-line coverage cannot - so that file excludes their glue by FUNCTION
+  # (exclude_re) rather than by file, and records how far the measurements
+  # actually reach. Keep the shared entries in sync.
   - "crates/pixtuoid/src/main.rs"               # binary entry: arg-parse + dispatch + terminal preflights
   - "crates/pixtuoid/src/crash.rs"              # panic hook: terminal restore + crash.log (was main.rs; its pure helpers stay unit-tested)
   - "crates/pixtuoid/src/logging.rs"            # global tracing-subscriber init (once per process; was main.rs; pure helpers unit-tested)

--- a/deny.toml
+++ b/deny.toml
@@ -1,13 +1,6 @@
 [advisories]
-# Each ignore is Linux-only build-graph exposure with no untrusted input;
-# issue #440 owns removal when upstream releases (full dependency-path
-# traces there; the winit-0.31 route is #441).
+# Issue #440 owns removal when upstream releases.
 ignore = [
-    # quick-xml 0.39 pair, reachable only via wayland-scanner (build-time
-    # codegen over vendored Wayland protocol XML — never attacker input).
-    # Fix needs wayland-rs to release against quick-xml >=0.41.
-    "RUSTSEC-2026-0194",
-    "RUSTSEC-2026-0195",
     # ttf-parser declared unmaintained; only via sctk-adwaita (Linux Wayland
     # CSD titlebar text, local system fonts). Upstream is migrating to skrifa.
     "RUSTSEC-2026-0192",

--- a/deny.toml
+++ b/deny.toml
@@ -1,8 +1,13 @@
 [advisories]
 # Issue #440 owns removal when upstream releases.
 ignore = [
-    # ttf-parser declared unmaintained; only via sctk-adwaita (Linux Wayland
-    # CSD titlebar text, local system fonts). Upstream is migrating to skrifa.
+    # ttf-parser declared unmaintained, and no fixed release exists. It is NOT
+    # the Linux-only sctk-adwaita titlebar route #440's table records: the
+    # primary path is our OWN direct `ab_glyph` dep (crates/pixtuoid/src/aa_text.rs),
+    # so it is in the graph on macOS and Windows too and winit dropping
+    # ab_glyph would NOT clear it. Exposure is nil regardless — the only face
+    # ab_glyph ever parses is the `include_bytes!`-compiled Monaspace Neon,
+    # never a user-supplied font.
     "RUSTSEC-2026-0192",
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,13 +1,25 @@
 [advisories]
-# Issue #440 owns removal when upstream releases.
+# An `ignore` entry whose advisory no longer matches any crate is dead config,
+# and cargo-deny only warns on it — a shipped upstream fix would leave the entry
+# rotting behind a green run. Config, not a CLI flag, so EVERY consumer of
+# `check advisories` enforces it, not just whichever caller remembered to pass
+# `-D advisory-not-detected` (verified against cargo-deny 0.20.2, the version
+# both the local tool and cargo-deny-action's Dockerfile pin).
+unused-ignored-advisory = "deny"
+# Issue #440 tracks dropping this ignore, but there is no upstream release to
+# wait for: RUSTSEC-2026-0192 is `informational = "unmaintained"` with
+# `patched = []`. It clears only when ab_glyph moves off ttf-parser (the
+# advisory points at skrifa) or when we drop ab_glyph.
 ignore = [
-    # ttf-parser declared unmaintained, and no fixed release exists. It is NOT
-    # the Linux-only sctk-adwaita titlebar route #440's table records: the
-    # primary path is our OWN direct `ab_glyph` dep (crates/pixtuoid/src/aa_text.rs),
-    # so it is in the graph on macOS and Windows too and winit dropping
-    # ab_glyph would NOT clear it. Exposure is nil regardless — the only face
-    # ab_glyph ever parses is the `include_bytes!`-compiled Monaspace Neon,
-    # never a user-supplied font.
+    # ttf-parser is unmaintained. It enters the graph by TWO routes, not the one
+    # #440's table records: our OWN direct `ab_glyph` dep (crates/pixtuoid,
+    # rasterizing in src/aa_text.rs) carries it on macOS and Windows as well, and
+    # `sctk-adwaita <- winit` adds the Linux Wayland CSD titlebar. So winit or
+    # sctk-adwaita moving off ab_glyph would NOT clear this row. Neither route
+    # takes attacker input: aa_text parses the one `include_bytes!`-compiled
+    # Monaspace Neon face, and sctk-adwaita parses the local system font fc-match
+    # resolves (or its embedded Cantarell fallback) — on a titlebar our floating
+    # window disables anyway (`with_decorations(false)`).
     "RUSTSEC-2026-0192",
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -3,17 +3,18 @@
 # and cargo-deny only warns on it — a shipped upstream fix would leave the entry
 # rotting behind a green run. Config, not a CLI flag, so EVERY consumer of
 # `check advisories` enforces it, not just whichever caller remembered to pass
-# `-D advisory-not-detected` (verified against cargo-deny 0.20.2, the version
-# both the local tool and cargo-deny-action's Dockerfile pin).
+# `-D advisory-not-detected`. The key needs cargo-deny 0.20.2, which is what
+# cargo-deny-action@v2.1.1's Dockerfile pins — re-check that pin before bumping
+# the action, since an older cargo-deny rejects the whole file over it.
 unused-ignored-advisory = "deny"
 # Issue #440 tracks dropping this ignore, but there is no upstream release to
 # wait for: RUSTSEC-2026-0192 is `informational = "unmaintained"` with
 # `patched = []`. It clears only when ab_glyph moves off ttf-parser (the
 # advisory points at skrifa) or when we drop ab_glyph.
 ignore = [
-    # ttf-parser is unmaintained. It enters the graph by TWO routes, not the one
-    # #440's table records: our OWN direct `ab_glyph` dep (crates/pixtuoid,
-    # rasterizing in src/aa_text.rs) carries it on macOS and Windows as well, and
+    # ttf-parser is unmaintained. It enters the graph by TWO routes, not one:
+    # our OWN direct `ab_glyph` dep (crates/pixtuoid, rasterizing in
+    # src/aa_text.rs) carries it on macOS and Windows as well, and
     # `sctk-adwaita <- winit` adds the Linux Wayland CSD titlebar. So winit or
     # sctk-adwaita moving off ab_glyph would NOT clear this row. Neither route
     # takes attacker input: aa_text parses the one `include_bytes!`-compiled

--- a/justfile
+++ b/justfile
@@ -132,6 +132,19 @@ actionlint-composites:
 # audit catalog; .github/zizmor.yml records the repository's deliberate
 # ref-or-SHA pin policy and every accepted finding is suppressed at its exact
 # source location with a WHY.
+# The operating MODE is env-derived, not chosen here, and the asymmetry is
+# deliberate: tokenless it runs OFFLINE (it says so on stderr) and skips the
+# four audits that need the GitHub API — impostor-commit,
+# known-vulnerable-actions, ref-confusion, stale-action-refs (typosquat-uses
+# still runs, at reduced confidence). ci-lint.yml's hygiene job passes
+# GH_TOKEN, so those DO gate in CI, and a ci-observability rule pins that step
+# so the online half cannot be dropped silently. Same call as `links`
+# (--offline) and `deny` (advisories deferred to audit.yml): a check whose
+# verdict depends on the network and an upstream feed must not redden a push of
+# unchanged code. Do NOT auto-export `gh auth token` to close the gap — it puts
+# a real token on the wire on every pre-push run and makes the local gate
+# depend on gh auth + API rate limits, the exact flakiness those two siblings
+# were written to avoid.
 [group('rust')]
 [doc('Audit GitHub automation security with zizmor')]
 zizmor:

--- a/justfile
+++ b/justfile
@@ -513,7 +513,8 @@ mutants *args:
     if [ -z "$listed" ]; then
         echo "error: the diff vs $base yields ZERO mutants — nothing would be tested." >&2
         echo "  Either there are no .rs changes, or every changed .rs is test code" >&2
-        echo "  or listed in .cargo/mutants.toml exclude_globs." >&2
+        echo "  or excluded by .cargo/mutants.toml (exclude_globs OR exclude_re —" >&2
+        echo "  the latter can empty a file's mutants function by function)." >&2
         echo "  Run from a branch touching mutable production Rust, or set MUTANTS_BASE." >&2
         exit 1
     fi

--- a/justfile
+++ b/justfile
@@ -243,11 +243,18 @@ arch:
     # painters + audio gateway own those. The
     # crate boundary already makes this a COMPILER fact; this pins it at the dep-tree
     # level too (a transitive pull-in via a feature would slip past the boundary).
+    # `--target all` + `--all-features` are LOAD-BEARING, not thoroughness: cargo
+    # tree defaults to the runner's own triple under default features, so a
+    # `[target.'cfg(windows)'.dependencies] crossterm` in pixtuoid-core resolved
+    # green on macOS AND on the ubuntu CI runner — invariant #1 broken on Windows
+    # behind a passing gate, and `just check-windows` compiles it happily because
+    # the dep is legitimate for that target. `--target all` is metadata-only (it
+    # installs nothing), and both crates' feature sets are one flag wide.
     for crate in pixtuoid-core pixtuoid-scene; do
         # Capture first so a cargo-tree ERROR (e.g. a crate rename) kills the
         # recipe via set -e, instead of reading as "no match" inside the if —
         # which would print the green line without having checked anything.
-        deps="$(cargo tree -p "$crate" --edges normal --prefix none)"
+        deps="$(cargo tree -p "$crate" --edges normal --prefix none --target all --all-features)"
         if grep -qE '^(ratatui|crossterm|winit|softbuffer|rodio|cpal)' <<<"$deps"; then
             echo "ARCH VIOLATION: $crate depends on a terminal/window crate (CLAUDE.md invariant #1)"; exit 1
         fi

--- a/justfile
+++ b/justfile
@@ -320,9 +320,23 @@ hack:
     cargo hack --feature-powerset --no-dev-deps check --workspace
 
 # Cross-lint the workspace for Windows (clippy subsumes check; no linking).
+# Same toolchain gotcha as `api-surface` and `wasm-build`, and it bites HARDER
+# here because the compiler's own advice is wrong: a Homebrew cargo ahead of the
+# rustup proxy on PATH ships only the host std, so the cross-lint dies on E0463
+# "can't find crate for `core`" while suggesting `rustup target add
+# x86_64-pc-windows-msvc` for a target rustup already has. Prepending the proxy
+# (a no-op on CI, where it is already first) fixes it; the explicit preflight
+# then owns the genuinely-missing case with an accurate message. This is the
+# documented way to pre-verify a path-string change against `windows-test`,
+# which local preflight is otherwise blind to — so it has to actually run.
 [group('rust')]
 [doc('Cross-lint the workspace for x86_64-pc-windows-msvc via clippy (no linking; ubuntu runner suffices)')]
 check-windows:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:$PATH"
+    rustup target list --toolchain stable --installed | grep -q x86_64-pc-windows-msvc \
+        || { echo "needs the target: rustup target add x86_64-pc-windows-msvc" >&2; exit 1; }
     cargo clippy --workspace --all-targets --target x86_64-pc-windows-msvc -- -D warnings
 
 # Verify the workspace builds on the DECLARED MSRV (rust-version in Cargo.toml).

--- a/justfile
+++ b/justfile
@@ -815,6 +815,7 @@ gen-wasm: gen-wasm-tools wasm-build
 # Bloat + PAIR gate for the committed wasm artifact. Size: the hero must stay
 # a lazy-load behind the poster, so a silent size regression (a dep pulling in
 # formatting machinery, an accidental debug build) fails loudly — 1 MiB raw ≈
+# ~350-400 KB gzipped over the wire, which is where the cap comes from.
 # The artifact is ~900 KB (the recipe prints the exact figure and the headroom
 # left against the cap — read it there rather than trusting this line). Pair (#424): the
 # wasm-bindgen JS glue's ABI must match the exact .wasm it was generated with;
@@ -822,8 +823,18 @@ gen-wasm: gen-wasm-tools wasm-build
 # so every committed file must match gen-wasm's sha256 manifest AND every file
 # must be covered by it. Byte-exact rebuild-match is deliberately NOT checked
 # in CI — wasm output drifts across rustc versions, and CI installs latest
-# stable (local `just gen-wasm` + review is the freshness authority, like the
-# committed demo media).
+# stable, so local `just gen-wasm` + review is the freshness authority. Note
+# what that does and does NOT resemble in the committed demo media: the
+# clips/gif are presence-only for this same non-determinism reason, but the
+# STILLS are re-rendered and pixel-diffed at threshold 0 by gen-check, so media
+# staleness IS mechanically gated and wasm staleness is not. Nothing here reads
+# a scene/core/web source, so a merge that skips `just gen-wasm` ships a stale
+# hero with every gate green; the compensating control is the merge-gate brief
+# (.github/prompts/pr-review.prompt.md, "a scene change stales the wasm"), not
+# this recipe. Input-hash stamping was considered and rejected: most commits
+# under crates/pixtuoid-{core,scene}/src are `native`-gated code the wasm never
+# links, so the gate would demand a ~1 MB binary regen on changes that provably
+# cannot alter it.
 [group('gen')]
 [doc('Fail if the committed wasm pair is missing, over the size cap, or hash-mismatched')]
 gen-wasm-check:

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -26,6 +26,8 @@ zizmor_config_path := ".github/zizmor.yml"
 dependabot_config_path := ".github/dependabot.yml"
 composite_action_root := ".github/actions"
 github_actions_ecosystem := "github-actions"
+lint_workflow_path := ".github/workflows/ci-lint.yml"
+zizmor_recipe := "just zizmor"
 cache_cleanup_workflow_path := ".github/workflows/cache-cleanup.yml"
 claude_action := "anthropics/claude-code-action@v1"
 json_schema_flag := "--json-schema"
@@ -1141,6 +1143,24 @@ deny contains msg if {
 	directory := dependabot_directory(entry.path)
 	not dependabot_covers(directory)
 	msg := sprintf("%s must list a github-actions directory covering %s: %s is otherwise invisible to Dependabot", [dependabot_config_path, directory, entry.uses])
+}
+
+# zizmor picks its operating mode from ambient env, not from the recipe: with no
+# token it runs OFFLINE and silently skips impostor-commit,
+# known-vulnerable-actions, ref-confusion and stale-action-refs. The local gate
+# is tokenless on purpose (see the justfile recipe's WHY), so this step is the
+# ONLY place those four ever run — dropping its env would retire them
+# repository-wide while every gate stayed green. actionlint cannot express
+# "this step's env is load-bearing for that recipe's coverage".
+deny contains msg if {
+	some job_name, job in object.get(documents[lint_workflow_path], "jobs", {})
+	some step in object.get(job, "steps", [])
+	object.get(step, "run", "") == zizmor_recipe
+	object.get(object.get(step, "env", {}), "GH_TOKEN", "") == ""
+	msg := sprintf(
+		"%s job %q must pass GH_TOKEN to `%s` — its four online audits run nowhere else",
+		[lint_workflow_path, job_name, zizmor_recipe],
+	)
 }
 
 deny contains msg if {

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -28,6 +28,7 @@ composite_action_root := ".github/actions"
 github_actions_ecosystem := "github-actions"
 lint_workflow_path := ".github/workflows/ci-lint.yml"
 zizmor_recipe := "just zizmor"
+github_token_env := "GH_TOKEN"
 cache_cleanup_workflow_path := ".github/workflows/cache-cleanup.yml"
 claude_action := "anthropics/claude-code-action@v1"
 json_schema_flag := "--json-schema"
@@ -282,6 +283,28 @@ pinned_npm_setup_steps(path, job_name) := [step |
 	object.get(step, "if", null) == null
 	object.get(step, "continue-on-error", false) == false
 ]
+
+# GitHub layers a step's environment workflow < job < step, so the token is
+# equally live wherever it is declared and hoisting it to the job is a valid
+# refactor. The nearest DECLARATION wins even when its value is empty, which is
+# why these arms are mutually exclusive rather than an any-of: a step-level
+# `GH_TOKEN: ""` shadows the job's token and puts zizmor back offline.
+effective_gh_token(_, _, step) := token if {
+	token := object.get(step, ["env", github_token_env], null)
+	token != null
+}
+
+effective_gh_token(_, job, step) := token if {
+	object.get(step, ["env", github_token_env], null) == null
+	token := object.get(job, ["env", github_token_env], null)
+	token != null
+}
+
+effective_gh_token(workflow, job, step) := token if {
+	object.get(step, ["env", github_token_env], null) == null
+	object.get(job, ["env", github_token_env], null) == null
+	token := object.get(workflow, ["env", github_token_env], "")
+}
 
 codecov_uploads := [entry |
 	some entry in uses_entries
@@ -1153,13 +1176,14 @@ deny contains msg if {
 # repository-wide while every gate stayed green. actionlint cannot express
 # "this step's env is load-bearing for that recipe's coverage".
 deny contains msg if {
-	some job_name, job in object.get(documents[lint_workflow_path], "jobs", {})
+	workflow := documents[lint_workflow_path]
+	some job_name, job in object.get(workflow, "jobs", {})
 	some step in object.get(job, "steps", [])
 	object.get(step, "run", "") == zizmor_recipe
-	object.get(object.get(step, "env", {}), "GH_TOKEN", "") == ""
+	effective_gh_token(workflow, job, step) == ""
 	msg := sprintf(
-		"%s job %q must pass GH_TOKEN to `%s` — its four online audits run nowhere else",
-		[lint_workflow_path, job_name, zizmor_recipe],
+		"%s job %q must give `%s` a non-empty %s — GitHub layers step env over job env over workflow env, so declaring it at any one of the three is enough; tokenless, zizmor drops to offline and silently skips impostor-commit, known-vulnerable-actions, ref-confusion and stale-action-refs, which run nowhere else",
+		[lint_workflow_path, job_name, zizmor_recipe, github_token_env],
 	)
 }
 

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -284,11 +284,17 @@ pinned_npm_setup_steps(path, job_name) := [step |
 	object.get(step, "continue-on-error", false) == false
 ]
 
-# GitHub layers a step's environment workflow < job < step, so the token is
-# equally live wherever it is declared and hoisting it to the job is a valid
-# refactor. The nearest DECLARATION wins even when its value is empty, which is
-# why these arms are mutually exclusive rather than an any-of: a step-level
-# `GH_TOKEN: ""` shadows the job's token and puts zizmor back offline.
+# `run: just zizmor` and its `run: |` block-scalar twin differ only by the
+# trailing newline yq preserves — the same command either way, so matching the
+# raw string would report a rename that never happened.
+runs_zizmor(step) if trim_space(object.get(step, "run", "")) == zizmor_recipe
+
+# GitHub layers a step's environment workflow < job < step and "uses the most
+# specific variable" (workflow-syntax reference, `env`), so the token is equally
+# live wherever it is declared and hoisting it to the job is a valid refactor.
+# The nearest DECLARATION wins even when its value is empty, which is why these
+# arms are mutually exclusive rather than an any-of: a step-level `GH_TOKEN: ""`
+# shadows the job's token and puts zizmor back offline.
 effective_gh_token(_, _, step) := token if {
 	token := object.get(step, ["env", github_token_env], null)
 	token != null
@@ -305,6 +311,20 @@ effective_gh_token(workflow, job, step) := token if {
 	object.get(job, ["env", github_token_env], null) == null
 	token := object.get(workflow, ["env", github_token_env], "")
 }
+
+# One entry per LIVE `just zizmor` invocation, carrying the token GitHub would
+# actually place in that step's environment. A conditional or continue-on-error
+# step is not a live invocation — it reaches green without auditing anything.
+zizmor_invocations(path) := [{"job": job_name, "token": effective_gh_token(workflow, job, step)} |
+	workflow := documents[path]
+	some job_name, job in object.get(workflow, "jobs", {})
+	object.get(job, "if", null) == null
+	object.get(job, "continue-on-error", false) == false
+	some step in object.get(job, "steps", [])
+	runs_zizmor(step)
+	object.get(step, "if", null) == null
+	object.get(step, "continue-on-error", false) == false
+]
 
 codecov_uploads := [entry |
 	some entry in uses_entries
@@ -1175,15 +1195,26 @@ deny contains msg if {
 # ONLY place those four ever run — dropping its env would retire them
 # repository-wide while every gate stayed green. actionlint cannot express
 # "this step's env is load-bearing for that recipe's coverage".
+# Two halves, because the property rule alone retires itself: it is keyed on the
+# step it describes, so any edit that stops the match — a renamed recipe, an
+# `if:`, a continue-on-error — makes it vacuously true and the missing env
+# invisible again. The count rule is the existence half; it fires when the step
+# this policy is about stops being there to check.
 deny contains msg if {
-	workflow := documents[lint_workflow_path]
-	some job_name, job in object.get(workflow, "jobs", {})
-	some step in object.get(job, "steps", [])
-	object.get(step, "run", "") == zizmor_recipe
-	effective_gh_token(workflow, job, step) == ""
+	invocations := zizmor_invocations(lint_workflow_path)
+	count(invocations) != 1
+	msg := sprintf(
+		"%s must run `%s` in exactly one step that nothing skips or softens — no `if:` or continue-on-error on either the step or its job — found %d; restore that step, or retarget this policy's zizmor_recipe if the recipe was genuinely renamed, because zizmor's four online audits run nowhere else",
+		[lint_workflow_path, zizmor_recipe, count(invocations)],
+	)
+}
+
+deny contains msg if {
+	some invocation in zizmor_invocations(lint_workflow_path)
+	invocation.token == ""
 	msg := sprintf(
 		"%s job %q must give `%s` a non-empty %s — GitHub layers step env over job env over workflow env, so declaring it at any one of the three is enough; tokenless, zizmor drops to offline and silently skips impostor-commit, known-vulnerable-actions, ref-confusion and stale-action-refs, which run nowhere else",
-		[lint_workflow_path, job_name, zizmor_recipe, github_token_env],
+		[lint_workflow_path, invocation.job, zizmor_recipe, github_token_env],
 	)
 }
 

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -545,6 +545,32 @@ test_zizmor_pin_policy_cannot_be_tightened_or_disabled_silently if {
 	sprintf("%s must require every action to use a symbolic ref or SHA", [zizmor_config_path]) in violations
 }
 
+zizmor_token_message(job_name) := sprintf(
+	"%s job %q must pass GH_TOKEN to `%s` — its four online audits run nowhere else",
+	[lint_workflow_path, job_name, zizmor_recipe],
+)
+
+test_zizmor_online_audits_cannot_be_retired_by_dropping_the_token if {
+	fixture := {"documents": [{
+		"path": lint_workflow_path,
+		"contents": {"jobs": {"hygiene": {"steps": [{"run": "just zizmor"}]}}},
+	}]}
+	violations := deny with input as fixture
+	zizmor_token_message("hygiene") in violations
+}
+
+test_zizmor_step_carrying_the_token_is_silent if {
+	fixture := {"documents": [{
+		"path": lint_workflow_path,
+		"contents": {"jobs": {"hygiene": {"steps": [{
+			"run": "just zizmor",
+			"env": {"GH_TOKEN": "${{ github.token }}"},
+		}]}}},
+	}]}
+	violations := deny with input as fixture
+	not zizmor_token_message("hygiene") in violations
+}
+
 test_cache_cleanup_cannot_execute_pull_request_code if {
 	fixture := {"documents": [{
 		"path": cache_cleanup_workflow_path,

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -552,6 +552,11 @@ zizmor_token_message(job_name) := sprintf(
 	[lint_workflow_path, job_name, zizmor_recipe, github_token_env],
 )
 
+zizmor_presence_message(found) := sprintf(
+	"%s must run `%s` in exactly one step that nothing skips or softens — no `if:` or continue-on-error on either the step or its job — found %d; restore that step, or retarget this policy's zizmor_recipe if the recipe was genuinely renamed, because zizmor's four online audits run nowhere else",
+	[lint_workflow_path, zizmor_recipe, found],
+)
+
 test_zizmor_online_audits_cannot_be_retired_by_dropping_the_token if {
 	fixture := zizmor_fixture({"jobs": {"hygiene": {"steps": [{"run": "just zizmor"}]}}})
 	violations := deny with input as fixture
@@ -597,6 +602,64 @@ test_zizmor_step_blanking_an_inherited_token_still_fires if {
 		"env": {"GH_TOKEN": "${{ github.token }}"},
 		"steps": [{"run": "just zizmor", "env": {"GH_TOKEN": ""}}],
 	}}})
+	violations := deny with input as fixture
+	zizmor_token_message("hygiene") in violations
+}
+
+# The existence half. Without it the token rule is keyed on a step it can no
+# longer find, so it passes by matching nothing at all.
+test_zizmor_cannot_be_retired_by_renaming_the_recipe if {
+	fixture := zizmor_fixture({"jobs": {"hygiene": {"steps": [{
+		"run": "just zizmor --fix",
+		"env": {"GH_TOKEN": "${{ github.token }}"},
+	}]}}})
+	violations := deny with input as fixture
+	zizmor_presence_message(0) in violations
+}
+
+# A skipped or soft-failing step reaches green without auditing anything, and a
+# guard on the JOB retires it just as completely as one on the step — so all
+# four positions have to count, not just the two on the step.
+test_zizmor_cannot_be_retired_by_guarding_or_softening_the_step_or_its_job if {
+	tokened_step := {"run": "just zizmor", "env": {"GH_TOKEN": "${{ github.token }}"}}
+	guard := "${{ github.event_name == 'schedule' }}"
+
+	retirements := [
+		{"jobs": {"hygiene": {"steps": [object.union(tokened_step, {"if": guard})]}}},
+		{"jobs": {"hygiene": {"steps": [object.union(tokened_step, {"continue-on-error": true})]}}},
+		{"jobs": {"hygiene": {"if": guard, "steps": [tokened_step]}}},
+		{"jobs": {"hygiene": {"continue-on-error": true, "steps": [tokened_step]}}},
+	]
+
+	every contents in retirements {
+		zizmor_presence_message(0) in deny with input as zizmor_fixture(contents)
+	}
+}
+
+test_zizmor_running_in_two_jobs_is_denied if {
+	fixture := zizmor_fixture({"jobs": {
+		"hygiene": {"steps": [{"run": "just zizmor", "env": {"GH_TOKEN": "${{ github.token }}"}}]},
+		"security": {"steps": [{"run": "just zizmor", "env": {"GH_TOKEN": "${{ github.token }}"}}]},
+	}})
+	violations := deny with input as fixture
+	zizmor_presence_message(2) in violations
+}
+
+# A `run: |` block scalar is the same command with the newline yq preserves.
+# Matching the raw string would report a rename that never happened AND blind
+# the token half, so the existence rule must stay silent here.
+test_zizmor_block_scalar_invocation_is_silent if {
+	fixture := zizmor_fixture({"jobs": {"hygiene": {"steps": [{
+		"run": "just zizmor\n",
+		"env": {"GH_TOKEN": "${{ github.token }}"},
+	}]}}})
+	violations := deny with input as fixture
+	not zizmor_presence_message(0) in violations
+	not zizmor_token_message("hygiene") in violations
+}
+
+test_zizmor_block_scalar_invocation_still_needs_the_token if {
+	fixture := zizmor_fixture({"jobs": {"hygiene": {"steps": [{"run": "just zizmor\n"}]}}})
 	violations := deny with input as fixture
 	zizmor_token_message("hygiene") in violations
 }

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -545,30 +545,60 @@ test_zizmor_pin_policy_cannot_be_tightened_or_disabled_silently if {
 	sprintf("%s must require every action to use a symbolic ref or SHA", [zizmor_config_path]) in violations
 }
 
+zizmor_fixture(contents) := {"documents": [{"path": lint_workflow_path, "contents": contents}]}
+
 zizmor_token_message(job_name) := sprintf(
-	"%s job %q must pass GH_TOKEN to `%s` — its four online audits run nowhere else",
-	[lint_workflow_path, job_name, zizmor_recipe],
+	"%s job %q must give `%s` a non-empty %s — GitHub layers step env over job env over workflow env, so declaring it at any one of the three is enough; tokenless, zizmor drops to offline and silently skips impostor-commit, known-vulnerable-actions, ref-confusion and stale-action-refs, which run nowhere else",
+	[lint_workflow_path, job_name, zizmor_recipe, github_token_env],
 )
 
 test_zizmor_online_audits_cannot_be_retired_by_dropping_the_token if {
-	fixture := {"documents": [{
-		"path": lint_workflow_path,
-		"contents": {"jobs": {"hygiene": {"steps": [{"run": "just zizmor"}]}}},
-	}]}
+	fixture := zizmor_fixture({"jobs": {"hygiene": {"steps": [{"run": "just zizmor"}]}}})
 	violations := deny with input as fixture
 	zizmor_token_message("hygiene") in violations
 }
 
 test_zizmor_step_carrying_the_token_is_silent if {
-	fixture := {"documents": [{
-		"path": lint_workflow_path,
-		"contents": {"jobs": {"hygiene": {"steps": [{
-			"run": "just zizmor",
-			"env": {"GH_TOKEN": "${{ github.token }}"},
-		}]}}},
-	}]}
+	fixture := zizmor_fixture({"jobs": {"hygiene": {"steps": [{
+		"run": "just zizmor",
+		"env": {"GH_TOKEN": "${{ github.token }}"},
+	}]}}})
 	violations := deny with input as fixture
 	not zizmor_token_message("hygiene") in violations
+}
+
+# The legitimate variant nobody writes a test for: hoisting the token to the job
+# once a second step in that job needs it changes nothing about what zizmor
+# sees, so a rule that denies it would order the maintainer to undo a valid
+# refactor while wearing a required gate's authority.
+test_zizmor_step_inheriting_a_job_level_token_is_silent if {
+	fixture := zizmor_fixture({"jobs": {"hygiene": {
+		"env": {"GH_TOKEN": "${{ github.token }}"},
+		"steps": [{"run": "just zizmor"}],
+	}}})
+	violations := deny with input as fixture
+	not zizmor_token_message("hygiene") in violations
+}
+
+test_zizmor_step_inheriting_a_workflow_level_token_is_silent if {
+	fixture := zizmor_fixture({
+		"env": {"GH_TOKEN": "${{ github.token }}"},
+		"jobs": {"hygiene": {"steps": [{"run": "just zizmor"}]}},
+	})
+	violations := deny with input as fixture
+	not zizmor_token_message("hygiene") in violations
+}
+
+# The nearest DECLARATION wins even when it is empty, so accepting inheritance
+# must not degrade into "a token exists somewhere": a step-level blank shadows
+# the job's token and puts zizmor back offline.
+test_zizmor_step_blanking_an_inherited_token_still_fires if {
+	fixture := zizmor_fixture({"jobs": {"hygiene": {
+		"env": {"GH_TOKEN": "${{ github.token }}"},
+		"steps": [{"run": "just zizmor", "env": {"GH_TOKEN": ""}}],
+	}}})
+	violations := deny with input as fixture
+	zizmor_token_message("hygiene") in violations
 }
 
 test_cache_cleanup_cannot_execute_pull_request_code if {


### PR DESCRIPTION
Fixes 14 confirmed audit defects in `justfile` / `deny.toml` / `.cargo` / policy.

Two zizmor policy rules were structurally broken: one **false-fired** on a legitimate variant (`GH_TOKEN` declared at job or workflow level is env-equivalent for the step), and the other had **no existence half**, so changing the `run:` string retired it vacuously — silently green while checking nothing. Both now test both directions.

Verified against primary sources rather than memory: GitHub's own workflow-syntax reference on env precedence (which showed the reviewer's suggested fix was *wrong* — a step-level `GH_TOKEN: ""` shadows a job token), and `yq` itself for block-scalar behaviour. Two stale quick-xml advisory ignores dropped now the upstream fix shipped; `just arch` resolves every target and feature rather than only the runner's own.

### Commits

- `6f0c0b92` fix(policy): give the zizmor rule an existence half so it cannot retire itself
- `d8e35ff3` fix(policy): read the zizmor token the way GitHub resolves it, not step-only
- `2428579f` docs(deny): stop describing #440's table now that #440's table is fixed
- `74154130` docs(mutants): finish the sweep for exclusions that are no longer path-only
- `63170cbc` test(mutants): narrow e6491b4a's claim to what was run, exclude the glue by function
- `e09542aa` fix(deny): restore the ttf-parser route 8db35b7b deleted, own stale-ignore in config
- `7de2061f` docs(just): repair the wasm gate's truncated cap rationale and media analogy
- `720de8cc` fix(ci): pin the CI half of zizmor's online audits, document the local half
- `71f59808` fix(just): make check-windows runnable on a Homebrew-cargo PATH
- `819c1984` fix(arch): resolve every target and feature, not just the runner's own
- `e6491b4a` test(mutants): stop excluding the two files whose mutants tests do kill
- `8a06f63d` ci(audit): fail the daily advisory run on a stale ignore
- `8db35b7b` docs(deny): correct the ttf-parser advisory's dependency path and platform
- `9599d951` fix(deps): take the shipped quick-xml fix and drop the two stale ignores

---

### Provenance

Part of a whole-codebase audit (13 branches, 136 commits). Pipeline: 11 subsystem
finders + 8 whole-tree specialist sweeps + loop-until-dry security/concurrency
hunts → 312 raw findings → adversarial skeptics (default REFUTE, 3 differentiated
lenses on HIGH/security/concurrency) → **108 distinct confirmed defects** (35%
refutation rate, stable across two rounds) → fixes → a two-lens merge review per
branch plus trigger-driven escalation lenses → a fix round on that review's
findings.

Every defect has exactly one terminal state: **181 FIXED · 8 REFUTED-with-citation
· 12 ISSUE-NEEDED** (filed: #799 #800 #802 #803 #804).

### Composition verified

All 13 branches were merged together in a throwaway worktree and gated as one tree
— the step no per-branch review can perform:

- `just preflight` → **exit 0** (13 lint sub-gates → clippy → hack → **2,795 tests passed**)
- `just site-check` · `just site-e2e` (96) · `just ci-observability` (107 Rego + 108 conftest) → all exit 0

That pass found **5 genuine cross-branch contradictions** in prose that merged
cleanly — e.g. one branch documenting a sweep as "per-frame" while another had
memoized it. Resolved against the merged code, not mechanically.

### Merge order

Measured, not inferred: `site → ci-tooling → tui → bin-runtime → scene-painter →
core → scene-sim → ci-policy → bin-install → docs → scripts` (+ `hook-docs`,
`consumer-gaps`, independent). Each branch is individually clean against `main`;
later ones may need a rebase once earlier ones land. Known collision points:
`crates/pixtuoid/CLAUDE.md` (5 branches), `crates/pixtuoid-core/CLAUDE.md` (4),
`policy/ci-observability/main.rego` (2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
