### PR TITLE
test(pathfind): replace the router cache's false-green assertion with a real oracle

### DIFF
--- a/crates/pixtuoid-scene/src/pathfind/tests.rs
+++ b/crates/pixtuoid-scene/src/pathfind/tests.rs
@@ -326,16 +326,17 @@ fn every_aimless_wander_destination_is_routable_from_its_home_desk() {
     }
 }
 
-/// The cache is observed through a SEALED mask: `find_path` on a fully-blocked
-/// grid can only return the 2-point `[from, to]` fallback, so a multi-point
-/// answer proves the cached polyline was served instead of a fresh A* run.
+/// The cache is observed through a SEALED mask: on a fully-blocked grid
+/// `find_path` returns `None` and `route` mints the 2-point `[from, to]`
+/// fallback, so a multi-point answer proves the cached polyline was served
+/// instead of a fresh A* run.
 ///
-/// `router.len()` cannot see this. The miss arm re-`insert`s the SAME `(from,
-/// to)` key, so deleting the cache-hit branch entirely leaves `len() == 1` — the
-/// old `assert_eq!(router.len(), 1, "should hit cache")` was green either way
-/// (#750). The mask is a sound probe because the cache is deliberately mask-BLIND:
-/// it keys on `(from, to)` and invalidates on the OVERLAY signature, the mask
-/// being static per layout.
+/// `route`'s miss arm re-`insert`s the SAME `(from, to)` key, so deleting the
+/// cache-hit branch entirely leaves `len() == 1` — the old
+/// `assert_eq!(router.len(), 1, "should hit cache")` was green either way (#750).
+/// The mask is a sound probe because the cache is deliberately mask-BLIND: it
+/// keys on `(from, to)` and invalidates on the OVERLAY signature, the mask being
+/// static per layout.
 #[test]
 fn router_serves_the_cached_path_instead_of_re_running_astar() {
     let l = make_layout();
@@ -360,28 +361,41 @@ fn router_serves_the_cached_path_instead_of_re_running_astar() {
     );
 }
 
-/// The other half: an overlay rect laid ACROSS a cached path evicts that entry
-/// (`path_clear_under`), so the next call genuinely re-routes. Same sealed-mask
-/// oracle, opposite verdict — the fallback IS the evidence of a recompute.
+/// Invalidation is PER-PATH, not a global wipe: an overlay change that misses a
+/// cached polyline must leave it cached, and one laid across it must drop it.
+/// Both directions ride the same sealed-mask oracle — after a sealed re-route the
+/// cached answer and the 2-point fallback are distinguishable, so each assertion
+/// names which side of `path_clear_under` it exercises.
+///
+/// The MISS direction is what pins the optimisation itself (`retain`, not
+/// `clear`): swapping the per-path retain for a global wipe passes every other
+/// test in the crate.
 #[test]
