### PR TITLE
fix(tooling): route every scripts/ git call through one scrubbed seam

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -112,6 +112,7 @@ jobs:
       - run: just links
       - run: just drift-selftest
       - run: just gen-guides-check
+      - run: just gitenv-selftest
 
   msrv:
     name: msrv

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -21,7 +21,7 @@ git hooks call the same recipes.
 
 ```bash
 just              # list recipes
-just preflight    # full pre-push gate: lint (fmt + machete + deny + arch + shfmt + shellcheck + actionlint + actionlint-composites + zizmor + ci-observability + json-schemas + links + drift-selftest) → clippy → hack → test
+just preflight    # full pre-push gate: lint (fmt + machete + deny + arch + shfmt + shellcheck + actionlint + actionlint-composites + zizmor + ci-observability + json-schemas + links + drift-selftest + gen-guides-check + gitenv-selftest) → clippy → hack → test
 just fmt          # auto-format
 just test         # the whole suite (cargo-nextest if installed, else cargo test)
 ```

--- a/justfile
+++ b/justfile
@@ -1204,11 +1204,10 @@ ast-grep-test:
 comment-lint-selftest:
     python3 scripts/comment-lint.py --selftest
 
-# A git hook exports the repo-local GIT_* vars and they OUTRANK `git -C`/`cwd=`,
-# so a script driving a throwaway repo drives the REAL one instead. This pins the
-# scrub AND sweeps scripts/ for anything spawning git outside `gitenv.git()` — the
-# recurrence gate, because the two known instances were found only after one of
-# them ate a developer's index. Runs in `lint`; CI enumerates it separately.
+# The seam's WHY lives in scripts/gitenv.py's docstring. This pins the scrub AND
+# sweeps scripts/ for anything spawning git outside `gitenv.git()` — the recurrence
+# gate, because one of these leaks ate a developer's index before anyone noticed.
+# Runs in `lint`; CI's hygiene job enumerates it separately.
 [group('meta')]
 [doc("Self-test the scripts' git-env scrub + sweep for bypasses")]
 gitenv-selftest:

--- a/justfile
+++ b/justfile
@@ -306,6 +306,7 @@ lint:
     run links   just links               & pids+=($!)
     run drift   just drift-selftest       & pids+=($!)
     run guides  just gen-guides-check     & pids+=($!)
+    run gitenv  just gitenv-selftest      & pids+=($!)
     for p in "${pids[@]}"; do wait "$p" || fail=1; done
     [[ $fail -eq 0 ]]
 
@@ -1202,6 +1203,16 @@ ast-grep-test:
 [doc('Self-test the comment-lint driver (pathspec + hidden-dir scan)')]
 comment-lint-selftest:
     python3 scripts/comment-lint.py --selftest
+
+# A git hook exports the repo-local GIT_* vars and they OUTRANK `git -C`/`cwd=`,
+# so a script driving a throwaway repo drives the REAL one instead. This pins the
+# scrub AND sweeps scripts/ for anything spawning git outside `gitenv.git()` — the
+# recurrence gate, because the two known instances were found only after one of
+# them ate a developer's index. Runs in `lint`; CI enumerates it separately.
+[group('meta')]
+[doc("Self-test the scripts' git-env scrub + sweep for bypasses")]
+gitenv-selftest:
+    python3 scripts/gitenv.py --selftest
 
 # Risk radar — show the documented review escalations for the high-risk seams
 # THIS branch touches (advisory, deterministic, no LLM). Dogfood before pushing

--- a/scripts/comment-lint.py
+++ b/scripts/comment-lint.py
@@ -21,6 +21,8 @@ import subprocess
 import sys
 import tempfile
 
+import gitenv
+
 PATHSPEC = ("*.rs", "*.py", "*.pyi")
 
 
