### PR TITLE
fix(test): give the shim env-mode test the exclusivity its two siblings have

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -15,8 +15,14 @@ path = "junit.xml"
 # These assert wall-clock bounds on a CHILD PROCESS's spawn+exit; under the
 # fully-parallel suite on a loaded machine, exec/dyld scheduling jitter alone
 # blows the bound, so give them the machine to themselves.
+# Listed by NAME, not by suffix: the shape is "spawns the shim and polls a
+# deadline", which no name pattern infers — a suffix filter silently missed one.
 [[profile.default.overrides]]
-filter = 'test(_exits_zero_without_blocking) | test(_within_watchdog_bound)'
+filter = '''
+  test(missing_socket_exits_zero_without_blocking)
+  | test(stalled_listener_shim_exits_zero_within_watchdog_bound)
+  | test(codewhale_event_mode_builds_envelope_from_env_and_ignores_stdin)
+'''
 threads-required = "num-cpus"
 
 # Same load-sensitivity as the shim bounds above: this pair spawns a real

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -15,14 +15,8 @@ path = "junit.xml"
 # These assert wall-clock bounds on a CHILD PROCESS's spawn+exit; under the
 # fully-parallel suite on a loaded machine, exec/dyld scheduling jitter alone
 # blows the bound, so give them the machine to themselves.
-# Listed by NAME, not by suffix: the shape is "spawns the shim and polls a
-# deadline", which no name pattern infers — a suffix filter silently missed one.
 [[profile.default.overrides]]
-filter = '''
-  test(missing_socket_exits_zero_without_blocking)
-  | test(stalled_listener_shim_exits_zero_within_watchdog_bound)
-  | test(codewhale_event_mode_builds_envelope_from_env_and_ignores_stdin)
-'''
+filter = 'test(_exits_zero_without_blocking) | test(_within_watchdog_bound) | test(_and_ignores_stdin)'
 threads-required = "num-cpus"
 
 # Same load-sensitivity as the shim bounds above: this pair spawns a real

--- a/crates/pixtuoid-hook/tests/shim.rs
+++ b/crates/pixtuoid-hook/tests/shim.rs
@@ -290,32 +290,3 @@ fn malformed_stdin_exits_zero() {
         "malformed stdin must still exit 0; got {status:?}"
     );
 }
-
-/// Pins the `.config/nextest.toml` exclusivity roster against this file.
-/// nextest accepts a filter naming a test that does not exist, exits 0, and
-/// warns nothing — so nothing else would notice.
-#[test]
-fn every_child_process_timing_test_has_a_nextest_exclusivity_override() {
-    // `file!()` is WORKSPACE-relative while the test's cwd is the crate dir.
-    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
-    let toml = std::fs::read_to_string(root.join(".config/nextest.toml"))
-        .expect("workspace .config/nextest.toml");
-    let own_source = std::fs::read_to_string(root.join(file!())).expect("read own source");
-
-    for name in [
-        "missing_socket_exits_zero_without_blocking",
-        "stalled_listener_shim_exits_zero_within_watchdog_bound",
-        "codewhale_event_mode_builds_envelope_from_env_and_ignores_stdin",
-    ] {
-        assert!(
-            toml.contains(name),
-            "`{name}` spawns the shim and polls a deadline; it needs \
-             threads-required exclusivity in .config/nextest.toml"
-        );
-        assert!(
-            own_source.contains(&format!("fn {name}(")),
-            "`{name}` is named in .config/nextest.toml but gone from here — \
-             drop the dead filter arm"
-        );
-    }
-}

--- a/crates/pixtuoid-hook/tests/shim.rs
+++ b/crates/pixtuoid-hook/tests/shim.rs
@@ -290,3 +290,32 @@ fn malformed_stdin_exits_zero() {
         "malformed stdin must still exit 0; got {status:?}"
     );
 }
