### PR TITLE
feat(hooks): a closing keyword may only be a trailer, never prose

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Commit-msg hook: a GitHub closing keyword may only appear as a trailer.
+# The rule and its WHY live in scripts/issue-links.py; this is the local arm of
+# the same check CI runs over the whole branch, so the two cannot drift.
+#
+# Set up once per clone with:
+#   git config core.hooksPath .githooks
+set -euo pipefail
+
+[[ "${SKIP_PREFLIGHT:-0}" == "1" ]] && exit 0
+cd "$(git rev-parse --show-toplevel)"
+python3 scripts/issue-links.py --stdin <"$1"

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -133,6 +133,7 @@ jobs:
       - run: just gen-guides-check
       - run: just env-paths
       - run: just gitenv-selftest
+      - run: just issue-links
 
   msrv:
     name: msrv

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -67,6 +67,14 @@ Cross-file report/upload semantics that actionlint cannot express are pinned by
 the yq + Conftest/OPA policy and real action/workflow behavior tests under
 `policy/ci-observability/`; `just ci-observability` runs them inside both
 `just lint` and the CI hygiene job.
+An issue link closes its issue from a merged commit message or a PR description, and
+GitHub reads the KEYWORD, not the sentence — `Why this does NOT close #907` and
+`(the alternative that also fixes #912)` each closed an issue they were denying. So a
+closing keyword belongs on its own trailer line (`Closes: #N`) and nowhere else;
+`just issue-links` enforces that over commit messages, from the `commit-msg` hook where
+it can still be fixed and from `lint`/hygiene to catch a bypass. A PR DESCRIPTION is
+authored on GitHub and passes through no hook — that half stays on the author.
+
 `just zizmor` adds the upstream workflow/action/Dependabot security analyzer:
 the repository deliberately requires a symbolic ref or SHA (not SHA-only),
 every checkout drops persisted credentials, and accepted analyzer findings use

--- a/justfile
+++ b/justfile
@@ -318,6 +318,7 @@ lint:
     run guides  just gen-guides-check     & pids+=($!)
     run prose   just comment-lint-gate    & pids+=($!)
     run gitenv  just gitenv-selftest      & pids+=($!)
+    run isslink just issue-links        & pids+=($!)
     for p in "${pids[@]}"; do wait "$p" || fail=1; done
     [[ $fail -eq 0 ]]
 
@@ -1293,6 +1294,16 @@ comment-lint-replay n="20":
     echo "fn-body arm (advisory): $advisory/$total merged commits, $flagged lines"
     echo "blocking arms (--gate): $gated/$total merged commits — an arm reds the"
     echo "  commits that predate its own calibration, so read this against \`git log -S\`"
+
+# A closing keyword GitHub reads but the sentence does not mean. Wired in three
+# places that must stay in step: the `commit-msg` hook, `just lint`, and CI's
+# hygiene job — a commit message is authored locally, so the hook is where it can
+# still be fixed, and the other two catch a bypass.
+[group('meta')]
+[doc('Check commit messages for inline GitHub closing keywords')]
+issue-links range="origin/main..HEAD":
+    python3 scripts/issue-links.py --selftest
+    python3 scripts/issue-links.py {{ range }}
 
 # The seam's WHY lives in scripts/gitenv.py's docstring. This pins the scrub AND
 # sweeps scripts/ for anything spawning git outside `gitenv.git()` — the recurrence

