### PR TITLE
refactor(scripts): remove the hazard's precondition instead of policing it

### DIFF
--- a/scripts/comment-lint.py
+++ b/scripts/comment-lint.py
@@ -26,20 +26,22 @@ import gitenv
 PATHSPEC = ("*.rs", "*.py", "*.pyi")
 
 
-def added_lines_by_file(
-    base: str, worktree: bool, cwd: str | None = None
-) -> dict[str, set[int]]:
-    """Map each changed file → its NEW-side added/changed line numbers, 1-indexed."""
+def unified_diff(base: str, worktree: bool, cwd: str | None = None) -> str:
+    """The raw diff to scope against — the ONLY git this module does."""
     # `base...HEAD` is the merge-base range (the PR's own commits); bare `base`
     # also folds in uncommitted working-tree edits.
     rev = base if worktree else f"{base}...HEAD"
-    diff = gitenv.git(
+    return gitenv.git(
         "diff", "--unified=0", "--no-color", rev, "--", *PATHSPEC,
         capture_output=True,
         text=True,
         check=True,
         cwd=cwd,
     ).stdout
+
+
+def added_lines_by_file(diff: str) -> dict[str, set[int]]:
+    """Map each changed file → its NEW-side added/changed line numbers, 1-indexed."""
     added: dict[str, set[int]] = {}
     cur: str | None = None
     hunk = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
@@ -104,14 +106,10 @@ def selftest() -> int:
 
         # Driven through the REAL reader, not a second copy of the extension list,
         # which would pass while the production pathspec changed underneath it.
-        added = added_lines_by_file("HEAD~1", worktree=False, cwd=str(repo))
+        added = added_lines_by_file(unified_diff("HEAD~1", worktree=False, cwd=str(repo)))
         for path in ("src/plain.py", ".claude/skills/hidden.py", "src/keep.rs"):
             if not added.get(path):
                 fails.append(f"the pathspec drops {path}: {sorted(added)}")
-
-    # Outside the fixture block: this spawns the whole selftest again.
-    if leak := gitenv.ambient_git_control(pathlib.Path(__file__)):
-        fails.append(leak)
 
     if fails:
         print("comment-lint selftest FAILED:")
@@ -132,7 +130,7 @@ def main() -> int:
     worktree = "--worktree" in sys.argv[1:]
     base = args[0] if args else "origin/main"
 
-    added = added_lines_by_file(base, worktree)
+    added = added_lines_by_file(unified_diff(base, worktree))
     if not any(added.values()):
         print("comment-lint: no added/changed Rust or Python lines vs", base)
         return 0

--- a/scripts/gen-guides.py
+++ b/scripts/gen-guides.py
@@ -173,11 +173,15 @@ def assert_verbatim(guide: pathlib.Path, sib: pathlib.Path, built: list[str]) ->
             )
 
 
