### PR TITLE
docs(hook): describe the shim's real 200ms bound (watchdog, not a write timeout)

### DIFF
--- a/crates/pixtuoid-hook/src/main.rs
+++ b/crates/pixtuoid-hook/src/main.rs
@@ -198,7 +198,7 @@ fn env_payload_from(
 ) -> serde_json::Map<String, Value> {
     let mut map = serde_json::Map::new();
     map.insert("event".into(), Value::from(event));
-    // CodeWhale's pid for the daemon's liveness watch (see `cw_parent_pid`).
+    // CodeWhale's pid for the daemon's liveness watch (see `parent_pid`).
     if let Some(pid) = pid {
         map.insert("_pid".into(), Value::from(pid));
     }

--- a/crates/pixtuoid-hook/src/transport.rs
+++ b/crates/pixtuoid-hook/src/transport.rs
@@ -33,8 +33,9 @@ pub(crate) fn send_line(endpoint: &str, line: &[u8]) {
     // does: a watchdog thread that hard-exits the process — after stdin is
     // consumed this send is the shim's only job (see main), and
     // exit(0)-on-timeout IS the contract (never block CC, spec §2). The write
-    // timeout stays as a second layer: it usually errors out of a stalled write
-    // before the watchdog has to shoot the process.
+    // timeout below is a secondary backstop only: it is armed AFTER connect, so
+    // its deadline is strictly later than the watchdog's and it can only matter
+    // if the watchdog thread is starved of its wakeup.
     if !spawn_timeout_watchdog() {
         return;
     }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -116,7 +116,8 @@ flowchart TB
 **Walking the pipeline (real symbols):**
 
 1. **Ingest.** Claude Code fires a hook → the **`pixtuoid-hook`** shim
-   (`enrich_payload` stamps `_pixtuoid_source`, a 200 ms write timeout, exit 0) →
+   (`enrich_payload` stamps `_pixtuoid_source`, a 200 ms watchdog-bounded send,
+   exit 0) →
    `HookSocketListener` on a Unix socket (a named pipe on Windows) →
    **`decode_hook_payload`** turns the JSON into one or more `AgentEvent`s —
    tool/permission payloads are preceded by an `Identity` event the reducer uses
@@ -190,8 +191,9 @@ These are load-bearing — see `CLAUDE.md` and the nested guides before changing
 - **`pixtuoid-core` has no terminal dependencies.** Anything terminal-specific
   lives in a thin painter over the engine's render seam (`render_floor` /
   `render_to_rgb_buffer`), never in the core or the scene engine.
-- **The hook shim must never block the agent** — always exit 0, 200 ms write
-  timeout.
+- **The hook shim must never block the agent** — always exit 0, and the 200 ms
+  send bound is enforced by a watchdog thread that hard-exits the process, on
+  both platforms.
 - **Subagent supervision is a scope tree** (`state/scope.rs`): exit cascades
   *down* (a parent's `SessionEnd` reaps its subtree), liveness flows *up* (a
   working subagent keeps its ancestors fresh), and permission-blocked subagents


### PR DESCRIPTION
Fixes 3 confirmed drift defects in and around the hook shim.

`docs/ARCHITECTURE.md` described the shim's bound as a "200 ms write timeout" — a mechanism that **does not exist on Windows** and is not load-bearing on either platform; the real bound is the watchdog thread that hard-exits. A `transport.rs` comment inverted the safety layering (the write timeout cannot fire before the watchdog it claimed to pre-empt), and another referenced a renamed function.

Context: `crates/pixtuoid-hook` had **no owning finder** in the audit's original partition — a real coverage miss, since its never-panic contract is the repo's most-documented invariant and PR #198 already broke it once past both the bot and a local review round. A dedicated pass read 100% of the crate, ran the never-panic trigger as written, and empirically fed the built shim empty / 10 MB / invalid-UTF-8 / null-byte stdin and non-UTF-8 argv — **all exit 0, empty stderr**. A claimed MEDIUM (stdin unbounded in time) was refuted by both skeptics. The shim is sound; only these artifacts were misleading.

### Commits

- `80531fe5` docs(hook): describe the shim's real 200 ms bound, and fix a stale symbol

---

### Provenance

Part of a whole-codebase audit (13 branches, 136 commits). Pipeline: 11 subsystem
finders + 8 whole-tree specialist sweeps + loop-until-dry security/concurrency
hunts → 312 raw findings → adversarial skeptics (default REFUTE, 3 differentiated
lenses on HIGH/security/concurrency) → **108 distinct confirmed defects** (35%
refutation rate, stable across two rounds) → fixes → a two-lens merge review per
branch plus trigger-driven escalation lenses → a fix round on that review's
findings.

Every defect has exactly one terminal state: **181 FIXED · 8 REFUTED-with-citation
· 12 ISSUE-NEEDED** (filed: #799 #800 #802 #803 #804).

### Composition verified

All 13 branches were merged together in a throwaway worktree and gated as one tree
— the step no per-branch review can perform:

- `just preflight` → **exit 0** (13 lint sub-gates → clippy → hack → **2,795 tests passed**)
- `just site-check` · `just site-e2e` (96) · `just ci-observability` (107 Rego + 108 conftest) → all exit 0

That pass found **5 genuine cross-branch contradictions** in prose that merged
cleanly — e.g. one branch documenting a sweep as "per-frame" while another had
memoized it. Resolved against the merged code, not mechanically.

### Merge order

Measured, not inferred: `site → ci-tooling → tui → bin-runtime → scene-painter →
core → scene-sim → ci-policy → bin-install → docs → scripts` (+ `hook-docs`,
`consumer-gaps`, independent). Each branch is individually clean against `main`;
later ones may need a rebase once earlier ones land. Known collision points:
`crates/pixtuoid/CLAUDE.md` (5 branches), `crates/pixtuoid-core/CLAUDE.md` (4),
`policy/ci-observability/main.rego` (2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
