### PR TITLE
fix(gen): gate the wasm on GZIP bytes, the size a user actually downloads

### DIFF
--- a/crates/pixtuoid-scene/CLAUDE.md
+++ b/crates/pixtuoid-scene/CLAUDE.md
@@ -347,11 +347,15 @@ src/                (the pixtuoid-scene crate root; default pack at ../sprites/d
 │                   CAN SELECT IT — `pixtuoid-web` paints at `RenderScale::ONE` by design (the
 │                   chunky look), and only `densest_art` reads variants. Budgeting the art
 │                   phase: `gen-wasm-check` gates the GZIP size, because raw and served bytes
-│                   disagree by ~2.5x on this payload and sprite text is the most compressible
-│                   part of it — a variant that looks expensive on disk is cheap over the wire.
-│                   Run the recipe for the live numbers rather than trusting a figure written
-│                   here; the cap and its reasoning are in the justfile above it. GitHub Pages
-│                   serves gzip and does not offer brotli.
+│                   disagree by more than 2x on this payload and sprite text compresses far
+│                   better than the wasm code around it — a variant that looks expensive on
+│                   disk is cheap over the wire.
+│                   Run the recipe for the live raw/gzip figures rather than trusting one
+│                   written here; the cap and its reasoning are in the justfile above it. What
+│                   the CDN actually transfers is a SEPARATE check the recipe cannot make —
+│                   `curl -sIL -H 'Accept-Encoding: gzip, br, zstd'` answered gzip as of
+│                   2026-08, with brotli an open GitHub feature request, not a published
+│                   contract; if it ever lands, this gate becomes a ~20% overestimate.
 │                   Also: `pack.toml` declares the variant, so dropping the `include_str!`
 │                   alone makes `build_pack` fail on a missing frame — the loader would have to
 │                   skip variant animations too.

--- a/crates/pixtuoid-scene/CLAUDE.md
+++ b/crates/pixtuoid-scene/CLAUDE.md
@@ -345,14 +345,13 @@ src/                (the pixtuoid-scene crate root; default pack at ../sprites/d
 │                   `the_drawn_size_is_the_same_whichever_density_the_art_came_from`).
 │                   VARIANT ART IS EMBEDDED FOR EVERY TARGET, INCLUDING WASM, WHERE NOTHING
 │                   CAN SELECT IT — `pixtuoid-web` paints at `RenderScale::ONE` by design (the
-│                   chunky look), and only `densest_art` reads variants. Numbers, measured
-│                   2026-08-04, for whoever budgets the art phase: `gen-wasm-check`'s 1 MiB is
-│                   a RAW cap standing in for ~350-400 KB gzipped (its rationale is in the
-│                   justfile above the recipe). The artifact is 1,006,260 raw / 394,722 gzip
-│                   locally; GitHub Pages serves it gzip at 390,240 and does not offer brotli.
-│                   Sprite files are palette-key text: `desk@4x` is 4,087 raw, 518 gzip, 388
-│                   brotli. So ~27 further pieces are ~110 KB raw, ~14 KB gzip. Note only that
-│                   raw and served-bytes disagree by an order of magnitude on this payload.
+│                   chunky look), and only `densest_art` reads variants. Budgeting the art
+│                   phase: `gen-wasm-check` gates the GZIP size, because raw and served bytes
+│                   disagree by ~2.5x on this payload and sprite text is the most compressible
+│                   part of it — a variant that looks expensive on disk is cheap over the wire.
+│                   Run the recipe for the live numbers rather than trusting a figure written
+│                   here; the cap and its reasoning are in the justfile above it. GitHub Pages
+│                   serves gzip and does not offer brotli.
 │                   Also: `pack.toml` declares the variant, so dropping the `include_str!`
 │                   alone makes `build_pack` fail on a missing frame — the loader would have to
 │                   skip variant animations too.

--- a/justfile
+++ b/justfile
@@ -897,7 +897,7 @@ gen-wasm-check:
 # + a release build of the snapshot example.
 [group('gen')]
 [doc('Fail if any committed README section or rendered image has drifted')]
-gen-check: compare-selftest gen-readme-check gen-wasm-check
+gen-check: compare-selftest wasm-check-selftest gen-readme-check gen-wasm-check
     #!/usr/bin/env sh
     set -eu
     test -x .venv/bin/python3 || { echo "needs the venv: python3 -m venv .venv && .venv/bin/pip install -r requirements-dev.txt"; exit 1; }
@@ -1116,6 +1116,33 @@ setup-tools:
     # would otherwise be the only gate). Idempotent. CI re-runs `just preflight`
     # regardless, so a skipped local hook still meets the same checks at merge.
     git config core.hooksPath .githooks