-fn an_overlay_across_a_cached_path_forces_a_re_route() {
+fn an_overlay_evicts_only_the_paths_it_actually_crosses() {
     let l = make_layout();
     let mut router = AStarRouter::new();
     let mut overlay = OccupancyOverlay::new();
     let from = Point { x: 30, y: 80 };
     let to = Point { x: 30, y: 120 };
+    let sealed = WalkableMask::filled(l.walkable.width(), l.walkable.height(), false);
 
     let first = router.route(&l.walkable, &overlay, from, to);
     assert!(first.len() > 2, "fixture must corner: {first:?}");
 
-    // Cover a waypoint of the path just taken, so `path_clear_under` drops it.
+    // A rect far from the polyline changes the overlay SIGNATURE (so the
+    // invalidation branch runs) but crosses nothing.
+    overlay.add(0, 0, 8, 8);
+    assert_eq!(
+        router.route(&sealed, &overlay, from, to),
+        first,
+        "a rect clear of the polyline must leave its entry cached — `retain`, not `clear`"
+    );
+
+    // Now cover a waypoint of that same path, so `path_clear_under` drops it.
     let mid = first[first.len() / 2];
     overlay.add(mid.x.saturating_sub(4), mid.y.saturating_sub(4), 8, 8);
-
-    let sealed = WalkableMask::filled(l.walkable.width(), l.walkable.height(), false);
-    let after = router.route(&sealed, &overlay, from, to);
     assert_eq!(
-        after,
+        router.route(&sealed, &overlay, from, to),
         vec![from, to],
         "the crossed entry must be evicted and re-routed, not served stale"
     );

--- a/crates/pixtuoid-scene/src/pathfind/tests.rs
+++ b/crates/pixtuoid-scene/src/pathfind/tests.rs
@@ -326,22 +326,65 @@ fn every_aimless_wander_destination_is_routable_from_its_home_desk() {
     }
 }
 
+/// The cache is observed through a SEALED mask: `find_path` on a fully-blocked
+/// grid can only return the 2-point `[from, to]` fallback, so a multi-point
+/// answer proves the cached polyline was served instead of a fresh A* run.
+///
+/// `router.len()` cannot see this. The miss arm re-`insert`s the SAME `(from,
+/// to)` key, so deleting the cache-hit branch entirely leaves `len() == 1` — the
+/// old `assert_eq!(router.len(), 1, "should hit cache")` was green either way
+/// (#750). The mask is a sound probe because the cache is deliberately mask-BLIND:
+/// it keys on `(from, to)` and invalidates on the OVERLAY signature, the mask
+/// being static per layout.
 #[test]
-fn router_caches_until_overlay_changes() {
+fn router_serves_the_cached_path_instead_of_re_running_astar() {
+    let l = make_layout();
+    let mut router = AStarRouter::new();
+    let overlay = OccupancyOverlay::new();
+    let from = Point { x: 30, y: 80 };
+    let to = Point { x: 30, y: 120 };
+
+    let first = router.route(&l.walkable, &overlay, from, to);
+    assert!(
+        first.len() > 2,
+        "the fixture must CORNER, else a hit is indistinguishable from the \
+         straight-line fallback: {first:?}"
+    );
+
+    let sealed = WalkableMask::filled(l.walkable.width(), l.walkable.height(), false);
+    let second = router.route(&sealed, &overlay, from, to);
+    assert_eq!(
+        second, first,
+        "a repeat leg must be served from the cache — a re-route on the sealed \
+         mask could only yield the 2-point fallback"
+    );
+}
+
+/// The other half: an overlay rect laid ACROSS a cached path evicts that entry
+/// (`path_clear_under`), so the next call genuinely re-routes. Same sealed-mask
+/// oracle, opposite verdict — the fallback IS the evidence of a recompute.
+#[test]
+fn an_overlay_across_a_cached_path_forces_a_re_route() {
     let l = make_layout();
     let mut router = AStarRouter::new();
     let mut overlay = OccupancyOverlay::new();
     let from = Point { x: 30, y: 80 };
     let to = Point { x: 30, y: 120 };
-    let _ = router.route(&l.walkable, &overlay, from, to);
-    assert_eq!(router.len(), 1);
-    let _ = router.route(&l.walkable, &overlay, from, to);
-    assert_eq!(router.len(), 1, "should hit cache");
 
-    // Push an occupancy rect — cache should drop.
-    overlay.add(100, 100, 8, 8);
-    let _ = router.route(&l.walkable, &overlay, from, to);
-    assert_eq!(router.len(), 1, "cache rebuilt after overlay change");
+    let first = router.route(&l.walkable, &overlay, from, to);
+    assert!(first.len() > 2, "fixture must corner: {first:?}");
+
+    // Cover a waypoint of the path just taken, so `path_clear_under` drops it.
+    let mid = first[first.len() / 2];
+    overlay.add(mid.x.saturating_sub(4), mid.y.saturating_sub(4), 8, 8);
+
+    let sealed = WalkableMask::filled(l.walkable.width(), l.walkable.height(), false);
+    let after = router.route(&sealed, &overlay, from, to);
+    assert_eq!(
+        after,
+        vec![from, to],
+        "the crossed entry must be evicted and re-routed, not served stale"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`pathfind/tests.rs::router_caches_until_overlay_changes` asserted `assert_eq!(router.len(), 1, "should hit cache")`. That **cannot fail**: the miss arm re-`insert`s the same `(from, to)` key, so deleting the cache-hit branch at `pathfind/mod.rs:127` leaves `len() == 1` either way. Proved by mutation — with the hit branch removed the old assertion stays GREEN while the replacement reds.

## Related issue

Closes #750 (rescoped in place first — see below).

## Type of change

- [x] Refactor / chore  <!-- test-only; the template has no "test" type -->

## The new oracle

A SEALED mask: `find_path` on a fully-blocked grid returns `None` and `route` mints the 2-point `[from, to]` fallback, so a multi-point answer proves the cached polyline was served rather than recomputed. The mask is a sound probe precisely because the cache is deliberately mask-BLIND — it keys on `(from, to)` and invalidates on the OVERLAY signature, the mask being static per layout. No production instrumentation needed.

Split into the halves the one assertion conflated:
- `router_serves_the_cached_path_instead_of_re_running_astar` — the hit.
- `an_overlay_evicts_only_the_paths_it_actually_crosses` — **both** directions of `path_clear_under`: a rect far from the polyline changes the overlay signature but must leave the entry cached, then a rect over one of its own waypoints must drop it.

That MISS direction came out of the review and matters: swapping the per-path `retain` for a global `paths.clear()` — reverting the optimisation whose own comment says "paths in unaffected corridors stay cached" — passed **all 717** pixtuoid-scene lib tests. It now reds.

## Issue rescoped before any code — three premises were dead

- **The `#[cfg(test)]` counters are unbuildable as described.** The only ~120-frame driver, `render_until_settled`, lives in the **binary**, where `pixtuoid-scene` compiles with `cfg(test)` OFF. Counters gated that way read zeros, snapshot the zeros, and can never fail — the same defect class this PR removes.
- **The headline regression is already pinned.** `ChangingRouter` + `walk_leg_freezes_path_against_midleg_reroute` assert an exact `Router::route` call count, so "A* re-routed per frame instead of once per leg" is guarded today.
- **The #736 motivation is inverted.** #736 ("the suite is near its wall-clock cap") was closed by #795: the cost was `dev` opt-level 0 (87s → 15s). The standing reason to keep wall-clock asserts out of `just test` is #161's contention-flake stance, which stands on its own.

## The one composition worth measuring — measured, negative

An A\* `None` returns `vec![from, to]`, uncached by design **and** unfrozen by the `p.len() > 2` walk-path gate, so an unroutable leg would pay an uncapped scan every frame. Real on paper. But `find_path` snaps both endpoints to walkable (radius 12) first.

Measured across **6 layout sizes × 10 seeds × every home-desk → waypoint approach, plus 24 per-agent jittered goals each = 325,900 legs**: `find_path` returned `None` **0 times**, jitter included (the ±4px jitter is applied *after* the reachability filter — the one documented route into a pocket). So no negative-result cache ships: that would be a hot-path behavior change to a published semver-surface crate on an unmeasured scenario.

## How I tested it

- `just preflight` — exit 0 (observed directly).
- `just test` — 2844 passed, 2 skipped, exit 0. `just clippy` / `just doc-check` / `just lint` / `just comment-lint` — exit 0 / clean.
- Fault injection both ways: removing the cache-hit branch reds only the hit test; swapping `retain` for `clear()` reds only the new MISS assertion; restored, all 42 pathfind tests pass.

## Visual verification

- [x] Not a visual change, or — screenshot/GIF attached below and it reads at half-block scale.

## Two-lens review

Ran the repo's gate: correctness + design lenses plus a comment lens, every MEDIUM+ finding adversarially verified. Verdict **APPROVE-WITH-NITS**; both new tests were fault-injection proved to be the SOLE killer of their respective production line. Folded into `review(round-1)`: the unpinned per-path invalidation half above, plus a comment cut (4 sentences, 3 ideas) and one misattribution — on a sealed grid `find_path` returns `None` and it is `route`'s own miss arm that mints the fallback.

## Checklist

- [x] I read the relevant `CLAUDE.md` (root + the nested one for the crate I touched).
- [x] New behavior has a test (this repo is TDD-first).
- [x] No `unwrap()` in non-test code; errors propagate via `anyhow`/`thiserror`.
- [x] No new `println!`/`eprintln!` on a production path (use `tracing`).
- [x] Docs updated in the same commit if I changed module structure, architecture, or public API (`CLAUDE.md` / `README.md`).
- [x] Checked against the recurring pitfalls.
- [x] `just preflight` passes locally.

## AI assistance

- [x] This PR was written/heavily-assisted by an AI agent.
