### PR TITLE
chore(release): 0.16.0 — curate the release notes to the full cycle scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ config), see **[SECURITY.md](SECURITY.md)**.
 
 ## Contributing
 
-PRs welcome — especially new themes, sprite/decoration polish, and `Source` adapters for agent CLIs we don't support yet (the ten agent CLIs plus the OpenClaw gateway already wired up are in [Supported Tools](#supported-tools)). See **[CONTRIBUTING.md](docs/CONTRIBUTING.md)** for the build/test workflow, conventions, the review process, and how to add a new agent CLI. Architecture and the load-bearing invariants live in [`CLAUDE.md`](CLAUDE.md).
+PRs welcome — especially new themes, sprite/decoration polish, and `Source` adapters for agent CLIs we don't support yet (the twelve agent CLIs plus the OpenClaw gateway already wired up are in [Supported Tools](#supported-tools)). See **[CONTRIBUTING.md](docs/CONTRIBUTING.md)** for the build/test workflow, conventions, the review process, and how to add a new agent CLI. Architecture and the load-bearing invariants live in [`CLAUDE.md`](CLAUDE.md).
 
 ## Acknowledgments
 

--- a/crates/pixtuoid/src/version.rs
+++ b/crates/pixtuoid/src/version.rs
@@ -59,8 +59,12 @@ pub(crate) fn release_notes(version: &str) -> Option<&'static [&'static str]> {
         // brace would silently break if the indentation ever shifted.
         // [bump-inject-here]
         "0.16.0" => Some(&[
-            "The office you can hear — press m to turn on sound (starts muted, remembers your choice): a lofi band that layers up as your agents get busier (warm pad, sparkle, keys, drums — composed in-house, synthesized at startup, zero assets), typing that tracks the bustle, gentle rain when the office weather rains, and little moments — a door chime when someone walks in, the printer, the vending machine; you hear the floor you're looking at, and a footer ♩ shows when sound is live",
-            "Two moods, picked by the office itself — after dark (the same sundown the lights follow) or whenever it rains, the band switches to a slower night take: deeper bass, lazier drums, sparser keys; it crossfades back at sunrise",
+            "The office you can hear — press m for an all-procedural lofi score that layers up as agents get busier, plus typing, rain, and door/printer/vending cues. Starts muted; +/- sets volume",
+            "It never repeats — a fresh track composed every 10 minutes, in a slower night take after dark or when it rains",
+            "Token meters — each desk grows a paper tower as its session burns tokens, with a Σ row in the dossier",
+            "Two new agents — Grok Build (gk·) and Kimi Code (km·), bringing the roster to 13",
+            "Fits small terminals, and the floating window no longer pins a CPU core (100% → ~13%)",
+            "Sturdier under the hood — review sweeps, one lobster per OpenClaw gateway, and decoders that flag an upstream format change instead of guessing",
         ]),
         "0.15.0" => Some(&[
             "A busier, better-looking office — denser desk pods that pack the grid at every size, agents walking behind their desks, and a full interior-decor pass: glass walls with door jambs and mullions, a lounge aquarium, real head-of-table meeting chairs, greenery (two ficus trees) and mats",

--- a/crates/pixtuoid/src/version.rs
+++ b/crates/pixtuoid/src/version.rs
@@ -59,12 +59,12 @@ pub(crate) fn release_notes(version: &str) -> Option<&'static [&'static str]> {
         // brace would silently break if the indentation ever shifted.
         // [bump-inject-here]
         "0.16.0" => Some(&[
-            "The office you can hear — press m for an all-procedural lofi score that layers up as agents get busier, plus typing, rain, and door/printer/vending cues. Starts muted; +/- sets volume",
-            "It never repeats — a fresh track composed every 10 minutes, in a slower night take after dark or when it rains",
-            "Token meters — each desk grows a paper tower as its session burns tokens, with a Σ row in the dossier",
-            "Two new agents — Grok Build (gk·) and Kimi Code (km·), bringing the roster to 13",
-            "Fits small terminals, and the floating window no longer pins a CPU core (100% → ~13%)",
-            "Sturdier under the hood — review sweeps, one lobster per OpenClaw gateway, and decoders that flag an upstream format change instead of guessing",
+            "The office you can hear — press m for procedural lofi that builds with the bustle, plus typing, rain, door and appliance cues. Starts muted; + and - set volume",
+            "It never repeats — a fresh 10-minute track, slower and sparser at night or in rain",
+            "Token meters — each desk grows a paper tower as it burns tokens; hover an agent for the Σ total",
+            "Two new agents — Grok Build (gk·) and Kimi Code CLI (km·), for 13 supported tools",
+            "The floating window no longer pins a CPU core — 100% → ~13% with agents, ~0.5% idle",
+            "Sturdier under the hood — a whole-codebase review sweep (correctness, security, performance), a mascot per OpenClaw gateway, and decoders that flag upstream format changes",
         ]),
         "0.15.0" => Some(&[
             "A busier, better-looking office — denser desk pods that pack the grid at every size, agents walking behind their desks, and a full interior-decor pass: glass walls with door jambs and mullions, a lounge aquarium, real head-of-table meeting chairs, greenery (two ficus trees) and mats",

--- a/crates/pixtuoid/src/version.rs
+++ b/crates/pixtuoid/src/version.rs
@@ -64,7 +64,7 @@ pub(crate) fn release_notes(version: &str) -> Option<&'static [&'static str]> {
             "Token meters — each desk grows a paper tower as it burns tokens; hover an agent for the Σ total",
             "Two new agents — Grok Build (gk·) and Kimi Code CLI (km·), for 13 supported tools",
             "The floating window no longer pins a CPU core — 100% → ~13% with agents, ~0.5% idle",
-            "Sturdier under the hood — a whole-codebase review sweep (correctness, security, performance), a mascot per OpenClaw gateway, and decoders that flag upstream format changes",
+            "Sturdier under the hood — a whole-codebase review sweep (correctness, security, performance), panels that fit a small terminal, and drift-flagging decoders",
         ]),
         "0.15.0" => Some(&[
             "A busier, better-looking office — denser desk pods that pack the grid at every size, agents walking behind their desks, and a full interior-decor pass: glass walls with door jambs and mullions, a lounge aquarium, real head-of-table meeting chairs, greenery (two ficus trees) and mats",


### PR DESCRIPTION
## What

Notes-only release prep for **0.16.0**. No version numbers move — `main` has been at `0.16.0` since #634 mid-cycle-bumped it.

## Why this isn't a `just bump`

`just bump 0.16.0` refuses by design (`error: 0.16.0 is not newer than the current 0.16.0`). The bump recipe drafts `release_notes()` **at bump time**, so a mid-cycle bump leaves the arm stale by construction — it only ever described the audio Phase 1 that triggered the bump, two bullets over what became a **139-commit** `v0.15.0..HEAD` cycle. Same shape as 0.14.0 (bumped mid-cycle at #532, re-curated at release time).

## The curated arm

Six highlights. App features only — site/web work stays out of the in-app popup (0.13.0 precedent).

1. **Sound** — `m` toggles procedural lofi that builds with the bustle, plus typing/rain/door/appliance cues; starts muted, `+`/`-` volume (#633/#642/#643/#651)
2. **Never repeats** — a fresh 10-minute track, slower and sparser at night or in rain (#644/#648/#704)
3. **Token meters** — paper tower per desk, `Σ` total on agent hover (#632/#646/#647)
4. **Two new agents** — Grok Build (`gk·`) and Kimi Code CLI (`km·`), 13 supported tools (#640/#692)
5. **Floating CPU** — no longer pins a core, 100% → ~13% with agents / ~0.5% idle (#807)
6. **Under the hood** — whole-codebase review sweep, one mascot per OpenClaw gateway, decoder drift-flagging (#787/#767/#768)

### Sizing (corrected)

An earlier revision of this PR body claimed the six bullets occupied "roughly the same ~19 wrapped rows" as the old two. **That was wrong and is retracted.** Measured against the real `wrap_notes` at the 48-char measure:

| | wrapped rows | chars |
|---|---|---|
| old arm (2 bullets) | 16 | 699 |
| first draft (6 bullets) | **19** | 702 |
| **current** | **16** | **671** |

The 19-row draft clipped 3 rows behind `⋮ 3 more` at the classic 80×24 — where the arm it replaced rendered completely — and guillotined the last bullet mid-sentence. The current arm is shorter than 0.15.0's and renders complete, verified by driving the real painter: `snapshot --popup --cols 80 --rows 24` shows all six bullets, no overflow marker, CTA intact.

## Gates

`just preflight` green (**exit 0**, 2799 passed / 2 skipped) · `notes-curated` ✓ · `npm-check` 23/23 · `gen-media --check` in sync · `gen-pix-icons --check` 17/17 · README drift in sync.

## Review

Four differentiated lenses (correctness, design, editorial, rendered-frame) — escalated past the two-lens floor because two triggers fire: *public-facing artifact (release notes)* and *a string a painter frames* (the #308 `⚠ ⚠` class). Findings and their dispositions are in the thread.

Note the online review bot cannot gate this PR: **#819** fails both Claude review jobs repo-wide (`--json-schema was provided but Claude did not return structured_output`), unrelated to this diff. The documented fallback — extra differentiated lenses + owner merge, recorded in the thread — is satisfied at 4 lenses.

## ⚠️ Pre-tag blocker

**#731 is still OPEN and fires on exactly this release.** The default-on `audio` feature (#633) landed after v0.15.0 and pulls rodio/cpal, which need ALSA on Linux. homebrew-core builds the workspace with **default** features on macOS *and* Linux; their formula declares no runtime deps.

Our artifacts are safe — `release.yml` builds Linux `--no-default-features` — but pushing the `v0.16.0` tag auto-triggers a homebrew-core bump whose from-source Linux build has no `depends_on "alsa-lib"`, breaking **their** CI on a bump we neither trigger nor get notified about. The fix lands in their formula alongside the version bump, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)