+
+# The size gate's own negative control, because nothing else can be one: the
+# justfile is outside SHELL_SOURCES, so shellcheck never reads a recipe body, and
+# a size cap that stops measuring reports success for any artifact at all. This
+# pins the FAIL-OPEN class specifically — the first draft of the gzip gate wrote
+# `gzip … | wc -c`, which under POSIX sh (no pipefail) reports wc's status, so a
+# broken gzip measured zero and PASSED. Driving the real recipe with a gzip that
+# exits 1 is what that form cannot survive.
+# Not covered, deliberately: the over-cap and empty-artifact arms, which would
+# have to mutate the committed wasm to exercise. Their failures are loud; the
+# fail-open one is the silent class worth a test.
+[group('meta')]
+[doc('Self-test the wasm size gate: prove it still reds when its measurement breaks')]
+wasm-check-selftest:
+    #!/usr/bin/env sh
+    set -eu
+    stub=$(mktemp -d)
+    trap 'rm -rf "$stub"' EXIT
+    printf '#!/bin/sh\nexit 1\n' > "$stub/gzip"
+    chmod +x "$stub/gzip"
+    if PATH="$stub:$PATH" just gen-wasm-check >/dev/null 2>&1; then
+        echo "wasm-check-selftest: FAIL — gen-wasm-check passed with a broken gzip;"
+        echo "  the size measurement is fail-OPEN. Did the gzip call become a pipe?"
+        exit 1
+    fi
+    just gen-wasm-check >/dev/null
+    echo "wasm-check-selftest: OK (reds on a broken measurement, greens on a real one)"
 
 # The pixel comparator is the primitive under `gen-check` and the smoke job, and
 # it had no test of its own — an always-green comparator reports success for any

--- a/justfile
+++ b/justfile
@@ -852,7 +852,10 @@ gen-wasm-check:
     set -eu
     W=site/public/wasm/pixtuoid_web_bg.wasm
     M=site/public/wasm/manifest.sha256
-    test -f "$W" || { echo "missing $W — run 'just gen-wasm'"; exit 1; }
+    # -s, not -f: an EMPTY committed wasm passes -f, and the ratio below divides
+    # by its size. Failing here says what is wrong; failing there says "division
+    # by 0".
+    test -s "$W" || { echo "missing or empty $W — run 'just gen-wasm'"; exit 1; }
     # Not tuned to the last KB: this measures gzip locally while the CDN does its
     # own, and the cap carries deliberate art-phase slack (see the note above).
     CAP=524288

--- a/justfile
+++ b/justfile
@@ -816,11 +816,18 @@ gen-wasm: gen-wasm-tools wasm-build
 # Bloat + PAIR gate for the committed wasm artifact. Size: the hero must stay
 # a lazy-load behind the poster, so a silent size regression (a dep pulling in
 # formatting machinery, an accidental debug build) fails loudly. The cap is on
-# the GZIPPED size, because the wire cost is what the poster is hiding; it was a
-# raw-byte PROXY for that number until the proxy ran high enough on this payload
-# to block density-variant sprite art (#871). The recipe prints both figures and
-# the headroom left against the cap — read it there rather than trusting a
-# number written into this line. Pair (#424): the
+# the GZIPPED size, because the wire cost is what the poster is hiding — gating
+# the raw proxy instead is what blocked the density-variant sprite art (#871).
+# Raw is REPORTED, not gated — it is parse/compile cost, which the site's own
+# Lighthouse budget measures DIRECTLY on the runner (total-blocking-time and
+# user-timings:pixtuoid-revealed are `error`-level in site/lighthouserc.json,
+# and site.yml fires on site/** which is where the wasm lives), so a byte-count
+# proxy for it would be the weaker instrument. Meanwhile the cap is deliberately
+# LOOSE — sized for the density-art phase
+# rather than today's payload, so its headroom is art budget and NOT regression
+# sensitivity; the recipe prints the gap so you can see how much. RETIRE that
+# slack once the art phase lands: re-run the recipe and set the cap to the new
+# figure plus a margin. Pair (#424): the
 # wasm-bindgen JS glue's ABI must match the exact .wasm it was generated with;
 # a one-sided merge resolution or partial regen ships a silent runtime throw,
 # so every committed file must match gen-wasm's sha256 manifest AND every file
@@ -846,14 +853,8 @@ gen-wasm-check:
     W=site/public/wasm/pixtuoid_web_bg.wasm
     M=site/public/wasm/manifest.sha256
     test -f "$W" || { echo "missing $W — run 'just gen-wasm'"; exit 1; }
