### PR TITLE
fix(ci): close the fork-tree exposure and the silent review gate

### DIFF
--- a/.claude/skills/two-lens-review/SKILL.md
+++ b/.claude/skills/two-lens-review/SKILL.md
@@ -76,7 +76,7 @@ silently dropped).
    the check table alone can't gate (#448). If the bot ERRORED or left no
    findings comment at HEAD (it can fail on a very large diff — `error_max_turns`
    with no comment — or on a spent quota, which the workflow now states itself in
-   an `<!-- absent-<marker> -->` comment; do NOT read that as a review),
+   an `<!-- absent-<marker>:<sha> -->` comment; do NOT read that as a review),
    the gate is unsatisfiable as written: split the PR smaller,
    else fall back to one extra differentiated lens + owner merge, recorded in the
    PR thread. State the condition behaviorally (errored/absent), never a fixed

--- a/.claude/skills/two-lens-review/SKILL.md
+++ b/.claude/skills/two-lens-review/SKILL.md
@@ -75,7 +75,9 @@ silently dropped).
    + `mergeStateStatus` — the review JOB passes even when it posts findings, so
    the check table alone can't gate (#448). If the bot ERRORED or left no
    findings comment at HEAD (it can fail on a very large diff — `error_max_turns`
-   with no comment), the gate is unsatisfiable as written: split the PR smaller,
+   with no comment — or on a spent quota, which the workflow now states itself in
+   an `<!-- absent-<marker> -->` comment; do NOT read that as a review),
+   the gate is unsatisfiable as written: split the PR smaller,
    else fall back to one extra differentiated lens + owner merge, recorded in the
    PR thread. State the condition behaviorally (errored/absent), never a fixed
    LOC ceiling.

--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -528,8 +528,9 @@ review's LATEST COMMENT verdict (`Findings: N`) plus `mergeStateStatus`,
 never the check table: the claude-review JOB is green even when it posts
 findings (#448 merged past a fresh MEDIUM; #449 onward reads the comment
 verdict). A run that produced NO verdict now says so in its own comment,
-carrying an `<!-- absent-<marker> -->` marker — that is an unreviewed head,
-not a clean one, and it is not a `Findings: 0`.
+carrying an `<!-- absent-<marker>:<sha> -->` marker — that is an unreviewed
+head, not a clean one, and it is not a `Findings: 0`. It is keyed to the head,
+so a notice for an older sha is not a verdict on this one.
 
 ---
 

--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -527,7 +527,9 @@ gates and watch the NEW head's CI — and gate the merge on the online bot
 review's LATEST COMMENT verdict (`Findings: N`) plus `mergeStateStatus`,
 never the check table: the claude-review JOB is green even when it posts
 findings (#448 merged past a fresh MEDIUM; #449 onward reads the comment
-verdict).
+verdict). A run that produced NO verdict now says so in its own comment,
+carrying an `<!-- absent-<marker> -->` marker — that is an unreviewed head,
+not a clean one, and it is not a `Findings: 0`.
 
 ---
 

--- a/.github/workflows/claude-readonly-review.yml
+++ b/.github/workflows/claude-readonly-review.yml
@@ -152,37 +152,6 @@ jobs:
             --allowedTools "Read,Glob,Grep"
             --json-schema ${{ steps.schema.outputs.json }}
 
-      # The action reports a rejected request as `subtype: "success"` with a
-      # missing structured_output, so its error blames the schema no matter the
-      # cause. `is_error` and a $0 cost are what actually separate "no quota"
-      # from "bad contract"; both sit in the same object, unread. #819
-      - name: Explain a failed analysis
-        if: always() && steps.claude.outcome == 'failure'
-        env:
-          EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
-        run: |
-          set -uo pipefail
-          if [[ -z "${EXECUTION_FILE:-}" || ! -f "$EXECUTION_FILE" ]]; then
-            echo "No execution file was propagated: the action failed before Claude produced one." >>"$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-          result="$(jq -c '[.. | objects | select(.type? == "result")] | last // {}' "$EXECUTION_FILE" 2>/dev/null)"
-          if [[ -z "$result" || "$result" == "{}" ]]; then
-            echo "Execution file unreadable, or carrying no \`result\` object." >>"$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-          {
-            echo "### Why the analysis failed"
-            echo
-            jq -r '"- is_error: `\(.is_error)`\n- num_turns: `\(.num_turns)`\n- duration_ms: `\(.duration_ms)`\n- total_cost_usd: `\(.total_cost_usd)`"' <<<"$result"
-            echo
-            if [[ "$(jq -r '.total_cost_usd // 1' <<<"$result")" == "0" ]]; then
-              echo "**\$0 spent — the request was rejected before inference. Spent quota or auth, NOT the JSON schema.**"
-            else
-              echo "Tokens were spent, so Claude ran: this is a contract or content failure, not quota."
-            fi
-          } >>"$GITHUB_STEP_SUMMARY"
-
       - name: Require a valid structured review
         if: steps.pr.outputs.reviewable == 'true'
         env:
@@ -195,28 +164,16 @@ jobs:
             and (.findings | type == "array" and length <= 5)
           ' <<< "$REVIEW_JSON" > /dev/null
 
-  # A spent quota is an operating condition, not an incident, and it is the one
-  # the check table renders indistinguishably from a flaky advisory: analyze
-  # fails, publish skips, no comment lands, and `ci-gate` being the only
-  # required check leaves the PR merely UNSTABLE. The merge gate is "Findings: 0
-  # at HEAD", so an absent verdict has to SAY it is absent. #819
-  #
-  # Absence has TWO shapes and the quieter one is the greener: analyze FAILS
-  # (quota, timeout), or it DECLINES — `reviewable=false` exits 0, so the job
-  # goes green while publish skips on the same flag. A maintainer running
-  # `/claude-review` on a fork PR hits the second and sees an all-green check
-  # table with no comment at all. `!cancelled()` rather than `always()` so a
-  # superseded run stays quiet.
-  #
-  # The failure arm reads no `outputs` — a failed job propagating them is not a
-  # documented guarantee, and this job is worthless if it silently stops
-  # running. The decline arm can: that job succeeded.
+  # A spent quota is rare but silent: analyze fails, publish skips on its
+  # outcome, nothing comments, and `ci-gate` being the only required check
+  # leaves the PR merely UNSTABLE. The merge gate is "Findings: 0 at HEAD", so
+  # an absent verdict has to say it is absent. `!cancelled()` is load-bearing —
+  # without a status function an implicit `success()` skips this job in exactly
+  # the situation it exists for. #819
   report_absence:
     name: Report a missing review
     needs: analyze
-    if: >
-      !cancelled() &&
-      (needs.analyze.result == 'failure' || needs.analyze.outputs.reviewable == 'false')
+    if: "!cancelled() && needs.analyze.result == 'failure'"
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -224,7 +181,6 @@ jobs:
     steps:
       - name: Say the second lens did not run
         env:
-          ANALYZE_RESULT: ${{ needs.analyze.result }}
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.pr_number }}
           REPOSITORY: ${{ github.repository }}
@@ -234,49 +190,20 @@ jobs:
         run: |
           set -euo pipefail
           [[ "$REVIEW_MARKER" =~ ^[a-z0-9-]+$ ]]
-          [[ -n "$REVIEW_TITLE" ]]
           head_sha="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')"
-          # `absent-<marker>`, not `<marker>-absent`: the review's own marker is
-          # `<marker>:<sha>`, so a prefix matcher would read the latter as a review.
-          # Keyed to the HEAD, so a later head posts a NEW notice rather than
-          # editing an old one in place and leaving a stale verdict as the latest.
-          marker="<!-- absent-${REVIEW_MARKER}:${head_sha} -->"
           note="$RUNNER_TEMP/claude-review-absent.md"
           {
-            echo "$marker"
+            # `absent-<marker>`, not `<marker>-absent`: the review's own marker is
+            # `<marker>:<sha>`, so a prefix matcher would read the latter as a review.
+            echo "<!-- absent-${REVIEW_MARKER}:${head_sha} -->"
             echo "## $REVIEW_TITLE — did not run"
             echo
             echo "Head: \`$head_sha\`"
             echo
-            echo "**The automated second lens is ABSENT, not clean.** Treat this as"
-            echo "an unreviewed head: no findings were produced, so none being shown"
-            echo "means nothing."
-            echo
-            if [[ "$ANALYZE_RESULT" == "failure" ]]; then
-              echo "The analysis job failed; its job summary names the cause"
-              echo "(a spent quota and a broken contract fail identically here)."
-            else
-              echo "This pull request is out of scope for the reviewer: a fork head,"
-              echo "a base other than the default branch, or already closed."
-            fi
-            echo
-            echo "[Run log]($RUN_URL)."
+            echo "**The automated second lens is ABSENT, not clean.** No findings were"
+            echo "produced, so none being shown means nothing. [Run log]($RUN_URL)."
           } > "$note"
-
-          # Upsert so a re-run of the same head edits its notice instead of
-          # stacking another. A failed listing must not read as "none yet".
-          if ! ids="$(gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
-            --paginate --jq ".[] | select(.body | startswith(\"$marker\")) | .id")"; then
-            echo "::warning::could not list comments; skipping to avoid a duplicate notice"
-            exit 0
-          fi
-          existing="${ids%%$'\n'*}"
-          body="$(cat "$note")"
-          if [[ -n "$existing" ]]; then
-            gh api -X PATCH "repos/${REPOSITORY}/issues/comments/${existing}" -f body="$body" >/dev/null
-          else
-            gh api -X POST "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" -f body="$body" >/dev/null
-          fi
+          gh pr comment "$PR_NUMBER" --repo "$REPOSITORY" --body-file "$note"
 
   publish:
     name: Publish review

--- a/.github/workflows/claude-readonly-review.yml
+++ b/.github/workflows/claude-readonly-review.yml
@@ -163,12 +163,12 @@ jobs:
         run: |
           set -uo pipefail
           if [[ -z "${EXECUTION_FILE:-}" || ! -f "$EXECUTION_FILE" ]]; then
-            echo "No execution file: the action failed before Claude ran." >>"$GITHUB_STEP_SUMMARY"
+            echo "No execution file was propagated: the action failed before Claude produced one." >>"$GITHUB_STEP_SUMMARY"
             exit 0
           fi
           result="$(jq -c '[.. | objects | select(.type? == "result")] | last // {}' "$EXECUTION_FILE" 2>/dev/null)"
           if [[ -z "$result" || "$result" == "{}" ]]; then
-            echo "Execution file carries no \`result\` object." >>"$GITHUB_STEP_SUMMARY"
+            echo "Execution file unreadable, or carrying no \`result\` object." >>"$GITHUB_STEP_SUMMARY"
             exit 0
           fi
           {
@@ -201,13 +201,22 @@ jobs:
   # required check leaves the PR merely UNSTABLE. The merge gate is "Findings: 0
   # at HEAD", so an absent verdict has to SAY it is absent. #819
   #
-  # Keyed on `needs.analyze.result` and `inputs.pr_number`, never on the failed
-  # job's `outputs` — a failed job propagating its outputs is not a documented
-  # guarantee, and this job is worthless if it silently stops running.
+  # Absence has TWO shapes and the quieter one is the greener: analyze FAILS
+  # (quota, timeout), or it DECLINES — `reviewable=false` exits 0, so the job
+  # goes green while publish skips on the same flag. A maintainer running
+  # `/claude-review` on a fork PR hits the second and sees an all-green check
+  # table with no comment at all. `!cancelled()` rather than `always()` so a
+  # superseded run stays quiet.
+  #
+  # The failure arm reads no `outputs` — a failed job propagating them is not a
+  # documented guarantee, and this job is worthless if it silently stops
+  # running. The decline arm can: that job succeeded.
   report_absence:
     name: Report a missing review
     needs: analyze
-    if: always() && needs.analyze.result == 'failure'
+    if: >
+      !cancelled() &&
+      (needs.analyze.result == 'failure' || needs.analyze.outputs.reviewable == 'false')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -215,6 +224,7 @@ jobs:
     steps:
       - name: Say the second lens did not run
         env:
+          ANALYZE_RESULT: ${{ needs.analyze.result }}
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.pr_number }}
           REPOSITORY: ${{ github.repository }}