-def run(root: pathlib.Path, check: bool, quiet: bool = False) -> int:
-    tracked = gitenv.git(
+def tracked_guides(root: pathlib.Path) -> list[str]:
+    """The guides git knows about — the ONLY git this module needs."""
+    return gitenv.git(
         "-C", str(root), "ls-files", "*CLAUDE.md",
         capture_output=True, text=True, check=True,
     ).stdout.splitlines()
+
+
+def run(root: pathlib.Path, tracked: list[str], check: bool, quiet: bool = False) -> int:
     drifted = []
     for rel in tracked:
         guide = root / rel
@@ -200,24 +204,27 @@ def run(root: pathlib.Path, check: bool, quiet: bool = False) -> int:
 
 
 def selftest() -> int:
-    """Negative-control every failure arm on a throwaway repo — a generator whose
-    own fires/does-not-fire contract broke rewrites blocks with garbage quietly."""
+    """Negative-control every failure arm on a throwaway tree — a generator whose
+    own fires/does-not-fire contract broke rewrites blocks with garbage quietly.
+
+    The fixture is a plain directory, not a git repo: `tracked_guides` is the only
+    git this module does, and injecting its result keeps every control here unable
+    to reach a real index at all.
+    """
     import tempfile
 
     fails: list[str] = []
     with tempfile.TemporaryDirectory() as tmp:
         repo = pathlib.Path(tmp) / "repo"
         (repo / "crate").mkdir(parents=True)
-        at_repo = ("-C", str(repo))
-        gitenv.git(*at_repo, "init", "-q", check=True)
+        tracked = ["crate/CLAUDE.md"]
 
         def stage(rel: str, body: str) -> None:
             (repo / rel).write_text(body)
-            gitenv.git(*at_repo, "add", "-A", check=True, capture_output=True)
 
         def gen(check: bool) -> int:
             try:
-                return run(repo, check, quiet=True)
+                return run(repo, tracked, check, quiet=True)
             except SystemExit as e:  # sys.exit from a builder/assert arm
                 return 1 if e.code else 0
 
@@ -275,23 +282,19 @@ def selftest() -> int:
         if gen(False) != 0 or gen(True) != 0:
             fails.append("fixture must return to green after the controls")
 
-    # Outside the fixture block: this spawns the whole selftest again.
-    if leak := gitenv.ambient_git_control(pathlib.Path(__file__)):
-        fails.append(leak)
-
     if fails:
         print("gen-guides selftest FAILED:")
         for f in fails:
             print(f"  - {f}")
         return 1
-    print("gen-guides selftest: all 11 controls passed")
+    print("gen-guides selftest: every control passed")
     return 0
 
 
 def main() -> int:
     if "--selftest" in sys.argv[1:]:
         return selftest()
-    return run(ROOT, "--check" in sys.argv[1:])
+    return run(ROOT, tracked_guides(ROOT), "--check" in sys.argv[1:])
 
 
 if __name__ == "__main__":

--- a/scripts/gitenv.py
+++ b/scripts/gitenv.py
@@ -139,6 +139,9 @@ def bypass_sweep(where: pathlib.Path = SCRIPTS) -> list[str]:
 def selftest() -> int:
     """Negative-control the scrub, the sweep, and the control — each must FAIL on cue."""
     fails: list[str] = []
+    # `lint` runs this from the developer's checkout, and an untracked stray fails
+    # no gate — which is how #893's `PHANTOM.md` shipped. Cheap recurrence guard.
+    entered_cwd = set(os.listdir("."))
 
     if offenders := bypass_sweep():
         fails.append(f"these bypass `gitenv.git()` and can be relocated by a hook: {offenders}")
@@ -208,6 +211,9 @@ def selftest() -> int:
             clean_env.cache_clear()
         if snap() != before:
             fails.append("`git()` must not let an ambient GIT_DIR relocate a `-C` call")
+
+    if strays := sorted(set(os.listdir(".")) - entered_cwd):
+        fails.append(f"the selftest must not write into the caller's cwd (created {strays})")
 
     if fails:
         print("gitenv selftest FAILED:")

--- a/scripts/gitenv.py
+++ b/scripts/gitenv.py
@@ -18,6 +18,12 @@ scrub lives in `git()` and `bypass_sweep()` fails the build for any git argv in
 `scripts/**/*.py` that does not go through it. Python only, by decision rather
 than oversight: nothing in `scripts/*.sh` or `*.mjs` spawns git at all, and the
 class that bit us twice was the Python tools that drive throwaway repos.
+
+Only `comment-lint`'s selftest still builds one — its pathspec control has to
+drive a real `git diff`. `gen-guides` injects `tracked_guides` instead, so its
+fixture is a plain directory that cannot reach an index at all. Removing the
+precondition is why the controls below are this small: with `git()` the only
+path, there is no per-`main()` call left to forget.
 """
 
 from __future__ import annotations
@@ -34,16 +40,10 @@ from typing import Any
 SCRIPTS = pathlib.Path(__file__).resolve().parent
 SELF = pathlib.Path(__file__).resolve()
 
-# Set on the child in `ambient_git_control` so the child's own control is a no-op.
-INNER_ENV = "PIXTUOID_GITENV_INNER"
-
 # Callables that spawn a process, for the `shell=True` / `os.system` string form.
 SPAWNERS = frozenset(
     {"run", "Popen", "call", "check_call", "check_output", "system", "getoutput"}
 )
-
-# A hung child would hang `lint` inside a backgrounded `run` with no diagnostic.
-CHILD_TIMEOUT_S = 120
 
 
 @functools.cache
@@ -136,57 +136,6 @@ def bypass_sweep(where: pathlib.Path = SCRIPTS) -> list[str]:
     return out
 
 
-def ambient_git_control(script: pathlib.Path) -> str | None:
-    """Fail-message if `script --selftest` reaches the repo an ambient `GIT_DIR` names.
-
-    It SPAWNS the entry point rather than calling the scrub in-process, because
-    losing the scrub is the regression and an in-process control walks straight
-    past it. The snapshots go through `_harness_git` aimed positively at `outer`:
-    routing them through `git()` would let a broken `git()` redirect BOTH to the
-    same wrong index, where they match and the control passes mid-corruption.
-    """
-    if os.environ.get(INNER_ENV):
-        return None
-    with tempfile.TemporaryDirectory() as tmp:
-        outer = pathlib.Path(tmp) / "outer"
-        (outer / "sub").mkdir(parents=True)
-        (outer / "sub" / "kept.md").write_text("# kept\n")
-        at_outer = _at(outer)
-        _harness_git("init", "-q", env=at_outer, check=True, capture_output=True)
-        _harness_git("add", "-A", env=at_outer, check=True, capture_output=True)
-
-        def snap() -> str:
-            return _harness_git(
-                "ls-files", env=at_outer, capture_output=True, text=True, check=True
-            ).stdout
-
-        before = snap()
-        try:
-            child = subprocess.run(
-                [sys.executable, str(script), "--selftest"],
-                env={**_hook_env(outer), INNER_ENV: "1"},
-                capture_output=True,
-                text=True,
-                timeout=CHILD_TIMEOUT_S,
-            )
-        except subprocess.TimeoutExpired:
-            return f"`{script.name} --selftest` hung under the control (>{CHILD_TIMEOUT_S}s)"
-        after = snap()
-    # A child that died before its git calls leaks nothing, so the index check
-    # alone would read that as a pass.
-    if child.returncode != 0:
-        return (
-            f"`{script.name} --selftest` did not run under the control "
-            f"(exit {child.returncode}): {child.stderr.strip()[-300:]}"
-        )
-    if after != before:
-        return (
-            f"an inherited GIT_DIR must not let `{script.name} --selftest` reach the "
-            f"outer index (it now holds {after.split() or '<empty>'})"
-        )
-    return None
-
-
 def selftest() -> int:
     """Negative-control the scrub, the sweep, and the control — each must FAIL on cue."""
     fails: list[str] = []
@@ -232,7 +181,11 @@ def selftest() -> int:
                 "ls-files", env=at_victim, capture_output=True, text=True, check=True
             ).stdout
 
-        before = snap()
+        # Assert the CONTENT, not just before==after: if the harness ever reads the
+        # wrong repo — e.g. someone folds `_harness_git` into `git()` and loses the
+        # aim — a self-comparison matches trivially and the control goes vacuous.
+        if (before := snap()) != "sub/kept.md\n":
+            fails.append(f"the control's own fixture must be the repo it reads (got {before!r})")
 
         leaky = pathlib.Path(tmp) / "leaky"
         leaky.mkdir()
@@ -255,33 +208,6 @@ def selftest() -> int:
             clean_env.cache_clear()
         if snap() != before:
             fails.append("`git()` must not let an ambient GIT_DIR relocate a `-C` call")
-
-        # Both directions on `ambient_git_control` itself — it is the only pin on
-        # gen-guides' and comment-lint's entry points, and nothing else tests it.
-        probes = pathlib.Path(tmp) / "probes"
-        probes.mkdir()
-        # A probe writes relative to the CALLER's cwd unless told otherwise, and
-        # `--selftest` runs from the developer's checkout via `lint`.
-        littered = set(os.listdir("."))
-        clean = probes / "clean_child.py"
-        clean.write_text("import sys\nsys.exit(0)\n")
-        if (msg := ambient_git_control(clean)) is not None:
-            fails.append(f"the control must PASS a child that touches nothing: {msg}")
-        leaker = probes / "leaky_child.py"
-        leaker.write_text(
-            "import pathlib, subprocess\n"
-            "d = pathlib.Path(__file__).parent\n"
-            "(d / 'PHANTOM.md').write_text('x')\n"
-            "subprocess.run(['git', '-C', str(d), 'add', '-A'])\n"
-        )
-        if ambient_git_control(leaker) is None:
-            fails.append("the control must FIRE on a child that stages into the ambient repo")
-        dier = probes / "dying_child.py"
-        dier.write_text("import sys\nsys.exit(3)\n")
-        if ambient_git_control(dier) is None:
-            fails.append("the control must FIRE on a child that never reached its git calls")
-        if strays := sorted(set(os.listdir(".")) - littered):
-            fails.append(f"the selftest must not write into the caller's cwd (created {strays})")
 
     if fails:
         print("gitenv selftest FAILED:")


### PR DESCRIPTION
## Summary

#890 built ~190 lines of control apparatus to stop the selftests staging into the developer's repo. Nobody asked the prior question: **why does a docs generator's test need a real git repo at all?**

The repo's own arc loop has a deepening lens for exactly this — *"would deleting this concentrate complexity or just move it?"* — and no review round ran it. Not mine, and not the four lenses on #890, whose briefs all said "validate this design" and none said "should it exist".

**Net −73 lines, and fewer lines is the smaller half: the tests no longer need the thing that made them dangerous.**

## What changed

**`gen-guides`** — `run()` had `git ls-files` welded into its front. Split into `tracked_guides()` (the I/O) and `run(root, tracked, …)` (pure). The selftest injects a literal list, so its fixture is a plain directory: all 11 controls keep their teeth and **cannot reach an index at all**.

**`comment-lint`** — same split, `unified_diff()` out of `added_lines_by_file()`. Its fixture **does** stay a real repo: the pathspec control has to drive a real `git diff`, and feeding it a canned string would gut the one thing that control exists to pin (*"driven through the REAL reader… which would pass while the production pathspec changed underneath it"*). So the hazard class survives for one script — which is the honest reason `git()`'s scrub stays.

**Deleted** — `ambient_git_control` + its three probes + `INNER_ENV` + `CHILD_TIMEOUT_S`. Its unique value was catching a deleted per-`main()` scrub call, a call site the wrapper design does not have. `bypass_sweep` is the durable protection; the spawning apparatus was the expensive, fragile half (it is also what shipped the `PHANTOM.md` litter bug in #893).

## The one line added is worth more than what it replaced

The leak control now asserts its snapshot's **content** (`"sub/kept.md\n"`) rather than only `before == after`. A self-comparison goes vacuous the moment the harness reads the wrong repo — the exact trap I hit three times on #890.

| mutant | before | after |
|---|---|---|
| `git()` drops the scrub | killed | killed |
| `clean_env` scrubs only `GIT_DIR` | killed | killed |
| **`_harness_git` routes through `git()`** | **SURVIVED** | **killed** |
| `_at` drops the aim | n/a | killed |

Less machinery, more teeth.

## Deliberately NOT cut

Audited alongside this, and rejected on evidence:

- **`policy/ci-observability/` (3,745 lines, 111 rules)** — I suspected dead rules on the #789 precedent. Measured: first deny rule is at line 695, every uncovered line falls in 65–618, i.e. **all 111 deny rules are covered**. My size-based suspicion did not survive measurement. Leave it.
- **The advisory lanes** (comment-lint / risk-radar / mutants) — one session of me ignoring 6 comments is not evidence about whether they're read.
- **`check_upstream_drift.py` + selftest (3,035 lines)** — I have not read it. Cutting 3,000 lines I don't understand is the recklessness this PR is about.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] New theme / sprite pack
- [ ] New `Source` adapter (another agent CLI)
- [ ] Docs only
- [x] Refactor / chore

## How I tested it

- `just lint` — 15/15 green including `gitenv` and `guides`.
- All three selftests green; `gen-guides` and `comment-lint` keep every control they had.
- Mutation matrix above, run on scratch copies. Note the earlier matrix I ran was **contaminated** — `comment-lint` cannot run from a scratch copy (it copies `.ast-grep` from `__file__.parent.parent`), so its baseline was already red and its "KILLED" verdicts were meaningless. Re-run on valid detectors only.
- `just preflight` via the real `pre-push` hook.
- Selftests leave the working tree clean (the litter probes are gone, so there is nothing left to litter).

## Visual verification (required for sprite / rendering changes)

- [x] Not a visual change.

## Checklist

- [x] I read the relevant `CLAUDE.md` (root + the nested one for the crate I touched).
- [x] New behavior has a test (this repo is TDD-first) — the content assertion, mutation-verified.
- [x] No `unwrap()` in non-test code; errors propagate via `anyhow`/`thiserror`.
- [x] No new `println!`/`eprintln!` on a production path (use `tracing`).
- [x] Docs updated in the same commit if I changed module structure, architecture, or public API — `gitenv.py`'s docstring now records why the controls are this small.
- [x] Checked against the [recurring pitfalls](https://github.com/IvanWng97/pixtuoid/blob/main/docs/CONTRIBUTING.md#recurring-pitfalls-this-codebases-review-history-distilled).
- [x] `just preflight` passes locally.

## AI assistance

- [x] This PR was written/heavily-assisted by an AI agent.