### PR TITLE
fix(scripts): squattable e2e sockets and a PATH-resolved replay binary

### DIFF
--- a/scripts/openclaw-cc-backend-e2e.sh
+++ b/scripts/openclaw-cc-backend-e2e.sh
@@ -5,7 +5,7 @@
 # bundled `claude-cli` backend coding session renders as a full-fidelity `cc·`
 # desk sprite. One headless scene, two sources, two sprites:
 #
-#   agents=[… cc·<workspace>@N …] daemons=[openclaw@18789:busy]
+#   agents=[… cc·<workspace>@N …] daemons=[openclaw@<port>:busy]
 #
 # Flow:
 #   1. headless pixtuoid binds an ISOLATED socket + watches ~/.claude/projects
@@ -65,25 +65,49 @@ done
     echo "no $PROJECTS — has Claude Code ever run on this machine?" >&2
     exit 2
 }
+# The port THIS run's gateway will bind. The assertions below deliberately match
+# the `openclaw@` prefix because the user's config need not resolve the default —
+# so the conflict guard and the cleanup reap have to resolve it the same way
+# instead of pinning the default, or on a non-default box the guard passes while a
+# gateway IS running and the reap leaks the one we started. Falls back to the ONE
+# in-repo copy of OpenClaw's default (the plugin template's DEFAULT_GATEWAY_PORT,
+# the same literal check_upstream_drift.py compares against upstream) rather than
+# a second hardcoded number. Env overrides are NOT mirrored — that would mean
+# re-implementing upstream's `parseGatewayPortEnvValue` in shell.
+PORT="$(openclaw config get gateway.port 2>/dev/null | tr -d '" ' | tail -1)"
+case "$PORT" in
+'' | *[!0-9]*)
+    PORT="$(sed -n 's/^const DEFAULT_GATEWAY_PORT = \([0-9][0-9]*\);.*/\1/p' \
+        "$REPO/crates/pixtuoid/src/install/openclaw_plugin.js")"
+    ;;
+esac
+[ -n "$PORT" ] || {
+    echo "could not resolve the gateway port (openclaw config, nor openclaw_plugin.js)" >&2
+    exit 2
+}
+
 # Don't fight an already-running gateway: its plugin uses ITS env's socket, so we
 # could not isolate. Bail rather than --force-kill the user's gateway.
