### PR TITLE
test(comment-lint): price the reverted gate, and give the selftest eyes on main()

### DIFF
--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -407,7 +407,7 @@ history:
   relocate-to-the-declaration-or-a-CLAUDE.md-sharp-edge call is this lens's.
   Its COUNT is that candidate list, not a status line: report N items each
   carrying a disposition, never "the run passed" — on #904 eighteen findings
-  were reported as a pass, and the diff then gained another.
+  mid-PR were reported as a pass, and the diff then gained another.
   **Redundancy-within is the axis this lens kept missing**: the other four
   compare the comment to the CODE, and a restatement repeats no code, so
   nothing else can flag it. Apply CLAUDE.md's comment test #2 verbatim — do

--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -405,6 +405,9 @@ history:
   the diff's new lines only — the ~5k
   pre-existing legitimate WHY are grandfathered), but the keep / trim-to-≤2 /
   relocate-to-the-declaration-or-a-CLAUDE.md-sharp-edge call is this lens's.
+  Its COUNT is that candidate list, not a status line: report N items each
+  carrying a disposition, never "the run passed" — on #904 eighteen findings
+  were reported as a pass, and the diff then gained another.
   **Redundancy-within is the axis this lens kept missing**: the other four
   compare the comment to the CODE, and a restatement repeats no code, so
   nothing else can flag it. Apply CLAUDE.md's comment test #2 verbatim — do

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -273,9 +273,8 @@ path matching that posts the documented blast-radius escalations as a sticky PR 
 prose-only escalation can't be silently skipped (#198); and `just comment-lint`'s ast-grep
 arm, whose npm install keeps it in advisory `ci-supplemental` where a registry outage cannot
 become a required check. A proposal to make that arm BLOCK is priced by `just
-comment-lint-replay N`, which replays today's rules against already-merged commits, so each
-finding it reports is a block that proposal would have imposed on work that shipped (#907).
-Merged is not adjudicated — read the flagged lines before calling them false positives.
+comment-lint-replay N` (#907). Merged is not adjudicated — read the flagged lines before
+calling them false positives.
 
 Which `comment-lint` arms BLOCK is stated once, in `gate_fails`' docstring in
 `scripts/comment-lint.py` — pinned in both directions by that script's selftest.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -273,8 +273,9 @@ path matching that posts the documented blast-radius escalations as a sticky PR 
 prose-only escalation can't be silently skipped (#198); and `just comment-lint`'s ast-grep
 arm, whose npm install keeps it in advisory `ci-supplemental` where a registry outage cannot
 become a required check. A proposal to make that arm BLOCK is priced by `just
-comment-lint-replay N`, which replays today's rules against already-merged commits, where
-every finding it reports is a false positive by construction (#907).
+comment-lint-replay N`, which replays today's rules against already-merged commits, so each
+finding it reports is a block that proposal would have imposed on work that shipped (#907).
+Merged is not adjudicated — read the flagged lines before calling them false positives.
 
 Which `comment-lint` arms BLOCK is stated once, in `gate_fails`' docstring in
 `scripts/comment-lint.py` — pinned in both directions by that script's selftest.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -272,7 +272,9 @@ Advisory backstops that surface risk but NEVER gate: `scripts/check_upstream_dri
 path matching that posts the documented blast-radius escalations as a sticky PR comment so
 prose-only escalation can't be silently skipped (#198); and `just comment-lint`'s ast-grep
 arm, whose npm install keeps it in advisory `ci-supplemental` where a registry outage cannot
-become a required check.
+become a required check. A proposal to make that arm BLOCK is priced by `just
+comment-lint-replay N`, which replays today's rules against already-merged commits, where
+every finding it reports is a false positive by construction (#907).
 
 Which `comment-lint` arms BLOCK is stated once, in `gate_fails`' docstring in
 `scripts/comment-lint.py` — pinned in both directions by that script's selftest.

--- a/justfile
+++ b/justfile
@@ -1260,13 +1260,17 @@ comment-lint-replay n="20":
       cp -R "$root/.ast-grep" "$root/sgconfig.yml" "$tmp/wt/"
       rc=0
       out="$(cd "$tmp/wt" && python3 "$root/scripts/comment-lint.py" "$sha^" --gate 2>&1)" || rc=$?
-      # A crash prints no verdict line, and would otherwise count as zero.
-      case "$out" in
-        *"new comment-slop"*) n_hit="$(printf '%s' "$out" | sed -n 's/^comment-lint: \([0-9]*\) new comment-slop.*/\1/p')" ;;
-        *"no new 3+-comment runs"*|*"no added/changed Rust or Python lines"*) n_hit=0 ;;
-        *) echo "comment-lint-replay: no verdict from ${sha:0:8} — the replay is broken, not the commit" >&2
-           printf '%s\n' "$out" >&2; exit 1 ;;
-      esac
+      # Every path through the script prints a `comment-lint:` line; a crash
+      # prints none, and would otherwise be counted as zero findings.
+      if printf '%s\n' "$out" | grep -qE '^comment-lint: [0-9]+ new comment-slop'; then
+        n_hit="$(printf '%s\n' "$out" | sed -n 's/^comment-lint: \([0-9]*\) new comment-slop.*/\1/p')"
+      elif printf '%s\n' "$out" | grep -q '^comment-lint: '; then
+        n_hit=0
+      else
+        echo "comment-lint-replay: no verdict from ${sha:0:8} — the replay is broken, not the commit" >&2
+        printf '%s\n' "$out" >&2
+        exit 1
+      fi
       total=$((total + 1)) flagged=$((flagged + n_hit))
       if [ "$rc" -ne 0 ]; then
         gated=$((gated + 1))

