### PR TITLE
fix(scripts): restore comment-lint on stock macOS python 3.9

### DIFF
--- a/scripts/comment-lint.py
+++ b/scripts/comment-lint.py
@@ -10,6 +10,9 @@ Usage: comment-lint.py [BASE_REF] [--gate] [--worktree] [--selftest]
   --worktree   diff the WORKING TREE vs BASE, not the committed BASE...HEAD range
   --selftest   pin this driver's pathspec + hidden-dir scan on a throwaway repo
 """
+
+from __future__ import annotations
+
 import json
 import pathlib
 import re


### PR DESCRIPTION
## Summary

`scripts/comment-lint.py` fails at import under stock macOS Python `3.9`, so the comment-density gate has been silently unrunnable for anyone whose `python3` is `/usr/bin/python3`. The signature on line 25 uses PEP 604 (`str | None`) without `from __future__ import annotations`, which 3.9 evaluates eagerly.

_I hit this while running `just lint` on a contribution branch , so I figured it'd be good to raise a quick three-liner (realistically, a one-liner) to address the issue._

## Related issue

n/a

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New theme / sprite pack
- [ ] New `Source` adapter (another agent CLI)
- [ ] Docs only
- [ ] Refactor / chore

## How I tested it

Before, on a stock macOS interpreter:

```console
$ /usr/bin/python3 -V
Python 3.9.6
$ /usr/bin/python3 scripts/comment-lint.py --selftest
Traceback (most recent call last):
  File "scripts/comment-lint.py", line 25, in <module>
    base: str, worktree: bool, cwd: str | None = None
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

After:

```console
$ /usr/bin/python3 scripts/comment-lint.py --selftest
comment-lint selftest: all checks passed
```

Once runnable it immediately surfaced real findings on my own diff, which is how I know it is doing work rather than concealing an issue and passing.

I confirmed that `just preflight` is also happy.

## Visual verification (required for sprite / rendering changes)

- [x] Not a visual change, or — screenshot/GIF attached below and it reads at half-block scale.

## Checklist

- [x] I read the relevant `CLAUDE.md` (root + the nested one for the crate I touched).
- [x] New behavior has a test (this repo is TDD-first).
- [x] No `unwrap()` in non-test code; errors propagate via `anyhow`/`thiserror`.
- [x] No new `println!`/`eprintln!` on a production path (use `tracing`).
- [x] Docs updated in the same commit if I changed module structure, architecture, or public API (`CLAUDE.md` / `README.md`).
- [x] Checked against the [recurring pitfalls](https://github.com/IvanWng97/pixtuoid/blob/main/docs/CONTRIBUTING.md#recurring-pitfalls-this-codebases-review-history-distilled): char-safe slicing · no parallel copies without a bridge test · sanitize at the decode boundary · negative branches pinned.
- [x] `just preflight` passes locally.

## AI assistance

- [ ] This PR was written/heavily-assisted by an AI agent.

_(The change was tiny and hand-written, while the single commit's message was AI-written with my proofing – not sure if that justifies checking this box! 🤣 Also, this PR description itself was hand-written/completed)_