--- a/scripts/issue-links.py
+++ b/scripts/issue-links.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""A GitHub closing keyword may only appear as a trailer, never inside prose.
+
+GitHub closes an issue when a merged commit message or pull-request description
+contains `close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved`
+followed by `#N` — optionally with a colon, in any case, ANYWHERE in the text
+(the docs place no line-position requirement). It reads the keyword, not the
+sentence, so two issues here were closed by prose meaning the opposite: a
+heading `Why this does NOT close #907`, and `(the alternative that also fixes
+#912)` naming an option that was measured and rejected.
+
+The rule is therefore positional, which is what makes it mechanical: an
+INTENTIONAL link is a trailer line of its own (`Closes: #912`); a keyword
+touching `#N` anywhere else is prose that will fire by accident.
+
+Reads commit messages only. A pull-request DESCRIPTION is authored on GitHub and
+never passes through here — that half of the surface is unguarded.
+
+Usage: issue-links.py [RANGE | --stdin | --selftest]
+  RANGE      git rev range whose commit messages to check (default: origin/main..HEAD)
+  --stdin    check one message on stdin (the commit-msg hook's path)
+  --selftest pin both directions on the real incidents
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+
+import gitenv
+
+KEYWORDS = "close[sd]?|fix(?:e[sd])?|resolve[sd]?"
+# A keyword touching `#N`, with the word boundary spelled out so `postfix #912`
+# and `prefix #12` are prose, not links.
+INLINE = re.compile(rf"(?:^|[^\w-])({KEYWORDS})[\s:]+#(\d+)", re.IGNORECASE)
+# The whole line IS the link — the trailer form, and the only accepted one.
+TRAILER = re.compile(rf"^\s*(?:{KEYWORDS}):?\s+#\d+\s*$", re.IGNORECASE)
+
+
+def offenders(message: str) -> list[tuple[int, str]]:
+    """Lines carrying a closing keyword that is not the line's whole content."""
+    out = []
+    for n, line in enumerate(message.splitlines(), 1):
+        # `#`-led lines are git comments, stripped before the message is stored.
+        if line.startswith("#") or TRAILER.match(line) or not INLINE.search(line):
+            continue
+        out.append((n, line.strip()))
+    return out
+
+
+def report(label: str, message: str) -> int:
+    bad = offenders(message)
+    for n, line in bad:
+        print(f"  {label}:{n}: {line}")
+    return len(bad)
+
+
+def check_range(rev_range: str) -> int:
+    r = gitenv.git(
+        "log", "--format=%H%x00%B%x00%x00", rev_range, capture_output=True, text=True, check=False
+    )
+    if r.returncode != 0:
+        print(f"issue-links: cannot read {rev_range}", file=sys.stderr)
+        return 1
+    total = 0
+    for entry in r.stdout.split("\0\0"):
+        if "\0" not in entry:
+            continue
+        sha, body = entry.split("\0", 1)
+        total += report(sha.strip()[:8], body)
+    if total:
+        print(
+            f"\nissue-links: {total} inline closing keyword(s). GitHub closes the issue on\n"
+            "merge regardless of the sentence around it — move it to its own trailer line\n"
+            "(`Closes: #N`), or reword so the keyword does not touch the number.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"issue-links: no inline closing keywords in {rev_range} ✓")
+    return 0
+
+
+def selftest() -> int:
+    fails: list[str] = []
+    # The two REAL incidents, verbatim, plus the shapes around them.
+    cases = [
+        (True, "the #912 incident", "(the alternative that also fixes #912) fails 132 tests."),
+        (True, "the #907 incident", "Why this does NOT close #907 — the residual is the painter's."),
+        (True, "mid-sentence past tense", "we Fixed #916 while we were in there"),
+        (True, "mid-sentence with colon", "this Resolves: #900 only partially"),
+        (False, "trailer with colon", "Closes: #912"),
+        (False, "trailer without colon", "Closes #912"),
+        (False, "indented trailer", "   closes #912   "),
+        (False, "a non-keyword reference", "Refs #912, which stays open."),
+        (False, "a word merely ending in fix", "the postfix #912 notation"),
+        (False, "a hyphenated word", "the auto-fix #912 pass"),
+        (False, "no reference at all", "nothing to see here"),
+        (False, "a git comment line", "# Why this does NOT close #907"),
+    ]
+    for want, why, line in cases:
+        got = bool(offenders(line))
+        if got is not want:
+            fails.append(f"{why}: expected {'a hit' if want else 'no hit'} — {line!r}")
+    # A keyword and a number on one line, separated by other words, is prose to
+    # GitHub too — the guard must not over-reach into things it cannot fire on.
+    if offenders("closes the door on #912"):
+        fails.append("a keyword NOT touching the number must not be reported")
+    if fails:
+        print("issue-links selftest FAILED:")
+        for f in fails:
+            print(f"  - {f}")
+        return 1
+    print("issue-links selftest: all checks passed")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    args = argv[1:]
+    if "--selftest" in args:
+        return selftest()
+    if "--stdin" in args:
+        n = report("message", sys.stdin.read())
+        if n:
+            print(
+                "\nissue-links: move it to its own trailer line (`Closes: #N`), or reword\n"
+                "so the keyword does not touch the number.",
+                file=sys.stderr,
+            )
+        return 1 if n else 0
+    return check_range(args[0] if args else "origin/main..HEAD")
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Three incidents in one day, the third inside this PR

GitHub reads the **keyword**, not the sentence around it. Two issues were retired today by prose that denied it — a heading asking why a PR does *not* retire 907, and a clause naming the **rejected** alternative that would also have resolved 912. Both were mine, both in this repo's own "don't do this" class, and I had quoted that rule earlier the same day.

The third instance happened while writing this: the first draft of the guard's own commit message quoted both incidents verbatim, and the guard rejected it. That draft would have re-retired both issues on merge.

## Checked against the docs, not my memory of them

I had been asserting the keyword rules from memory all day. [GitHub's docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue):

- nine keywords — `close/closes/closed`, `fix/fixes/fixed`, `resolve/resolves/resolved`
- the colon form counts (`Closes: #10`), case does not matter
- **no line-position requirement** — which is precisely why both incidents fired mid-sentence
- **commit messages AND pull-request descriptions** are scanned

## Why a keyword-presence grep would be wrong

`Closes: #N` is the *correct*, daily-used form — #910 retired four issues that way. A guard that fires on every closing keyword is noise people learn to skip, which is the exact failure mode this repo already documented for a length-based comment gate.

The discriminator is **position**, and that is what makes it mechanical instead of a judgment call:

```
Closes: #912                                  trailer, the whole line  → intentional
(the alternative that also fixes #912)        mid-sentence             → accident
```

`Refs #N` remains available for a mention that must not retire anything.

## Wired per this repo's own architecture rule

> "the justfile is the single source of truth for every check — CI and the git hooks call the same recipes (no local-vs-CI drift)"

One implementation, three call sites: `commit-msg` (where the message is still editable), `just lint`, and CI's hygiene job (to catch a bypass). Logic living inside the hook would have been exactly the drift that sentence forbids.

`just lint` is 18 arms now, and the wiring is controlled: breaking the script reds `isslink`.

## Bounded on both sides

The selftest carries both real incidents verbatim — which is *why* they live there and not in the commit message. Twelve cases, both directions:

| must fire | must stay silent |
|---|---|
| the 912 incident, verbatim | `Closes: #912` / `Closes #912` / indented |
| the 907 incident, verbatim | `Refs #912` |
| `we Fixed #916 while we were in there` | `the postfix #912 notation` |
| `this Resolves: #900 only partially` | `the auto-fix #912 pass` |
| | `closes the door on #912` — a keyword NOT touching the number |
| | a `#`-led git comment line |

## Is this best practice? Partly, and here is the honest split

- **The convention** (issue links only as trailers) — standard. Git trailers are documented practice; GitHub's own docs show the colon form; Conventional Commits puts refs in a footer.
- **The enforcement point** (`commit-msg`) — standard. That hook exists for commit-message policy; commitlint/husky occupy the same slot.
- **The rule itself** — **bespoke**. I searched: commitlint has no such rule, you would write a custom one. So this is not reimplementing a wheel, but it is not adopting an established one either.
- **GitHub's repository setting** is the wrong instrument. It is scoped to "auto-close issues with merged linked pull requests", the docs do not say it covers commit keywords, and disabling it would kill the legitimate usage this repo relies on.

## NOT covered, stated rather than implied

A pull-request **description** is authored on GitHub and passes through no hook. **One of today's two incidents came from exactly there.** Covering it needs a workflow that reads `pull_request.body`; that is a separate decision, and this PR does not pretend to have made it.

## Gates

`just lint` 18/18 · `just issue-links` green · selftest 12 cases both directions · the wiring's negative control reds `isslink`.