-if lsof -nP -iTCP:18789 -sTCP:LISTEN >/dev/null 2>&1; then
-    echo "a gateway is already listening on :18789 — stop it first (this test starts its own)" >&2
+if lsof -nP -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+    echo "a gateway is already listening on :$PORT — stop it first (this test starts its own)" >&2
     exit 2
 fi
 
 cleanup() {
     [ -n "$GWPID" ] && kill "$GWPID" 2>/dev/null
-    pkill -f 'openclaw gateway run' 2>/dev/null
     # `openclaw gateway run` execs/forks a child node that holds the port — killing
-    # the CLI wrapper alone LEAKS it. Kill whatever actually LISTENS on :18789
+    # the CLI wrapper alone LEAKS it. Kill whatever actually LISTENS on OUR port
     # (TERM, then KILL), so the user's machine isn't left with a stray gateway.
+    # Reaping by port, not by `pkill -f 'openclaw gateway run'`: that pattern kills
+    # EVERY gateway on the box, including one on another port that the guard above
+    # never checked and this script never started. Same job-pid + port-listener
+    # pair the sibling openclaw-multi-gateway-e2e.sh uses.
     local port_pids
-    port_pids="$(lsof -ti tcp:18789 -sTCP:LISTEN 2>/dev/null)"
+    port_pids="$(lsof -ti tcp:"$PORT" -sTCP:LISTEN 2>/dev/null)"
     # shellcheck disable=SC2086  # word-split is intended — one kill per listener pid
     [ -n "$port_pids" ] && kill $port_pids 2>/dev/null
     sleep 1
-    port_pids="$(lsof -ti tcp:18789 -sTCP:LISTEN 2>/dev/null)"
+    port_pids="$(lsof -ti tcp:"$PORT" -sTCP:LISTEN 2>/dev/null)"
     # shellcheck disable=SC2086  # word-split is intended — one kill per listener pid
     [ -n "$port_pids" ] && kill -9 $port_pids 2>/dev/null
     [ -n "$PIXPID" ] && kill "$PIXPID" 2>/dev/null

--- a/scripts/openclaw-cc-backend-e2e.sh
+++ b/scripts/openclaw-cc-backend-e2e.sh
@@ -41,8 +41,7 @@ CFGDIR="$(mktemp -d)"
 # temp dir: a fixed name makes two concurrent runs bind/`rm` each other's socket,
 # and on a shared /tmp it is pre-plantable by another user (nothing downstream
 # polices it — `ensure_owned_socket_dir` in hook/unix.rs deliberately leaves an
-# explicit PIXTUOID_SOCKET path alone). Same shape as replay-fixture.sh and the
-# sibling openclaw-multi-gateway-e2e.sh.
+# explicit PIXTUOID_SOCKET path alone).
 SOCKDIR="$(mktemp -d)"
 SOCK="$SOCKDIR/pixtuoid.sock"
 PIXLOG="$(mktemp)"
@@ -93,17 +92,13 @@ if lsof -nP -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1; then
     exit 2
 fi
 
+# Reaps the gateway by job pid AND by listening port: `$!` is the listener on
+# openclaw 2026.7.1, so the pid kill normally suffices, but a version that
+# daemonises — or a kill that failed — would leak the port. The port reap is
+# scoped to OUR resolved port, never `pkill -f 'openclaw gateway run'`, which
+# would kill a gateway this script never started.
 cleanup() {
     [ -n "$GWPID" ] && kill "$GWPID" 2>/dev/null
-    # Belt-and-braces port reap (TERM, then KILL). `$!` IS the listener on openclaw
-    # 2026.7.1 (verified: the job pid holds the port, comm `openclaw-gateway`, no
-    # children), so the kill above is normally enough — this catches a version that
-    # daemonises instead, or a gateway that outlived a failed kill, so the user's
-    # machine isn't left with a stray gateway. Scoped to OUR resolved port, never
-    # `pkill -f 'openclaw gateway run'`: that pattern matches nothing today (the
-    # gateway rewrites its process title) and, if upstream ever stopped, would kill
-    # EVERY gateway on the box — including one this script never started. Same
-    # job-pid + port-listener pair the sibling openclaw-multi-gateway-e2e.sh uses.
     local port_pids
     port_pids="$(lsof -ti tcp:"$PORT" -sTCP:LISTEN 2>/dev/null)"
     # shellcheck disable=SC2086  # word-split is intended — one kill per listener pid

--- a/scripts/openclaw-cc-backend-e2e.sh
+++ b/scripts/openclaw-cc-backend-e2e.sh
@@ -35,9 +35,16 @@ set -uo pipefail
 
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PIX="$REPO/target/release/pixtuoid"
-SOCK="${TMPDIR:-/tmp}/pixtuoid-openclaw-cc-e2e.sock"
 PROJECTS="$HOME/.claude/projects"
 CFGDIR="$(mktemp -d)"
+# The socket lives inside a PRIVATE 0700 dir, never as a fixed name in the shared
+# temp dir: a fixed name makes two concurrent runs bind/`rm` each other's socket,
+# and on a shared /tmp it is pre-plantable by another user (nothing downstream
+# polices it — `ensure_owned_socket_dir` in hook/unix.rs deliberately leaves an
+# explicit PIXTUOID_SOCKET path alone). Same shape as replay-fixture.sh and the
+# sibling openclaw-multi-gateway-e2e.sh.
+SOCKDIR="$(mktemp -d)"
+SOCK="$SOCKDIR/pixtuoid.sock"
 PIXLOG="$(mktemp)"
 GWLOG="$(mktemp)"
 AGENTLOG="$(mktemp)"
@@ -80,11 +87,10 @@ cleanup() {
     # shellcheck disable=SC2086  # word-split is intended — one kill per listener pid
     [ -n "$port_pids" ] && kill -9 $port_pids 2>/dev/null
     [ -n "$PIXPID" ] && kill "$PIXPID" 2>/dev/null
-    rm -f "$SOCK" "$PIXLOG" "$GWLOG" "$AGENTLOG"
-    rm -rf "$CFGDIR"
+    rm -f "$PIXLOG" "$GWLOG" "$AGENTLOG"
+    rm -rf "$CFGDIR" "$SOCKDIR"
 }
 trap cleanup EXIT
-rm -f "$SOCK"
 
 # The backend's `cc·` label is the openclaw agent WORKSPACE's cwd basename (the
 # claude-cli backend runs there → its transcript keys on that cwd). Naming the

--- a/scripts/openclaw-cc-backend-e2e.sh
+++ b/scripts/openclaw-cc-backend-e2e.sh
@@ -95,13 +95,15 @@ fi
 
 cleanup() {
     [ -n "$GWPID" ] && kill "$GWPID" 2>/dev/null
-    # `openclaw gateway run` execs/forks a child node that holds the port — killing
-    # the CLI wrapper alone LEAKS it. Kill whatever actually LISTENS on OUR port
-    # (TERM, then KILL), so the user's machine isn't left with a stray gateway.
-    # Reaping by port, not by `pkill -f 'openclaw gateway run'`: that pattern kills
-    # EVERY gateway on the box, including one on another port that the guard above
-    # never checked and this script never started. Same job-pid + port-listener
-    # pair the sibling openclaw-multi-gateway-e2e.sh uses.
+    # Belt-and-braces port reap (TERM, then KILL). `$!` IS the listener on openclaw
+    # 2026.7.1 (verified: the job pid holds the port, comm `openclaw-gateway`, no
+    # children), so the kill above is normally enough — this catches a version that
+    # daemonises instead, or a gateway that outlived a failed kill, so the user's
+    # machine isn't left with a stray gateway. Scoped to OUR resolved port, never
+    # `pkill -f 'openclaw gateway run'`: that pattern matches nothing today (the
+    # gateway rewrites its process title) and, if upstream ever stopped, would kill
+    # EVERY gateway on the box — including one this script never started. Same
+    # job-pid + port-listener pair the sibling openclaw-multi-gateway-e2e.sh uses.
     local port_pids
     port_pids="$(lsof -ti tcp:"$PORT" -sTCP:LISTEN 2>/dev/null)"
     # shellcheck disable=SC2086  # word-split is intended — one kill per listener pid

--- a/scripts/openclaw-live-e2e.sh
+++ b/scripts/openclaw-live-e2e.sh
@@ -26,10 +26,17 @@ set -uo pipefail
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PIX="$REPO/target/release/pixtuoid"
 HOOK="$REPO/target/release/pixtuoid-hook"
-SOCK="${TMPDIR:-/tmp}/pixtuoid-openclaw-e2e.sock"
 OUT="$(mktemp)"
 PROJ="$(mktemp -d)"
 CFGDIR="$(mktemp -d)"
+# The socket lives inside a PRIVATE 0700 dir, never as a fixed name in the shared
+# temp dir: a fixed name makes two concurrent runs bind/`rm` each other's socket,
+# and on a shared /tmp it is pre-plantable by another user (nothing downstream
+# polices it — `ensure_owned_socket_dir` in hook/unix.rs deliberately leaves an
+# explicit PIXTUOID_SOCKET path alone). Same shape as replay-fixture.sh and the
+# sibling openclaw-multi-gateway-e2e.sh.
+SOCKDIR="$(mktemp -d)"
+SOCK="$SOCKDIR/pixtuoid.sock"
 PIXPID=""
 
 for bin in "$PIX" "$HOOK"; do
@@ -46,11 +53,10 @@ cleanup() {
     for p in "${SPID:-}" "${APID:-}" "${BPID:-}"; do
         [ -n "$p" ] && kill "$p" 2>/dev/null
     done
-    rm -f "$SOCK" "$OUT"
-    rm -rf "$PROJ" "$CFGDIR"
+    rm -f "$OUT"
+    rm -rf "$PROJ" "$CFGDIR" "$SOCKDIR"
 }
 trap cleanup EXIT
-rm -f "$SOCK"
 
 # Self-contained: an ISOLATED config (via XDG_CONFIG_HOME) that marks OpenClaw
 # connected — the reducer's presence connection-gate drops every delta for a

--- a/scripts/openclaw-live-e2e.sh
+++ b/scripts/openclaw-live-e2e.sh
@@ -33,8 +33,7 @@ CFGDIR="$(mktemp -d)"
 # temp dir: a fixed name makes two concurrent runs bind/`rm` each other's socket,
 # and on a shared /tmp it is pre-plantable by another user (nothing downstream
 # polices it — `ensure_owned_socket_dir` in hook/unix.rs deliberately leaves an
-# explicit PIXTUOID_SOCKET path alone). Same shape as replay-fixture.sh and the
-# sibling openclaw-multi-gateway-e2e.sh.
+# explicit PIXTUOID_SOCKET path alone).
 SOCKDIR="$(mktemp -d)"
 SOCK="$SOCKDIR/pixtuoid.sock"
 PIXPID=""

--- a/scripts/openclaw-multi-gateway-e2e.sh
+++ b/scripts/openclaw-multi-gateway-e2e.sh
@@ -150,18 +150,28 @@ while read -r port; do
 done < <(printf '%s\n' "${PORTS[@]}" | LC_ALL=C sort)
 expect_line "daemons=[$want]" "${#PORTS[@]} gateways render ${#PORTS[@]} independent mascots"
 
-echo "[2] kill the FIRST gateway (${PORTS[0]}) — only its own mascot walks out"
-# `$!` is the process that holds the port and stamps `_pid` into every envelope, so
-# this exercises the INSTANT abrupt-down rung (ExitWatch on the gateway pid), not a
-# timeout. That the assertion below can pass at all is the proof: `expect_line` gives
-# up after ~36s while the silence path (`PresenceTtl::DEFAULT.presence_ttl_ms`) is
-# FIVE MINUTES, so a regression that lost the pid rung could not sneak through here.
-kill "${GW_PIDS[0]}" 2>/dev/null
-GW_PIDS[0]=""
-expect_line "openclaw@${PORTS[0]}:down" "the killed gateway goes down (instant pid rung)"
-for port in "${PORTS[@]:1}"; do
-    expect_line "openclaw@$port:idle" "sibling $port is untouched"
-done
+# Step [1] is a hard PRECONDITION for step [2], not just another assertion.
+# `expect_line` matches a substring of the LATEST line, so a gateway that has not
+# announced yet satisfies "sibling $port is untouched" on its FIRST-EVER announce —
+# which, after a step-[1] timeout, lands AFTER the kill. Observed: one slow start
+# printed `1 FAIL / 4 PASS` where three of those PASSes were vacuous, reading as
+# "instance-local death mostly works" when the precondition never held.
+if [ "$FAILED" != 0 ]; then
+    echo "  SKIP [2] — not every gateway announced; the instance-local assertions would be vacuous" >&2
+else
+    echo "[2] kill the FIRST gateway (${PORTS[0]}) — only its own mascot walks out"
+    # `$!` is the process that holds the port and stamps `_pid` into every envelope, so
+    # this exercises the INSTANT abrupt-down rung (ExitWatch on the gateway pid), not a
+    # timeout. That the assertion below can pass at all is the proof: `expect_line` gives
+    # up after ~36s while the silence path (`PresenceTtl::DEFAULT.presence_ttl_ms`) is
+    # FIVE MINUTES, so a regression that lost the pid rung could not sneak through here.
+    kill "${GW_PIDS[0]}" 2>/dev/null
+    GW_PIDS[0]=""
+    expect_line "openclaw@${PORTS[0]}:down" "the killed gateway goes down (instant pid rung)"
+    for port in "${PORTS[@]:1}"; do
+        expect_line "openclaw@$port:idle" "sibling $port is untouched"
+    done
+fi
 
 echo "--- the lobster timeline (headless):"
 grep 'daemons=' "$OUT" | sed 's/^/    /'

--- a/scripts/openclaw-multi-gateway-e2e.sh
+++ b/scripts/openclaw-multi-gateway-e2e.sh
@@ -153,9 +153,7 @@ expect_line "daemons=[$want]" "${#PORTS[@]} gateways render ${#PORTS[@]} indepen
 # Step [1] is a hard PRECONDITION for step [2], not just another assertion.
 # `expect_line` matches a substring of the LATEST line, so a gateway that has not
 # announced yet satisfies "sibling $port is untouched" on its FIRST-EVER announce —
-# which, after a step-[1] timeout, lands AFTER the kill. Observed: one slow start
-# printed `1 FAIL / 4 PASS` where three of those PASSes were vacuous, reading as
-# "instance-local death mostly works" when the precondition never held.
+# which, after a step-[1] timeout, lands AFTER the kill.
 if [ "$FAILED" != 0 ]; then
     echo "  SKIP [2] — not every gateway announced; the instance-local assertions would be vacuous" >&2
 else

--- a/scripts/replay-fixture.sh
+++ b/scripts/replay-fixture.sh
@@ -12,20 +12,26 @@
 # Usage:  scripts/replay-fixture.sh <rollout.jsonl> [delay_secs]
 #   e.g.  scripts/replay-fixture.sh \
 #           crates/pixtuoid-core/tests/sources/fixtures/codex/permission-flow/rollout-*.jsonl
-#   PIXTUOID_BIN overrides the binary (default: `pixtuoid` on PATH).
+#   PIXTUOID_BIN overrides the binary (default: this tree's target/release build).
 set -euo pipefail
 
+repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 fixture="${1:?usage: replay-fixture.sh <rollout.jsonl> [delay_secs]}"
 delay="${2:-3}"
-bin="${PIXTUOID_BIN:-pixtuoid}"
+# The WORKING TREE's binary, never a bare `pixtuoid` off PATH: this script is
+# cited as a verification step, and a maintainer normally has a RELEASED pixtuoid
+# installed — so a PATH default replays the last release and prints PASS with none
+# of the change under test in it. The sibling e2e scripts hard-wire
+# $REPO/target/release for the same reason; PIXTUOID_BIN stays the escape hatch.
+bin="${PIXTUOID_BIN:-$repo/target/release/pixtuoid}"
 
 [ -f "$fixture" ] || {
     echo "no such fixture: $fixture" >&2
     exit 1
 }
 command -v "$bin" >/dev/null 2>&1 || {
-    echo "binary not found: $bin (set PIXTUOID_BIN)" >&2
-    exit 1
+    echo "binary not found: $bin — run: just build --release (or set PIXTUOID_BIN)" >&2
+    exit 2
 }
 
 root="$(mktemp -d)"

--- a/scripts/replay-fixture.sh
+++ b/scripts/replay-fixture.sh
@@ -21,8 +21,7 @@ delay="${2:-3}"
 # The WORKING TREE's binary, never a bare `pixtuoid` off PATH: this script is
 # cited as a verification step, and a maintainer normally has a RELEASED pixtuoid
 # installed — so a PATH default replays the last release and prints PASS with none
-# of the change under test in it. The sibling e2e scripts hard-wire
-# $REPO/target/release for the same reason; PIXTUOID_BIN stays the escape hatch.
+# of the change under test in it.
 bin="${PIXTUOID_BIN:-$repo/target/release/pixtuoid}"
 
 [ -f "$fixture" ] || {


### PR DESCRIPTION
Fixes 5 confirmed audit defects in the e2e and replay tooling.

Two e2e scripts bound the hook socket at a **fixed, predictable name in the shared temp dir** — two concurrent runs destroyed each other, and the path was squattable. `replay-fixture.sh` defaulted to whatever `pixtuoid` was on PATH, so the documented dogfood step could green-light a stale release binary. The multi-gateway e2e printed "PASS sibling N is untouched" for gateways that had never appeared.

**Four commits from this branch were dropped, not merged.** #796 landed mid-audit and solved the same CodeWhale facade-split and unanchored-sweep problems *more completely* — 17 anchored call sites plus `test_every_swept_url_declares_an_anchor`, a mechanical guard this branch never had. The audit finding its own work redundant is the correct outcome.

### Commits

- `95cea2dd` style(scripts): apply the redundancy-within comment test to the e2e WHY
- `b54e0976` fix(scripts): stop the cc-backend e2e asserting an upstream fact its sibling measured false
- `432e21a1` fix(scripts): make the multi-gateway e2e's step [1] a hard precondition
- `dac2fadc` fix(scripts): replay the WORKING TREE's binary, not whatever `pixtuoid` is on PATH
- `56e9a7a2` fix(scripts): resolve the cc-backend e2e's gateway port instead of pinning 18789
- `35c4ad3e` fix(scripts): put the e2e hook socket in a private dir, not a fixed shared-tmp name

---

### Provenance

Part of a whole-codebase audit (13 branches, 136 commits). Pipeline: 11 subsystem
finders + 8 whole-tree specialist sweeps + loop-until-dry security/concurrency
hunts → 312 raw findings → adversarial skeptics (default REFUTE, 3 differentiated
lenses on HIGH/security/concurrency) → **108 distinct confirmed defects** (35%
refutation rate, stable across two rounds) → fixes → a two-lens merge review per
branch plus trigger-driven escalation lenses → a fix round on that review's
findings.

Every defect has exactly one terminal state: **181 FIXED · 8 REFUTED-with-citation
· 12 ISSUE-NEEDED** (filed: #799 #800 #802 #803 #804).

### Composition verified

All 13 branches were merged together in a throwaway worktree and gated as one tree
— the step no per-branch review can perform:

- `just preflight` → **exit 0** (13 lint sub-gates → clippy → hack → **2,795 tests passed**)
- `just site-check` · `just site-e2e` (96) · `just ci-observability` (107 Rego + 108 conftest) → all exit 0

That pass found **5 genuine cross-branch contradictions** in prose that merged
cleanly — e.g. one branch documenting a sweep as "per-frame" while another had
memoized it. Resolved against the merged code, not mechanically.

### Merge order

Measured, not inferred: `site → ci-tooling → tui → bin-runtime → scene-painter →
core → scene-sim → ci-policy → bin-install → docs → scripts` (+ `hook-docs`,
`consumer-gaps`, independent). Each branch is individually clean against `main`;
later ones may need a rebase once earlier ones land. Known collision points:
`crates/pixtuoid/CLAUDE.md` (5 branches), `crates/pixtuoid-core/CLAUDE.md` (4),
`policy/ci-observability/main.rego` (2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