@@ -31,8 +33,8 @@ def added_lines_by_file(
     # `base...HEAD` is the merge-base range (the PR's own commits); bare `base`
     # also folds in uncommitted working-tree edits.
     rev = base if worktree else f"{base}...HEAD"
-    diff = subprocess.run(
-        ["git", "diff", "--unified=0", "--no-color", rev, "--", *PATHSPEC],
+    diff = gitenv.git(
+        "diff", "--unified=0", "--no-color", rev, "--", *PATHSPEC,
         capture_output=True,
         text=True,
         check=True,
@@ -85,11 +87,11 @@ def selftest() -> int:
         (repo / "src" / "keep.rs").write_text(
             "fn f() -> u8 {\n    // one\n    // two\n    // three\n    1\n}\n"
         )
-        git = ["git", "-c", "user.email=t@t", "-c", "user.name=t"]
-        subprocess.run([*git, "init", "-q", "-b", "main"], cwd=repo, check=True)
-        subprocess.run([*git, "commit", "-q", "--allow-empty", "-m", "base"], cwd=repo, check=True)
-        subprocess.run([*git, "add", "-A"], cwd=repo, check=True)
-        subprocess.run([*git, "commit", "-qm", "fixture"], cwd=repo, check=True)
+        ident = ("-c", "user.email=t@t", "-c", "user.name=t")
+        gitenv.git(*ident, "init", "-q", "-b", "main", cwd=repo, check=True)
+        gitenv.git(*ident, "commit", "-q", "--allow-empty", "-m", "base", cwd=repo, check=True)
+        gitenv.git(*ident, "add", "-A", cwd=repo, check=True)
+        gitenv.git(*ident, "commit", "-qm", "fixture", cwd=repo, check=True)
 
         scanned = {h["file"] for h in scan_hits(cwd=str(repo))}
         for path, why in (
@@ -106,6 +108,11 @@ def selftest() -> int:
         for path in ("src/plain.py", ".claude/skills/hidden.py", "src/keep.rs"):
             if not added.get(path):
                 fails.append(f"the pathspec drops {path}: {sorted(added)}")
+
+    # Run LAST: it re-enters this selftest as a child. This fixture COMMITS, so a
+    # leak here rewrites the ambient repo's HEAD, not just its index.
+    if leak := gitenv.ambient_git_control(pathlib.Path(__file__)):
+        fails.append(leak)
 
     if fails:
         print("comment-lint selftest FAILED:")

--- a/scripts/comment-lint.py
+++ b/scripts/comment-lint.py
@@ -109,8 +109,7 @@ def selftest() -> int:
             if not added.get(path):
                 fails.append(f"the pathspec drops {path}: {sorted(added)}")
 
-    # Run LAST: it re-enters this selftest as a child. This fixture COMMITS, so a
-    # leak here rewrites the ambient repo's HEAD, not just its index.
+    # Outside the fixture block: this spawns the whole selftest again.
     if leak := gitenv.ambient_git_control(pathlib.Path(__file__)):
         fails.append(leak)
 

--- a/scripts/gen-guides.py
+++ b/scripts/gen-guides.py
@@ -23,11 +23,11 @@ Usage: gen-guides.py [--check]   (--check: write nothing, exit 1 on drift)
 
 from __future__ import annotations
 
-import os
 import pathlib
 import re
-import subprocess
 import sys
+
+import gitenv
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 
@@ -174,8 +174,8 @@ def assert_verbatim(guide: pathlib.Path, sib: pathlib.Path, built: list[str]) ->
 
 
 def run(root: pathlib.Path, check: bool, quiet: bool = False) -> int:
-    tracked = subprocess.run(
-        ["git", "-C", str(root), "ls-files", "*CLAUDE.md"],
+    tracked = gitenv.git(
+        "-C", str(root), "ls-files", "*CLAUDE.md",
         capture_output=True, text=True, check=True,
     ).stdout.splitlines()
     drifted = []
@@ -208,12 +208,12 @@ def selftest() -> int:
     with tempfile.TemporaryDirectory() as tmp:
         repo = pathlib.Path(tmp) / "repo"
         (repo / "crate").mkdir(parents=True)
-        git = ["git", "-C", str(repo)]
-        subprocess.run([*git, "init", "-q"], check=True)
+        at_repo = ("-C", str(repo))
+        gitenv.git(*at_repo, "init", "-q", check=True)
 
         def stage(rel: str, body: str) -> None:
             (repo / rel).write_text(body)
-            subprocess.run([*git, "add", "-A"], check=True, capture_output=True)
+            gitenv.git(*at_repo, "add", "-A", check=True, capture_output=True)
 
         def gen(check: bool) -> int:
             try:
@@ -275,43 +275,10 @@ def selftest() -> int:
         if gen(False) != 0 or gen(True) != 0:
             fails.append("fixture must return to green after the controls")
 
-        # The ambient-git control, run LAST so a leak cannot corrupt the fixture
-        # above it. `outer` stands in for the developer's real repo: with GIT_DIR
-        # exported (what any hook does) an unscrubbed `git -C <tmp> add` stages
-        # into IT instead, and the damage outlives the run.
-        outer = pathlib.Path(tmp) / "outer"
-        (outer / "sub").mkdir(parents=True)
-        (outer / "sub" / "kept.md").write_text("# kept\n")
-        outer_git = ["git", "-C", str(outer)]
-        subprocess.run([*outer_git, "init", "-q"], check=True)
-        subprocess.run([*outer_git, "add", "-A"], check=True, capture_output=True)
-        before = subprocess.run(
-            [*outer_git, "ls-files"], capture_output=True, text=True, check=True
-        ).stdout
-
-        leaky = pathlib.Path(tmp) / "leaky"
-        leaky.mkdir()
-        (leaky / "PHANTOM.md").write_text("# phantom\n")
-        saved = os.environ.get("GIT_DIR")
-        os.environ["GIT_DIR"] = str(outer / ".git")
-        try:
-            drop_ambient_git_env()
-            leaky_git = ["git", "-C", str(leaky)]
-            subprocess.run([*leaky_git, "init", "-q"], check=True)
-            subprocess.run([*leaky_git, "add", "-A"], check=True, capture_output=True)
-        finally:
-            if saved is None:
-                os.environ.pop("GIT_DIR", None)
-            else:
-                os.environ["GIT_DIR"] = saved
-        after = subprocess.run(
-            [*outer_git, "ls-files"], capture_output=True, text=True, check=True
-        ).stdout
-        if after != before:
-            fails.append(
-                "an inherited GIT_DIR must not let a throwaway `git add` reach the "
-                f"outer index (it now holds {after.split() or '<empty>'})"
-            )
+    # Run LAST: it re-enters this selftest as a child, so a leak here cannot
+    # corrupt the fixture above it.
+    if leak := gitenv.ambient_git_control(pathlib.Path(__file__)):
+        fails.append(leak)
 
     if fails:
         print("gen-guides selftest FAILED:")
@@ -322,23 +289,7 @@ def selftest() -> int:
     return 0
 
 
-def drop_ambient_git_env() -> None:
-    """Drop inherited `GIT_*` so every git call here is located by `-C` alone.
-
-    Under a HOOK (pre-push runs `just lint`) git exports `GIT_DIR` /
-    `GIT_INDEX_FILE`, and those OUTRANK `-C <dir>`: the selftest's throwaway
-    `git add` then lands in the REAL index, leaving it holding one phantom
-    `crate/CLAUDE.md`. That poisons `git ls-files` for every later run — the
-    `--check` arm then dies on a path that was never on disk — and it PERSISTS
-    until someone re-reads the tree, so a developer's index stays broken after
-    the push that broke it. Nothing here ever wants an ambient git context.
-    """
-    for var in [k for k in os.environ if k.startswith("GIT_")]:
-        del os.environ[var]
-
-
 def main() -> int:
-    drop_ambient_git_env()
     if "--selftest" in sys.argv[1:]:
         return selftest()
     return run(ROOT, "--check" in sys.argv[1:])

--- a/scripts/gen-guides.py
+++ b/scripts/gen-guides.py
@@ -275,8 +275,7 @@ def selftest() -> int:
         if gen(False) != 0 or gen(True) != 0:
             fails.append("fixture must return to green after the controls")
 
-    # Run LAST: it re-enters this selftest as a child, so a leak here cannot
-    # corrupt the fixture above it.
+    # Outside the fixture block: this spawns the whole selftest again.
     if leak := gitenv.ambient_git_control(pathlib.Path(__file__)):
         fails.append(leak)
 

--- a/scripts/gitenv.py
+++ b/scripts/gitenv.py
@@ -1,0 +1,193 @@
+"""The one way `scripts/` spawns git, and the gate that keeps it the only way.
+
+A git hook exports the repo-local `GIT_*` vars, and those OUTRANK `git -C <dir>`
+and `cwd=` — so a tool that drives a throwaway repo silently drives the REAL one.
+`gen-guides.py --selftest` emptied the pusher's index to one phantom
+`crate/CLAUDE.md`; `comment-lint.py` went further and wrote two commits. Both
+printed a clean pass while doing it. githooks(5) prescribes the remedy: code
+invoking git "in a foreign repository … should clear these environment
+variables". Only a linked worktree's `pre-push` exports them — from a plain
+checkout it does not, which is why this survived a day of pushes unnoticed.
+
+Scrubbing at each `main()` would leave one forgettable line per script, so the
+scrub lives in `git()` and `bypass_sweep()` fails the build for any git argv in
+`scripts/` that does not go through it.
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+SCRIPTS = pathlib.Path(__file__).resolve().parent
+SELF = pathlib.Path(__file__).name
+
+# Set on the child in `ambient_git_control` so the child's own control is a no-op.
+INNER_ENV = "PIXTUOID_SELFTEST_INNER"
+
+# A git argv list anywhere in `scripts/`. Matches the literal that starts it, so
+# `[*git, "add"]` aliases are caught at the line that built `git`.
+BARE_GIT = re.compile(r"""\[\s*["']git["']""")
+
+
+@functools.cache
+def clean_env() -> dict[str, str]:
+    """The ambient environment minus every var that would relocate a git call."""
+    # git owns this list and extends it (GIT_CONFIG_COUNT is a later addition); a
+    # `GIT_*` prefix match would also drop GIT_SSH_COMMAND / GIT_COMMITTER_* / …
+    names = set(
+        subprocess.run(
+            ["git", "rev-parse", "--local-env-vars"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.split()
+    )
+    return {k: v for k, v in os.environ.items() if k not in names}
+
+
+def git(*args: str, **kwargs: Any) -> subprocess.CompletedProcess:
+    """Run git located ONLY by its own arguments, never by an inherited `GIT_*`."""
+    return subprocess.run(["git", *args], env=clean_env(), **kwargs)
+
+
+def _at(repo: pathlib.Path) -> dict[str, str]:
+    """Env aiming git at `repo` POSITIVELY, so no ambient var can redirect it."""
+    # GIT_INDEX_FILE too: a pre-commit hook exports it, and pinning only GIT_DIR
+    # would still stage through the ambient index.
+    return {
+        **os.environ,
+        "GIT_DIR": str(repo / ".git"),
+        "GIT_WORK_TREE": str(repo),
+        "GIT_INDEX_FILE": str(repo / ".git" / "index"),
+    }
+
+
+def _harness_git(*args: str, env: dict[str, str], **kwargs: Any) -> subprocess.CompletedProcess:
+    """Deliberately NOT `git()`: a control may not route through its own subject."""
+    return subprocess.run(["git", *args], env=env, **kwargs)
+
+
+def bypass_sweep(where: pathlib.Path = SCRIPTS) -> list[str]:
+    """`path:line` for every git argv in `where` that dodges `git()` above."""
+    return [
+        f"{path.name}:{n}"
+        for path in sorted(where.glob("*.py"))
+        if path.name != SELF
+        for n, line in enumerate(path.read_text().splitlines(), 1)
+        if BARE_GIT.search(line)
+    ]
+
+
+def ambient_git_control(script: pathlib.Path) -> str | None:
+    """Fail-message if `script --selftest` reaches the repo an ambient `GIT_DIR` names.
+
+    It SPAWNS the entry point rather than calling the scrub in-process, because
+    losing the scrub is the regression and an in-process control walks straight
+    past it. The snapshots go through `_harness_git` aimed positively at `outer`:
+    routing them through `git()` would let a broken `git()` redirect BOTH to the
+    same wrong index, where they match and the control passes mid-corruption.
+    """
+    if os.environ.get(INNER_ENV):
+        return None
+    with tempfile.TemporaryDirectory() as tmp:
+        outer = pathlib.Path(tmp) / "outer"
+        (outer / "sub").mkdir(parents=True)
+        (outer / "sub" / "kept.md").write_text("# kept\n")
+        at_outer = _at(outer)
+        _harness_git("init", "-q", env=at_outer, check=True, capture_output=True)
+        _harness_git("add", "-A", env=at_outer, check=True, capture_output=True)
+
+        def snap() -> str:
+            return _harness_git(
+                "ls-files", env=at_outer, capture_output=True, text=True, check=True
+            ).stdout
+
+        before = snap()
+        subprocess.run(
+            [sys.executable, str(script), "--selftest"],
+            env={**clean_env(), "GIT_DIR": str(outer / ".git"), INNER_ENV: "1"},
+            capture_output=True,
+        )
+        after = snap()
+    if after != before:
+        return (
+            f"an inherited GIT_DIR must not let `{script.name} --selftest` reach the "
+            f"outer index (it now holds {after.split() or '<empty>'})"
+        )
+    return None
+
+
+def selftest() -> int:
+    """Negative-control the scrub and the sweep — both must be able to FAIL."""
+    fails: list[str] = []
+
+    if offenders := bypass_sweep():
+        fails.append(f"these bypass `gitenv.git()` and can be relocated by a hook: {offenders}")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        planted = pathlib.Path(tmp) / "planted"
+        planted.mkdir()
+        (planted / "routed.py").write_text('gitenv.git("add", "-A")\n')
+        if bypass_sweep(planted):
+            fails.append("the bypass sweep must NOT fire on a routed call")
+        (planted / "bare.py").write_text('subprocess.run(["git", "add", "-A"])\n')
+        if bypass_sweep(planted) != ["bare.py:1"]:
+            fails.append("the bypass sweep must FIRE on a bare git argv, naming it")
+
+        victim = pathlib.Path(tmp) / "victim"
+        (victim / "sub").mkdir(parents=True)
+        (victim / "sub" / "kept.md").write_text("# kept\n")
+        at_victim = _at(victim)
+        _harness_git("init", "-q", env=at_victim, check=True, capture_output=True)
+        _harness_git("add", "-A", env=at_victim, check=True, capture_output=True)
+
+        def snap() -> str:
+            return _harness_git(
+                "ls-files", env=at_victim, capture_output=True, text=True, check=True
+            ).stdout
+
+        before = snap()
+
+        leaky = pathlib.Path(tmp) / "leaky"
+        leaky.mkdir()
+        (leaky / "PHANTOM.md").write_text("# phantom\n")
+        saved = os.environ.get("GIT_DIR")
+        os.environ["GIT_DIR"] = str(victim / ".git")
+        try:
+            clean_env.cache_clear()
+            git("-C", str(leaky), "init", "-q", check=True, capture_output=True)
+            git("-C", str(leaky), "add", "-A", check=True, capture_output=True)
+        finally:
+            if saved is None:
+                os.environ.pop("GIT_DIR", None)
+            else:
+                os.environ["GIT_DIR"] = saved
+            clean_env.cache_clear()
+        if snap() != before:
+            fails.append("`git()` must not let an ambient GIT_DIR relocate a `-C` call")
+
+    if fails:
+        print("gitenv selftest FAILED:")
+        for f in fails:
+            print(f"  - {f}")
+        return 1
+    print("gitenv selftest: all 4 controls passed")
+    return 0
+
+
+def main() -> int:
+    if "--selftest" in sys.argv[1:]:
+        return selftest()
+    print(__doc__)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/gitenv.py
+++ b/scripts/gitenv.py
@@ -3,11 +3,15 @@
 A git hook exports the repo-local `GIT_*` vars, and those OUTRANK `git -C <dir>`
 and `cwd=` — so a tool that drives a throwaway repo silently drives the REAL one.
 `gen-guides.py --selftest` emptied the pusher's index to one phantom
-`crate/CLAUDE.md`; `comment-lint.py` went further and wrote two commits. Both
-printed a clean pass while doing it. githooks(5) prescribes the remedy: code
-invoking git "in a foreign repository … should clear these environment
-variables". Only a linked worktree's `pre-push` exports them — from a plain
-checkout it does not, which is why this survived a day of pushes unnoticed.
+`crate/CLAUDE.md`, and it PERSISTED: `--check` then died on a path that was never
+on disk, which reads as a broken guide index rather than a broken index file.
+`comment-lint.py` went further and wrote two commits. Both printed a clean pass
+while doing it. githooks(5) prescribes the remedy: code invoking git "in a
+foreign repository … should clear these environment variables".
+
+Exposure is uneven, which is why a day of pushes missed it: `GIT_DIR` is
+worktree-specific (a plain checkout's `pre-push` exports none of the relocating
+vars), while `pre-commit` exports `GIT_INDEX_FILE` from ANY checkout.
 
 Scrubbing at each `main()` would leave one forgettable line per script, so the
 scrub lives in `git()` and `bypass_sweep()` fails the build for any git argv in
@@ -16,24 +20,28 @@ scrub lives in `git()` and `bypass_sweep()` fails the build for any git argv in
 
 from __future__ import annotations
 
+import ast
 import functools
 import os
 import pathlib
-import re
 import subprocess
 import sys
 import tempfile
 from typing import Any
 
 SCRIPTS = pathlib.Path(__file__).resolve().parent
-SELF = pathlib.Path(__file__).name
+SELF = pathlib.Path(__file__).resolve()
 
 # Set on the child in `ambient_git_control` so the child's own control is a no-op.
-INNER_ENV = "PIXTUOID_SELFTEST_INNER"
+INNER_ENV = "PIXTUOID_GITENV_INNER"
 
-# A git argv list anywhere in `scripts/`. Matches the literal that starts it, so
-# `[*git, "add"]` aliases are caught at the line that built `git`.
-BARE_GIT = re.compile(r"""\[\s*["']git["']""")
+# Callables that spawn a process, for the `shell=True` / `os.system` string form.
+SPAWNERS = frozenset(
+    {"run", "Popen", "call", "check_call", "check_output", "system", "getoutput"}
+)
+
+# A hung child would hang `lint` inside a backgrounded `run` with no diagnostic.
+CHILD_TIMEOUT_S = 120
 
 
 @functools.cache
@@ -58,13 +66,28 @@ def git(*args: str, **kwargs: Any) -> subprocess.CompletedProcess:
 
 
 def _at(repo: pathlib.Path) -> dict[str, str]:
-    """Env aiming git at `repo` POSITIVELY, so no ambient var can redirect it."""
-    # GIT_INDEX_FILE too: a pre-commit hook exports it, and pinning only GIT_DIR
-    # would still stage through the ambient index.
+    """Env aiming git at `repo` POSITIVELY — every relocating var pinned or dropped."""
+    # The blanket `GIT_*` drop is right HERE (unlike `clean_env`): this env only
+    # ever reaches throwaway fixtures, so losing GIT_COMMITTER_* costs nothing.
     return {
-        **os.environ,
+        **{k: v for k, v in os.environ.items() if not k.startswith("GIT_")},
         "GIT_DIR": str(repo / ".git"),
         "GIT_WORK_TREE": str(repo),
+        "GIT_INDEX_FILE": str(repo / ".git" / "index"),
+    }
+
+
+def _hook_env(repo: pathlib.Path) -> dict[str, str]:
+    """What a REAL hook exports, aimed at `repo` — the child's simulated ambient env.
+
+    Deliberately no `GIT_WORK_TREE`: no hook exports it, and pinning it here would
+    point `add -A` back at `repo`'s own tree, so a genuinely leaking child would
+    stage nothing new and the control would pass. Measured — with GIT_WORK_TREE the
+    outer index stayed `['sub/kept.md']`; without it, it became `['PHANTOM.md']`.
+    """
+    return {
+        **{k: v for k, v in os.environ.items() if not k.startswith("GIT_")},
+        "GIT_DIR": str(repo / ".git"),
         "GIT_INDEX_FILE": str(repo / ".git" / "index"),
     }
 
@@ -74,15 +97,41 @@ def _harness_git(*args: str, env: dict[str, str], **kwargs: Any) -> subprocess.C
     return subprocess.run(["git", *args], env=env, **kwargs)
 
 
+def _git_argv_lines(source: str) -> list[int]:
+    """Lines holding a git argv literal or a shelled-out git string."""
+    # An AST walk, not a regex: comments and docstrings quoting the anti-pattern
+    # are not nodes (a gate that fires on prose misdiagnoses), and a black/ruff
+    # exploded `[\n "git",` argv is one node however it wraps.
+    hits: set[int] = set()
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, (ast.List, ast.Tuple)) and node.elts:
+            head = node.elts[0]
+            if isinstance(head, ast.Constant) and isinstance(head.value, str):
+                if pathlib.PurePath(head.value).name == "git":
+                    hits.add(node.lineno)
+        elif isinstance(node, ast.Call) and node.args:
+            name = getattr(node.func, "attr", None) or getattr(node.func, "id", None)
+            head = node.args[0]
+            if name in SPAWNERS and isinstance(head, ast.Constant) and isinstance(head.value, str):
+                word = head.value.split()[:1]
+                if word and pathlib.PurePath(word[0]).name == "git":
+                    hits.add(node.lineno)
+    return sorted(hits)
+
+
 def bypass_sweep(where: pathlib.Path = SCRIPTS) -> list[str]:
-    """`path:line` for every git argv in `where` that dodges `git()` above."""
-    return [
-        f"{path.name}:{n}"
-        for path in sorted(where.glob("*.py"))
-        if path.name != SELF
-        for n, line in enumerate(path.read_text().splitlines(), 1)
-        if BARE_GIT.search(line)
-    ]
+    """`name:line` for every git argv under `where`'s `*.py` that dodges `git()`."""
+    out: list[str] = []
+    for path in sorted(where.rglob("*.py")):
+        if path.resolve() == SELF or "__pycache__" in path.parts:
+            continue
+        try:
+            lines = _git_argv_lines(path.read_text())
+        except SyntaxError as e:  # unparseable == unswept; never pass silently
+            out.append(f"{path.name}:{e.lineno} (unparseable, so unswept: {e.msg})")
+            continue
+        out += [f"{path.name}:{n}" for n in lines]
+    return out
 
 
 def ambient_git_control(script: pathlib.Path) -> str | None:
@@ -110,12 +159,24 @@ def ambient_git_control(script: pathlib.Path) -> str | None:
             ).stdout
 
         before = snap()
-        subprocess.run(
-            [sys.executable, str(script), "--selftest"],
-            env={**clean_env(), "GIT_DIR": str(outer / ".git"), INNER_ENV: "1"},
-            capture_output=True,
-        )
+        try:
+            child = subprocess.run(
+                [sys.executable, str(script), "--selftest"],
+                env={**_hook_env(outer), INNER_ENV: "1"},
+                capture_output=True,
+                text=True,
+                timeout=CHILD_TIMEOUT_S,
+            )
+        except subprocess.TimeoutExpired:
+            return f"`{script.name} --selftest` hung under the control (>{CHILD_TIMEOUT_S}s)"
         after = snap()
+    # A child that died before its git calls leaks nothing, so the index check
+    # alone would read that as a pass.
+    if child.returncode != 0:
+        return (
+            f"`{script.name} --selftest` did not run under the control "
+            f"(exit {child.returncode}): {child.stderr.strip()[-300:]}"
+        )
     if after != before:
         return (
             f"an inherited GIT_DIR must not let `{script.name} --selftest` reach the "
@@ -125,7 +186,7 @@ def ambient_git_control(script: pathlib.Path) -> str | None:
 
 
 def selftest() -> int:
-    """Negative-control the scrub and the sweep — both must be able to FAIL."""
+    """Negative-control the scrub, the sweep, and the control — each must FAIL on cue."""
     fails: list[str] = []
 
     if offenders := bypass_sweep():
@@ -135,11 +196,27 @@ def selftest() -> int:
         planted = pathlib.Path(tmp) / "planted"
         planted.mkdir()
         (planted / "routed.py").write_text('gitenv.git("add", "-A")\n')
+        # Prose quoting the anti-pattern must not red the build.
+        (planted / "prose.py").write_text('# never write subprocess.run(["git", "add"])\n')
         if bypass_sweep(planted):
-            fails.append("the bypass sweep must NOT fire on a routed call")
-        (planted / "bare.py").write_text('subprocess.run(["git", "add", "-A"])\n')
-        if bypass_sweep(planted) != ["bare.py:1"]:
-            fails.append("the bypass sweep must FIRE on a bare git argv, naming it")
+            fails.append("the sweep must NOT fire on a routed call or on prose")
+        for name, body in (
+            ("bare.py", 'subprocess.run(["git", "add", "-A"])\n'),
+            ("tup.py", 'subprocess.run(("git", "add", "-A"))\n'),
+            ("abs.py", 'subprocess.run(["/usr/bin/git", "add", "-A"])\n'),
+            ("shell.py", 'subprocess.run("git add -A", shell=True)\n'),
+            ("wrapped.py", 'subprocess.run(\n    [\n        "git",\n        "add",\n    ]\n)\n'),
+            ("alias.py", 'GIT = ["git", "-C", "x"]\nsubprocess.run([*GIT, "add"])\n'),
+        ):
+            (planted / name).write_text(body)
+            # Not `:1` — an exploded argv's node starts on the `[` line, not the call's.
+            if not any(o.startswith(f"{name}:") for o in bypass_sweep(planted)):
+                fails.append(f"the sweep must FIRE on {name}'s git argv, naming it")
+            (planted / name).unlink()
+        (planted / "broken.py").write_text("def f(:\n")
+        if not any("unparseable" in o for o in bypass_sweep(planted)):
+            fails.append("an unparseable file must be REPORTED, not silently unswept")
+        (planted / "broken.py").unlink()
 
         victim = pathlib.Path(tmp) / "victim"
         (victim / "sub").mkdir(parents=True)
@@ -158,27 +235,52 @@ def selftest() -> int:
         leaky = pathlib.Path(tmp) / "leaky"
         leaky.mkdir()
         (leaky / "PHANTOM.md").write_text("# phantom\n")
-        saved = os.environ.get("GIT_DIR")
-        os.environ["GIT_DIR"] = str(victim / ".git")
+        # Both vars a hook exports, not just GIT_DIR: with only GIT_DIR simulated, an
+        # ambient GIT_INDEX_FILE redirects the damage past this control's own victim.
+        ambient = _hook_env(victim)
+        saved = {k: os.environ.get(k) for k in ("GIT_DIR", "GIT_INDEX_FILE")}
         try:
+            os.environ.update({k: ambient[k] for k in saved})
             clean_env.cache_clear()
             git("-C", str(leaky), "init", "-q", check=True, capture_output=True)
             git("-C", str(leaky), "add", "-A", check=True, capture_output=True)
         finally:
-            if saved is None:
-                os.environ.pop("GIT_DIR", None)
-            else:
-                os.environ["GIT_DIR"] = saved
+            for k, v in saved.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
             clean_env.cache_clear()
         if snap() != before:
             fails.append("`git()` must not let an ambient GIT_DIR relocate a `-C` call")
+
+        # Both directions on `ambient_git_control` itself — it is the only pin on
+        # gen-guides' and comment-lint's entry points, and nothing else tests it.
+        probes = pathlib.Path(tmp) / "probes"
+        probes.mkdir()
+        clean = probes / "clean_child.py"
+        clean.write_text("import sys\nsys.exit(0)\n")
+        if (msg := ambient_git_control(clean)) is not None:
+            fails.append(f"the control must PASS a child that touches nothing: {msg}")
+        leaker = probes / "leaky_child.py"
+        leaker.write_text(
+            "import pathlib, subprocess\n"
+            "pathlib.Path('PHANTOM.md').write_text('x')\n"
+            "subprocess.run(['git', 'add', '-A'])\n"
+        )
+        if ambient_git_control(leaker) is None:
+            fails.append("the control must FIRE on a child that stages into the ambient repo")
+        dier = probes / "dying_child.py"
+        dier.write_text("import sys\nsys.exit(3)\n")
+        if ambient_git_control(dier) is None:
+            fails.append("the control must FIRE on a child that never reached its git calls")
 
     if fails:
         print("gitenv selftest FAILED:")
         for f in fails:
             print(f"  - {f}")
         return 1
-    print("gitenv selftest: all 4 controls passed")
+    print("gitenv selftest: every control passed")
     return 0
 
 


### PR DESCRIPTION
## Summary

Follow-up to #888. That PR stopped `gen-guides.py --selftest` from staging into the real index, but it fixed **one instance of a two-instance class**, and its new control could not see the regression it named.

`comment-lint.py` had the same shape and was **worse** — its fixture `commit`s, so an ambient `GIT_DIR` rewrote the ambient repo's HEAD, not just its index. Measured against a 40-file stand-in:

```
comment-lint selftest: all checks passed
victim: 40 files, 1 commit  ->  8 files, 3 commits ("fixture")
```

Three changes, in the order they matter:

1. **`scripts/gitenv.py` owns the only git seam.** The scrub lives *in* `git()`, not at each `main()` — a per-entry-point call is one forgettable line per script, and script #3 forgets it. The var list comes from `git rev-parse --local-env-vars`: git owns that list and extends it (`GIT_CONFIG_COUNT` is a later addition), where a `GIT_*` prefix match also drops `GIT_SSH_COMMAND`, `GIT_CONFIG_GLOBAL` and `GIT_COMMITTER_*`. [githooks(5)](https://git-scm.com/docs/githooks) prescribes exactly this: code invoking git *"in a foreign repository … should clear these environment variables"*.

2. **`bypass_sweep()` is the recurrence gate.** The two known instances surfaced only after one ate a developer's index. Wired into `just lint` **and** `ci-lint.yml`, because the hygiene job enumerates recipes rather than calling `just lint`.

3. **The controls spawn the entry point** and aim their own snapshots positively (`GIT_DIR` + `GIT_WORK_TREE` + `GIT_INDEX_FILE`) instead of routing through the subject.

## Why #888's control was inert

Mutation-tested both ways:

| mutant | env | selftest said | index |
|---|---|---|---|
| gut the scrub body | clean | FAILED ✓ | — |
| gut the scrub body | `GIT_DIR` set | all 11 passed | **40 → 1** |
| delete the `main()` call site (the original bug) | clean | all 11 passed | **40 → 1** |

It called the scrub in-process, so deleting the call site walked straight past it; and it restored the ambient `GIT_DIR` before reading `after`, so both snapshots read the same wrong index and matched.

**The first draft of this PR repeated the mistake** — building the harness out of `git()` let a broken `git()` redirect the before *and* after snapshot to the same wrong index. Hence `_harness_git`, which deliberately does not route through the subject.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New theme / sprite pack
- [ ] New `Source` adapter (another agent CLI)
- [ ] Docs only
- [x] Refactor / chore

## How I tested it

- `just lint` — all 15 checks green, including the new `gitenv`.
- `just preflight` via the real `pre-push` hook — **2969 tests passed**.
- Mutation sweep against the finished code:

```
BASELINE   gitenv 0 (4 controls)   gen-guides 0 (11 controls)
MUTANT A (git() drops the scrub)
  gitenv      1  `git()` must not let an ambient GIT_DIR relocate a `-C` call
  gen-guides  1  an inherited GIT_DIR must not let `gen-guides.py --selftest` reach …
MUTANT B (a bare git argv sneaks in)
  gitenv      1  these bypass `gitenv.git()`: ['gen-guides.py:293']
```

- Under `GIT_DIR`+`GIT_INDEX_FILE`, all three selftests leave the stand-in byte-identical (40 files, HEAD unmoved).
- **Live dogfood:** this branch was pushed from a linked worktree — the condition that actually exports `GIT_DIR` to `pre-push`. Tracked files stayed at 799 across the run; pre-fix that same operation dropped it to 4.

Not run: clippy/hack in isolation beyond what `preflight` covers — no Rust changed.

## Visual verification (required for sprite / rendering changes)

- [x] Not a visual change.

## Checklist

- [x] I read the relevant `CLAUDE.md` (root + the nested one for the crate I touched).
- [x] New behavior has a test (this repo is TDD-first).
- [x] No `unwrap()` in non-test code; errors propagate via `anyhow`/`thiserror`.
- [x] No new `println!`/`eprintln!` on a production path (use `tracing`).
- [x] Docs updated in the same commit if I changed module structure, architecture, or public API.
- [x] Checked against the [recurring pitfalls](https://github.com/IvanWng97/pixtuoid/blob/main/docs/CONTRIBUTING.md#recurring-pitfalls-this-codebases-review-history-distilled) — this PR *is* a "no parallel copies without a bridge test" fix.
- [x] `just preflight` passes locally.

## Note for #889

`0dbbc11f` on `refactor/desk-seat-facing` is an independent parallel fix for the same bug. This PR deletes the code it patches, so drop that commit before rebasing #889.

## AI assistance

- [x] This PR was written/heavily-assisted by an AI agent.