### PR TITLE
fix(site): clear GHSA-jmr9-qjv8-65gv by overriding @puppeteer/browsers to 3.x

### DIFF
--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -233,15 +233,20 @@ old CommonJS launcher line to 0.15.2 (removing its deprecated
 `rimraf → glob → inflight` chain); do not widen it to 1.x, which is ESM-only
 while LHCI 0.15.1 still calls `require('chrome-launcher')`.
 The unqualified `@puppeteer/browsers` → 3.x override is the only route past
-GHSA-jmr9-qjv8-65gv, because no bump anywhere clears it: `extract-zip` has no
-patched release (the advisory range is `*`) and every link above it is an
-upstream EXACT pin — latest `@lhci/cli` 0.15.1 pins `lighthouse 12.6.1`, which
-pins `puppeteer-core ^24`, which pins `@puppeteer/browsers 2.13.2`; 3.x is the
-first to swap extract-zip for `modern-tar`. Crossing that major under
-puppeteer-core 24 holds only because LHCI launches Chrome through
-`chrome-launcher` and never enters puppeteer's download path, so the gate that
-proves it is `npm run lighthouse` — `site-check` stops short of the browser.
-Retire the entry once `@lhci/cli` ships a `lighthouse >= 13.4.1`.
+GHSA-jmr9-qjv8-65gv, because no bump clears it in place: `extract-zip` has no
+patched release (npm audit prints its range as `*`) and nothing above it can
+float past one — `@lhci/cli` 0.15.1 pins `lighthouse 12.6.1` exactly, which
+takes `puppeteer-core ^24`, and every published 24.x pins an exact
+`@puppeteer/browsers` 2.x; 3.x is the first major without extract-zip. Crossing
+that major under puppeteer-core 24 rests on two things: LHCI launches Chrome
+through `chrome-launcher`, so puppeteer's download path never runs, and 3.x
+being ESM-only (2.x shipped dual) is survivable only because puppeteer-core's
+CJS `require` rides Node's `require(esm)` — available from 22.12, under this
+project's node-26 floor. The gate that proves it is `npm run lighthouse` —
+`site-check` never runs LHCI.
+Retire it once nothing requests `@puppeteer/browsers < 3`: drop the entry per
+the protocol below and read the top of npm audit's vulnerable `lighthouse`
+range — 13.3.0 today, so a `lighthouse >= 13.4.0` reaching `@lhci/cli` clears it.
 
 **Nothing gates a STALE `overrides` entry**, so retiring one is a manual
 audit: copy `package.json` to a scratch dir (never the working tree, whose

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -232,6 +232,16 @@ The version-qualified `chrome-launcher@^0.13.4` override upgrades only LHCI's
 old CommonJS launcher line to 0.15.2 (removing its deprecated
 `rimraf → glob → inflight` chain); do not widen it to 1.x, which is ESM-only
 while LHCI 0.15.1 still calls `require('chrome-launcher')`.
+The unqualified `@puppeteer/browsers` → 3.x override is the only route past
+GHSA-jmr9-qjv8-65gv, because no bump anywhere clears it: `extract-zip` has no
+patched release (the advisory range is `*`) and every link above it is an
+upstream EXACT pin — latest `@lhci/cli` 0.15.1 pins `lighthouse 12.6.1`, which
+pins `puppeteer-core ^24`, which pins `@puppeteer/browsers 2.13.2`; 3.x is the
+first to swap extract-zip for `modern-tar`. Crossing that major under
+puppeteer-core 24 holds only because LHCI launches Chrome through
+`chrome-launcher` and never enters puppeteer's download path, so the gate that
+proves it is `npm run lighthouse` — `site-check` stops short of the browser.
+Retire the entry once `@lhci/cli` ships a `lighthouse >= 13.4.1`.
 
 **Nothing gates a STALE `overrides` entry**, so retiring one is a manual
 audit: copy `package.json` to a scratch dir (never the working tree, whose

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -3223,174 +3223,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/@puppeteer/browsers": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.2.tgz",
-      "integrity": "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "debug": "^4.4.3",
-        "extract-zip": "^2.0.1",
-        "progress": "^2.0.3",
-        "proxy-agent": "^6.5.0",
-        "semver": "^7.7.4",
-        "tar-fs": "^3.1.1",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "browsers": "lib/cjs/main-cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@puppeteer/browsers/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/yargs": {
-      "version": "17.7.3",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
-      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.2.tgz",
@@ -4290,17 +4122,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.66.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
@@ -5004,21 +4825,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/b4a": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
-      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react-native-b4a": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-b4a": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/bail": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
@@ -5038,91 +4844,6 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/bare-events": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
-      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "bare-abort-controller": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-abort-controller": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-fs": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.8.0.tgz",
-      "integrity": "sha512-fM+MhCvdQhZ7NV6S95a07gPSqjIYKn6mFaXfx266wN3ajZGl/+1AzH+ubkXQ0fFZvOe2nk9VHkzdYkQE5zMV3Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-events": "^2.5.4",
-        "bare-path": "^3.0.0",
-        "bare-stream": "^2.6.4",
-        "bare-url": "^2.2.2",
-        "fast-fifo": "^1.3.2"
-      },
-      "engines": {
-        "bare": ">=1.28.0"
-      },
-      "peerDependencies": {
-        "bare-buffer": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-buffer": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-path": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
-      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/bare-stream": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
-      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "b4a": "^1.8.1",
-        "streamx": "^2.25.0",
-        "teex": "^1.0.1"
-      },
-      "peerDependencies": {
-        "bare-abort-controller": "*",
-        "bare-buffer": "*",
-        "bare-events": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-abort-controller": {
-          "optional": true
-        },
-        "bare-buffer": {
-          "optional": true
-        },
-        "bare-events": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-url": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.7.tgz",
-      "integrity": "sha512-o8CRCiJtib+ycO3mE4A5UChtGX4dDP2XxsWVu9P+Zc3H8tcmKwNVEDoDTXmwN+uuMhfKeT7/i7Y26xS8W7ohoA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-path": "^3.0.0"
       }
     },
     "node_modules/basic-ftp": {
@@ -5195,16 +4916,6 @@
       },
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/bytes": {
@@ -6735,16 +6446,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
-      }
-    },
     "node_modules/enquirer": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
