### PR TITLE
fix(site): clear GHSA-2v37-7h3g-55p8 with an in-range nanoid bump

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -10085,9 +10085,9 @@
       "license": "ISC"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Unblocks the site job that went red mid-afternoon on every branch: GHSA-2v37-7h3g-55p8 (nanoid custom generators loop on size 0) was published 2026-07-29 covering 4.x/5.x only; its 2026-08-13T15:43Z update added the `<3.3.18` range, so the unchanged lockfile started failing `npm audit` (chain: `eslint-plugin-astro → postcss → nanoid@3.3.17`, dev-only).

postcss wants `^3.3.x`, so this is a plain in-range lock refresh to 3.3.18 — no new `overrides` entry to carry (the ladder per site/CLAUDE.md stays: in-range bump → upstream bump → override as last resort). Diff is the 3-line nanoid lock entry; `npm audit` 0 vulnerabilities; `just site-check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQULEd97BBLcYgYwGM3VDi