--- a/justfile
+++ b/justfile
@@ -1287,6 +1287,9 @@ comment-lint-replay n="20":
         printf '  %s  %-4s %s\n' "${sha:0:8}" "$n_hit" "$(git log -1 --format=%s "$sha" | cut -c1-52)"
       fi
     done
+    # A bad N leaves the `for` word list empty without tripping `set -e`, and the
+    # summary then reports its most reassuring shape.
+    [ "$total" -gt 0 ] || { echo "comment-lint-replay: no commits walked — check N" >&2; exit 1; }
     echo "fn-body arm (advisory): $advisory/$total merged commits, $flagged lines"
     echo "blocking arms (--gate): $gated/$total merged commits — an arm reds the"
     echo "  commits that predate its own calibration, so read this against \`git log -S\`"

--- a/justfile
+++ b/justfile
@@ -1238,17 +1238,21 @@ comment-lint-gate:
     python3 scripts/comment-lint.py origin/main --gate
 
 # Prices any proposal to make an arm BLOCK: today's rules replayed against
-# already-merged commits, where every finding is by construction a false
-# positive. On-demand like `fuzz` — N checkouts, and it needs origin/main.
+# already-merged commits, so each finding is a block the proposal would have
+# imposed on work that shipped. On-demand like `fuzz` — N checkouts, origin/main.
 [group('meta')]
 [doc('Replay the comment-lint arms against the last N merged commits (default 20)')]
 comment-lint-replay n="20":
     #!/usr/bin/env bash
     set -euo pipefail
+    # Without it the fn-body count is 0 for every commit and the run still exits
+    # 0 — the fail-open `fuzz` guards for the same reason.
+    command -v ast-grep >/dev/null \
+      || { echo "comment-lint-replay: needs ast-grep — run \`just setup-tools\`" >&2; exit 1; }
     root="$(git rev-parse --show-toplevel)"
     tmp="$(mktemp -d)"
-    git worktree add -q --detach "$tmp/wt" HEAD
     trap 'git worktree remove --force "$tmp/wt" >/dev/null 2>&1 || true; rm -rf "$tmp"' EXIT
+    git worktree add -q --detach "$tmp/wt" HEAD
     git -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=20 fetch --quiet origin main \
       || { echo "comment-lint-replay: cannot reach origin" >&2; exit 1; }
     total=0 advisory=0 gated=0 flagged=0
@@ -1260,11 +1264,13 @@ comment-lint-replay n="20":
       cp -R "$root/.ast-grep" "$root/sgconfig.yml" "$tmp/wt/"
       rc=0
       out="$(cd "$tmp/wt" && python3 "$root/scripts/comment-lint.py" "$sha^" --gate 2>&1)" || rc=$?