@@ -226,23 +236,46 @@ jobs:
           [[ "$REVIEW_MARKER" =~ ^[a-z0-9-]+$ ]]
           [[ -n "$REVIEW_TITLE" ]]
           head_sha="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')"
+          # `absent-<marker>`, not `<marker>-absent`: the published review's own
+          # marker is `<marker>:<sha>`, and a consumer matching it by prefix
+          # would read `<marker>-absent` as a review.
+          marker="<!-- absent-${REVIEW_MARKER} -->"
           note="$RUNNER_TEMP/claude-review-absent.md"
           {
-            echo "<!-- ${REVIEW_MARKER}-absent:${head_sha} -->"
+            echo "$marker"
             echo "## $REVIEW_TITLE — did not run"
             echo
             echo "Head: \`$head_sha\`"
             echo
             echo "**The automated second lens is ABSENT, not clean.** Treat this as"
             echo "an unreviewed head: no findings were produced, so none being shown"
-            echo "means nothing. [Run log]($RUN_URL)."
+            echo "means nothing."
             echo
-            echo "The usual cause is a spent model quota. In the run log, the"
-            echo "\`\"type\": \"result\"\` object tells you which: \`total_cost_usd\` of 0"
-            echo "with 1 turn means the request never reached inference — the"
-            echo "action's own error message blames the JSON schema either way."
+            if [[ "$ANALYZE_RESULT" == "failure" ]]; then
+              echo "The analysis job failed; its job summary names the cause"
+              echo "(a spent quota and a broken contract fail identically here)."
+            else
+              echo "This pull request is out of scope for the reviewer: a fork head,"
+              echo "a base other than the default branch, or already closed."
+            fi
+            echo
+            echo "[Run log]($RUN_URL)."
           } > "$note"
-          gh pr comment "$PR_NUMBER" --repo "$REPOSITORY" --body-file "$note"
+
+          # Upsert, because a multi-hour outage fires this on every push of
+          # every PR, from BOTH callers. A failed listing must not be read as
+          # "no comment yet" — that posts a duplicate and loses idempotency.
+          if ! existing="$(gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --paginate --jq "[.[] | select(.body | startswith(\"$marker\")) | .id] | first // empty")"; then
+            echo "::warning::could not list comments; skipping to avoid a duplicate notice"
+            exit 0
+          fi
+          body="$(cat "$note")"
+          if [[ -n "$existing" ]]; then
+            gh api -X PATCH "repos/${REPOSITORY}/issues/comments/${existing}" -f body="$body" >/dev/null
+          else
+            gh api -X POST "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" -f body="$body" >/dev/null
+          fi
 
   publish:
     name: Publish review

--- a/.github/workflows/claude-readonly-review.yml
+++ b/.github/workflows/claude-readonly-review.yml
@@ -152,6 +152,37 @@ jobs:
             --allowedTools "Read,Glob,Grep"
             --json-schema ${{ steps.schema.outputs.json }}
 
+      # The action reports a rejected request as `subtype: "success"` with a
+      # missing structured_output, so its error blames the schema no matter the
+      # cause. `is_error` and a $0 cost are what actually separate "no quota"
+      # from "bad contract"; both sit in the same object, unread. #819
+      - name: Explain a failed analysis
+        if: always() && steps.claude.outcome == 'failure'
+        env:
+          EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
+        run: |
+          set -uo pipefail
+          if [[ -z "${EXECUTION_FILE:-}" || ! -f "$EXECUTION_FILE" ]]; then
+            echo "No execution file: the action failed before Claude ran." >>"$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          result="$(jq -c '[.. | objects | select(.type? == "result")] | last // {}' "$EXECUTION_FILE" 2>/dev/null)"
+          if [[ -z "$result" || "$result" == "{}" ]]; then
+            echo "Execution file carries no \`result\` object." >>"$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          {
+            echo "### Why the analysis failed"
+            echo
+            jq -r '"- is_error: `\(.is_error)`\n- num_turns: `\(.num_turns)`\n- duration_ms: `\(.duration_ms)`\n- total_cost_usd: `\(.total_cost_usd)`"' <<<"$result"
+            echo
+            if [[ "$(jq -r '.total_cost_usd // 1' <<<"$result")" == "0" ]]; then
+              echo "**\$0 spent — the request was rejected before inference. Spent quota or auth, NOT the JSON schema.**"
+            else
+              echo "Tokens were spent, so Claude ran: this is a contract or content failure, not quota."
+            fi
+          } >>"$GITHUB_STEP_SUMMARY"
+
       - name: Require a valid structured review
         if: steps.pr.outputs.reviewable == 'true'
         env:
@@ -163,6 +194,55 @@ jobs:
             and (.summary | type == "string" and length > 0)
             and (.findings | type == "array" and length <= 5)
           ' <<< "$REVIEW_JSON" > /dev/null
+
+  # A spent quota is an operating condition, not an incident, and it is the one
+  # the check table renders indistinguishably from a flaky advisory: analyze
+  # fails, publish skips, no comment lands, and `ci-gate` being the only
+  # required check leaves the PR merely UNSTABLE. The merge gate is "Findings: 0
+  # at HEAD", so an absent verdict has to SAY it is absent. #819
+  #
+  # Keyed on `needs.analyze.result` and `inputs.pr_number`, never on the failed
+  # job's `outputs` — a failed job propagating its outputs is not a documented
+  # guarantee, and this job is worthless if it silently stops running.
+  report_absence:
+    name: Report a missing review
+    needs: analyze
+    if: always() && needs.analyze.result == 'failure'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Say the second lens did not run
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          REPOSITORY: ${{ github.repository }}
+          REVIEW_MARKER: ${{ inputs.review_marker }}
+          REVIEW_TITLE: ${{ inputs.review_title }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          [[ "$REVIEW_MARKER" =~ ^[a-z0-9-]+$ ]]
+          [[ -n "$REVIEW_TITLE" ]]
+          head_sha="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')"
+          note="$RUNNER_TEMP/claude-review-absent.md"
+          {
+            echo "<!-- ${REVIEW_MARKER}-absent:${head_sha} -->"
+            echo "## $REVIEW_TITLE — did not run"
+            echo
+            echo "Head: \`$head_sha\`"
+            echo
+            echo "**The automated second lens is ABSENT, not clean.** Treat this as"
+            echo "an unreviewed head: no findings were produced, so none being shown"
+            echo "means nothing. [Run log]($RUN_URL)."
+            echo
+            echo "The usual cause is a spent model quota. In the run log, the"
+            echo "\`\"type\": \"result\"\` object tells you which: \`total_cost_usd\` of 0"
+            echo "with 1 turn means the request never reached inference — the"
+            echo "action's own error message blames the JSON schema either way."
+          } > "$note"
+          gh pr comment "$PR_NUMBER" --repo "$REPOSITORY" --body-file "$note"
 
   publish:
     name: Publish review

--- a/.github/workflows/claude-readonly-review.yml
+++ b/.github/workflows/claude-readonly-review.yml
@@ -236,10 +236,11 @@ jobs:
           [[ "$REVIEW_MARKER" =~ ^[a-z0-9-]+$ ]]
           [[ -n "$REVIEW_TITLE" ]]
           head_sha="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')"
-          # `absent-<marker>`, not `<marker>-absent`: the published review's own
-          # marker is `<marker>:<sha>`, and a consumer matching it by prefix
-          # would read `<marker>-absent` as a review.
-          marker="<!-- absent-${REVIEW_MARKER} -->"
+          # `absent-<marker>`, not `<marker>-absent`: the review's own marker is
+          # `<marker>:<sha>`, so a prefix matcher would read the latter as a review.
+          # Keyed to the HEAD, so a later head posts a NEW notice rather than
+          # editing an old one in place and leaving a stale verdict as the latest.
+          marker="<!-- absent-${REVIEW_MARKER}:${head_sha} -->"
           note="$RUNNER_TEMP/claude-review-absent.md"
           {
             echo "$marker"
@@ -262,14 +263,14 @@ jobs:
             echo "[Run log]($RUN_URL)."
           } > "$note"
 
-          # Upsert, because a multi-hour outage fires this on every push of
-          # every PR, from BOTH callers. A failed listing must not be read as
-          # "no comment yet" — that posts a duplicate and loses idempotency.
-          if ! existing="$(gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
-            --paginate --jq "[.[] | select(.body | startswith(\"$marker\")) | .id] | first // empty")"; then
+          # Upsert so a re-run of the same head edits its notice instead of
+          # stacking another. A failed listing must not read as "none yet".
+          if ! ids="$(gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --paginate --jq ".[] | select(.body | startswith(\"$marker\")) | .id")"; then
             echo "::warning::could not list comments; skipping to avoid a duplicate notice"
             exit 0
           fi
+          existing="${ids%%$'\n'*}"
           body="$(cat "$note")"
           if [[ -n "$existing" ]]; then
             gh api -X PATCH "repos/${REPOSITORY}/issues/comments/${existing}" -f body="$body" >/dev/null

--- a/.github/workflows/claude-readonly-review.yml
+++ b/.github/workflows/claude-readonly-review.yml
@@ -164,16 +164,21 @@ jobs:
             and (.findings | type == "array" and length <= 5)
           ' <<< "$REVIEW_JSON" > /dev/null
 
-  # A spent quota is rare but silent: analyze fails, publish skips on its
-  # outcome, nothing comments, and `ci-gate` being the only required check
-  # leaves the PR merely UNSTABLE. The merge gate is "Findings: 0 at HEAD", so
-  # an absent verdict has to say it is absent. `!cancelled()` is load-bearing —
+  # Absence renders as a pass: publish skips, nothing comments, and `ci-gate`
+  # being the only required check leaves the PR merely UNSTABLE. The merge gate
+  # is "Findings: 0 at HEAD", so an absent verdict has to say it is absent.
+  #
+  # Two shapes, and the quieter one is greener: analyze FAILS, or it DECLINES
+  # (`reviewable=false` exits 0, so that arm has no red job at all — a
+  # `/claude-review` on a fork PR hits it). `!cancelled()` is load-bearing:
   # without a status function an implicit `success()` skips this job in exactly
   # the situation it exists for. #819
   report_absence:
     name: Report a missing review
     needs: analyze
-    if: "!cancelled() && needs.analyze.result == 'failure'"
+    if: >
+      !cancelled() &&
+      (needs.analyze.result == 'failure' || needs.analyze.outputs.reviewable == 'false')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -181,6 +186,7 @@ jobs:
     steps:
       - name: Say the second lens did not run
         env:
+          ANALYZE_RESULT: ${{ needs.analyze.result }}
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.pr_number }}
           REPOSITORY: ${{ github.repository }}
@@ -202,6 +208,17 @@ jobs:
             echo
             echo "**The automated second lens is ABSENT, not clean.** No findings were"
             echo "produced, so none being shown means nothing. [Run log]($RUN_URL)."
+            echo
+            if [[ "$ANALYZE_RESULT" == "failure" ]]; then
+              # The action blames the JSON schema whatever the cause, so name the
+              # field that actually separates a spent quota from a real fault.
+              echo "In the run log, \`total_cost_usd\` of 0 in the \`result\` object"
+              echo "means the request never reached inference — a spent quota, not a"
+              echo "broken contract."
+            else
+              echo "This pull request is out of scope for the reviewer: a fork head,"
+              echo "a base other than the default branch, or already closed."
+            fi
           } > "$note"
           gh pr comment "$PR_NUMBER" --repo "$REPOSITORY" --body-file "$note"
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,10 +27,11 @@ jobs:
     # GITHUB_REF to refs/pull/<n>/merge, so the ref-less checkout below lands
     # fork-authored files — including a repo-root CLAUDE.md the agent auto-loads
     # as instructions — in the workspace of the one job holding contents:write