@@ -7190,16 +6891,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/events-universal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
-      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-events": "^2.7.0"
-      }
-    },
     "node_modules/express": {
       "version": "4.22.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
@@ -7296,38 +6987,10 @@
         "node": ">=4"
       }
     },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/fast-fifo": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
-      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -7397,16 +7060,6 @@
       "license": "MIT",
       "dependencies": {
         "walk-up-path": "^4.0.0"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
       }
     },
     "node_modules/fdir": {
@@ -7691,22 +7344,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-tsconfig": {
@@ -10406,6 +10043,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/modern-tar": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.8.4.tgz",
+      "integrity": "sha512-gN54ddmyzEg10orwZ2u4OOv+bjpMWdIl5jIkodK97bMq8QBSL5c0D7YX0lT1Ooz+99S7+PvFbnxzdjgHo1r41g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -10632,16 +10279,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
       }
     },
     "node_modules/onetime": {
@@ -11027,13 +10664,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/piccolore": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
@@ -11215,16 +10845,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/property-information": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
@@ -11277,17 +10897,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/pump": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -11315,6 +10924,35 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/puppeteer-core/node_modules/@puppeteer/browsers": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.2.0.tgz",
+      "integrity": "sha512-LlBrE8oqGfU7b1Nk2d5Q1SbuPhZxTj0cJEMDPEws28OjNMELlflekmPPuf4FnK03x0ZRjKaYwJElUcKK4kyqJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "modern-tar": "^0.8.0",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "browsers": "lib/main-cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "proxy-agent": ">=8.0.1",
+        "yauzl": "^2.10.0 || ^3.4.0"
+      },
+      "peerDependenciesMeta": {
+        "proxy-agent": {
+          "optional": true
+        },
+        "yauzl": {
+          "optional": true
+        }
       }
     },
     "node_modules/puppeteer-core/node_modules/devtools-protocol": {
@@ -12312,18 +11950,6 @@
       "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
       "license": "MIT"
     },
-    "node_modules/streamx": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
-      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "events-universal": "^1.0.0",
-        "fast-fifo": "^1.3.2",
-        "text-decoder": "^1.1.0"
-      }
-    },
     "node_modules/string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -12466,54 +12092,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/tar-fs": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.3.tgz",