-      # Every path through the script prints a `comment-lint:` line; a crash
-      # prints none, and would otherwise be counted as zero findings.
-      if printf '%s\n' "$out" | grep -qE '^comment-lint: [0-9]+ new comment-slop'; then
+      # Every path through the script prints a `comment-lint:` line (pinned by its
+      # selftest); a crash prints none, and would count as zero findings. Matched
+      # off a HERESTRING: `grep -q` quits early, and through a pipe that SIGPIPEs
+      # the writer, which `pipefail` then reads as no-match on a long verdict.
+      if grep -qE '^comment-lint: [0-9]+ new comment-slop' <<<"$out"; then
         n_hit="$(printf '%s\n' "$out" | sed -n 's/^comment-lint: \([0-9]*\) new comment-slop.*/\1/p')"
-      elif printf '%s\n' "$out" | grep -q '^comment-lint: '; then
+      elif grep -q '^comment-lint: ' <<<"$out"; then
         n_hit=0
       else
         echo "comment-lint-replay: no verdict from ${sha:0:8} — the replay is broken, not the commit" >&2
@@ -1281,9 +1287,9 @@ comment-lint-replay n="20":
         printf '  %s  %-4s %s\n' "${sha:0:8}" "$n_hit" "$(git log -1 --format=%s "$sha" | cut -c1-52)"
       fi
     done
-    echo "fn-body arm (advisory): $advisory/$total merged commits, $flagged lines — all false positives"
-    echo "blocking arms (--gate): $gated/$total merged commits — must be 0"
-    [ "$gated" -eq 0 ]
+    echo "fn-body arm (advisory): $advisory/$total merged commits, $flagged lines"
+    echo "blocking arms (--gate): $gated/$total merged commits — an arm reds the"
+    echo "  commits that predate its own calibration, so read this against \`git log -S\`"
 
 # The seam's WHY lives in scripts/gitenv.py's docstring. This pins the scrub AND
 # sweeps scripts/ for anything spawning git outside `gitenv.git()` — the recurrence

--- a/justfile
+++ b/justfile
@@ -1237,6 +1237,50 @@ comment-lint-gate:
     python3 scripts/comment-lint.py --selftest
     python3 scripts/comment-lint.py origin/main --gate
 
+# Prices any proposal to make an arm BLOCK: today's rules replayed against
+# already-merged commits, where every finding is by construction a false
+# positive. On-demand like `fuzz` — N checkouts, and it needs origin/main.
+[group('meta')]
+[doc('Replay the comment-lint arms against the last N merged commits (default 20)')]
+comment-lint-replay n="20":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    root="$(git rev-parse --show-toplevel)"
+    tmp="$(mktemp -d)"
+    git worktree add -q --detach "$tmp/wt" HEAD
+    trap 'git worktree remove --force "$tmp/wt" >/dev/null 2>&1 || true; rm -rf "$tmp"' EXIT
+    git -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=20 fetch --quiet origin main \
+      || { echo "comment-lint-replay: cannot reach origin" >&2; exit 1; }
+    total=0 advisory=0 gated=0 flagged=0
+    for sha in $(git log --first-parent --format=%H -n {{ n }} origin/main); do
+      git -C "$tmp/wt" checkout -q --force --detach "$sha"
+      # Only the RULES are injected — YAML, outside the scanned pathspec.
+      # Injecting the scripts counts their own comments as the commit's.
+      rm -rf "$tmp/wt/.ast-grep"
+      cp -R "$root/.ast-grep" "$root/sgconfig.yml" "$tmp/wt/"
+      rc=0
+      out="$(cd "$tmp/wt" && python3 "$root/scripts/comment-lint.py" "$sha^" --gate 2>&1)" || rc=$?
+      # A crash prints no verdict line, and would otherwise count as zero.
+      case "$out" in
+        *"new comment-slop"*) n_hit="$(printf '%s' "$out" | sed -n 's/^comment-lint: \([0-9]*\) new comment-slop.*/\1/p')" ;;
+        *"no new 3+-comment runs"*|*"no added/changed Rust or Python lines"*) n_hit=0 ;;
+        *) echo "comment-lint-replay: no verdict from ${sha:0:8} — the replay is broken, not the commit" >&2
+           printf '%s\n' "$out" >&2; exit 1 ;;
+      esac
+      total=$((total + 1)) flagged=$((flagged + n_hit))
+      if [ "$rc" -ne 0 ]; then
+        gated=$((gated + 1))
+        echo "GATE REDS ${sha:0:8}  $(git log -1 --format=%s "$sha")"
+      fi
+      if [ "$n_hit" -gt 0 ]; then
+        advisory=$((advisory + 1))
+        printf '  %s  %-4s %s\n' "${sha:0:8}" "$n_hit" "$(git log -1 --format=%s "$sha" | cut -c1-52)"
+      fi
+    done
+    echo "fn-body arm (advisory): $advisory/$total merged commits, $flagged lines — all false positives"
+    echo "blocking arms (--gate): $gated/$total merged commits — must be 0"
+    [ "$gated" -eq 0 ]
+
 # The seam's WHY lives in scripts/gitenv.py's docstring. This pins the scrub AND
 # sweeps scripts/ for anything spawning git outside `gitenv.git()` — the recurrence
 # gate, because one of these leaks ate a developer's index before anyone noticed.

