### PR TITLE
fix(gitenv): stop the selftest littering the developer's working tree

### DIFF
--- a/scripts/gitenv.py
+++ b/scripts/gitenv.py
@@ -260,6 +260,9 @@ def selftest() -> int:
         # gen-guides' and comment-lint's entry points, and nothing else tests it.
         probes = pathlib.Path(tmp) / "probes"
         probes.mkdir()
+        # A probe writes relative to the CALLER's cwd unless told otherwise, and
+        # `--selftest` runs from the developer's checkout via `lint`.
+        littered = set(os.listdir("."))
         clean = probes / "clean_child.py"
         clean.write_text("import sys\nsys.exit(0)\n")
         if (msg := ambient_git_control(clean)) is not None:
@@ -267,8 +270,9 @@ def selftest() -> int:
         leaker = probes / "leaky_child.py"
         leaker.write_text(
             "import pathlib, subprocess\n"
-            "pathlib.Path('PHANTOM.md').write_text('x')\n"
-            "subprocess.run(['git', 'add', '-A'])\n"
+            "d = pathlib.Path(__file__).parent\n"
+            "(d / 'PHANTOM.md').write_text('x')\n"
+            "subprocess.run(['git', '-C', str(d), 'add', '-A'])\n"
         )
         if ambient_git_control(leaker) is None:
             fails.append("the control must FIRE on a child that stages into the ambient repo")
@@ -276,6 +280,8 @@ def selftest() -> int:
         dier.write_text("import sys\nsys.exit(3)\n")
         if ambient_git_control(dier) is None:
             fails.append("the control must FIRE on a child that never reached its git calls")
+        if strays := sorted(set(os.listdir(".")) - littered):
+            fails.append(f"the selftest must not write into the caller's cwd (created {strays})")
 
     if fails:
         print("gitenv selftest FAILED:")


### PR DESCRIPTION
## Summary

`gitenv.py --selftest` created a stray untracked `PHANTOM.md` in the caller's cwd on **every run** — and it runs in `just lint`, so in `preflight`, so on every push.

The leak probe added in #890's review round wrote `pathlib.Path('PHANTOM.md')` — relative, so it resolved against the cwd the child inherited, which is the developer's checkout. It now writes inside its own directory under the control's tmpdir and stages from there with `-C`, which reproduces the leak identically (the worktree is cwd when `GIT_DIR` is set without `GIT_WORK_TREE`).

Grimly on-theme: a tool whose entire purpose is stopping scripts from touching the developer's repo was touching the developer's repo.

## Why nothing caught it

- **An untracked file fails nothing.** Nothing in `lint`, `preflight`, or CI reads `git status`; tests assert on their own outputs, not on the tree.
- **CI structurally cannot see it.** Every job runs in a fresh, discarded checkout — litter in the runner's workspace is invisible by construction.
- **Diff review cannot see it either.** Both bots returned `Findings: 0` on the commit that introduced it. A runtime side-effect on the developer's environment does not appear in a diff.
- **The lens that did check was looking at the wrong commit.** The correctness lens explicitly verified ``git status --porcelain -uall` is clean` — but it reviewed `6d565708`, and the probe arrived in the review round (`729ef80a`), which was never lens-reviewed. I treated the bots' `Findings: 0` at the new head as equivalent to re-review; the protocol asks for both.

Found by running `git status` before closing the session.

## Pinned by

A control that diffs `os.listdir(".")` across the probes. Reverting the probe fix reds it by name:

```
gitenv selftest FAILED:
  - the selftest must not write into the caller's cwd (created ['PHANTOM.md'])
```

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New theme / sprite pack
- [ ] New `Source` adapter (another agent CLI)
- [ ] Docs only
- [ ] Refactor / chore

## How I tested it

- `python3 scripts/gitenv.py --selftest` → `every control passed`, and `git status --porcelain` afterwards shows only the intended edit (previously `?? PHANTOM.md`).
- Negative control: reverted the probe fix on a scratch copy, ran from a scratch cwd → selftest exits 1 with the message above, and `PHANTOM.md` (1B) is confirmed present on disk, so the check detects a real file rather than a listing artefact.
- `just preflight` via the real `pre-push` hook.

## Visual verification (required for sprite / rendering changes)

- [x] Not a visual change.

## Checklist

- [x] I read the relevant `CLAUDE.md` (root + the nested one for the crate I touched).
- [x] New behavior has a test (this repo is TDD-first) — the litter control, negative-controlled above.
- [x] No `unwrap()` in non-test code; errors propagate via `anyhow`/`thiserror`.
- [x] No new `println!`/`eprintln!` on a production path (use `tracing`).
- [x] Docs updated in the same commit if I changed module structure, architecture, or public API — n/a.
- [x] Checked against the [recurring pitfalls](https://github.com/IvanWng97/pixtuoid/blob/main/docs/CONTRIBUTING.md#recurring-pitfalls-this-codebases-review-history-distilled).
- [x] `just preflight` passes locally.

## AI assistance

- [x] This PR was written/heavily-assisted by an AI agent.