### PR TITLE
docs(gitenv): scope the sweep claim to what it actually walks

### DIFF
--- a/scripts/gitenv.py
+++ b/scripts/gitenv.py
@@ -15,7 +15,9 @@ vars), while `pre-commit` exports `GIT_INDEX_FILE` from ANY checkout.
 
 Scrubbing at each `main()` would leave one forgettable line per script, so the
 scrub lives in `git()` and `bypass_sweep()` fails the build for any git argv in
-`scripts/` that does not go through it.
+`scripts/**/*.py` that does not go through it. Python only, by decision rather
+than oversight: nothing in `scripts/*.sh` or `*.mjs` spawns git at all, and the
+class that bit us twice was the Python tools that drive throwaway repos.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

One-line docstring correction, plus retiring half of #891.

`scripts/gitenv.py`'s **module** docstring promised the recurrence gate covers *"any git argv in `scripts/`"*, while `bypass_sweep` walks `*.py` only. The **function** docstring was scoped during #890's review round; this one was missed — so the file shipped the exact defect class that review kept flagging, one level up.

A false universal in a don't-touch note is worse than no note: it either misleads the next reader about coverage, or invites a "fix" for a limit that is deliberate.

The new text states the scope as a *decision* and gives the reason that retires the question, rather than just narrowing the claim:

> …fails the build for any git argv in `scripts/**/*.py` that does not go through it. Python only, by decision rather than oversight: nothing in `scripts/*.sh` or `*.mjs` spawns git at all, and the class that bit us twice was the Python tools that drive throwaway repos.

## Why this wasn't left in #891

#891's second item ("should the sweep cover non-Python spawners?") was a **parked non-decision**, not a tracked defect — the scope was chosen deliberately at authoring time and verified (`scripts/*.sh` and `*.mjs` contain zero git invocations). Filing an issue for that is the "acknowledged, no action" state wearing a tracking number, which the disposition rule disallows; the honest home is the docstring. #891 is being trimmed to its one genuine open decision (comment-lint's ambient control living in the advisory lane, which needs `ast-grep` in the `hygiene` job and touches the policy-pinned advisory/gating boundary).

## Related issue

Retires half of #891 (issue trimmed, not closed).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] New theme / sprite pack
- [ ] New `Source` adapter (another agent CLI)
- [x] Docs only
- [ ] Refactor / chore

## How I tested it

- `just gitenv-selftest` → `gitenv selftest: every control passed`.
- `just preflight` via the real `pre-push` hook.
- No behavior change: the diff is 3 lines of module docstring; `bypass_sweep`'s code and its `*.py` glob are untouched.

## Visual verification (required for sprite / rendering changes)

- [x] Not a visual change.

## Checklist

- [x] I read the relevant `CLAUDE.md` (root + the nested one for the crate I touched).
- [x] New behavior has a test — n/a, docstring only; the existing controls are unchanged and still green.
- [x] No `unwrap()` in non-test code; errors propagate via `anyhow`/`thiserror`.
- [x] No new `println!`/`eprintln!` on a production path (use `tracing`).
- [x] Docs updated in the same commit if I changed module structure, architecture, or public API — this IS the docs update.
- [x] Checked against the [recurring pitfalls](https://github.com/IvanWng97/pixtuoid/blob/main/docs/CONTRIBUTING.md#recurring-pitfalls-this-codebases-review-history-distilled).
- [x] `just preflight` passes locally.

## AI assistance

- [x] This PR was written/heavily-assisted by an AI agent.