-    # Gate the GZIP size — that is what GitHub Pages transfers, and the raw byte
-    # count is a number no user ever downloads. Local gzip runs slightly UNDER
-    # what the CDN sends (different implementation and level), so the cap carries
-    # margin rather than being tuned to the last KB. Raw stays REPORTED, not
-    # gated: it is browser parse/compile cost, a real but much looser constraint
-    # than transfer — and gating it is what blocked the density-variant art
-    # (#871), whose sprite text costs several times less over the wire than on
-    # disk.
+    # Not tuned to the last KB: this measures gzip locally while the CDN does its
+    # own, and the cap carries deliberate art-phase slack (see the note above).
     CAP=524288
     # Compress to a FILE, not through a pipe: POSIX sh has no `pipefail`, so
     # `gzip … | wc -c` reports wc's status and a broken gzip would measure zero
@@ -868,7 +869,10 @@ gen-wasm-check:
     # Report the headroom, don't just pass silently. A ratchet you can only read
     # at the moment it breaks gives no warning that it is about to — and a prose
     # estimate of the size drifts unnoticed precisely because every run is green.
-    echo "wasm $WIRE / $CAP bytes gzipped ($((WIRE * 100 / CAP))% of cap, $(((CAP - WIRE) / 1024)) KB headroom; $RAW raw)"
+    # Raw rides along with its RATIO, not bare: a bare byte count has nothing to
+    # be read against. The ratio does — it is gzipped-over-raw, so RISING means
+    # new poorly-compressible code and falling means new sprite text.
+    echo "wasm $WIRE / $CAP bytes gzipped ($((WIRE * 100 / CAP))% of cap, $(((CAP - WIRE) / 1024)) KB headroom; $RAW raw, compressing to $((WIRE * 100 / RAW))%)"
     test -f "$M" || { echo "missing $M — run 'just gen-wasm' (the wasm/glue pair manifest)"; exit 1; }
     (cd site/public/wasm && shasum -a 256 --strict -c manifest.sha256 >/dev/null) \
         || { echo "wasm/glue pair MISMATCH vs $M — a partial regen or one-sided merge; run 'just gen-wasm' and commit all of site/public/wasm/"; exit 1; }

--- a/justfile
+++ b/justfile
@@ -815,10 +815,12 @@ gen-wasm: gen-wasm-tools wasm-build
 
 # Bloat + PAIR gate for the committed wasm artifact. Size: the hero must stay
 # a lazy-load behind the poster, so a silent size regression (a dep pulling in
-# formatting machinery, an accidental debug build) fails loudly — 1 MiB raw ≈
-# ~350-400 KB gzipped over the wire, which is where the cap comes from.
-# The artifact is ~900 KB (the recipe prints the exact figure and the headroom
-# left against the cap — read it there rather than trusting this line). Pair (#424): the
+# formatting machinery, an accidental debug build) fails loudly. The cap is on
+# the GZIPPED size, because the wire cost is what the poster is hiding; it was a
+# raw-byte PROXY for that number until the proxy ran high enough on this payload
+# to block density-variant sprite art (#871). The recipe prints both figures and
+# the headroom left against the cap — read it there rather than trusting a
+# number written into this line. Pair (#424): the
 # wasm-bindgen JS glue's ABI must match the exact .wasm it was generated with;
 # a one-sided merge resolution or partial regen ships a silent runtime throw,
 # so every committed file must match gen-wasm's sha256 manifest AND every file
@@ -844,13 +846,29 @@ gen-wasm-check:
     W=site/public/wasm/pixtuoid_web_bg.wasm
     M=site/public/wasm/manifest.sha256
     test -f "$W" || { echo "missing $W — run 'just gen-wasm'"; exit 1; }
-    CAP=1048576
-    SIZE=$(wc -c < "$W" | tr -d ' ')
-    test "$SIZE" -le "$CAP" || { echo "$W is $SIZE bytes (> $CAP cap) — investigate the bloat"; exit 1; }
+    # Gate the GZIP size — that is what GitHub Pages transfers, and the raw byte
+    # count is a number no user ever downloads. Local gzip runs slightly UNDER
+    # what the CDN sends (different implementation and level), so the cap carries
+    # margin rather than being tuned to the last KB. Raw stays REPORTED, not
+    # gated: it is browser parse/compile cost, a real but much looser constraint
+    # than transfer — and gating it is what blocked the density-variant art
+    # (#871), whose sprite text costs several times less over the wire than on
+    # disk.
+    CAP=524288
+    # Compress to a FILE, not through a pipe: POSIX sh has no `pipefail`, so
+    # `gzip … | wc -c` reports wc's status and a broken gzip would measure zero
+    # bytes and pass the cap unconditionally — the gate would go green exactly
+    # when it stopped working.
+    GZ=$(mktemp)
+    trap 'rm -f "$GZ"' EXIT
+    gzip -9 -c "$W" > "$GZ"
+    WIRE=$(wc -c < "$GZ" | tr -d ' ')
+    RAW=$(wc -c < "$W" | tr -d ' ')
+    test "$WIRE" -le "$CAP" || { echo "$W gzips to $WIRE bytes (> $CAP cap) — investigate the bloat"; exit 1; }
     # Report the headroom, don't just pass silently. A ratchet you can only read
     # at the moment it breaks gives no warning that it is about to — and a prose
     # estimate of the size drifts unnoticed precisely because every run is green.