+
+/// Pins the `.config/nextest.toml` exclusivity roster against this file.
+/// nextest accepts a filter naming a test that does not exist, exits 0, and
+/// warns nothing — so nothing else would notice.
+#[test]
+fn every_child_process_timing_test_has_a_nextest_exclusivity_override() {
+    // `file!()` is WORKSPACE-relative while the test's cwd is the crate dir.
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let toml = std::fs::read_to_string(root.join(".config/nextest.toml"))
+        .expect("workspace .config/nextest.toml");
+    let own_source = std::fs::read_to_string(root.join(file!())).expect("read own source");
+
+    for name in [
+        "missing_socket_exits_zero_without_blocking",
+        "stalled_listener_shim_exits_zero_within_watchdog_bound",
+        "codewhale_event_mode_builds_envelope_from_env_and_ignores_stdin",
+    ] {
+        assert!(
+            toml.contains(name),
+            "`{name}` spawns the shim and polls a deadline; it needs \
+             threads-required exclusivity in .config/nextest.toml"
+        );
+        assert!(
+            own_source.contains(&format!("fn {name}(")),
+            "`{name}` is named in .config/nextest.toml but gone from here — \
+             drop the dead filter arm"
+        );
+    }
+}


### PR DESCRIPTION
Refs #866. **Net change vs `main` is one line.**

```diff
-filter = 'test(_exits_zero_without_blocking) | test(_within_watchdog_bound)'
+filter = 'test(_exits_zero_without_blocking) | test(_within_watchdog_bound) | test(_and_ignores_stdin)'
```

## The gap

`.config/nextest.toml` already grants `threads-required = "num-cpus"` to the tests that spawn the shim and poll a wall-clock deadline, because that class flaked before — **#161**, at a 1s bound. The filter matched by **suffix**, and `codewhale_event_mode_builds_envelope_from_env_and_ignores_stdin` matches neither `_exits_zero_without_blocking` nor `_within_watchdog_bound`. So it was the one test of that shape running unprotected.

That is also why #866 only ever saw it under `--workspace`: a 32-test `-p pixtuoid-hook` run has nobody to contend with; a 2865-test workspace run does.

## Why additive, and why the history on this branch is messy

The first attempt (`b91e0f4f`) rewrote the filter as an explicit **name list** and added a 25-line roster-pinning test. Review caught a **HIGH**, correctly: the substring form had *also* been covering `shim_pipe.rs`'s two `cfg(windows)` tests — `missing_pipe_exits_zero_without_blocking` and `stalled_daemon_shim_exits_zero_within_watchdog_bound` — and the three-entry name list silently dropped both. **The same defect this branch exists to fix, reintroduced in the other direction.** The pin couldn't catch it either: `file!()` resolves to `shim.rs`, so it only ever read half the population.

`378a3e11` reverts all of that. Appending one alternation **cannot** remove coverage — on unix the match set goes 2 → 3, and the two original alternations are byte-identical, so the Windows pair is untouched by construction. That property is exactly what the rewrite gave up.

## Not raising the 2s budget

This file's own note already answers it — raising it *"would only lengthen the failure path — they exit on a positive signal, so exclusivity is nearly free."* Applies here identically.

`threads-required = "num-cpus"` verified against nextest's docs rather than inferred from the repo comment: it reserves every logical CPU for the test, *"effectively giving it exclusive use of the machine."*

## Honest limitation: no reproduction

| attempt | result |
|---|---|
| full workspace @ `5ddc09c0` (the sha #866 reported) | 2865 pass, exit 0 |
| full workspace @ `main`, ×3 | 2868 pass, exit 0 |
| the test alone, ×5 | 0.07–0.15s vs a 2s budget |
| under 20 CPU spin-loops (load 16) | 0.075–0.142s |
| under fork/exec storm (**load 107**) | 0.084–0.149s, 0/6 fail |

The justification is the missing override, which is verifiable directly from the config; **#161 is the evidence that the class bites.** Not a repro-driven patch, and I'd rather say so than imply otherwise.

Note CI green is weak evidence here either way: what was missing is flake-protection, not correctness, so every job passes with or without it. That blindness is why the gap survived.

## Verification

`just clippy` exit 0 · full workspace 2887 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TDXH8k2NaWmrY6gYv25rBZ