### PR TITLE
fix(tooling): stop gen-guides' selftest from staging into the real index

### DIFF
--- a/scripts/gen-guides.py
+++ b/scripts/gen-guides.py
@@ -23,6 +23,7 @@ Usage: gen-guides.py [--check]   (--check: write nothing, exit 1 on drift)
 
 from __future__ import annotations
 
+import os
 import pathlib
 import re
 import subprocess
@@ -274,16 +275,70 @@ def selftest() -> int:
         if gen(False) != 0 or gen(True) != 0:
             fails.append("fixture must return to green after the controls")
 
+        # The ambient-git control, run LAST so a leak cannot corrupt the fixture
+        # above it. `outer` stands in for the developer's real repo: with GIT_DIR
+        # exported (what any hook does) an unscrubbed `git -C <tmp> add` stages
+        # into IT instead, and the damage outlives the run.
+        outer = pathlib.Path(tmp) / "outer"
+        (outer / "sub").mkdir(parents=True)
+        (outer / "sub" / "kept.md").write_text("# kept\n")
+        outer_git = ["git", "-C", str(outer)]
+        subprocess.run([*outer_git, "init", "-q"], check=True)
+        subprocess.run([*outer_git, "add", "-A"], check=True, capture_output=True)
+        before = subprocess.run(
+            [*outer_git, "ls-files"], capture_output=True, text=True, check=True
+        ).stdout
+
+        leaky = pathlib.Path(tmp) / "leaky"
+        leaky.mkdir()
+        (leaky / "PHANTOM.md").write_text("# phantom\n")
+        saved = os.environ.get("GIT_DIR")
+        os.environ["GIT_DIR"] = str(outer / ".git")
+        try:
+            drop_ambient_git_env()
+            leaky_git = ["git", "-C", str(leaky)]
+            subprocess.run([*leaky_git, "init", "-q"], check=True)
+            subprocess.run([*leaky_git, "add", "-A"], check=True, capture_output=True)
+        finally:
+            if saved is None:
+                os.environ.pop("GIT_DIR", None)
+            else:
+                os.environ["GIT_DIR"] = saved
+        after = subprocess.run(
+            [*outer_git, "ls-files"], capture_output=True, text=True, check=True
+        ).stdout
+        if after != before:
+            fails.append(
+                "an inherited GIT_DIR must not let a throwaway `git add` reach the "
+                f"outer index (it now holds {after.split() or '<empty>'})"
+            )
+
     if fails:
         print("gen-guides selftest FAILED:")
         for f in fails:
             print(f"  - {f}")
         return 1
-    print("gen-guides selftest: all 10 controls passed")
+    print("gen-guides selftest: all 11 controls passed")
     return 0
 
 
+def drop_ambient_git_env() -> None:
+    """Drop inherited `GIT_*` so every git call here is located by `-C` alone.
+
+    Under a HOOK (pre-push runs `just lint`) git exports `GIT_DIR` /
+    `GIT_INDEX_FILE`, and those OUTRANK `-C <dir>`: the selftest's throwaway
+    `git add` then lands in the REAL index, leaving it holding one phantom
+    `crate/CLAUDE.md`. That poisons `git ls-files` for every later run — the
+    `--check` arm then dies on a path that was never on disk — and it PERSISTS
+    until someone re-reads the tree, so a developer's index stays broken after
+    the push that broke it. Nothing here ever wants an ambient git context.
+    """
+    for var in [k for k in os.environ if k.startswith("GIT_")]:
+        del os.environ[var]
+
+
 def main() -> int:
+    drop_ambient_git_env()
     if "--selftest" in sys.argv[1:]:
         return selftest()
     return run(ROOT, "--check" in sys.argv[1:])


### PR DESCRIPTION
## Summary

`git -C <dir>` doesn't outrank an inherited `GIT_DIR`/`GIT_INDEX_FILE` (git's environment wins) so `gen-guides.py --selftest`, which stages into a throwaway repo, was staging into the real index whenever it ran under a git hook.

`just lint` runs the selftest and the pre-push hook runs `just lint`, so every `git push` corrupted the pusher's index (`drop_ambient_git_env()` clears `GIT_*` once at the entry point).

## Related issue

n/a

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New theme / sprite pack
- [ ] New `Source` adapter (another agent CLI)
- [ ] Docs only
- [ ] Refactor / chore

## How I tested it

Observed damage before the fix: the outer index dropped from 798 tracked files to 4, holding one phantom `crate/CLAUDE.md` (the selftest fixture's path, staged into the wrong repo). It then persists, with nothing re-reading the tree, so the next `gen-guides.py --check` gets the phantom back from `git ls-files` and dies on a path that was never on disk (`FileNotFoundError: .../crate/CLAUDE.md`), which reads as a broken guide index rather than a broken index file. 

CI never runs into it since no hooks are leant on there.

- `python3 scripts/gen-guides.py --selftest` confirms all 11 controls passed.
- `just gen-guides-check` results in `all index blocks current ✓`.
- `just preflight` cleanly results in an exit 0 (2969 tests).
- Under a simulated hook (`GIT_DIR` exported), `--selftest` and `--check` both pass and the index stays at 798 files.
- I've also run end-to-end test and can confirm pushing this branch runs the real pre-push hook. The index remains intact at 798 afterwards (i.e. the bug's own reproduction no longer triggers).

I've verified the test is sound also. With scrub removed, the control tests go red, naming the symptom rather than returning a bare boolean:

```
gen-guides selftest FAILED:
  - an inherited GIT_DIR must not let a throwaway `git add` reach the outer index (it now holds ['PHANTOM.md'])
```

## Visual verification (required for sprite / rendering changes)

- [x] Not a visual change, or — screenshot/GIF attached below and it reads at half-block scale.

## Checklist

- [x] I read the relevant `CLAUDE.md` (root + the nested one for the crate I touched).
- [x] New behavior has a test (this repo is TDD-first).
- [x] No `unwrap()` in non-test code; errors propagate via `anyhow`/`thiserror`.
- [x] No new `println!`/`eprintln!` on a production path (use `tracing`).
- [x] Docs updated in the same commit if I changed module structure, architecture, or public API (`CLAUDE.md` / `README.md`).
- [x] Checked against the [recurring pitfalls](https://github.com/IvanWng97/pixtuoid/blob/main/docs/CONTRIBUTING.md#recurring-pitfalls-this-codebases-review-history-distilled): char-safe slicing · no parallel copies without a bridge test · sanitize at the decode boundary · negative branches pinned.
- [x] `just preflight` passes locally.

## AI assistance

- [x] This PR was written/heavily-assisted by an AI agent.