--- a/scripts/comment-lint.py
+++ b/scripts/comment-lint.py
@@ -294,27 +294,37 @@ def selftest() -> int:
 
         # `gate_fails` is a pure predicate, so the pins above cannot see main()'s
         # wiring — where #907's reverted attempt broke the ast-grep-free CI job.
-        (repo / "src" / "advisory.rs").write_text(
-            "fn g() -> u8 {\n    // one\n    // two\n    // three\n    2\n}\n"
-        )
-        gitenv.git(*ident, "add", "src/advisory.rs", cwd=repo, check=True)
-        gitenv.git(*ident, "commit", "-qm", "advisory", cwd=repo, check=True)
         script = str(pathlib.Path(__file__).resolve())
-        for label, path, want_absent in (
-            ("PATH as-is", os.environ.get("PATH", ""), False),
-            ("ast-grep off PATH", path_without("ast-grep"), True),
+        states = [
+            ("PATH as-is", os.environ.get("PATH", "")),
+            ("ast-grep off PATH", path_without("ast-grep")),
+        ]
+        if shutil.which("ast-grep", path=states[1][1]) is not None:
+            fails.append("the ast-grep-free PATH still resolves it — that control is inert")
+        # One fixture commit per case, so `HEAD~1...HEAD` isolates the arm named:
+        # a shared range blocks on whichever arm fires first.
+        for path, body, want_block, why in (
+            (
+                "src/advisory.rs",
+                "fn g() -> u8 {\n    // one\n    // two\n    // three\n    2\n}\n",
+                False,
+                "fn-body findings alone must not block",
+            ),
+            (
+                "src/renamed.rs",
+                "/// Doc for the fn.\nconst LATE_WEDGE: u8 = 0;\n\nfn after() {}\n",
+                True,
+                "the re-parent arm must still block",
+            ),
         ):
-            if want_absent and shutil.which("ast-grep", path=path) is not None:
-                fails.append(f"{label}: ast-grep still resolves — this control is inert")
-            env = {**os.environ, "PATH": path}
-            for base, want_block, why in (
-                ("HEAD~1", False, "fn-body findings alone must not block"),
-                ("HEAD~2", True, "the re-parent arm must still block"),
-            ):
+            (repo / path).write_text(body)
+            gitenv.git(*ident, "add", path, cwd=repo, check=True)
+            gitenv.git(*ident, "commit", "-qm", f"e2e {path}", cwd=repo, check=True)
+            for label, env_path in states:
                 r = subprocess.run(
-                    [sys.executable, script, base, "--gate"],
+                    [sys.executable, script, "HEAD~1", "--gate"],
                     cwd=repo,
-                    env=env,
+                    env={**os.environ, "PATH": env_path},
                     capture_output=True,
                     text=True,
                 )

--- a/scripts/comment-lint.py
+++ b/scripts/comment-lint.py
@@ -82,7 +82,7 @@ def scan_hits(cwd: str | None = None) -> list[dict]:
 
 
 def path_without(tool: str) -> str:
-    """PATH with every directory that provides `tool` stripped, other tools intact."""
+    """PATH with every DIRECTORY that provides `tool` stripped."""
     dirs = os.environ.get("PATH", "").split(os.pathsep)
     while (hit := shutil.which(tool, path=os.pathsep.join(dirs))) is not None:
         home = os.path.normpath(os.path.dirname(hit) or ".")
@@ -136,11 +136,23 @@ def selftest() -> int:
         # renames the documented fn (must not).
         (repo / "src" / "moved.rs").write_text("/// Doc for the fn.\nfn owner() {}\n")
         (repo / "src" / "renamed.rs").write_text("/// Doc for the fn.\nfn before() {}\n")
+        # The end-to-end re-parent case wedges into THIS one, so `renamed.rs` is
+        # not asked to be a must-not-fire and a must-fire fixture at once.
+        (repo / "src" / "e2e_wedge.rs").write_text("/// Doc for the wedged fn.\nfn wedged() {}\n")
         twins = "/// Shared opening line.\n/// One.\nfn a() {}\n\n/// Shared opening line.\n/// Two.\nfn b() {}\n"
         (repo / "src" / "twins.rs").write_text(twins)
         # Staged by PATH, not `-A`: everything else must stay NEW in the fixture
         # commit or the diff-scoped checks above see an empty diff.
-        gitenv.git(*ident, "add", "src/moved.rs", "src/renamed.rs", "src/twins.rs", cwd=repo, check=True)
+        gitenv.git(
+            *ident,
+            "add",
+            "src/moved.rs",
+            "src/renamed.rs",
+            "src/twins.rs",
+            "src/e2e_wedge.rs",
+            cwd=repo,
+            check=True,
+        )
         gitenv.git(*ident, "commit", "-qm", "base", cwd=repo, check=True)
         (repo / "src" / "moved.rs").write_text(
             "/// Doc for the fn.\nconst WEDGE: u8 = 0;\n\nfn owner() {}\n"
@@ -302,20 +314,28 @@ def selftest() -> int:
         if shutil.which("ast-grep", path=states[1][1]) is not None:
             fails.append("the ast-grep-free PATH still resolves it — that control is inert")
         # One fixture commit per case, so `HEAD~1...HEAD` isolates the arm named:
-        # a shared range blocks on whichever arm fires first.
+        # a shared range blocks on whichever arm fires first. Each body carries
+        # `code_floor` where the ratio would otherwise decide the case.
         for path, body, want_block, why in (
             (
                 "src/advisory.rs",
-                "fn g() -> u8 {\n    // one\n    // two\n    // three\n    2\n}\n",
+                "fn g() -> u8 {\n    // one\n    // two\n    // three\n    2\n}\n" + code_floor,
                 False,
                 "fn-body findings alone must not block",
             ),
             (
-                "src/renamed.rs",
-                "/// Doc for the fn.\nconst LATE_WEDGE: u8 = 0;\n\nfn after() {}\n",
+                "src/e2e_wedge.rs",
+                "/// Doc for the wedged fn.\nconst LATE_WEDGE: u8 = 0;\n\nfn wedged() {}\n",
                 True,
                 "the re-parent arm must still block",
             ),
+            (
+                "src/e2e_prose.rs",
+                "".join(f"// n{n}\n" for n in range(9)) + code_floor,
+                True,
+                "the prose arm must still block",
+            ),
+            ("src/e2e_clean.rs", code_floor, False, "a findingless diff must not block"),
         ):
             (repo / path).write_text(body)
             gitenv.git(*ident, "add", path, cwd=repo, check=True)
@@ -329,7 +349,11 @@ def selftest() -> int:
                     text=True,
                 )
                 if (r.returncode != 0) is not want_block:
-                    fails.append(f"{label}: {why} (exit {r.returncode})\n{r.stdout}")
+                    fails.append(f"{label}: {why} (exit {r.returncode})\n{r.stdout}{r.stderr}")
+                # `comment-lint-replay` parses for this line to tell a run from a
+                # crash, and nothing else pins the string.
+                if not any(l.startswith("comment-lint: ") for l in r.stdout.splitlines()):
+                    fails.append(f"{label} {path}: no `comment-lint:` verdict line\n{r.stdout}")
     if fails:
         print("comment-lint selftest FAILED:")
         for f in fails:

--- a/scripts/comment-lint.py
+++ b/scripts/comment-lint.py
@@ -81,6 +81,18 @@ def scan_hits(cwd: str | None = None) -> list[dict]:
     return json.loads(out)
 
 
+def path_without(tool: str) -> str:
+    """PATH with every directory that provides `tool` stripped, other tools intact."""
+    dirs = os.environ.get("PATH", "").split(os.pathsep)
+    while (hit := shutil.which(tool, path=os.pathsep.join(dirs))) is not None:
+        home = os.path.normpath(os.path.dirname(hit) or ".")
+        pruned = [d for d in dirs if os.path.normpath(d or ".") != home]
+        if len(pruned) == len(dirs):
+            break
+        dirs = pruned
+    return os.pathsep.join(dirs)
+
+
 def selftest() -> int:
     """Pin this DRIVER's two behaviors: which files it diffs, and which it scans.
     The ast-grep RULES have their own pins (`just ast-grep-test`)."""
@@ -279,6 +291,35 @@ def selftest() -> int:
         # advisory by design must stay advisory. `docs` alone may never block.
         if gate_fails(True, ["d"], [], False):
             fails.append("the doc-run arm is advisory and must NOT block")
+
+        # `gate_fails` is a pure predicate, so the pins above cannot see main()'s
+        # wiring — where #907's reverted attempt broke the ast-grep-free CI job.
+        (repo / "src" / "advisory.rs").write_text(
+            "fn g() -> u8 {\n    // one\n    // two\n    // three\n    2\n}\n"
+        )
+        gitenv.git(*ident, "add", "src/advisory.rs", cwd=repo, check=True)
+        gitenv.git(*ident, "commit", "-qm", "advisory", cwd=repo, check=True)
+        script = str(pathlib.Path(__file__).resolve())
+        for label, path, want_absent in (
+            ("PATH as-is", os.environ.get("PATH", ""), False),
+            ("ast-grep off PATH", path_without("ast-grep"), True),
+        ):
+            if want_absent and shutil.which("ast-grep", path=path) is not None:
+                fails.append(f"{label}: ast-grep still resolves — this control is inert")
+            env = {**os.environ, "PATH": path}
+            for base, want_block, why in (
+                ("HEAD~1", False, "fn-body findings alone must not block"),
+                ("HEAD~2", True, "the re-parent arm must still block"),
+            ):
+                r = subprocess.run(
+                    [sys.executable, script, base, "--gate"],
+                    cwd=repo,
+                    env=env,
+                    capture_output=True,
+                    text=True,
+                )
+                if (r.returncode != 0) is not want_block:
+                    fails.append(f"{label}: {why} (exit {r.returncode})\n{r.stdout}")
     if fails:
         print("comment-lint selftest FAILED:")
         for f in fails:

--- a/scripts/comment-lint.py
+++ b/scripts/comment-lint.py
@@ -307,40 +307,49 @@ def selftest() -> int:
         # `gate_fails` is a pure predicate, so the pins above cannot see main()'s
         # wiring — where #907's reverted attempt broke the ast-grep-free CI job.
         script = str(pathlib.Path(__file__).resolve())
-        states = [
-            ("PATH as-is", os.environ.get("PATH", "")),
-            ("ast-grep off PATH", path_without("ast-grep")),
-        ]
-        if shutil.which("ast-grep", path=states[1][1]) is not None:
+        full = os.environ.get("PATH", "")
+        bare = path_without("ast-grep")
+        if shutil.which("ast-grep", path=bare) is not None:
             fails.append("the ast-grep-free PATH still resolves it — that control is inert")
+        if shutil.which("git", path=bare) is None:
+            fails.append("the ast-grep-free PATH lost git too — that control cannot run")
+        # A box without ast-grep makes the two PATHs identical, and running the
+        # same environment twice buys nothing.
+        states = [("PATH as-is", full, shutil.which("ast-grep", path=full) is not None)]
+        if bare != full:
+            states.append(("ast-grep off PATH", bare, False))
+        clean = "no new 3+-comment runs"
         # One fixture commit per case, so `HEAD~1...HEAD` isolates the arm named:
         # a shared range blocks on whichever arm fires first. Each body carries
         # `code_floor` where the ratio would otherwise decide the case.
-        for path, body, want_block, why in (
+        for path, body, want_block, why, want in (
             (
                 "src/advisory.rs",
                 "fn g() -> u8 {\n    // one\n    // two\n    // three\n    2\n}\n" + code_floor,
                 False,
                 "fn-body findings alone must not block",
+                ("1 new comment-slop finding(s) in a fn body", clean),
             ),
             (
                 "src/e2e_wedge.rs",
                 "/// Doc for the wedged fn.\nconst LATE_WEDGE: u8 = 0;\n\nfn wedged() {}\n",
                 True,
                 "the re-parent arm must still block",
+                ("doc block re-homed from", "doc block re-homed from"),
             ),
             (
                 "src/e2e_prose.rs",
                 "".join(f"// n{n}\n" for n in range(9)) + code_floor,
                 True,
                 "the prose arm must still block",
+                ("are narrative prose", "are narrative prose"),
             ),
-            ("src/e2e_clean.rs", code_floor, False, "a findingless diff must not block"),
+            ("src/e2e_clean.rs", code_floor, False, "a findingless diff must not block", (clean, clean)),
         ):
             (repo / path).write_text(body)
             gitenv.git(*ident, "add", path, cwd=repo, check=True)
             gitenv.git(*ident, "commit", "-qm", f"e2e {path}", cwd=repo, check=True)
-            for label, env_path in states:
+            for label, env_path, scans in states:
                 r = subprocess.run(
                     [sys.executable, script, "HEAD~1", "--gate"],
                     cwd=repo,
@@ -350,10 +359,12 @@ def selftest() -> int:
                 )
                 if (r.returncode != 0) is not want_block:
                     fails.append(f"{label}: {why} (exit {r.returncode})\n{r.stdout}{r.stderr}")
-                # `comment-lint-replay` parses for this line to tell a run from a
-                # crash, and nothing else pins the string.
-                if not any(l.startswith("comment-lint: ") for l in r.stdout.splitlines()):
-                    fails.append(f"{label} {path}: no `comment-lint:` verdict line\n{r.stdout}")
+                # This arm's OWN line, not just a `comment-lint:` prefix: the
+                # ast-grep-absent notice prints one before any arm runs, and
+                # `comment-lint-replay` reads the fn-body COUNT out of its text.
+                expect = want[0] if scans else want[1]
+                if expect not in r.stdout:
+                    fails.append(f"{label} {path}: stdout lacks {expect!r}\n{r.stdout}{r.stderr}")
     if fails:
         print("comment-lint selftest FAILED:")
         for f in fails:


### PR DESCRIPTION
## What this is

#907 asked for teeth on `comment-lint`'s fn-body arm. **The answer is that
mechanical teeth are not available**, and this PR is the evidence plus the two
things that *are* fixable.

Per the plan agreed on the issue, the negative control came first. It killed
every candidate #907 listed — including one the issue got factually wrong.

## The measurement

`just comment-lint-replay 20` replays today's rules against already-merged
commits, so each finding is a block a would-be gate **would have imposed on work
that shipped**:

```
fn-body arm (advisory)   11/20 merged commits, 179 lines
blocking arms (--gate)    0/20 merged commits          <- the instrument's own control
```

Which prices all four candidates:

| Candidate | Verdict | Evidence |
|---|---|---|
| Semantic unit | not mechanizable | by definition — it counts ideas, not lines |
| Threshold calibration | no separation point | 86 runs at N=20 (3–10) and 818 at N=60 (3–12), **continuous, no gap**; #904's own slop sat at 3 |
| Motion-blindness | **0.0–1.1%** | 0–2 of 179 lines, and both matches are the bare string `//`. **#907 claims "most of the false positives are pure code motion" — wrong by a wide margin**; the issue text is corrected. |
| Escape hatch | **NOT PRICED — verdict withdrawn** | My rejection rested on "the author walks past the advisory", which the one observable counterfactual contradicts: on #904, 14 of 18 findings were acted on and the restructure stuck. See the round-2 disposition. |

A 3-consecutive-lines rule is a LENGTH cap, and `gate_fails`' docstring already
argues at length that a length cap contradicts the semantic rule it serves.
The data says the same thing quantitatively.

## What lands

**1. `--selftest` drives the real `main()`.** #907's second reproduction was
that the selftest could not see the regression it caused: it pinned
`gate_fails`, a pure predicate, while the breakage lived in `main()`'s wiring.
It now runs the script as a subprocess in both PATH states — the ast-grep-free
one being exactly what the protected `comment-gate` CI job carries — and pins
the exit-code contract in both directions.

Three controls, each applied then reverted after confirming it reds the
selftest:

| Mutation | Reproduces | Result |
|---|---|---|
| `docs_only and gate → return 1` | #907's CI breaker (absence ⇒ block) | selftest FAILS ✓ |
| `blocking \|= bool(new_hits)` | the reverted length cap | selftest FAILS ✓ |
| `gate_fails → False` | blocking arms going silent | selftest FAILS ✓ |

**2. `just comment-lint-replay N`** — on-demand, `fuzz`-tier, not in CI. The
next proposal to make an arm block is priced in one command instead of
re-derived. `CONTRIBUTING.md` names it where it explains why the arm stays
advisory.

**3. The advisory's COUNT is a candidate list, not a status line**
(`pr-review.prompt.md`). This is the half of #904 that was never a detection
failure: the arm printed 18 findings, they were reported as a passing run, and
the diff then gained another. The disposition contract already covers
*findings*; what was missing is that this count IS the candidate list the
comment lens owns.

## The instrument was wrong three times

Recorded because the numbers above are only worth what the harness is:

1. The first replay didn't inject `scripts/gitenv.py`, so `import gitenv` raised
   on every commit predating it, `2>/dev/null` swallowed the traceback, and the
   empty output parsed as **0 findings** — under-reporting by half (6/20).
2. Injecting the scripts instead made the replay count **the tool's own
   comments** as the commit's added lines — over-reporting.
3. The hardened guard then immediately caught a valid verdict I had not
   enumerated (a commit touching no Rust/Python).

The committed recipe aborts on an unparseable verdict rather than counting zero.

## Gates

- `just lint` — 17/17 green, exit 0
- `just comment-lint-gate` — green; this diff adds **zero** new fn-body runs
- `just comment-lint-replay 20` — reproduces the table above
- No Rust touched, so clippy/test surface is unaffected

## Why #907 stays open

It closes the two halves that are settled — the selftest gap the issue names in
its second reproduction, and the pricing of three of its four candidates. The
fourth, the **escape hatch, is unpriced**: my rejection of it was withdrawn under
review because its stated reason ("the author walks past the advisory") is
contradicted by the one observable counterfactual.

Closing #907 here would retire an option I explicitly declined to price. #907
stays open, re-scoped to that one candidate.

Refs #907

---

## Review rounds

**Round 1 — online bot at `c0889587`: Findings: 2 (1 high, 1 medium). Both verified before fixing, both fixed in `4e83c393`.**

| # | Finding | Verified how | Disposition |
|---|---|---|---|
| HIGH | The replay aborted on a *healthy* commit: when only the doc-run / re-parent / prose arm fires, `main()` prints a per-finding line and returns early, matching neither verdict shape the recipe enumerated. | Reproduced on a throwaway repo — a diff adding one 14-line `///` run prints `comment-lint: src/x.rs:1 — new 14-line doc-comment run (max 10)` and exits 0, which the recipe called a broken replay. | FIXED — the classifier now discriminates on what separates a run from a crash (any `comment-lint:` line), checked against all five real verdict shapes. |
| MEDIUM | The `HEAD~2` assertion passed for the wrong reason: each prose fixture is its own commit, so `HEAD~2` was a prose fixture and the gate blocked on `over_prose`. The assertion would have survived the re-parent arm being wholly broken. | Read the fixture history; confirmed `prose_case` commits per fixture. | FIXED — each case now gets its own fixture commit so `HEAD~1...HEAD` isolates the arm it names. Controlled both ways: stubbing `reparented_doc_hits` to `[]` reds it, stubbing `prose_share` does not. |

**Did the HIGH finding contaminate the published numbers?** No — it was fail-*loud* (`exit 1` aborting the whole run), not a silent skip, so the 20-commit measurement either completed or errored. It completed, and re-running after the fix gives the same 11/20 and 179.

**Round 2 — online bot at `4e83c393`: Findings: 0.**

Local differentiated lenses (correctness/grounding · design & blast-radius · adversarial measurement-validity) were run in parallel; the third exists because this PR's entire argument is one measurement, and the author's own instrument was wrong twice before it held.

## Gates at `4e83c393`

- CI: 49 SUCCESS, 2 SKIPPED, 0 failures
- pre-push: 3025 tests passed
- `just lint` 17/17, `just comment-lint-gate` green (this diff adds zero new fn-body runs)