-    # and the OAuth token. This does NOT make the rest safe: issues/issue_comment
-    # carry no pull_request object, so the guard is not expressible there, and
-    # claude-code-action checks the PR head out ITSELF (setupBranch, tag mode) —
-    # an @claude comment on a fork PR still stages fork files here. See #799.
+    # and the OAuth token. issue_comment reaches that same tree by a different
+    # route — the action's own setupBranch checks the PR head out for every open
+    # PR — which no `if:` here can express, since that payload carries no
+    # pull_request object; the "Refuse fork pull requests" step below closes it
+    # (#799). `issues` is unaffected: the action hardcodes isPR false there.
     if: >
       (github.event_name == 'issues' && contains(github.event.issue.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)) ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
@@ -42,6 +43,22 @@ jobs:
       group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
+      # First, so it precedes BOTH checkouts: ours, and the one the action does
+      # for itself. Resolving the PR is the only way to see fork-ness here.
+      - name: Refuse fork pull requests
+        if: github.event_name == 'issue_comment' && github.event.issue.pull_request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          head_repo="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.repo.full_name // ""')"
+          if [[ "$head_repo" != "$REPOSITORY" ]]; then
+            echo "::error::@claude does not run on fork pull requests: it would stage the fork's tree in the only contents:write job. Push the branch to this repository instead."
+            exit 1
+          fi
+
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,14 +222,16 @@ and emits schema-bound JSON; a separate no-checkout publisher revalidates the PR
 head before writing the review comment. A third job says so when no verdict was
 produced, because absence otherwise renders as a pass: the publisher skips, no
 `Findings:` comment lands, and the PR reads merely `UNSTABLE` — which is how
-#815–#818 merged with only a red job to say the gate was unsatisfiable. It
+#809 and #815–#818 merged with no verdict from either lens, and #813–#814 with
+only one of the two, a red job being the sole signal in every case. It
 covers BOTH shapes, the failure and the decline (`reviewable=false` exits 0, so
 that arm goes green and is the quieter one), reading `needs.analyze.result` and
 the workflow input for the first — a failed job propagating `outputs` is
 undocumented — and the successful job's `outputs` for the second. The policy
