### PR TITLE
fix(grok): route active_sessions pids through checked_pid so one bad entry skips

### DIFF
--- a/crates/pixtuoid-core/src/source/decoder.rs
+++ b/crates/pixtuoid-core/src/source/decoder.rs
@@ -72,8 +72,10 @@ pub(crate) fn accept_all_paths(_p: &Path) -> bool {
 /// ingress rides — the hook peek, the openclaw decode, and BOTH first-party
 /// session registries (`cc_probe::parse_registry_entry`,
 /// `grok::native::grok_ids_from_registry`) — so a new ingress can't ship the
-/// N-th unchecked pid; the sibling set the openclaw
-/// `nonpositive_pid_is_dropped_like_every_sibling_pid_ingest` test names.
+/// N-th unchecked pid. That four-site roster is THIS doc's, not a test's:
+/// openclaw's `nonpositive_pid_is_dropped_like_every_sibling_pid_ingest` pins
+/// only its own arm. `fd_probe` is deliberately NOT a rider — it filters `> 0`
+/// over kernel-enumerated `pid_t`, where the `i32`-range half is vacuous.
 ///
 /// Taking `i64` and narrowing HERE is what keeps an out-of-range value a
 /// per-entry skip: a caller that deserializes straight into `i32` fails its

--- a/crates/pixtuoid-core/src/source/decoder.rs
+++ b/crates/pixtuoid-core/src/source/decoder.rs
@@ -68,11 +68,17 @@ pub(crate) fn accept_all_paths(_p: &Path) -> bool {
 /// Narrow a raw JSON integer to a valid POSIX pid: in `i32` range AND strictly
 /// positive. The `> 0` reject is load-bearing — `kill(0)`/`kill(-n)` target
 /// process GROUPS, and a bogus/zero `_pid` would otherwise synthesize a phantom
-/// exit that flaps a LIVE gateway Down. The ONE narrowing every JSON `_pid`
-/// ingress rides (the hook peek, the openclaw decode, AND the CC
-/// sessions-registry probe in `cc_probe::parse_registry_entry`), so a new ingress
-/// can't ship the N-th unchecked pid — the sibling set the openclaw
+/// exit that flaps a LIVE gateway Down. The ONE narrowing every JSON pid
+/// ingress rides — the hook peek, the openclaw decode, and BOTH first-party
+/// session registries (`cc_probe::parse_registry_entry`,
+/// `grok::native::grok_ids_from_registry`) — so a new ingress can't ship the
+/// N-th unchecked pid; the sibling set the openclaw
 /// `nonpositive_pid_is_dropped_like_every_sibling_pid_ingest` test names.
+///
+/// Taking `i64` and narrowing HERE is what keeps an out-of-range value a
+/// per-entry skip: a caller that deserializes straight into `i32` fails its
+/// whole document instead, which the registry probes report as upstream SHAPE
+/// drift (#831).
 pub(crate) fn checked_pid(raw: i64) -> Option<i32> {
     i32::try_from(raw).ok().filter(|&p| p > 0)
 }

--- a/crates/pixtuoid-core/src/source/grok/native.rs
+++ b/crates/pixtuoid-core/src/source/grok/native.rs
@@ -199,9 +199,10 @@ fn augment_with_fresh_sessions(
 /// process start within [`cc_probe::PID_START_TOLERANCE_SECS`] (the #220
 /// pid-recycle identity check; either side missing → pid-alive-only, the
 /// check is additive). Returns `None` only when the DOCUMENT doesn't parse as
-/// an array of entries (format drift); junk VALUES inside an entry (pid <= 0)
-/// skip that entry silently, mirroring the CC registry's value-vs-shape
-/// distinction.
+/// an array of entries — a renamed or mistyped key, i.e. format drift; junk
+/// VALUES inside an entry (a pid `decoder::checked_pid` rejects — non-positive
+/// OR outside `i32` range — an empty `session_id`, a recycled pid) skip that
+/// entry silently, mirroring the CC registry's value-vs-shape distinction.
 #[cfg(unix)]
 fn grok_ids_from_registry(
     bytes: &[u8],
@@ -211,10 +212,8 @@ fn grok_ids_from_registry(
     #[derive(serde::Deserialize)]
     struct Entry {
         session_id: String,
-        // `i64`, narrowed below rather than deserialized as `i32`: an
-        // out-of-range VALUE must skip its own entry like every other junk
-        // value, not fail the whole document into the `shape_drift` arm that
-        // claims the registry's SHAPE changed upstream (#831).
+        // `i64`: an out-of-`i32` value must skip its entry, not fail the
+        // document — see `decoder::checked_pid` (#831).
         pid: i64,
         #[serde(default)]
         opened_at: Option<String>,

--- a/crates/pixtuoid-core/src/source/grok/native.rs
+++ b/crates/pixtuoid-core/src/source/grok/native.rs
@@ -211,21 +211,31 @@ fn grok_ids_from_registry(
     #[derive(serde::Deserialize)]
     struct Entry {
         session_id: String,
-        pid: i32,
+        // `i64`, narrowed below rather than deserialized as `i32`: an
+        // out-of-range VALUE must skip its own entry like every other junk
+        // value, not fail the whole document into the `shape_drift` arm that
+        // claims the registry's SHAPE changed upstream (#831).
+        pid: i64,
         #[serde(default)]
         opened_at: Option<String>,
     }
     let entries: Vec<Entry> = serde_json::from_slice(bytes).ok()?;
     let mut snap = ProbeSnapshot::default();
     for e in entries {
-        if e.pid <= 0 || e.session_id.is_empty() || !alive(e.pid) {
+        // The i32-range + strictly-positive narrowing every JSON pid ingress
+        // shares (the `kill(0)`/`kill(-n)`-targets-a-GROUP rationale lives on
+        // `checked_pid`) — the same call `cc_probe::parse_registry_entry` makes.
+        let Some(pid) = crate::source::decoder::checked_pid(e.pid) else {
+            continue;
+        };
+        if e.session_id.is_empty() || !alive(pid) {
             continue;
         }
         if let (Some(claimed_secs), Some(actual_secs)) = (
             e.opened_at
                 .as_deref()
                 .and_then(crate::source::decoder::rfc3339_to_epoch_secs),
-            start_time(e.pid),
+            start_time(pid),
         ) {
             // `opened_at` is stamped at session OPEN, which can lag process
             // start by however long the user sat on the welcome screen — the
@@ -236,7 +246,7 @@ fn grok_ids_from_registry(
             // process existed — that pid was recycled).
             if claimed_secs + crate::source::cc_probe::PID_START_TOLERANCE_SECS < actual_secs {
                 tracing::debug!(
-                    pid = e.pid,
+                    pid,
                     claimed_secs,
                     actual_secs,
                     "pid recycled — active_sessions opened_at predates process start; skipping"
@@ -246,7 +256,7 @@ fn grok_ids_from_registry(
         }
         // Duplicate session_id across entries is upstream junk — keep the
         // deterministic tiebreak winner (larger pid, the shared #252 rule).
-        snap.bind_pid(e.session_id, e.pid);
+        snap.bind_pid(e.session_id, pid);
     }
     Some(snap)
 }
@@ -436,16 +446,71 @@ mod tests {
         fn dead_pids_and_junk_values_are_skipped_not_failures() {
             let snap = grok_ids_from_registry(REG.as_bytes(), alive_none, |_| None).unwrap();
             assert!(snap.pid_of.is_empty(), "dead pids yield a healthy empty");
+            // Both halves of `checked_pid`'s narrowing — zero AND negative (a
+            // negative pid would make `kill(-n, 0)` probe a process GROUP).
             let junk = r#"[{"session_id":"","pid":100,"cwd":"/r","opened_at":"x"},
-                           {"session_id":"s","pid":0,"cwd":"/r","opened_at":"x"}]"#;
+                           {"session_id":"s","pid":0,"cwd":"/r","opened_at":"x"},
+                           {"session_id":"neg","pid":-42,"cwd":"/r","opened_at":"x"},
+                           {"session_id":"live","pid":77,"cwd":"/r","opened_at":"x"}]"#;
             let snap = grok_ids_from_registry(junk.as_bytes(), alive_all, |_| None).unwrap();
-            assert!(snap.pid_of.is_empty(), "junk VALUES skip entries silently");
+            assert_eq!(
+                snap.pid_of.get("live"),
+                Some(&77),
+                "a junk entry must not cost its healthy siblings"
+            );
+            assert_eq!(snap.pid_of.len(), 1, "junk VALUES skip entries silently");
+        }
+
+        /// A pid outside `i32` range skips ITS OWN entry, exactly like every
+        /// other junk value — it must not fail the whole document, because that
+        /// path emits a `shape_drift` breadcrumb claiming the registry's SHAPE
+        /// changed upstream and degrades all grok liveness to mtime (#831).
+        ///
+        /// The no-truncation assertion is the teeth: `4294967297 as i32` is
+        /// `1`, so an implementation that narrows by cast instead of
+        /// `checked_pid` would bind init's pid and vouch a session forever.
+        #[test]
+        fn out_of_i32_range_pid_skips_only_its_own_entry_and_never_truncates() {
+            let over = r#"{"session_id":"over","pid":4294967297,"cwd":"/r"}"#;
+            let ok = r#"{"session_id":"ok","pid":200,"cwd":"/r"}"#;
+            // BOTH orders: today the document fails whichever side the bad
+            // entry sits on, so ordering must not be what makes this pass.
+            for reg in [format!("[{over},{ok}]"), format!("[{ok},{over}]")] {
+                let snap = grok_ids_from_registry(reg.as_bytes(), alive_all, |_| None)
+                    .expect("one out-of-range VALUE is not document-level shape drift");
+                assert_eq!(snap.pid_of.get("ok"), Some(&200), "siblings still bind");
+                assert_eq!(snap.pid_of.get("over"), None, "the bad entry is skipped");
+                assert!(
+                    !snap.pid_of.values().any(|&p| p == 1),
+                    "narrowing must reject, never truncate ({over} casts to pid 1)"
+                );
+            }
         }
 
         #[test]
         fn unparseable_document_is_format_drift_none() {
             assert!(grok_ids_from_registry(b"not json", alive_all, |_| None).is_none());
             assert!(grok_ids_from_registry(br#"{"an":"object"}"#, alive_all, |_| None).is_none());
+        }
+
+        /// The negative control for the test above: widening `pid` to `i64` must
+        /// not widen the entry's TYPE discipline. A string-typed or renamed pid
+        /// is still document-level drift, because the derive's strictness IS the
+        /// #247 upstream-rename detector — a later "simplify to `Vec<Value>`"
+        /// refactor would pass every other test in this module while silently
+        /// deleting it.
+        #[test]
+        fn a_mistyped_or_renamed_pid_is_still_document_level_drift() {
+            for reg in [
+                r#"[{"session_id":"s","pid":"100","cwd":"/r"}]"#,
+                r#"[{"session_id":"s","pid":100.5,"cwd":"/r"}]"#,
+                r#"[{"session_id":"s","processId":100,"cwd":"/r"}]"#,
+            ] {
+                assert!(
+                    grok_ids_from_registry(reg.as_bytes(), alive_all, |_| None).is_none(),
+                    "a mistyped/renamed pid key is SHAPE drift, not a junk value: {reg}"
+                );
+            }
         }
 
         #[test]

--- a/crates/pixtuoid-core/src/source/openclaw.rs
+++ b/crates/pixtuoid-core/src/source/openclaw.rs
@@ -284,8 +284,9 @@ mod tests {
     fn nonpositive_pid_is_dropped_like_every_sibling_pid_ingest() {
         // kill(0)/kill(-n) target process GROUPS, and a bogus pid's ESRCH
         // receipt synthesizes an instant exit that flaps the LIVE gateway
-        // Down — cc_probe/fd_probe/the hook `_pid` peek all filter `> 0`;
-        // this decoder must too (the N-1-of-N guard gap).
+        // Down — every other JSON pid ingress (the hook `_pid` peek; both
+        // session registries, cc_probe + grok's active_sessions) narrows via
+        // `decoder::checked_pid`; this decoder must too (the N-1-of-N gap).
         assert_eq!(
             decode(json!({"type": "gateway_start", "_pid": -1})),
             vec![DaemonPresenceUpdate::GatewayUp { pid: None }]


### PR DESCRIPTION
## Summary

`grok_ids_from_registry` deserialized straight into `pid: i32` and hand-rolled `e.pid <= 0`, bypassing `decoder::checked_pid`. A pid outside `i32` range therefore failed `from_slice` for the **whole document** — `.ok()?` → `None` → the `shape_drift` breadcrumb asserting the registry's shape changed upstream → all grok liveness degraded to mtime. CC's registry skips the offending entry and keeps its siblings; grok now does too.

## Related issue

Closes #831

## Type of change

- [x] Bug fix

## What this actually buys (honest framing)

This is **not** a validation hole — grok already rejected non-positive pids twice over (`e.pid <= 0`, plus `Pid::from_raw` returning `None` for ≤ 0). And the out-of-range value is **not reachable from a real grok build**: upstream types the field `u32` and writes `std::process::id()`, and `pid_max ≤ 2²²`. Corruption or a hostile file only.

What it buys:

1. `checked_pid`'s completeness claim becomes true for the first time. That doc is what the *next* pid ingress reads to decide whether it is covered — an N-1-of-N contract defect.
2. A false `shape_drift` breadcrumb goes away. It claims *"the registry shape changed upstream"*, which would send an investigator to `check_upstream_drift.py` and xai-org for a rename that never happened.
3. It matches upstream's own per-entry semantics (`is_pid_alive` skips one entry).

Widening the field to `i64` makes the downstream fan-out **compiler-enforced** rather than review-enforced.

## Deliberately not adopted

`cc_probe`'s `RegistryParse` shape-vs-value split. CC's registry is one file per entry, so file-drift ≡ entry-drift and the consumer can name the vanished key. grok's is one document with N entries, where a per-entry `ShapeDrift` has no consumer and no defined aggregation rule.

## How I tested it

`just preflight` — 2851 tests, exit 0.

Three tests, driven red first:

- `out_of_i32_range_pid_skips_only_its_own_entry_and_never_truncates` — asserted in **both entry orders** (today the document fails whichever side the bad entry sits on), with a no-truncation check: `4294967297 as i32 == 1`, so a cast-based narrowing would bind init's pid and vouch a session forever.
- `dead_pids_and_junk_values_are_skipped_not_failures` grows a negative pid and a live sibling — pins the `> 0` half.
- `a_mistyped_or_renamed_pid_is_still_document_level_drift` — the negative control. The derive's remaining strictness **is** the #247 rename detector, and a later "simplify to `Vec<Value>`" refactor would pass every other test in the module while silently deleting it.

Sibling-set check per the parallel-drift pitfall: grepped every pid ingress. `checked_pid` now has exactly four call sites — hook peek, openclaw, cc_probe, grok. The remaining pid sites are the shim (producer), `pid_watch` (consumes an already-checked pid), and `fd_probe` (kernel-supplied, own `> 0` guard).

- [x] Not a visual change.

## Checklist

- [x] I read the relevant `CLAUDE.md` (root + `pixtuoid-core`).
- [x] New behavior has a test (this repo is TDD-first).
- [x] No `unwrap()` in non-test code.
- [x] No new `println!`/`eprintln!` on a production path.
- [x] Docs updated in the same commit (`checked_pid`'s doc, which is the point of the change).
- [x] Checked against the recurring pitfalls — see the sibling-set grep above and the negative-branch control.
- [x] `just preflight` passes locally.

## AI assistance

- [x] This PR was written/heavily-assisted by an AI agent.