-      "integrity": "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0",
-        "tar-stream": "^3.1.5"
-      },
-      "optionalDependencies": {
-        "bare-fs": "^4.0.1",
-        "bare-path": "^3.0.0"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
-      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "b4a": "^1.6.4",
-        "bare-fs": "^4.5.5",
-        "fast-fifo": "^1.2.0",
-        "streamx": "^2.15.0"
-      }
-    },
-    "node_modules/teex": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
-      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "streamx": "^2.12.5"
-      }
-    },
-    "node_modules/text-decoder": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
-      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "b4a": "^1.6.4"
       }
     },
     "node_modules/third-party-web": {
@@ -13810,13 +13388,6 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
@@ -14074,17 +13645,6 @@
       "license": "ISC",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
-      }
-    },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/site/package.json
+++ b/site/package.json
@@ -55,6 +55,7 @@
     "web-vitals": "6.0.1"
   },
   "overrides": {
+    "@puppeteer/browsers": "^3.2.0",
     "chrome-launcher@^0.13.4": "0.15.2",
     "esbuild": "0.28.1",
     "tmp": "^0.2.7",


### PR DESCRIPTION
## Summary

`npm run audit` has been red on **every** site-path CI run ([example](https://github.com/IvanWng97/pixtuoid/actions/runs/31661563962/job/94327261262)) — 6 high-severity findings, all one advisory: [GHSA-jmr9-qjv8-65gv](https://github.com/advisories/GHSA-jmr9-qjv8-65gv), extract-zip unvalidated symlink path traversal, reached through LHCI. One line of `site/package.json` overrides `@puppeteer/browsers` to `^3.2.0`, which drops the vulnerable subtree entirely.

## Related issue

n/a — no tracking issue. This closes Dependabot alert **#41** (same GHSA, manifest `site/package-lock.json`), which resolves on its own once the package leaves the lockfile.

## Why not just upgrade

That was the first thing checked, and it is **not possible** — nothing above `extract-zip` can float past it:

```
@lhci/cli 0.15.1          ← already latest (published 2025-06-25; `next` tag == `latest`)
  └ pins  lighthouse 12.6.1        ← EXACT, not a range (13.4.x exists but is unreachable)
      └ takes puppeteer-core ^24   ← a caret — but all 77 published 24.x releases pin an
          │                          EXACT @puppeteer/browsers (26 distinct values,
          │                          2.7.0 … 2.13.2), every one a vulnerable 2.x, so the
          │                          caret has nowhere clean to float
          └ pins  @puppeteer/browsers 2.13.2   ← exact
              └ extract-zip <= 2.0.1           ← first_patched_version: null
```

The bottom of the chain has no fix at all — confirmed against the GitHub advisory API rather than npm audit's rendering:

```
$ gh api /advisories/GHSA-jmr9-qjv8-65gv --jq '.vulnerabilities[]|{pkg:.package.name,patched:.first_patched_version}'
{"pkg":"extract-zip","patched":null}
```

2.0.1 is simultaneously the latest published version *and* vulnerable.

Proven empirically in a scratch dir (per the protocol in `site/CLAUDE.md` — never the working tree, whose lockfile is the artifact under test): with the override removed **and** `@lhci/cli` pinned to `latest`, npm still resolves `extract-zip 2.0.1` and `npm audit` exits 1.

`npm audit fix --force` proposes downgrading to `@lhci/cli@0.12.0` (2023) — a breaking change, and backwards.

## Why the override is safe

`@puppeteer/browsers` 3.x is the first major without extract-zip, so the whole subtree leaves: **37 lockfile packages out, 2 in** (−479/+39 lines).

<sub>(Precisely: `3.0.2` dropped extract-zip while still using `tar-fs`; `modern-tar` arrived two patches later in `3.0.4`, replacing `tar-fs`. Those are two separate upstream changes — an earlier draft of this PR fused them into one claim.)</sub>

That is a major-version swap underneath `puppeteer-core` 24's exact pin, so it did not get waved through on "LHCI never calls the download path anyway." Two independent checks:

1. **Full binding sweep.** Every binding puppeteer-core 24.43.1 takes from the package was extracted *mechanically* across both builds — `lib/esm` **and** `lib/cjs` — rather than from a hand-written list: **14** names (`Browser`, `CDP_WEBSOCKET_ENDPOINT_REGEX`, `ChromeReleaseChannel`, `TimeoutError`, `WEBDRIVER_BIDI_WEBSOCKET_ENDPOINT_REGEX`, `computeExecutablePath`, `computeSystemExecutablePath`, `createProfile`, `detectBrowserPlatform`, `getInstalledBrowsers`, `launch`, `resolveBuildId`, `resolveDefaultUserDataDir`, `uninstall`). All 14 exist in the installed 3.2.0.

   Two of those are reachable *only* by methods a static-import grep misses, which is why the sweep had to be mechanical: the CJS build uses `require(...)` + `browsers_1.<name>` member access, and `resolveDefaultUserDataDir` appears solely in a **dynamic** `await import(...)` inside `BrowserConnector` (esm:76 / cjs:113). ESM link-time checking cannot see either, so it is not on its own sufficient evidence.
2. **Both real entry points loaded**, exactly as their consumers do: ESM as `lighthouse` requires it, CJS as `@lhci/cli` does. The static-ESM link half was additionally negative-controlled — importing a deliberately bogus export from the same module *does* throw, so that half is not vacuously green.

3. **The module-system crossing**, which the first draft missed entirely: `2.13.2` was a *dual* package (`exports` carrying both `import` and `require`); `3.2.0` is `type: module` with no exports map at all — ESM-only. puppeteer-core's CJS build `require()`s it from five modules, so this only works via Node's `require(esm)`, unflagged from **22.12** — under this project's `engines.node >= 26` floor (`engine-strict=true`, both workflows on node 26). Both real entry points were loaded to confirm: ESM as `lighthouse` does, CJS as `@lhci/cli` does.

Independently: LHCI reaches Chrome through `chrome-launcher` (already overridden here), so puppeteer's browser-download path is not on the hot path to begin with.

**The shipped site is provably unaffected.** `dist/` built at base and at HEAD — with both non-deterministic inputs pinned identically (`GH_STARS_OVERRIDE`, and the GitHub PR-feed fetch stubbed) — is **byte-identical**: 76/76 files, same aggregate sha256 `de66018f…`. A set-difference over the lockfiles' `packages` keys shows **0 in-place version changes**, so no Astro/Vite/esbuild/TypeScript package moved. `puppeteer-core` has exactly one path in the tree (`@lhci/cli → lighthouse → puppeteer-core`), and `rehype-mermaid` renders via `mermaid-isomorphic`/Playwright, not puppeteer.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New theme / sprite pack
- [ ] New `Source` adapter (another agent CLI)
- [ ] Docs only
- [ ] Refactor / chore

## How I tested it

Run in `site.yml`'s real order, not just the static tier. This matters: the previously-drafted version of this fix was only ever validated with `just site-check`, which **never launches a browser** — and `npm run lighthouse` sits *ahead* of `audit` in the workflow, so it is the step an incompatible puppeteer would actually break.

| stage | result |
|---|---|
| `just preflight` (lint · clippy · hack · test) | **0** — 3039 passed, 2 skipped |
| `just site-check` (format · lint · astro check · knip · unit · build · check:docs · audit) | **0** — `found 0 vulnerabilities` |
| `npm run e2e` | **0** — 96 passed |
| `npm run lighthouse` | **0** — 18 runs across 6 URLs, all assertions pass |
| `npm install-scripts ls` | no unreviewed install scripts |
| `npm audit` **at base** (negative control) | **1** — GHSA-jmr9-qjv8-65gv, 6 high |

The last row is the point: the gate genuinely fails without this override, so `npm run audit` — last step of `verify`/`site-check`, and wired at `site.yml:69` + `pages.yml:58` — is the regression teeth. Observed, not reasoned.

<sub>One e2e spec (the ★ star chip) failed on the first pass because the local build lacked `GH_STARS_OVERRIDE=842`, which `site.yml` sets; rebuilt with it, 96/96 green. Unrelated to this change.</sub>

## Visual verification (required for sprite / rendering changes)

- [x] Not a visual change, or — screenshot/GIF attached below and it reads at half-block scale.

## Checklist

- [x] I read the relevant `CLAUDE.md` (root + the nested one for the crate I touched) — root + `site/CLAUDE.md`.
- [ ] New behavior has a test (this repo is TDD-first). — **n/a**: no new behavior. The regression gate is the existing `npm run audit` step, which was red before this commit and is green after; the override's compatibility is covered by the link-check + negative control described above.
- [x] No `unwrap()` in non-test code; errors propagate via `anyhow`/`thiserror`. — **n/a**, no Rust changed.
- [x] No new `println!`/`eprintln!` on a production path (use `tracing`). — **n/a**, no Rust changed.
- [x] Docs updated in the same commit if I changed module structure, architecture, or public API (`CLAUDE.md` / `README.md`) — see below.
- [ ] Checked against the [recurring pitfalls](https://github.com/IvanWng97/pixtuoid/blob/main/docs/CONTRIBUTING.md#recurring-pitfalls-this-codebases-review-history-distilled) — **n/a**: that list (char-safe slicing · parallel copies · decode-boundary sanitizing · negative branches) is about Rust decode paths; this diff touches no code.
- [x] `just preflight` passes locally.

## Docs

`site/CLAUDE.md` gains a paragraph beside the existing `chrome-launcher` override rationale: why no upgrade clears it, what the cross-major swap rests on, which gate proves it (`npm run lighthouse` — `site-check` never runs LHCI), and **the retirement condition**, routed through the scratch-dir protocol the very next paragraph already documents: drop the entry there and read the top of npm audit's vulnerable `lighthouse` range (`13.3.0` today, so a `lighthouse >= 13.4.0` reaching `@lhci/cli` clears it). That file already warns that *nothing gates a stale `overrides` entry*, so the exit condition has to be written down — and written as a live-checkable property rather than a version number that rots.

## AI assistance

- [x] This PR was written/heavily-assisted by an AI agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