-pins its existence, an exact `pull-requests: write`, that it checks nothing out,
-and that its condition carries a status function, without which an implicit
-`success()` would skip it exactly when it is needed (#819). The human-triggered `@claude` workflow
+pins its existence, both arms of its condition, an exact permission set of
+`pull-requests: write`, that it checks nothing out, and that its condition
+carries a status function — without one an implicit `success()` would skip it
+exactly when it is needed (#819). The human-triggered `@claude` workflow
 (`claude.yml`, the only `contents: write` Claude job) checks out without a ref,
 so its two `pull_request_review*` arms — the events whose `GITHUB_REF` is the PR
 merge ref — additionally require the head to live in this repository, and the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,19 +219,13 @@ The two automatic Claude reviewers are thin trigger policies over
 `claude-readonly-review.yml`: the model job checks out only the trusted default
 branch, receives the exact PR diff as inert data, has read-only GitHub/tools,
 and emits schema-bound JSON; a separate no-checkout publisher revalidates the PR
-head before writing the review comment. A third job says so when no verdict was
-produced, because absence otherwise renders as a pass: the publisher skips, no
-`Findings:` comment lands, and the PR reads merely `UNSTABLE` — which is how
-#809 and #815–#818 merged with no verdict from either lens, and #813–#814 with
-only one of the two, a red job being the sole signal in every case. It
-covers BOTH shapes, the failure and the decline (`reviewable=false` exits 0, so
-that arm goes green and is the quieter one), reading `needs.analyze.result` and
-the workflow input for the first — a failed job propagating `outputs` is
-undocumented — and the successful job's `outputs` for the second. The policy
-pins its existence, both arms of its condition, an exact permission set of
-`pull-requests: write`, that it checks nothing out, and that its condition
-carries a status function — without one an implicit `success()` would skip it
-exactly when it is needed (#819). The human-triggered `@claude` workflow
+head before writing the review comment. A third job comments when the model job
+FAILS, because absence otherwise renders as a pass — the publisher skips, no
+`Findings:` comment lands, and the PR reads merely `UNSTABLE`, which is how #809
+and #815–#818 merged with only a red job to say so. Rare, so it is deliberately
+thin: one comment, and one policy rule pinning that the job exists and that its
+condition carries a status function — without one an implicit `success()` would
+skip it exactly when it is needed (#819). The human-triggered `@claude` workflow
 (`claude.yml`, the only `contents: write` Claude job) checks out without a ref,
 so its two `pull_request_review*` arms — the events whose `GITHUB_REF` is the PR
 merge ref — additionally require the head to live in this repository, and the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,8 +227,12 @@ policy keys that requirement off the workflow's `on:` triggers rather than its
 surviving `if:` arms (a condition that never names an event SKIPS the job; a
 missing condition gates nothing). The `issues`/`issue_comment` arms carry no
 `pull_request` object, so the same guard is not expressible there — and
-claude-code-action checks the PR head out itself, which keeps `issue_comment`
-exposed on fork PRs (#799). Anthropic WIF is preferred when its
+claude-code-action stages the fork tree itself (tag mode's `setupBranch` checks
+the PR head out for every open PR), so `issue_comment` needs a job STEP instead:
+`Refuse fork pull requests` resolves the PR and exits first, and the policy pins
+both its existence and that it precedes the action, keyed on the API field it
+reads rather than its name (#799). `issues` is unaffected — the action hardcodes
+`isPR` false there. Anthropic WIF is preferred when its
 repository variables are configured, with the existing OAuth secret as a
 compatibility fallback. Codecov uploads likewise use job-scoped GitHub OIDC
 (fork PRs remain Codecov's tokenless path), never a repository upload token.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,13 +219,17 @@ The two automatic Claude reviewers are thin trigger policies over
 `claude-readonly-review.yml`: the model job checks out only the trusted default
 branch, receives the exact PR diff as inert data, has read-only GitHub/tools,
 and emits schema-bound JSON; a separate no-checkout publisher revalidates the PR
-head before writing the review comment. When the model job FAILS, a third job
-comments that the second lens is ABSENT rather than clean — a spent quota
-otherwise renders identically to a passing review (publisher skips, no
-`Findings:` comment, PR merely `UNSTABLE`), which is how #805–#818 merged with
-the gate silently unsatisfiable; it keys off `needs.analyze.result` and the
-workflow input, never the failed job's `outputs`, and the policy pins both its
-existence and its `pull-requests: write` (#819). The human-triggered `@claude` workflow
+head before writing the review comment. A third job says so when no verdict was
+produced, because absence otherwise renders as a pass: the publisher skips, no
+`Findings:` comment lands, and the PR reads merely `UNSTABLE` — which is how
+#815–#818 merged with only a red job to say the gate was unsatisfiable. It
+covers BOTH shapes, the failure and the decline (`reviewable=false` exits 0, so
+that arm goes green and is the quieter one), reading `needs.analyze.result` and
+the workflow input for the first — a failed job propagating `outputs` is
+undocumented — and the successful job's `outputs` for the second. The policy
+pins its existence, an exact `pull-requests: write`, that it checks nothing out,
+and that its condition carries a status function, without which an implicit
+`success()` would skip it exactly when it is needed (#819). The human-triggered `@claude` workflow
 (`claude.yml`, the only `contents: write` Claude job) checks out without a ref,
 so its two `pull_request_review*` arms — the events whose `GITHUB_REF` is the PR
 merge ref — additionally require the head to live in this repository, and the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,10 +222,11 @@ and emits schema-bound JSON; a separate no-checkout publisher revalidates the PR
 head before writing the review comment. A third job comments when the model job
 FAILS, because absence otherwise renders as a pass — the publisher skips, no
 `Findings:` comment lands, and the PR reads merely `UNSTABLE`, which is how #809
-and #815–#818 merged with only a red job to say so. Rare, so it is deliberately
-thin: one comment, and one policy rule pinning that the job exists and that its
-condition carries a status function — without one an implicit `success()` would
-skip it exactly when it is needed (#819). The human-triggered `@claude` workflow
+and #815–#818 merged with only a red job to say so. It covers both shapes — the
+failure and the decline (`reviewable=false` exits 0, so that arm has no red job
+at all). Rare, so it stays thin: one comment, and one rule pinning that the job
+exists with both arms and a status function, without which an implicit
+`success()` would skip it exactly when it is needed (#819). The human-triggered `@claude` workflow
 (`claude.yml`, the only `contents: write` Claude job) checks out without a ref,
 so its two `pull_request_review*` arms — the events whose `GITHUB_REF` is the PR
 merge ref — additionally require the head to live in this repository, and the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,8 +242,8 @@ missing condition gates nothing). The `issues`/`issue_comment` arms carry no
 claude-code-action stages the fork tree itself (tag mode's `setupBranch` checks
 the PR head out for every open PR), so `issue_comment` needs a job STEP instead:
 `Refuse fork pull requests` resolves the PR and exits first, and the policy pins
-both its existence and that it precedes the action, keyed on the API field it
-reads rather than its name (#799). `issues` is unaffected — the action hardcodes
+its existence, that it is scoped to `issue_comment`, and that it precedes the
+action, keyed on the API field it reads rather than its name (#799). `issues` is unaffected — the action hardcodes
 `isPR` false there. Anthropic WIF is preferred when its
 repository variables are configured, with the existing OAuth secret as a
 compatibility fallback. Codecov uploads likewise use job-scoped GitHub OIDC

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,7 +219,13 @@ The two automatic Claude reviewers are thin trigger policies over
 `claude-readonly-review.yml`: the model job checks out only the trusted default
 branch, receives the exact PR diff as inert data, has read-only GitHub/tools,
 and emits schema-bound JSON; a separate no-checkout publisher revalidates the PR
-head before writing the review comment. The human-triggered `@claude` workflow
+head before writing the review comment. When the model job FAILS, a third job
+comments that the second lens is ABSENT rather than clean — a spent quota
+otherwise renders identically to a passing review (publisher skips, no
+`Findings:` comment, PR merely `UNSTABLE`), which is how #805–#818 merged with
+the gate silently unsatisfiable; it keys off `needs.analyze.result` and the
+workflow input, never the failed job's `outputs`, and the policy pins both its
+existence and its `pull-requests: write` (#819). The human-triggered `@claude` workflow
 (`claude.yml`, the only `contents: write` Claude job) checks out without a ref,
 so its two `pull_request_review*` arms — the events whose `GITHUB_REF` is the PR
 merge ref — additionally require the head to live in this repository, and the

--- a/policy/ci-observability/action_behavior_test.sh
+++ b/policy/ci-observability/action_behavior_test.sh
@@ -466,3 +466,95 @@ if PATH="$fake_bin:$PATH" \
     bash -c "$publisher_script" >/dev/null 2>&1; then
     fail "Claude publisher accepted an unsafe finding path"
 fi
+
+# --- #799 fork refusal + #819 absence notice -------------------------------
+# Both are shell that GUARDS something, and the rego rules pin only that they
+# exist and where they sit. What they actually do is asserted here.
+CLAUDE_TAG_WORKFLOW_FILE="${CLAUDE_TAG_WORKFLOW_FILE:-.github/workflows/claude.yml}"
+
+# These steps pass --jq and hit two different endpoints, neither of which the
+# resolver stub above models.
+cat >"$fake_bin/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "$1" == api ]]
+jq_expr="" url="" body="" method=GET
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --jq) jq_expr="$2"; shift ;;
+        -X) method="$2"; shift ;;
+        -f) body="${2#body=}"; shift ;;
+        repos/*) url="$1" ;;
+    esac
+    shift
+done
+if [[ "$method" != GET ]]; then
+    printf '%s' "$body" >"$ABSENCE_CAPTURE"
+    exit 0
+fi
+case "$url" in
+    */comments) printf '%s' "${FAKE_COMMENTS:-[]}" | jq -r "$jq_expr" ;;
+    *) printf '%s' "$FAKE_PR_JSON" | jq -r "$jq_expr" ;;
+esac
+STUB
+chmod +x "$fake_bin/gh"
+
+refusal_script="$(workflow_step_script "$CLAUDE_TAG_WORKFLOW_FILE" "Refuse fork pull requests")"
+
+assert_refusal() {
+    local fixture="$1"
+    local expect_refused="$2"
+    local label="$3"
+    if PATH="$fake_bin:$PATH" \
+        FAKE_PR_JSON="$fixture" \
+        GH_TOKEN="test-token" \
+        PR_NUMBER="42" \
+        REPOSITORY="owner/repo" \
+        bash -c "$refusal_script" >/dev/null 2>&1; then
+        [[ "$expect_refused" == false ]] || fail "@claude fork guard admitted $label"
+    else
+        [[ "$expect_refused" == true ]] || fail "@claude fork guard rejected $label"
+    fi
+}
+
+assert_refusal "$valid_pr" false "an internal pull request"
+assert_refusal "$fork_pr" true "a fork pull request"
+assert_refusal '{"head":{"repo":null},"base":{"ref":"main"},"state":"open"}' true "a deleted fork head"
+
+absence_script="$(workflow_step_script "$CLAUDE_REVIEW_WORKFLOW_FILE" "Say the second lens did not run")"
+absence_capture="$test_dir/absence-body"
+
+run_absence() {
+    : >"$absence_capture"
+    PATH="$fake_bin:$PATH" \
+        ABSENCE_CAPTURE="$absence_capture" \
+        ANALYZE_RESULT="$1" \
+        FAKE_COMMENTS="${2:-[]}" \
+        FAKE_PR_JSON="$valid_pr" \
+        GH_TOKEN="test-token" \
+        PR_NUMBER="42" \
+        REPOSITORY="owner/repo" \
+        REVIEW_MARKER="claude-auto-review" \
+        REVIEW_TITLE="Claude Review" \
+        RUN_URL="https://example.invalid/run" \
+        bash -c "$absence_script" >/dev/null 2>&1 ||
+        fail "absence notice exited non-zero for result=$1"
+}
+
+run_absence failure
+absence_body="$(<"$absence_capture")"
+[[ "$absence_body" == *"ABSENT, not clean"* ]] ||
+    fail "absence notice did not say the review is absent rather than clean"
+[[ "$absence_body" == *"<!-- absent-claude-auto-review -->"* ]] ||
+    fail "absence notice omitted its own marker"
+# A prefix matcher on the published review's marker must not read this notice
+# as a review.
+[[ "$absence_body" != *"<!-- claude-auto-review"* ]] ||
+    fail "absence marker collides with the published review marker"
+[[ "$absence_body" == *"job summary names the cause"* ]] ||
+    fail "absence notice did not route a failed analysis to its summary"
+
+run_absence success
+absence_body="$(<"$absence_capture")"
+[[ "$absence_body" == *"out of scope for the reviewer"* ]] ||
+    fail "a declined review was reported as a failure"

--- a/policy/ci-observability/action_behavior_test.sh
+++ b/policy/ci-observability/action_behavior_test.sh
@@ -477,29 +477,20 @@ CLAUDE_TAG_WORKFLOW_FILE="${CLAUDE_TAG_WORKFLOW_FILE:-.github/workflows/claude.y
 cat >"$fake_bin/gh" <<'STUB'
 #!/usr/bin/env bash
 set -euo pipefail
-[[ "$1" == api ]]
-jq_expr="" url="" body="" method=GET
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --jq) jq_expr="$2"; shift ;;
-        -X) method="$2"; shift ;;
-        -f) body="${2#body=}"; shift ;;
-        repos/*) url="$1" ;;
-    esac
-    shift
-done
-if [[ "$method" != GET ]]; then
-    printf '%s' "$body" >"$ABSENCE_CAPTURE"
-    printf '%s' "$url" >"$ABSENCE_CAPTURE.url"
+if [[ "$1" == pr && "$2" == comment ]]; then
+    while [[ $# -gt 0 ]]; do
+        [[ "$1" == --body-file ]] && cp "$2" "$ABSENCE_CAPTURE"
+        shift
+    done
     exit 0
 fi
-case "$url" in
-    */comments)
-        [[ -z "${FAKE_LIST_FAILS:-}" ]] || exit 1
-        printf '%s' "${FAKE_COMMENTS:-[]}" | jq -r "$jq_expr"
-        ;;
-    *) printf '%s' "$FAKE_PR_JSON" | jq -r "$jq_expr" ;;
-esac
+[[ "$1" == api ]]
+jq_expr=""
+while [[ $# -gt 0 ]]; do
+    [[ "$1" == --jq ]] && jq_expr="$2"
+    shift
+done
+printf '%s' "$FAKE_PR_JSON" | jq -r "$jq_expr"
 STUB
 chmod +x "$fake_bin/gh"
 
@@ -527,57 +518,22 @@ assert_refusal '{"head":{"repo":null},"base":{"ref":"main"},"state":"open"}' tru
 
 absence_script="$(workflow_step_script "$CLAUDE_REVIEW_WORKFLOW_FILE" "Say the second lens did not run")"
 absence_capture="$test_dir/absence-body"
+: >"$absence_capture"
+PATH="$fake_bin:$PATH" \
+    ABSENCE_CAPTURE="$absence_capture" \
+    FAKE_PR_JSON="$valid_pr" \
+    GH_TOKEN="test-token" \
+    PR_NUMBER="42" \
+    REPOSITORY="owner/repo" \
+    REVIEW_MARKER="claude-auto-review" \
+    REVIEW_TITLE="Claude Review" \
+    RUN_URL="https://example.invalid/run" \
+    bash -c "$absence_script" >/dev/null 2>&1 ||
+    fail "absence notice exited non-zero"
 
-run_absence() {
-    : >"$absence_capture"
-    : >"$absence_capture.url"
-    PATH="$fake_bin:$PATH" \
-        ABSENCE_CAPTURE="$absence_capture" \
-        ANALYZE_RESULT="$1" \
-        FAKE_COMMENTS="${2:-[]}" \
-        FAKE_LIST_FAILS="${3:-}" \
-        FAKE_PR_JSON="$valid_pr" \
-        GH_TOKEN="test-token" \
-        PR_NUMBER="42" \
-        REPOSITORY="owner/repo" \
-        REVIEW_MARKER="claude-auto-review" \
-        REVIEW_TITLE="Claude Review" \
-        RUN_URL="https://example.invalid/run" \
-        bash -c "$absence_script" >/dev/null 2>&1 ||
-        fail "absence notice exited non-zero for result=$1"
-}
-
-run_absence failure
 absence_body="$(<"$absence_capture")"
 [[ "$absence_body" == *"ABSENT, not clean"* ]] ||
     fail "absence notice did not say the review is absent rather than clean"
-[[ "$absence_body" == *"<!-- absent-claude-auto-review:abc123 -->"* ]] ||
-    fail "absence notice omitted its own marker"
-# A prefix matcher on the published review's marker must not read this notice
-# as a review.
+# A prefix matcher on the published review's marker must not read this as a review.
 [[ "$absence_body" != *"<!-- claude-auto-review"* ]] ||
     fail "absence marker collides with the published review marker"
-[[ "$absence_body" == *"job summary names the cause"* ]] ||
-    fail "absence notice did not route a failed analysis to its summary"
-
-run_absence success
-absence_body="$(<"$absence_capture")"
-[[ "$absence_body" == *"out of scope for the reviewer"* ]] ||
-    fail "a declined review was reported as a failure"
-
-# A re-run of the same head must REPLACE its notice, not stack another.
-run_absence failure '[{"id":7,"body":"<!-- absent-claude-auto-review:abc123 -->\nstale"}]'
-[[ "$(<"$absence_capture.url")" == *"/issues/comments/7" ]] ||
-    fail "an existing notice was duplicated instead of refreshed in place"
-
-# `--jq` runs per page, so two matching notices yield two ids; splicing both
-# into the PATCH url would wedge the job exactly when it should self-heal.
-run_absence failure '[{"id":7,"body":"<!-- absent-claude-auto-review:abc123 -->\na"},{"id":8,"body":"<!-- absent-claude-auto-review:abc123 -->\nb"}]'
-[[ "$(<"$absence_capture.url")" == *"/issues/comments/7" ]] ||
-    fail "a second matching notice was spliced into the update target"
-
-# A listing that ERRORS is not "no notice yet": writing here posts the duplicate
-# the guard exists to prevent.
-run_absence failure '[]' fail-the-listing
-[[ ! -s "$absence_capture" ]] ||
-    fail "a failed comment listing still wrote a notice"

--- a/policy/ci-observability/action_behavior_test.sh
+++ b/policy/ci-observability/action_behavior_test.sh
@@ -490,10 +490,14 @@ while [[ $# -gt 0 ]]; do
 done
 if [[ "$method" != GET ]]; then
     printf '%s' "$body" >"$ABSENCE_CAPTURE"
+    printf '%s' "$url" >"$ABSENCE_CAPTURE.url"
     exit 0
 fi
 case "$url" in
-    */comments) printf '%s' "${FAKE_COMMENTS:-[]}" | jq -r "$jq_expr" ;;
+    */comments)
+        [[ -z "${FAKE_LIST_FAILS:-}" ]] || exit 1
+        printf '%s' "${FAKE_COMMENTS:-[]}" | jq -r "$jq_expr"
+        ;;
     *) printf '%s' "$FAKE_PR_JSON" | jq -r "$jq_expr" ;;
 esac
 STUB
@@ -526,10 +530,12 @@ absence_capture="$test_dir/absence-body"
 
 run_absence() {
     : >"$absence_capture"
+    : >"$absence_capture.url"
     PATH="$fake_bin:$PATH" \
         ABSENCE_CAPTURE="$absence_capture" \
         ANALYZE_RESULT="$1" \
         FAKE_COMMENTS="${2:-[]}" \
+        FAKE_LIST_FAILS="${3:-}" \
         FAKE_PR_JSON="$valid_pr" \
         GH_TOKEN="test-token" \
         PR_NUMBER="42" \
@@ -545,7 +551,7 @@ run_absence failure
 absence_body="$(<"$absence_capture")"
 [[ "$absence_body" == *"ABSENT, not clean"* ]] ||
     fail "absence notice did not say the review is absent rather than clean"
-[[ "$absence_body" == *"<!-- absent-claude-auto-review -->"* ]] ||
+[[ "$absence_body" == *"<!-- absent-claude-auto-review:abc123 -->"* ]] ||
     fail "absence notice omitted its own marker"
 # A prefix matcher on the published review's marker must not read this notice
 # as a review.
@@ -558,3 +564,14 @@ run_absence success
 absence_body="$(<"$absence_capture")"
 [[ "$absence_body" == *"out of scope for the reviewer"* ]] ||
     fail "a declined review was reported as a failure"
+
+# A re-run of the same head must REPLACE its notice, not stack another.
+run_absence failure '[{"id":7,"body":"<!-- absent-claude-auto-review:abc123 -->\nstale"}]'
+[[ "$(<"$absence_capture.url")" == *"/issues/comments/7" ]] ||
+    fail "an existing notice was duplicated instead of refreshed in place"
+
+# A listing that ERRORS is not "no notice yet": writing here posts the duplicate
+# the guard exists to prevent.
+run_absence failure '[]' fail-the-listing
+[[ ! -s "$absence_capture" ]] ||
+    fail "a failed comment listing still wrote a notice"

--- a/policy/ci-observability/action_behavior_test.sh
+++ b/policy/ci-observability/action_behavior_test.sh
@@ -570,6 +570,12 @@ run_absence failure '[{"id":7,"body":"<!-- absent-claude-auto-review:abc123 -->\
 [[ "$(<"$absence_capture.url")" == *"/issues/comments/7" ]] ||
     fail "an existing notice was duplicated instead of refreshed in place"
 
+# `--jq` runs per page, so two matching notices yield two ids; splicing both
+# into the PATCH url would wedge the job exactly when it should self-heal.
+run_absence failure '[{"id":7,"body":"<!-- absent-claude-auto-review:abc123 -->\na"},{"id":8,"body":"<!-- absent-claude-auto-review:abc123 -->\nb"}]'
+[[ "$(<"$absence_capture.url")" == *"/issues/comments/7" ]] ||
+    fail "a second matching notice was spliced into the update target"
+
 # A listing that ERRORS is not "no notice yet": writing here posts the duplicate
 # the guard exists to prevent.
 run_absence failure '[]' fail-the-listing

--- a/policy/ci-observability/action_behavior_test.sh
+++ b/policy/ci-observability/action_behavior_test.sh
@@ -518,22 +518,34 @@ assert_refusal '{"head":{"repo":null},"base":{"ref":"main"},"state":"open"}' tru
 
 absence_script="$(workflow_step_script "$CLAUDE_REVIEW_WORKFLOW_FILE" "Say the second lens did not run")"
 absence_capture="$test_dir/absence-body"
-: >"$absence_capture"
-PATH="$fake_bin:$PATH" \
-    ABSENCE_CAPTURE="$absence_capture" \
-    FAKE_PR_JSON="$valid_pr" \
-    GH_TOKEN="test-token" \
-    PR_NUMBER="42" \
-    REPOSITORY="owner/repo" \
-    REVIEW_MARKER="claude-auto-review" \
-    REVIEW_TITLE="Claude Review" \
-    RUN_URL="https://example.invalid/run" \
-    bash -c "$absence_script" >/dev/null 2>&1 ||
-    fail "absence notice exited non-zero"
 
+run_absence() {
+    : >"$absence_capture"
+    PATH="$fake_bin:$PATH" \
+        ABSENCE_CAPTURE="$absence_capture" \
+        ANALYZE_RESULT="$1" \
+        FAKE_PR_JSON="$valid_pr" \
+        GH_TOKEN="test-token" \
+        PR_NUMBER="42" \
+        REPOSITORY="owner/repo" \
+        REVIEW_MARKER="claude-auto-review" \
+        REVIEW_TITLE="Claude Review" \
+        RUN_URL="https://example.invalid/run" \
+        bash -c "$absence_script" >/dev/null 2>&1 ||
+        fail "absence notice exited non-zero for result=$1"
+}
+
+run_absence failure
 absence_body="$(<"$absence_capture")"
 [[ "$absence_body" == *"ABSENT, not clean"* ]] ||
     fail "absence notice did not say the review is absent rather than clean"
 # A prefix matcher on the published review's marker must not read this as a review.
 [[ "$absence_body" != *"<!-- claude-auto-review"* ]] ||
     fail "absence marker collides with the published review marker"
+[[ "$absence_body" == *"total_cost_usd"* ]] ||
+    fail "a failed analysis did not name the field that identifies a spent quota"
+
+# The decline arm has no red job behind it; it must still say something.
+run_absence success
+[[ "$(<"$absence_capture")" == *"out of scope for the reviewer"* ]] ||
+    fail "a declined review was reported as a failure"

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -446,6 +446,7 @@ claude_fork_refusal_marker := "head.repo.full_name"
 claude_fork_refusal_indices := [idx |
 	some idx, step in claude_tag_steps
 	contains(object.get(step, "run", ""), claude_fork_refusal_marker)
+	contains(object.get(step, "if", ""), "issue_comment")
 ]
 
 claude_action_step_indices := [idx |
@@ -462,10 +463,23 @@ claude_reusable_jobs := object.get(claude_reusable, "jobs", {})
 
 claude_absence_condition := "needs.analyze.result == 'failure'"
 
+# Without one of these an implicit `success()` is applied over `needs: analyze`,
+# so the job is skipped in precisely the situation it exists for — and the
+# inert form reads like a tidy-up, which is how it would land.
+claude_status_functions := {"always()", "!cancelled()", "failure()"}
+
 claude_absence_jobs := [job |
 	some job in claude_reusable_jobs
-	contains(normalized_claude_condition(object.get(job, "if", "")), claude_absence_condition)
+	condition := normalized_claude_condition(object.get(job, "if", ""))
+	contains(condition, claude_absence_condition)
+	some status_function in claude_status_functions
+	contains(condition, status_function)
 ]
+
+claude_absence_job_checks_out if {
+	some step in object.get(claude_absence_jobs[0], "steps", [])
+	object.get(step, "uses", "") != ""
+}
 
 claude_analyze_job := object.get(claude_reusable_jobs, "analyze", {})
 claude_publish_job := object.get(claude_reusable_jobs, "publish", {})
@@ -773,13 +787,22 @@ deny contains msg if {
 	msg := sprintf("%s must report an absent review in exactly one job conditioned on `%s`", [claude_reusable_workflow_path, claude_absence_condition])
 }
 
-# A reporter that cannot comment is inert, and inert is the failure mode this
-# whole job exists to prevent.
+# An exact set, like its two siblings: a lower bound would let this job carry
+# `contents: write` into the workflow whose whole design is read-only.
 deny contains msg if {
 	_ := documents[claude_reusable_workflow_path]
 	count(claude_absence_jobs) == 1
-	object.get(claude_absence_jobs[0], ["permissions", "pull-requests"], "") != "write"
-	msg := sprintf("%s absent-review job needs `pull-requests: write` to post its notice", [claude_reusable_workflow_path])
+	object.get(claude_absence_jobs[0], "permissions", {}) != {"pull-requests": "write"}
+	msg := sprintf("%s absent-review job must carry exactly `pull-requests: write`", [claude_reusable_workflow_path])
+}
+
+# It reports on a head it must never fetch; a checkout here would reintroduce
+# the untrusted-tree class the analyze job is built to avoid.
+deny contains msg if {
+	_ := documents[claude_reusable_workflow_path]
+	count(claude_absence_jobs) == 1
+	claude_absence_job_checks_out
+	msg := sprintf("%s absent-review job must not check anything out", [claude_reusable_workflow_path])
 }
 
 deny contains msg if {

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -467,6 +467,10 @@ claude_reusable_jobs := object.get(claude_reusable, "jobs", {})
 
 claude_absence_condition := "needs.analyze.result == 'failure'"
 
+# The decline arm has no red job behind it, so its removal is what nothing else
+# would catch.
+claude_decline_condition := "needs.analyze.outputs.reviewable == 'false'"
+
 # Without one of these an implicit `success()` is applied over `needs: analyze`,
 # so the job is skipped in precisely the situation it exists for — and the
 # inert form reads like a tidy-up, which is how it would land.
@@ -474,7 +478,9 @@ claude_status_functions := {"always()", "!cancelled()", "failure()"}
 
 claude_absence_conditioned_jobs := [job |
 	some job in claude_reusable_jobs
-	contains(normalized_claude_condition(object.get(job, "if", "")), claude_absence_condition)
+	condition := normalized_claude_condition(object.get(job, "if", ""))
+	contains(condition, claude_absence_condition)
+	contains(condition, claude_decline_condition)
 ]
 
 claude_condition_has_status_function(condition) if {
@@ -790,7 +796,7 @@ deny contains msg if {
 deny contains msg if {
 	_ := documents[claude_reusable_workflow_path]
 	count(claude_absence_conditioned_jobs) != 1
-	msg := sprintf("%s must report an absent review in exactly one job conditioned on `%s`", [claude_reusable_workflow_path, claude_absence_condition])
+	msg := sprintf("%s must report an absent review in exactly one job, conditioned on BOTH `%s` and `%s`", [claude_reusable_workflow_path, claude_absence_condition, claude_decline_condition])
 }
 
 # Split from the rule above so the maintainer who deleted `always()` as tidy-up

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -467,10 +467,6 @@ claude_reusable_jobs := object.get(claude_reusable, "jobs", {})
 
 claude_absence_condition := "needs.analyze.result == 'failure'"
 
-# The decline arm is the one with no red job behind it, so its silent removal
-# is what nothing else would catch.
-claude_decline_condition := "needs.analyze.outputs.reviewable == 'false'"
-
 # Without one of these an implicit `success()` is applied over `needs: analyze`,
 # so the job is skipped in precisely the situation it exists for — and the
 # inert form reads like a tidy-up, which is how it would land.
@@ -478,9 +474,7 @@ claude_status_functions := {"always()", "!cancelled()", "failure()"}
 
 claude_absence_conditioned_jobs := [job |
 	some job in claude_reusable_jobs
-	condition := normalized_claude_condition(object.get(job, "if", ""))
-	contains(condition, claude_absence_condition)
-	contains(condition, claude_decline_condition)
+	contains(normalized_claude_condition(object.get(job, "if", "")), claude_absence_condition)
 ]
 
 claude_condition_has_status_function(condition) if {
@@ -492,11 +486,6 @@ claude_absence_jobs := [job |
 	some job in claude_absence_conditioned_jobs
 	claude_condition_has_status_function(normalized_claude_condition(object.get(job, "if", "")))
 ]
-
-claude_absence_job_checks_out if {
-	some step in object.get(claude_absence_jobs[0], "steps", [])
-	object.get(step, "uses", "") != ""
-}
 
 claude_analyze_job := object.get(claude_reusable_jobs, "analyze", {})
 claude_publish_job := object.get(claude_reusable_jobs, "publish", {})
@@ -801,7 +790,7 @@ deny contains msg if {
 deny contains msg if {
 	_ := documents[claude_reusable_workflow_path]
 	count(claude_absence_conditioned_jobs) != 1
-	msg := sprintf("%s must report an absent review in exactly one job, conditioned on BOTH `%s` and `%s`", [claude_reusable_workflow_path, claude_absence_condition, claude_decline_condition])
+	msg := sprintf("%s must report an absent review in exactly one job conditioned on `%s`", [claude_reusable_workflow_path, claude_absence_condition])
 }
 
 # Split from the rule above so the maintainer who deleted `always()` as tidy-up
@@ -811,24 +800,6 @@ deny contains msg if {
 	count(claude_absence_conditioned_jobs) == 1
 	count(claude_absence_jobs) == 0
 	msg := sprintf("%s absent-review job's `if:` needs a status function (one of %v) — without one an implicit `success()` skips it exactly when analyze fails", [claude_reusable_workflow_path, claude_status_functions])
-}
-
-# An exact set, like its two siblings: a lower bound would let this job carry
-# `contents: write` into the workflow whose whole design is read-only.
-deny contains msg if {
-	_ := documents[claude_reusable_workflow_path]
-	count(claude_absence_jobs) == 1
-	object.get(claude_absence_jobs[0], "permissions", {}) != {"pull-requests": "write"}
-	msg := sprintf("%s absent-review job must carry exactly `pull-requests: write`", [claude_reusable_workflow_path])
-}
-
-# It reports on a head it must never fetch; a checkout here would reintroduce
-# the untrusted-tree class the analyze job is built to avoid.
-deny contains msg if {
-	_ := documents[claude_reusable_workflow_path]
-	count(claude_absence_jobs) == 1
-	claude_absence_job_checks_out
-	msg := sprintf("%s absent-review job must not check anything out", [claude_reusable_workflow_path])
 }
 
 deny contains msg if {

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -437,6 +437,26 @@ claude_tag_event_is_guarded(event) if {
 	}
 }
 
+claude_tag_steps := object.get(claude_tag_jobs[0], "steps", [])
+
+# Keyed on the API field the refusal must READ, not on its step name — the same
+# reason `claude_tag_jobs` keys off the action instead of the job name.
+claude_fork_refusal_marker := "head.repo.full_name"
+
+claude_fork_refusal_indices := [idx |
+	some idx, step in claude_tag_steps
+	contains(object.get(step, "run", ""), claude_fork_refusal_marker)
+]
+
+claude_action_step_indices := [idx |
+	some idx, step in claude_tag_steps
+	action_matches(object.get(step, "uses", ""), claude_action)
+]
+
+claude_fork_refusal_precedes_the_action if {
+	min(claude_fork_refusal_indices) < min(claude_action_step_indices)
+}
+
 claude_reusable := object.get(documents, claude_reusable_workflow_path, {})
 claude_reusable_jobs := object.get(claude_reusable, "jobs", {})
 claude_analyze_job := object.get(claude_reusable_jobs, "analyze", {})
@@ -714,6 +734,18 @@ deny contains msg if {
 	claude_tag_triggers_event(event)
 	not claude_tag_event_is_guarded(event)
 	msg := sprintf("%s %s arm must require `%s`", [claude_tag_workflow_path, event, claude_same_repo_head_condition])
+}
+
+# The issue_comment arm cannot be closed by an `if:` at all: its payload carries
+# no pull_request object, and the fork tree arrives through the action's own
+# setupBranch (tag mode checks the PR head out for every open PR, fork or not)
+# rather than through GITHUB_REF. So the guard has to be a STEP, and it has to
+# run before the action stages that tree. #799
+deny contains msg if {
+	claude_tag_triggers_event("issue_comment")
+	count(claude_tag_jobs) == 1
+	not claude_fork_refusal_precedes_the_action
+	msg := sprintf("%s must refuse fork pull requests in a step before `%s` runs", [claude_tag_workflow_path, claude_action])
 }
 
 # The existence half: the guard above resolves the job through its action step,

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -459,6 +459,14 @@ claude_fork_refusal_precedes_the_action if {
 
 claude_reusable := object.get(documents, claude_reusable_workflow_path, {})
 claude_reusable_jobs := object.get(claude_reusable, "jobs", {})
+
+claude_absence_condition := "needs.analyze.result == 'failure'"
+
+claude_absence_jobs := [job |
+	some job in claude_reusable_jobs
+	contains(normalized_claude_condition(object.get(job, "if", "")), claude_absence_condition)
+]
+
 claude_analyze_job := object.get(claude_reusable_jobs, "analyze", {})
 claude_publish_job := object.get(claude_reusable_jobs, "publish", {})
 claude_analyze_steps := object.get(claude_analyze_job, "steps", [])
@@ -754,6 +762,24 @@ deny contains msg if {
 	_ := documents[claude_tag_workflow_path]
 	count(claude_tag_jobs) != 1
 	msg := sprintf("%s must run `%s` in exactly one job — the fork-head guard is keyed to that job's condition", [claude_tag_workflow_path, claude_action])
+}
+
+# The merge gate reads "Findings: 0 at HEAD", so a run that produces no verdict
+# must SAY so — otherwise a spent quota is indistinguishable from a clean review
+# (publish skips, nothing comments, the PR just reads UNSTABLE). #819
+deny contains msg if {
+	_ := documents[claude_reusable_workflow_path]
+	count(claude_absence_jobs) != 1
+	msg := sprintf("%s must report an absent review in exactly one job conditioned on `%s`", [claude_reusable_workflow_path, claude_absence_condition])
+}
+
+# A reporter that cannot comment is inert, and inert is the failure mode this
+# whole job exists to prevent.
+deny contains msg if {
+	_ := documents[claude_reusable_workflow_path]
+	count(claude_absence_jobs) == 1
+	object.get(claude_absence_jobs[0], ["permissions", "pull-requests"], "") != "write"
+	msg := sprintf("%s absent-review job needs `pull-requests: write` to post its notice", [claude_reusable_workflow_path])
 }
 
 deny contains msg if {

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -402,10 +402,14 @@ claude_trigger_workflow_paths := {
 
 # Identified by the action it runs, not by its job NAME: keying on the literal
 # name `claude` let a rename retire the head guard below in silence.
-claude_tag_jobs := [job |
-	some job in object.get(documents[claude_tag_workflow_path], "jobs", {})
+claude_job_runs_the_action(job) if {
 	some step in object.get(job, "steps", [])
 	action_matches(object.get(step, "uses", ""), claude_action)
+}
+
+claude_tag_jobs := [job |
+	some job in object.get(documents[claude_tag_workflow_path], "jobs", {})
+	claude_job_runs_the_action(job)
 ]
 
 claude_tag_condition := normalized_claude_condition(object.get(claude_tag_jobs[0], "if", ""))
@@ -479,10 +483,14 @@ claude_absence_conditioned_jobs := [job |
 	contains(condition, claude_decline_condition)
 ]
 
+claude_condition_has_status_function(condition) if {
+	some status_function in claude_status_functions
+	contains(condition, status_function)
+}
+
 claude_absence_jobs := [job |
 	some job in claude_absence_conditioned_jobs
-	some status_function in claude_status_functions
-	contains(normalized_claude_condition(object.get(job, "if", "")), status_function)
+	claude_condition_has_status_function(normalized_claude_condition(object.get(job, "if", "")))
 ]
 
 claude_absence_job_checks_out if {

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -463,17 +463,26 @@ claude_reusable_jobs := object.get(claude_reusable, "jobs", {})
 
 claude_absence_condition := "needs.analyze.result == 'failure'"
 
+# The decline arm is the one with no red job behind it, so its silent removal
+# is what nothing else would catch.
+claude_decline_condition := "needs.analyze.outputs.reviewable == 'false'"
+
 # Without one of these an implicit `success()` is applied over `needs: analyze`,
 # so the job is skipped in precisely the situation it exists for — and the
 # inert form reads like a tidy-up, which is how it would land.
 claude_status_functions := {"always()", "!cancelled()", "failure()"}
 
-claude_absence_jobs := [job |
+claude_absence_conditioned_jobs := [job |
 	some job in claude_reusable_jobs
 	condition := normalized_claude_condition(object.get(job, "if", ""))
 	contains(condition, claude_absence_condition)
+	contains(condition, claude_decline_condition)
+]
+
+claude_absence_jobs := [job |
+	some job in claude_absence_conditioned_jobs
 	some status_function in claude_status_functions
-	contains(condition, status_function)
+	contains(normalized_claude_condition(object.get(job, "if", "")), status_function)
 ]
 
 claude_absence_job_checks_out if {
@@ -767,7 +776,7 @@ deny contains msg if {
 	claude_tag_triggers_event("issue_comment")
 	count(claude_tag_jobs) == 1
 	not claude_fork_refusal_precedes_the_action
-	msg := sprintf("%s must refuse fork pull requests in a step before `%s` runs", [claude_tag_workflow_path, claude_action])
+	msg := sprintf("%s must refuse fork pull requests in a step scoped to `issue_comment`, before `%s` runs", [claude_tag_workflow_path, claude_action])
 }
 
 # The existence half: the guard above resolves the job through its action step,
@@ -783,8 +792,17 @@ deny contains msg if {
 # (publish skips, nothing comments, the PR just reads UNSTABLE). #819
 deny contains msg if {
 	_ := documents[claude_reusable_workflow_path]
-	count(claude_absence_jobs) != 1
-	msg := sprintf("%s must report an absent review in exactly one job conditioned on `%s`", [claude_reusable_workflow_path, claude_absence_condition])
+	count(claude_absence_conditioned_jobs) != 1
+	msg := sprintf("%s must report an absent review in exactly one job, conditioned on BOTH `%s` and `%s`", [claude_reusable_workflow_path, claude_absence_condition, claude_decline_condition])
+}
+
+# Split from the rule above so the maintainer who deleted `always()` as tidy-up
+# is not told to add a condition they can see is already there.
+deny contains msg if {
+	_ := documents[claude_reusable_workflow_path]
+	count(claude_absence_conditioned_jobs) == 1
+	count(claude_absence_jobs) == 0
+	msg := sprintf("%s absent-review job's `if:` needs a status function (one of %v) — without one an implicit `success()` skips it exactly when analyze fails", [claude_reusable_workflow_path, claude_status_functions])
 }
 
 # An exact set, like its two siblings: a lower bound would let this job carry

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -811,6 +811,47 @@ test_claude_resolver_is_required if {
 	sprintf("%s must resolve one open internal default-branch pull request", [claude_reusable_workflow_path]) in violations
 }
 
+claude_absence_missing_message := sprintf("%s must report an absent review in exactly one job conditioned on `%s`", [claude_reusable_workflow_path, claude_absence_condition])
+
+claude_absence_permission_message := sprintf("%s absent-review job needs `pull-requests: write` to post its notice", [claude_reusable_workflow_path])
+
+claude_absence_reusable(jobs) := {"documents": [{
+	"path": claude_reusable_workflow_path,
+	"contents": {"jobs": jobs},
+}]}
+
+# Without this job a spent quota reads exactly like a clean review: publish
+# skips, nothing comments, the PR sits at UNSTABLE. #819
+test_claude_absent_review_must_be_reported if {
+	violations := deny with input as claude_absence_reusable({"analyze": {"steps": []}})
+	claude_absence_missing_message in violations
+}
+
+test_claude_absent_review_reporter_without_comment_permission_is_denied if {
+	violations := deny with input as claude_absence_reusable({
+		"analyze": {"steps": []},
+		"report_absence": {
+			"if": sprintf("always() && %s", [claude_absence_condition]),
+			"permissions": {"pull-requests": "read"},
+			"steps": [],
+		},
+	})
+	claude_absence_permission_message in violations
+}
+
+test_claude_absent_review_reporter_is_accepted if {
+	violations := deny with input as claude_absence_reusable({
+		"analyze": {"steps": []},
+		"report_absence": {
+			"if": sprintf("always() && %s", [claude_absence_condition]),
+			"permissions": {"pull-requests": "write"},
+			"steps": [],
+		},
+	})
+	not claude_absence_missing_message in violations
+	not claude_absence_permission_message in violations
+}
+
 test_claude_oauth_fallback_requires_all_wif_authority_fields_to_be_absent if {
 	fixture := {"documents": [{
 		"path": claude_reusable_workflow_path,

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -811,13 +811,9 @@ test_claude_resolver_is_required if {
 	sprintf("%s must resolve one open internal default-branch pull request", [claude_reusable_workflow_path]) in violations
 }
 
-claude_absence_missing_message := sprintf("%s must report an absent review in exactly one job, conditioned on BOTH `%s` and `%s`", [claude_reusable_workflow_path, claude_absence_condition, claude_decline_condition])
+claude_absence_missing_message := sprintf("%s must report an absent review in exactly one job conditioned on `%s`", [claude_reusable_workflow_path, claude_absence_condition])
 
 claude_absence_status_message := sprintf("%s absent-review job's `if:` needs a status function (one of %v) — without one an implicit `success()` skips it exactly when analyze fails", [claude_reusable_workflow_path, claude_status_functions])
-
-claude_absence_permission_message := sprintf("%s absent-review job must carry exactly `pull-requests: write`", [claude_reusable_workflow_path])
-
-claude_absence_checkout_message := sprintf("%s absent-review job must not check anything out", [claude_reusable_workflow_path])
 
 claude_absence_reusable(jobs) := {"documents": [{
 	"path": claude_reusable_workflow_path,
@@ -831,59 +827,16 @@ test_claude_absent_review_must_be_reported if {
 	claude_absence_missing_message in violations
 }
 
-test_claude_absent_review_reporter_without_comment_permission_is_denied if {
-	violations := deny with input as claude_absence_reusable({
-		"analyze": {"steps": []},
-		"report_absence": {
-			"if": sprintf("always() && (%s || %s)", [claude_absence_condition, claude_decline_condition]),
-			"permissions": {"pull-requests": "read"},
-			"steps": [],
-		},
-	})
-	claude_absence_permission_message in violations
-}
-
 test_claude_absent_review_reporter_is_accepted if {
 	violations := deny with input as claude_absence_reusable({
 		"analyze": {"steps": []},
 		"report_absence": {
-			"if": sprintf("always() && (%s || %s)", [claude_absence_condition, claude_decline_condition]),
+			"if": sprintf("always() && %s", [claude_absence_condition]),
 			"permissions": {"pull-requests": "write"},
 			"steps": [],
 		},
 	})
 	not claude_absence_missing_message in violations
-	not claude_absence_permission_message in violations
-	not claude_absence_checkout_message in violations
-}
-
-# Dropping the decline arm leaves the shape with no red job behind it silent
-# again, and the shell tests cannot see it — they drive the step, not the `if:`.
-test_claude_absent_review_without_the_decline_arm_is_denied if {
-	violations := deny with input as claude_absence_reusable({
-		"analyze": {"steps": []},
-		"report_absence": {
-			"if": sprintf("!cancelled() && %s", [claude_absence_condition]),
-			"permissions": {"pull-requests": "write"},
-			"steps": [],
-		},
-	})
-	claude_absence_missing_message in violations
-}
-
-# A second status function used to append the job TWICE, and every sibling rule
-# guards on `count == 1` — so writing both defensively disarmed them all.
-test_claude_absent_review_with_two_status_functions_still_pins_permissions if {
-	violations := deny with input as claude_absence_reusable({
-		"analyze": {"steps": []},
-		"report_absence": {
-			"if": sprintf("always() && !cancelled() && (%s || %s)", [claude_absence_condition, claude_decline_condition]),
-			"permissions": {"contents": "write", "pull-requests": "write"},
-			"steps": [{"uses": "actions/checkout@v7"}],
-		},
-	})
-	claude_absence_permission_message in violations
-	claude_absence_checkout_message in violations
 }
 
 # The inert variant, and the one that would land as a cleanup — see
@@ -892,37 +845,12 @@ test_claude_absent_review_without_a_status_function_is_denied if {
 	violations := deny with input as claude_absence_reusable({
 		"analyze": {"steps": []},
 		"report_absence": {
-			"if": sprintf("%s || %s", [claude_absence_condition, claude_decline_condition]),
+			"if": claude_absence_condition,
 			"permissions": {"pull-requests": "write"},
 			"steps": [],
 		},
 	})
 	claude_absence_status_message in violations
-}
-
-# A lower bound is not enough — see the rule in main.rego.
-test_claude_absent_review_reporter_with_extra_permissions_is_denied if {
-	violations := deny with input as claude_absence_reusable({
-		"analyze": {"steps": []},
-		"report_absence": {
-			"if": sprintf("!cancelled() && (%s || %s)", [claude_absence_condition, claude_decline_condition]),
-			"permissions": {"contents": "write", "pull-requests": "write"},
-			"steps": [],
-		},
-	})
-	claude_absence_permission_message in violations
-}
-
-test_claude_absent_review_reporter_checking_out_is_denied if {
-	violations := deny with input as claude_absence_reusable({
-		"analyze": {"steps": []},
-		"report_absence": {
-			"if": sprintf("!cancelled() && (%s || %s)", [claude_absence_condition, claude_decline_condition]),
-			"permissions": {"pull-requests": "write"},
-			"steps": [{"uses": "actions/checkout@v7"}],
-		},
-	})
-	claude_absence_checkout_message in violations
 }
 
 test_claude_oauth_fallback_requires_all_wif_authority_fields_to_be_absent if {

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -813,15 +813,17 @@ test_claude_resolver_is_required if {
 
 claude_absence_missing_message := sprintf("%s must report an absent review in exactly one job conditioned on `%s`", [claude_reusable_workflow_path, claude_absence_condition])
 
-claude_absence_permission_message := sprintf("%s absent-review job needs `pull-requests: write` to post its notice", [claude_reusable_workflow_path])
+claude_absence_permission_message := sprintf("%s absent-review job must carry exactly `pull-requests: write`", [claude_reusable_workflow_path])
+
+claude_absence_checkout_message := sprintf("%s absent-review job must not check anything out", [claude_reusable_workflow_path])
 
 claude_absence_reusable(jobs) := {"documents": [{
 	"path": claude_reusable_workflow_path,
 	"contents": {"jobs": jobs},
 }]}
 
-# Without this job a spent quota reads exactly like a clean review: publish
-# skips, nothing comments, the PR sits at UNSTABLE. #819
+# Absence and a clean review render identically without this job — see the
+# rule in main.rego. #819
 test_claude_absent_review_must_be_reported if {
 	violations := deny with input as claude_absence_reusable({"analyze": {"steps": []}})
 	claude_absence_missing_message in violations
@@ -850,6 +852,48 @@ test_claude_absent_review_reporter_is_accepted if {
 	})
 	not claude_absence_missing_message in violations
 	not claude_absence_permission_message in violations
+	not claude_absence_checkout_message in violations
+}
+
+# The inert variant, and the one that would land as a cleanup: GitHub applies
+# an implicit `success()` over `needs:` unless a status function is present, so
+# this job would be SKIPPED exactly when analyze fails.
+test_claude_absent_review_without_a_status_function_is_denied if {
+	violations := deny with input as claude_absence_reusable({
+		"analyze": {"steps": []},
+		"report_absence": {
+			"if": claude_absence_condition,
+			"permissions": {"pull-requests": "write"},
+			"steps": [],
+		},
+	})
+	claude_absence_missing_message in violations
+}
+
+# A lower bound would let the reporter carry write scopes into a workflow whose
+# whole design is read-only.
+test_claude_absent_review_reporter_with_extra_permissions_is_denied if {
+	violations := deny with input as claude_absence_reusable({
+		"analyze": {"steps": []},
+		"report_absence": {
+			"if": sprintf("!cancelled() && %s", [claude_absence_condition]),
+			"permissions": {"contents": "write", "pull-requests": "write"},
+			"steps": [],
+		},
+	})
+	claude_absence_permission_message in violations
+}
+
+test_claude_absent_review_reporter_checking_out_is_denied if {
+	violations := deny with input as claude_absence_reusable({
+		"analyze": {"steps": []},
+		"report_absence": {
+			"if": sprintf("!cancelled() && %s", [claude_absence_condition]),
+			"permissions": {"pull-requests": "write"},
+			"steps": [{"uses": "actions/checkout@v7"}],
+		},
+	})
+	claude_absence_checkout_message in violations
 }
 
 test_claude_oauth_fallback_requires_all_wif_authority_fields_to_be_absent if {
@@ -1221,7 +1265,10 @@ claude_tag_head_guard_message(event) := sprintf("%s %s arm must require `%s`", [
 
 claude_tag_fork_refusal_message := sprintf("%s must refuse fork pull requests in a step before `%s` runs", [claude_tag_workflow_path, claude_action])
 
-claude_tag_fork_refusal_step := {"run": sprintf("head_repo=\"$(gh api \"repos/$REPOSITORY/pulls/$PR_NUMBER\" --jq '.%s')\"", [claude_fork_refusal_marker])}
+claude_tag_fork_refusal_step := {
+	"if": "github.event_name == 'issue_comment' && github.event.issue.pull_request",
+	"run": sprintf("head_repo=\"$(gh api \"repos/$REPOSITORY/pulls/$PR_NUMBER\" --jq '.%s')\"", [claude_fork_refusal_marker]),
+}
 
 claude_tag_single_job_message := sprintf("%s must run `%s` in exactly one job — the fork-head guard is keyed to that job's condition", [claude_tag_workflow_path, claude_action])
 
@@ -1327,10 +1374,8 @@ test_claude_tag_dropping_a_pull_request_trigger_is_accepted if {
 	}
 }
 
-# The `if:` guard the other arms use is INEXPRESSIBLE here: an issue_comment
-# payload carries no pull_request object, and the fork tree arrives through the
-# action's own setupBranch rather than through GITHUB_REF. Only a step can
-# close it, so the policy demands one. #799
+# The `if:` guard the other arms use is inexpressible here — see the rule in
+# main.rego. #799
 test_claude_tag_issue_comment_without_a_fork_refusal_step_is_denied if {
 	violations := deny with input as claude_tag_fixture(sprintf(" && %s", [claude_same_repo_head_condition]))
 	claude_tag_fork_refusal_message in violations
@@ -1342,6 +1387,19 @@ test_claude_tag_fork_refusal_after_the_action_is_denied if {
 	violations := deny with input as claude_tag_workflow("claude", {
 		"if": claude_tag_condition_text(sprintf(" && %s", [claude_same_repo_head_condition])),
 		"steps": [{"uses": claude_action}, claude_tag_fork_refusal_step],
+	})
+	claude_tag_fork_refusal_message in violations
+}
+
+# Narrowing the step's own condition reopens #799 in full while leaving the
+# `run:` body — and so a run-only rule — untouched.
+test_claude_tag_fork_refusal_not_scoped_to_issue_comment_is_denied if {
+	violations := deny with input as claude_tag_workflow("claude", {
+		"if": claude_tag_condition_text(sprintf(" && %s", [claude_same_repo_head_condition])),
+		"steps": [
+			object.union(claude_tag_fork_refusal_step, {"if": "github.event_name == 'pull_request_review'"}),
+			{"uses": claude_action},
+		],
 	})
 	claude_tag_fork_refusal_message in violations
 }

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -811,7 +811,7 @@ test_claude_resolver_is_required if {
 	sprintf("%s must resolve one open internal default-branch pull request", [claude_reusable_workflow_path]) in violations
 }
 
-claude_absence_missing_message := sprintf("%s must report an absent review in exactly one job conditioned on `%s`", [claude_reusable_workflow_path, claude_absence_condition])
+claude_absence_missing_message := sprintf("%s must report an absent review in exactly one job, conditioned on BOTH `%s` and `%s`", [claude_reusable_workflow_path, claude_absence_condition, claude_decline_condition])
 
 claude_absence_status_message := sprintf("%s absent-review job's `if:` needs a status function (one of %v) — without one an implicit `success()` skips it exactly when analyze fails", [claude_reusable_workflow_path, claude_status_functions])
 
@@ -831,12 +831,25 @@ test_claude_absent_review_reporter_is_accepted if {
 	violations := deny with input as claude_absence_reusable({
 		"analyze": {"steps": []},
 		"report_absence": {
-			"if": sprintf("always() && %s", [claude_absence_condition]),
+			"if": sprintf("always() && (%s || %s)", [claude_absence_condition, claude_decline_condition]),
 			"permissions": {"pull-requests": "write"},
 			"steps": [],
 		},
 	})
 	not claude_absence_missing_message in violations
+}
+
+# The decline arm is the shape with no red job behind it, so nothing else would
+# notice its removal.
+test_claude_absent_review_without_the_decline_arm_is_denied if {
+	violations := deny with input as claude_absence_reusable({
+		"analyze": {"steps": []},
+		"report_absence": {
+			"if": sprintf("!cancelled() && %s", [claude_absence_condition]),
+			"steps": [],
+		},
+	})
+	claude_absence_missing_message in violations
 }
 
 # The inert variant, and the one that would land as a cleanup — see
@@ -845,7 +858,7 @@ test_claude_absent_review_without_a_status_function_is_denied if {
 	violations := deny with input as claude_absence_reusable({
 		"analyze": {"steps": []},
 		"report_absence": {
-			"if": claude_absence_condition,
+			"if": sprintf("%s || %s", [claude_absence_condition, claude_decline_condition]),
 			"permissions": {"pull-requests": "write"},
 			"steps": [],
 		},

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -811,7 +811,9 @@ test_claude_resolver_is_required if {
 	sprintf("%s must resolve one open internal default-branch pull request", [claude_reusable_workflow_path]) in violations
 }
 
-claude_absence_missing_message := sprintf("%s must report an absent review in exactly one job conditioned on `%s`", [claude_reusable_workflow_path, claude_absence_condition])
+claude_absence_missing_message := sprintf("%s must report an absent review in exactly one job, conditioned on BOTH `%s` and `%s`", [claude_reusable_workflow_path, claude_absence_condition, claude_decline_condition])
+
+claude_absence_status_message := sprintf("%s absent-review job's `if:` needs a status function (one of %v) — without one an implicit `success()` skips it exactly when analyze fails", [claude_reusable_workflow_path, claude_status_functions])
 
 claude_absence_permission_message := sprintf("%s absent-review job must carry exactly `pull-requests: write`", [claude_reusable_workflow_path])
 
@@ -833,7 +835,7 @@ test_claude_absent_review_reporter_without_comment_permission_is_denied if {
 	violations := deny with input as claude_absence_reusable({
 		"analyze": {"steps": []},
 		"report_absence": {
-			"if": sprintf("always() && %s", [claude_absence_condition]),
+			"if": sprintf("always() && (%s || %s)", [claude_absence_condition, claude_decline_condition]),
 			"permissions": {"pull-requests": "read"},
 			"steps": [],
 		},
@@ -845,7 +847,7 @@ test_claude_absent_review_reporter_is_accepted if {
 	violations := deny with input as claude_absence_reusable({
 		"analyze": {"steps": []},
 		"report_absence": {
-			"if": sprintf("always() && %s", [claude_absence_condition]),
+			"if": sprintf("always() && (%s || %s)", [claude_absence_condition, claude_decline_condition]),
 			"permissions": {"pull-requests": "write"},
 			"steps": [],
 		},
@@ -855,14 +857,13 @@ test_claude_absent_review_reporter_is_accepted if {
 	not claude_absence_checkout_message in violations
 }
 
-# The inert variant, and the one that would land as a cleanup: GitHub applies
-# an implicit `success()` over `needs:` unless a status function is present, so
-# this job would be SKIPPED exactly when analyze fails.
-test_claude_absent_review_without_a_status_function_is_denied if {
+# Dropping the decline arm leaves the shape with no red job behind it silent
+# again, and the shell tests cannot see it — they drive the step, not the `if:`.
+test_claude_absent_review_without_the_decline_arm_is_denied if {
 	violations := deny with input as claude_absence_reusable({
 		"analyze": {"steps": []},
 		"report_absence": {
-			"if": claude_absence_condition,
+			"if": sprintf("!cancelled() && %s", [claude_absence_condition]),
 			"permissions": {"pull-requests": "write"},
 			"steps": [],
 		},
@@ -870,13 +871,26 @@ test_claude_absent_review_without_a_status_function_is_denied if {
 	claude_absence_missing_message in violations
 }
 
-# A lower bound would let the reporter carry write scopes into a workflow whose
-# whole design is read-only.
+# The inert variant, and the one that would land as a cleanup — see
+# `claude_status_functions` in main.rego.
+test_claude_absent_review_without_a_status_function_is_denied if {
+	violations := deny with input as claude_absence_reusable({
+		"analyze": {"steps": []},
+		"report_absence": {
+			"if": sprintf("%s || %s", [claude_absence_condition, claude_decline_condition]),
+			"permissions": {"pull-requests": "write"},
+			"steps": [],
+		},
+	})
+	claude_absence_status_message in violations
+}
+
+# A lower bound is not enough — see the rule in main.rego.
 test_claude_absent_review_reporter_with_extra_permissions_is_denied if {
 	violations := deny with input as claude_absence_reusable({
 		"analyze": {"steps": []},
 		"report_absence": {
-			"if": sprintf("!cancelled() && %s", [claude_absence_condition]),
+			"if": sprintf("!cancelled() && (%s || %s)", [claude_absence_condition, claude_decline_condition]),
 			"permissions": {"contents": "write", "pull-requests": "write"},
 			"steps": [],
 		},
@@ -888,7 +902,7 @@ test_claude_absent_review_reporter_checking_out_is_denied if {
 	violations := deny with input as claude_absence_reusable({
 		"analyze": {"steps": []},
 		"report_absence": {
-			"if": sprintf("!cancelled() && %s", [claude_absence_condition]),
+			"if": sprintf("!cancelled() && (%s || %s)", [claude_absence_condition, claude_decline_condition]),
 			"permissions": {"pull-requests": "write"},
 			"steps": [{"uses": "actions/checkout@v7"}],
 		},
@@ -1263,7 +1277,7 @@ test_codeql_health_gate_before_upload_is_accepted if {
 
 claude_tag_head_guard_message(event) := sprintf("%s %s arm must require `%s`", [claude_tag_workflow_path, event, claude_same_repo_head_condition])
 
-claude_tag_fork_refusal_message := sprintf("%s must refuse fork pull requests in a step before `%s` runs", [claude_tag_workflow_path, claude_action])
+claude_tag_fork_refusal_message := sprintf("%s must refuse fork pull requests in a step scoped to `issue_comment`, before `%s` runs", [claude_tag_workflow_path, claude_action])
 
 claude_tag_fork_refusal_step := {
 	"if": "github.event_name == 'issue_comment' && github.event.issue.pull_request",

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -871,6 +871,21 @@ test_claude_absent_review_without_the_decline_arm_is_denied if {
 	claude_absence_missing_message in violations
 }
 
+# A second status function used to append the job TWICE, and every sibling rule
+# guards on `count == 1` — so writing both defensively disarmed them all.
+test_claude_absent_review_with_two_status_functions_still_pins_permissions if {
+	violations := deny with input as claude_absence_reusable({
+		"analyze": {"steps": []},
+		"report_absence": {
+			"if": sprintf("always() && !cancelled() && (%s || %s)", [claude_absence_condition, claude_decline_condition]),
+			"permissions": {"contents": "write", "pull-requests": "write"},
+			"steps": [{"uses": "actions/checkout@v7"}],
+		},
+	})
+	claude_absence_permission_message in violations
+	claude_absence_checkout_message in violations
+}
+
 # The inert variant, and the one that would land as a cleanup — see
 # `claude_status_functions` in main.rego.
 test_claude_absent_review_without_a_status_function_is_denied if {

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -1178,6 +1178,10 @@ test_codeql_health_gate_before_upload_is_accepted if {
 
 claude_tag_head_guard_message(event) := sprintf("%s %s arm must require `%s`", [claude_tag_workflow_path, event, claude_same_repo_head_condition])
 
+claude_tag_fork_refusal_message := sprintf("%s must refuse fork pull requests in a step before `%s` runs", [claude_tag_workflow_path, claude_action])
+
+claude_tag_fork_refusal_step := {"run": sprintf("head_repo=\"$(gh api \"repos/$REPOSITORY/pulls/$PR_NUMBER\" --jq '.%s')\"", [claude_fork_refusal_marker])}
+
 claude_tag_single_job_message := sprintf("%s must run `%s` in exactly one job — the fork-head guard is keyed to that job's condition", [claude_tag_workflow_path, claude_action])
 
 claude_tag_triggers := {
@@ -1280,6 +1284,49 @@ test_claude_tag_dropping_a_pull_request_trigger_is_accepted if {
 	every violation in violations {
 		not contains(violation, "arm must require")
 	}
+}
+
+# The `if:` guard the other arms use is INEXPRESSIBLE here: an issue_comment
+# payload carries no pull_request object, and the fork tree arrives through the
+# action's own setupBranch rather than through GITHUB_REF. Only a step can
+# close it, so the policy demands one. #799
+test_claude_tag_issue_comment_without_a_fork_refusal_step_is_denied if {
+	violations := deny with input as claude_tag_fixture(sprintf(" && %s", [claude_same_repo_head_condition]))
+	claude_tag_fork_refusal_message in violations
+}
+
+# ORDER is the whole point — a refusal that runs after the action has already
+# staged the fork tree is decoration.
+test_claude_tag_fork_refusal_after_the_action_is_denied if {
+	violations := deny with input as claude_tag_workflow("claude", {
+		"if": claude_tag_condition_text(sprintf(" && %s", [claude_same_repo_head_condition])),
+		"steps": [{"uses": claude_action}, claude_tag_fork_refusal_step],
+	})
+	claude_tag_fork_refusal_message in violations
+}
+
+test_claude_tag_fork_refusal_before_the_action_is_accepted if {
+	violations := deny with input as claude_tag_workflow("claude", {
+		"if": claude_tag_condition_text(sprintf(" && %s", [claude_same_repo_head_condition])),
+		"steps": [claude_tag_fork_refusal_step, {"uses": claude_action}],
+	})
+	not claude_tag_fork_refusal_message in violations
+}
+
+# Retiring the trigger retires the requirement, same as the head-guard rule.
+test_claude_tag_without_the_issue_comment_trigger_needs_no_fork_refusal if {
+	fixture := {"documents": [{
+		"path": claude_tag_workflow_path,
+		"contents": {
+			"on": {"issues": {"types": ["opened"]}},
+			"jobs": {"claude": {
+				"if": "(github.event_name == 'issues' && trusted)",
+				"steps": [{"uses": claude_action}],
+			}},
+		},
+	}]}
+	violations := deny with input as fixture
+	not claude_tag_fork_refusal_message in violations
 }
 
 test_codeql_init_hardcoding_a_language_is_denied if {


### PR DESCRIPTION
Closes #799. Closes #819.

## #799 — `@claude` staged fork trees in the `contents: write` job

The whole fix, unchanged since the first commit: refuse fork PRs before the action runs.

`issue_comment` reaches a fork tree by a route **no `if:` can express** — its payload carries no `pull_request` object, and claude-code-action stages the head itself. From the pinned `v1` source, `setupBranch` runs `git checkout` for every open PR; the fork/non-fork split only changes how the ref is fetched, there is no guard, and no input disables it (`allowed_non_write_users` governs who may trigger, not what is checked out).

So a maintainer typing `@claude` on a fork PR staged fork-authored files — a repo-root `CLAUDE.md` the agent auto-loads as instructions among them — in the one job holding `contents: write` and the OAuth token. The existing `author_association` gate does not help: the trusted maintainer IS the trigger in that scenario.

Costs nothing real: both other Claude paths already refuse forks, so fork PRs had no Claude coverage to lose.

Verified against live data, both directions:

| PR | head | result |
|---|---|---|
| #818 | `IvanWng97/pixtuoid` | allowed |
| #726 (a real fork PR) | `chrisfinazzo/pixtuoid` | **refused** |
| deleted fork | `null` → `""` | **refused** (fail-closed) |

## #819 — a spent quota took the review gate down silently

When the model job fails, `publish` is gated on its outcome and skips, no comment lands, and with `ci-gate` the only required check the PR reads `UNSTABLE` — identical to a flaky advisory. That is how #809 and #815–#818 merged with only a red job to say so.

**A spent quota is rare, so this is deliberately thin**: one comment saying the second lens is ABSENT rather than clean, and one policy rule pinning that the job exists and carries a status function — without one an implicit `success()` skips it in exactly the situation it exists for.

An earlier revision of this PR carried an upsert, a diagnostic step, a decline arm and five policy rules for the same rare condition. Cut: 560 → 336 lines. `publish` posts a fresh comment per head too; matching that is enough.

## Regression cover

Where the test weight sits is deliberate — on the security control, not the notice:

- the fork refusal must exist, be **scoped to `issue_comment`**, and **precede the action** (a refusal running after the tree is staged is decoration), identified by the API field it must read rather than its name, so a rename cannot retire it
- behavior tests execute the guard itself: an internal PR is admitted, a fork and a deleted head are refused; the notice says ABSENT and cannot be prefix-matched as a review

Every guard negative-controlled — inverting the fork comparison, softening the ABSENT wording, and dropping the status function each fail.

`just preflight` exit 0 · 2799 tests · 115 rego unit tests · 111 conftest · 0 violations. Reviewed over four local two-lens rounds; both lenses APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012eeTnuzQZ2gSf8Mctswev7