-    echo "wasm $SIZE / $CAP bytes ($((SIZE * 100 / CAP))% of cap, $(((CAP - SIZE) / 1024)) KB headroom)"
+    echo "wasm $WIRE / $CAP bytes gzipped ($((WIRE * 100 / CAP))% of cap, $(((CAP - WIRE) / 1024)) KB headroom; $RAW raw)"
     test -f "$M" || { echo "missing $M — run 'just gen-wasm' (the wasm/glue pair manifest)"; exit 1; }
     (cd site/public/wasm && shasum -a 256 --strict -c manifest.sha256 >/dev/null) \
         || { echo "wasm/glue pair MISMATCH vs $M — a partial regen or one-sided merge; run 'just gen-wasm' and commit all of site/public/wasm/"; exit 1; }
@@ -860,7 +878,7 @@ gen-wasm-check:
         awk -v want="./$b" '$2 == want { found = 1 } END { exit !found }' "$M" \
             || { echo "$f is not covered by $M — run 'just gen-wasm'"; exit 1; }
     done
-    echo "gen-wasm-check OK: $W ($SIZE bytes <= $CAP), pair manifest verified"
+    echo "gen-wasm-check OK: $W ($WIRE bytes gzipped <= $CAP), pair manifest verified"
 
 # Drift gate: fail if any committed README section OR rendered still is stale.
 # Pixel-diffs every PNG (threshold 0); video clips + demo.gif are presence-only


### PR DESCRIPTION
`gen-wasm-check` capped the RAW `.wasm` at 1 MiB. GitHub Pages serves it
gzipped, so the gate was budgeting a number nobody downloads.

Measured against the live site, not estimated — the deployed etag `f5b65`
= 1,006,437 raw confirms Pages is serving the `34695274` build, so these
compare like for like:

| | bytes |
|---|---|
| Pages actually sends (gzip) | **398,811** |
| local `gzip -6` | 395,618 |
| local `gzip -9` | 394,829 |
| raw — what the gate capped | 1,006,437 |

## Why now

This stopped being cosmetic when #868 landed the `<base>@<N>x` density
contract. A full density pass over the 16-piece **furniture subset** costs
~55 KiB of raw sprite text (3,532 grid bytes × 16 for 4× area) against
**41 KB** of raw headroom — the *second* variant reds the gate. The same
content is a few KiB over the wire. The gate was blocking an entire
workstream on the wrong metric.

## The cap

**512 KiB.** Not 400 KB, which I proposed first and my own numbers kill:
389 KB today + the art phase ≈ 401 KB, red on the first complete landing.
Across *every* sprite at 4× the ceiling is ~407 KiB (9,160 grid bytes × 16
= 143 KiB raw, at the **measured 14.6%** compression — `desk@4x` is
4,266 raw for 624 B marginal inside the wasm). That leaves ~105 KiB spare,
and still reds on a debug build or a skipped `wasm-opt`, which are MB-scale.

Raw is now **reported, not gated** — and the review found the reason that
makes this safe, which was in the tree but cited nowhere: `site/lighthouserc.json`
asserts `total-blocking-time` and `user-timings:pixtuoid-revealed` at
`error` level, and `site.yml` fires on `site/**` where the wasm lives. Parse/
compile cost is **measured on the runner**, not proxied by a byte count.

## Review

Four lenses, all APPROVE-WITH-NITS. Dispositions in the thread. The three
that changed the diff:

- **Deleting the raw gate is not a coverage loss** — red-teamed and refuted
  with numbers, so no second cap was added.
- **The cap is deliberately loose and nothing said so**, meaning nobody
  would ever tighten it. The declaration block now names the retirement
  trigger and procedure.
- **The reading key I added for the raw ratio was inverted** — caught in the
  review round I was applying, and fixed before merge.

Also unwritten: three claims I had asserted without earning them (a cause I
never established, an inline number that rots, and a superlative I never
measured).

Verified after every round: gate green, `CAP=1024` reds, a failing `gzip`
stub reds, and the `trap` leaves zero files behind on both the success and
over-cap exit paths. `just preflight` green, 2947 tests.

Closes #871
Closes #877