### PR TITLE
perf(bench): CodSpeed gets occupancy, the wire path, memory mode — and a badge

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   bench:
-    name: render benchmarks (on-demand, advisory)
+    name: frame + wire benchmarks (on-demand, advisory)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -28,7 +28,7 @@ jobs:
         with:
           prefix-key: v1-rust # match setup-cargo-just's default cache namespace
       - uses: extractions/setup-just@v4
-      - name: Run render benchmarks (advisory, non-blocking)
+      - name: Run frame + wire benchmarks (advisory, non-blocking)
         run: just bench
       # JSON measurements only — the lean criterion feature set builds no HTML.
       - name: Upload criterion measurements

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,15 +1,20 @@
 name: codspeed
 
-# Instrumented (simulation-mode) benchmark trend on Rust-touching PRs + main
-# pushes — CodSpeed counts weighted instructions, not wall-clock, so
-# shared-runner noise doesn't apply (<1% variance; the same setup ruff/uv
-# run). ADVISORY by construction like bench.yml/mutants.yml: nothing `needs:`
-# it and it is not a required check — trend evidence, never a gate. Reports
-# need the CodSpeed GitHub App installed on the repo; auth is OIDC
-# (`id-token: write`, job-scoped per this repo's convention — see
-# ci-tests.yml's "Declared, not inherited"), no token secret. Steps follow
-# CodSpeed's documented criterion workflow; moonrepo/setup-rust installs
-# cargo-codspeed via binstall (revisit if taiki-e/install-action adds it).
+# Instrumented benchmark trend on Rust-touching PRs + main pushes, in TWO
+# modes: `simulation` counts weighted instructions (not wall-clock, so
+# shared-runner noise doesn't apply — <1% variance; the same setup ruff/uv
+# run) and `memory` counts heap allocations. ADVISORY by construction like
+# bench.yml/mutants.yml: nothing `needs:` it and it is not a required check —
+# trend evidence, never a gate. Reports need the CodSpeed GitHub App installed
+# on the repo; auth is OIDC (`id-token: write`, job-scoped per this repo's
+# convention — see ci-tests.yml's "Declared, not inherited"), no token secret.
+# Steps follow CodSpeed's documented criterion workflow; moonrepo/setup-rust
+# installs cargo-codspeed via binstall (revisit if taiki-e/install-action adds
+# it).
+#
+# Both modes are named on BOTH steps because build and run read the mode
+# independently (the run inherits it from the action via CODSPEED_RUNNER_MODE).
+# Measurement is per-mode, which is what the timeout headroom is for.
 on:
   push:
     branches: [main]
@@ -25,9 +30,9 @@ permissions:
 
 jobs:
   codspeed:
-    name: benchmarks (codspeed simulation, advisory)
+    name: benchmarks (codspeed simulation + memory, advisory)
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: read
       id-token: write
@@ -41,8 +46,8 @@ jobs:
           cache-target: release
           bins: cargo-codspeed
       - name: Build instrumented benchmarks
-        run: cargo codspeed build -p pixtuoid-scene -p pixtuoid-core
+        run: cargo codspeed build -p pixtuoid-scene -p pixtuoid-core -m simulation,memory
       - uses: CodSpeedHQ/action@v5
         with:
-          mode: simulation
+          mode: simulation,memory
           run: cargo codspeed run

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -12,9 +12,10 @@ name: codspeed
 # installs cargo-codspeed via binstall (revisit if taiki-e/install-action adds
 # it).
 #
-# Both modes are named on BOTH steps because build and run read the mode
-# independently (the run inherits it from the action via CODSPEED_RUNNER_MODE).
-# Measurement is per-mode, which is what the timeout headroom is for.
+# TWO action steps rather than one `mode: simulation,memory`: the runner uploads
+# only after EVERY mode's run part completes, so a single process drops an
+# already-good simulation result whenever the newer memory instrument fails.
+# The build takes no mode — both instruments consume the same build today.
 on:
   push:
     branches: [main]
@@ -32,7 +33,7 @@ jobs:
   codspeed:
     name: benchmarks (codspeed simulation + memory, advisory)
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 30
     permissions:
       contents: read
       id-token: write
@@ -46,8 +47,13 @@ jobs:
           cache-target: release
           bins: cargo-codspeed
       - name: Build instrumented benchmarks
-        run: cargo codspeed build -p pixtuoid-scene -p pixtuoid-core -m simulation,memory
+        run: cargo codspeed build -p pixtuoid-scene -p pixtuoid-core
       - uses: CodSpeedHQ/action@v5
         with:
-          mode: simulation,memory
+          mode: simulation
+          run: cargo codspeed run
+      - uses: CodSpeedHQ/action@v5
+        continue-on-error: true
+        with:
+          mode: memory
           run: cargo codspeed run

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -41,7 +41,7 @@ jobs:
           cache-target: release
           bins: cargo-codspeed
       - name: Build instrumented benchmarks
-        run: cargo codspeed build -p pixtuoid-scene
+        run: cargo codspeed build -p pixtuoid-scene -p pixtuoid-core
       - uses: CodSpeedHQ/action@v5
         with:
           mode: simulation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,8 @@ costs a FRAME (size + occupancy axes), `pixtuoid-core/benches/decode_reduce.rs`
 costs an EVENT (both transports). LOCAL statistical numbers; CI's `bench.yml` is
 on-demand advisory like mutants,
 never a gate (shared-runner wall-clock is noise), and `codspeed.yml` tracks the
-same benches per PR as instruction-count simulation (also advisory).
+same benches per PR in two modes — instruction-count simulation and heap
+allocations (both advisory).
 
 ### Visual verification
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,8 +133,10 @@ tool runs in CI.
 Mutation testing: `just mutants` (diff-scoped vs origin/main; in CI it is the
 on-demand `mutants.yml`, NOT per-PR — a surviving mutant is a hint, not a
 gate). Coverage: `just coverage`. Property invariants use `proptest`.
-Benchmarks: `just bench` (criterion, `pixtuoid-scene/benches/render_frame.rs`) —
-LOCAL statistical numbers; CI's `bench.yml` is on-demand advisory like mutants,
+Benchmarks: `just bench` (criterion) — `pixtuoid-scene/benches/render_frame.rs`
+costs a FRAME (size + occupancy axes), `pixtuoid-core/benches/decode_reduce.rs`
+costs an EVENT (both transports). LOCAL statistical numbers; CI's `bench.yml` is
+on-demand advisory like mutants,
 never a gate (shared-runner wall-clock is noise), and `codspeed.yml` tracks the
 same benches per PR as instruction-count simulation (also advisory).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2717,6 +2717,7 @@ name = "pixtuoid-core"
 version = "0.17.0"
 dependencies = [
  "anyhow",
+ "codspeed-criterion-compat",
  "filetime",
  "insta",
  "libc",

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
   <a href="https://github.com/IvanWng97/pixtuoid/releases"><img src="https://img.shields.io/github/v/release/IvanWng97/pixtuoid?label=version&style=flat-square" alt="Version" /></a>
   <a href="https://github.com/IvanWng97/pixtuoid/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/IvanWng97/pixtuoid/ci.yml?style=flat-square&label=CI" alt="CI" /></a>
   <a href="https://codecov.io/gh/IvanWng97/pixtuoid"><img src="https://img.shields.io/codecov/c/github/IvanWng97/pixtuoid?style=flat-square" alt="Coverage" /></a>
+  <a href="https://app.codspeed.io/IvanWng97/pixtuoid?utm_source=badge"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fapp.codspeed.io%2Fbadge.json&style=flat-square" alt="CodSpeed" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square" alt="License" /></a>
   <a href="https://buymeacoffee.com/IvanWng97"><img src="https://img.shields.io/badge/Buy%20Me%20a%20Coffee-ffdd00?style=flat-square&logo=buy-me-a-coffee&logoColor=black" alt="Buy Me a Coffee" /></a>
 </p>

--- a/crates/pixtuoid-core/Cargo.toml
+++ b/crates/pixtuoid-core/Cargo.toml
@@ -74,4 +74,11 @@ tempfile = "3"
 filetime = "0.2"
 insta = { version = "1", features = ["yaml"] }
 tracing-subscriber = { workspace = true }
+# Wire→state benchmarks (`just bench`), same CodSpeed compat passthrough as
+# pixtuoid-scene's: plain criterion locally, instrumented by codspeed.yml.
+criterion = { package = "codspeed-criterion-compat", version = "5", default-features = false, features = ["cargo_bench_support"] }
+
+[[bench]]
+name = "decode_reduce"
+harness = false
 

--- a/crates/pixtuoid-core/Cargo.toml
+++ b/crates/pixtuoid-core/Cargo.toml
@@ -74,8 +74,8 @@ tempfile = "3"
 filetime = "0.2"
 insta = { version = "1", features = ["yaml"] }
 tracing-subscriber = { workspace = true }
-# Wire→state benchmarks (`just bench`), same CodSpeed compat passthrough as
-# pixtuoid-scene's: plain criterion locally, instrumented by codspeed.yml.
+# Wire→state benchmarks (`just bench`); same CodSpeed compat passthrough as
+# `pixtuoid-scene`'s.
 criterion = { package = "codspeed-criterion-compat", version = "5", default-features = false, features = ["cargo_bench_support"] }
 
 [[bench]]

--- a/crates/pixtuoid-core/benches/decode_reduce.rs
+++ b/crates/pixtuoid-core/benches/decode_reduce.rs
@@ -1,0 +1,86 @@
+//! Wire→state benchmark: the decode→reduce half that runs on every transcript
+//! append and every hook envelope, driven through `harness::Drive` so it can't
+//! measure a decoder production doesn't use. The render benchmark next door
+//! costs a FRAME; this costs an EVENT, and the two scale with different things.
+//!
+//! Both transports are measured because their costs are structurally different:
+//! the JSONL arm parses the fatter envelope, the hook arm carries the
+//! `recent_hook_tool_uses` dedup bookkeeping.
+//!
+//! Lines are synthesized rather than read from `tests/sources/fixtures/`, which
+//! is the conformance harness's scanned population — one transcript per scenario
+//! dir, every dir a registered source — so a bench-shaped fixture there would be
+//! mis-scanned and panic.
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use pixtuoid_core::harness::Drive;
+
+const SESSION: &str = "01000000-0000-7000-8000-0000000000cc";
+const CWD: &str = "/home/user/demo-project";
+const TRANSCRIPT: &str = "/p/01000000-0000-7000-8000-0000000000cc.jsonl";
+/// One turn is a tool call and its result — two lines on either transport.
+const TURNS: usize = 200;
+
+fn jsonl_turns(n: usize) -> Vec<String> {
+    let mut out = Vec::with_capacity(n * 2);
+    for i in 0..n {
+        out.push(format!(
+            r#"{{"type":"assistant","cwd":"{CWD}","sessionId":"{SESSION}","timestamp":"2026-01-01T00:00:00.000Z","uuid":"00000000-0000-4000-8000-{i:012x}","message":{{"role":"assistant","content":[{{"type":"tool_use","id":"toolu_{i:016x}","name":"Glob","input":{{"pattern":"crates/**/*.rs"}}}}]}}}}"#
+        ));
+        out.push(format!(
+            r#"{{"type":"user","cwd":"{CWD}","sessionId":"{SESSION}","timestamp":"2026-01-01T00:00:00.500Z","uuid":"10000000-0000-4000-8000-{i:012x}","message":{{"role":"user","content":[{{"type":"tool_result","tool_use_id":"toolu_{i:016x}","content":"(matches)"}}]}}}}"#
+        ));
+    }
+    out
+}
+
+fn hook_turns(n: usize) -> Vec<String> {
+    let mut out = Vec::with_capacity(n * 2 + 1);
+    out.push(format!(
+        r#"{{"hook_event_name":"SessionStart","session_id":"{SESSION}","transcript_path":"{TRANSCRIPT}","cwd":"{CWD}","source":"startup"}}"#
+    ));
+    for i in 0..n {
+        out.push(format!(
+            r#"{{"hook_event_name":"PreToolUse","session_id":"{SESSION}","transcript_path":"{TRANSCRIPT}","cwd":"{CWD}","tool_name":"Glob","tool_input":{{"pattern":"crates/**/*.rs"}},"tool_use_id":"toolu_{i:016x}"}}"#
+        ));
+        out.push(format!(
+            r#"{{"hook_event_name":"PostToolUse","session_id":"{SESSION}","transcript_path":"{TRANSCRIPT}","tool_name":"Glob","tool_use_id":"toolu_{i:016x}"}}"#
+        ));
+    }
+    out
+}
+
+fn decode_reduce(c: &mut Criterion) {
+    let jsonl = jsonl_turns(TURNS);
+    let hooks = hook_turns(TURNS);
+    let transcript = Drive::transcript("claude-code", TRANSCRIPT)
+        .expect("claude-code is transcript-bearing")
+        .seeded();
+    let hook = Drive::hooks();
+
+    // A silently-rejected line would leave this benchmarking the decoder's error
+    // path, which is not the thing being measured.
+    for (what, driven) in [
+        ("jsonl", transcript.lines(&jsonl)),
+        ("hooks", hook.lines(&hooks)),
+    ] {
+        driven.assert_clean(what);
+        assert_eq!(driven.registered(), 1, "{what}: one session must register");
+        assert!(
+            driven.wire_events() >= TURNS,
+            "{what}: the wire must carry at least one event per turn"
+        );
+    }
+
+    let mut group = c.benchmark_group("decode_reduce");
+    group.bench_function(format!("jsonl_{TURNS}_turns"), |b| {
+        b.iter(|| transcript.lines(&jsonl))
+    });
+    group.bench_function(format!("hook_{TURNS}_turns"), |b| {
+        b.iter(|| hook.lines(&hooks))
+    });
+    group.finish();
+}
+
+criterion_group!(benches, decode_reduce);
+criterion_main!(benches);

--- a/crates/pixtuoid-core/benches/decode_reduce.rs
+++ b/crates/pixtuoid-core/benches/decode_reduce.rs
@@ -1,7 +1,12 @@
 //! Wire→state benchmark: the decode→reduce half that runs on every transcript
 //! append and every hook envelope, driven through `harness::Drive` so it can't
 //! measure a decoder production doesn't use. The render benchmark next door
-//! costs a FRAME; this costs an EVENT, and the two scale with different things.
+//! costs a FRAME; this costs an EVENT.
+//!
+//! `Drive` folds through a real `Reducer` and RETAINS every decoded event, so
+//! the curve carries a constant harness component production doesn't pay (one
+//! `AgentEvent` clone per event, plus a per-event `tick` the runtime schedules
+//! on a timer). Read the memory mode's movement as directional, not absolute.
 //!
 //! Both transports are measured because their costs are structurally different:
 //! the JSONL arm parses the fatter envelope, the hook arm carries the
@@ -58,18 +63,16 @@ fn decode_reduce(c: &mut Criterion) {
         .seeded();
     let hook = Drive::hooks();
 
-    // A silently-rejected line would leave this benchmarking the decoder's error
-    // path, which is not the thing being measured.
-    for (what, driven) in [
-        ("jsonl", transcript.lines(&jsonl)),
-        ("hooks", hook.lines(&hooks)),
+    // Exact counts, not a floor: a decoder arm that DECLINES (`Ok(vec![])`, the
+    // shape of the documented quiet-drop paths) halves this while leaving
+    // `assert_clean` green, and a floor would not notice.
+    for (what, driven, want) in [
+        ("jsonl", transcript.lines(&jsonl), 2 * TURNS),
+        ("hooks", hook.lines(&hooks), 4 * TURNS + 1),
     ] {
         driven.assert_clean(what);
         assert_eq!(driven.registered(), 1, "{what}: one session must register");
-        assert!(
-            driven.wire_events() >= TURNS,
-            "{what}: the wire must carry at least one event per turn"
-        );
+        assert_eq!(driven.wire_events(), want, "{what}: wire event count");
     }
 
     let mut group = c.benchmark_group("decode_reduce");

--- a/crates/pixtuoid-core/tests/CLAUDE.md
+++ b/crates/pixtuoid-core/tests/CLAUDE.md
@@ -66,7 +66,9 @@ Everything that feeds real wire bytes through the production path rides
 `pixtuoid_core::harness::Drive` (core's dev-only `harness` feature): this
 suite's `conformance.rs`, `pixtuoid/tests/wire_to_pixels.rs`, and the two
 on-demand tools (`examples/decoder_fuzz.rs`,
-`pixtuoid-scene/examples/corpus_check.rs`). A shell supplies bytes and asserts
+`pixtuoid-scene/examples/corpus_check.rs`). `benches/decode_reduce.rs` rides it
+too but SYNTHESIZES its lines — a bench-shaped fixture under `sources/fixtures/`
+would be mis-scanned (see the sharp edge below). A shell supplies bytes and asserts
 or reports; it does NOT re-roll decode → reduce, and in particular it does not
 re-derive the first-sight seed's `AgentId` (that comes from the source's
 registry row — see the core guide).

--- a/crates/pixtuoid-scene/benches/render_frame.rs
+++ b/crates/pixtuoid-scene/benches/render_frame.rs
@@ -1,10 +1,10 @@
 //! Whole-frame render benchmark over two axes: the two SIZES issue #900
 //! measured (12 agents, busy and idle), and OCCUPANCY at the larger of them.
-//! Size is the saturated axis — #900 put frame cost at 2.814x for 2.812x the
-//! pixels — and 360x240 is where it stops: `office_scale` pins the floating
-//! window's buffer near 180px tall, so a bigger display renders a SMALLER
-//! office. Occupancy is what still varies in real use, and the per-agent work
-//! (z-sort, routing, chitchat) is the part that isn't linear in pixels.
+//! Size is the near-linear axis — #900 measured frame cost tracking pixel
+//! count — so occupancy is the one that still teaches something: the per-agent
+//! work is the part that isn't linear in pixels. The largest crowd carries an
+//! idle twin for the same reason the size axis does: without it the delta can't
+//! be split into headcount-driven and activity-driven halves.
 //! Run via `just bench`; profile via
 //! `cargo bench -p pixtuoid-scene --bench render_frame -- --profile-time 10`
 //! under `samply record`. Numbers are LOCAL statistical evidence (criterion's
@@ -32,10 +32,12 @@ use pixtuoid_scene::layout::Size;
 const BASE_EPOCH_SECS: u64 = 1_700_000_200;
 const SIM_WINDOW_FRAMES: u32 = 600;
 const FRAME_STEP_MS: u64 = 100;
-/// The largest office buffer any painter produces (`FLOATING_DEFAULT_W/H`, and
-/// the scale-1 case of `office_scale`).
-const CEILING: (u16, u16) = (360, 240);
-/// Crowds above the 12 the size axis fixes — a busy pod-farm and a full floor.
+/// The DEFAULT floating window's office buffer (`pixtuoid`'s
+/// `FLOATING_DEFAULT_W/H`, which `office_scale` leaves at scale 1). NOT a
+/// ceiling: the TUI buffer is the terminal's own size and `office_scale`
+/// divides by HEIGHT only, so a wide window or wide terminal exceeds it.
+const FLOATING_DEFAULT: Size = Size { w: 360, h: 240 };
+/// Crowds above the 12 the size axis fixes — a busy pod-farm and a near-full floor.
 const OCCUPANCY: [usize; 2] = [32, 64];
 
 fn office_scene(n: usize, max_desks: usize, base: SystemTime, busy: bool) -> SceneState {
@@ -51,8 +53,7 @@ fn office_scene(n: usize, max_desks: usize, base: SystemTime, busy: bool) -> Sce
     // The idle office's clocks sit far in the past so agents settle into the
     // deep-idle poses a real overnight office shows.
     let idle_epoch = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
-    // Half the office mid-tool, a sixth parked on a prompt — at n=12 this is
-    // exactly the 6/2/4 split the size cases have measured since #900.
+    // At n=12 this is exactly the 6/2/4 split the size cases have measured since #900.
     let active = n / 2;
     let waiting = active + n / 6;
     for i in 0..n {
@@ -111,25 +112,41 @@ fn render_frame(c: &mut Criterion) {
     let base = SystemTime::UNIX_EPOCH + Duration::from_secs(BASE_EPOCH_SECS);
     let busy = office_scene(12, 16, base, true);
     let idle = office_scene(12, 16, base, false);
-    // A 360x240 floor lays out 80 desks, so both crowds seat fully.
     let crowds: Vec<(usize, SceneState)> = OCCUPANCY
         .iter()
         .map(|&n| (n, office_scene(n, n, base, true)))
         .collect();
+    let biggest = OCCUPANCY[OCCUPANCY.len() - 1];
+    let idle_crowd = office_scene(biggest, biggest, base, false);
+    // Every crowd must seat, else the case measures a smaller office than its name claims.
+    let seats = pixtuoid_scene::floor::floor_capacity(
+        FLOATING_DEFAULT.w,
+        FLOATING_DEFAULT.h,
+        pixtuoid_scene::floor::floor_seed(0),
+    );
+    assert!(
+        seats >= biggest,
+        "{FLOATING_DEFAULT:?} seats {seats} < {biggest}"
+    );
 
-    let mut cases: Vec<(String, &SceneState, u16, u16)> = Vec::new();
+    let mut cases: Vec<(String, &SceneState, Size)> = Vec::new();
     for (label, scene) in [("busy", &busy), ("idle", &idle)] {
-        for (w, h) in [(192u16, 160u16), CEILING] {
-            cases.push((format!("{label}12_{w}x{h}"), scene, w, h));
+        for size in [Size { w: 192, h: 160 }, FLOATING_DEFAULT] {
+            cases.push((format!("{label}12_{}x{}", size.w, size.h), scene, size));
         }
     }
+    let Size { w, h } = FLOATING_DEFAULT;
     for (n, scene) in &crowds {
-        let (w, h) = CEILING;
-        cases.push((format!("busy{n}_{w}x{h}"), scene, w, h));
+        cases.push((format!("busy{n}_{w}x{h}"), scene, FLOATING_DEFAULT));
     }
+    cases.push((
+        format!("idle{biggest}_{w}x{h}"),
+        &idle_crowd,
+        FLOATING_DEFAULT,
+    ));
 
     let mut group = c.benchmark_group("render_floor");
-    for (name, scene, w, h) in cases {
+    for (name, scene, size) in cases {
         group.bench_function(name, |b| {
             let mut fctx = FloorCtx::new();
             let mut buf = RgbBuffer::filled(0, 0, Rgb { r: 0, g: 0, b: 0 });
@@ -148,7 +165,7 @@ fn render_frame(c: &mut Criterion) {
                         pack: &pack,
                         theme,
                         now: base + Duration::from_millis(u64::from(i) * FRAME_STEP_MS),
-                        size: Size { w, h },
+                        size,
                         floor_meta: FloorMeta::ground(),
                         active_pet: None,
                         floor_pet: None,

--- a/crates/pixtuoid-scene/benches/render_frame.rs
+++ b/crates/pixtuoid-scene/benches/render_frame.rs
@@ -1,6 +1,11 @@
-//! Whole-frame render benchmark: `render_floor` on a 12-agent office at the
-//! two sizes issue #900 measured, in a busy (mixed-activity) and an idle
-//! configuration. Run via `just bench`; profile via
+//! Whole-frame render benchmark over two axes: the two SIZES issue #900
+//! measured (12 agents, busy and idle), and OCCUPANCY at the larger of them.
+//! Size is the saturated axis — #900 put frame cost at 2.814x for 2.812x the
+//! pixels — and 360x240 is where it stops: `office_scale` pins the floating
+//! window's buffer near 180px tall, so a bigger display renders a SMALLER
+//! office. Occupancy is what still varies in real use, and the per-agent work
+//! (z-sort, routing, chitchat) is the part that isn't linear in pixels.
+//! Run via `just bench`; profile via
 //! `cargo bench -p pixtuoid-scene --bench render_frame -- --profile-time 10`
 //! under `samply record`. Numbers are LOCAL statistical evidence (criterion's
 //! own FAQ warns shared-CI wall-clock is noise) — CI runs this advisory-only.
@@ -27,6 +32,11 @@ use pixtuoid_scene::layout::Size;
 const BASE_EPOCH_SECS: u64 = 1_700_000_200;
 const SIM_WINDOW_FRAMES: u32 = 600;
 const FRAME_STEP_MS: u64 = 100;
+/// The largest office buffer any painter produces (`FLOATING_DEFAULT_W/H`, and
+/// the scale-1 case of `office_scale`).
+const CEILING: (u16, u16) = (360, 240);
+/// Crowds above the 12 the size axis fixes — a busy pod-farm and a full floor.
+const OCCUPANCY: [usize; 2] = [32, 64];
 
 fn office_scene(n: usize, max_desks: usize, base: SystemTime, busy: bool) -> SceneState {
     let mut s = SceneState::uniform(max_desks);
@@ -41,18 +51,22 @@ fn office_scene(n: usize, max_desks: usize, base: SystemTime, busy: bool) -> Sce
     // The idle office's clocks sit far in the past so agents settle into the
     // deep-idle poses a real overnight office shows.
     let idle_epoch = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+    // Half the office mid-tool, a sixth parked on a prompt — at n=12 this is
+    // exactly the 6/2/4 split the size cases have measured since #900.
+    let active = n / 2;
+    let waiting = active + n / 6;
     for i in 0..n {
         let id = AgentId::from_transcript_path(&format!("/p/{i}.jsonl"));
         let state = match i {
-            0..=5 if busy => ActivityState::Active {
+            _ if !busy || i >= waiting => ActivityState::Idle,
+            _ if i < active => ActivityState::Active {
                 tool_use_id: Some(Arc::from(format!("t{i}").as_str())),
                 detail: Some(Arc::from("cargo test")),
                 kind: kinds[i % kinds.len()],
             },
-            6 | 7 if busy => ActivityState::Waiting {
+            _ => ActivityState::Waiting {
                 reason: Arc::from("permission"),
             },
-            _ => ActivityState::Idle,
         };
         let stamp = if busy {
             base + Duration::from_secs(i as u64)
@@ -97,39 +111,53 @@ fn render_frame(c: &mut Criterion) {
     let base = SystemTime::UNIX_EPOCH + Duration::from_secs(BASE_EPOCH_SECS);
     let busy = office_scene(12, 16, base, true);
     let idle = office_scene(12, 16, base, false);
+    // A 360x240 floor lays out 80 desks, so both crowds seat fully.
+    let crowds: Vec<(usize, SceneState)> = OCCUPANCY
+        .iter()
+        .map(|&n| (n, office_scene(n, n, base, true)))
+        .collect();
+
+    let mut cases: Vec<(String, &SceneState, u16, u16)> = Vec::new();
+    for (label, scene) in [("busy", &busy), ("idle", &idle)] {
+        for (w, h) in [(192u16, 160u16), CEILING] {
+            cases.push((format!("{label}12_{w}x{h}"), scene, w, h));
+        }
+    }
+    for (n, scene) in &crowds {
+        let (w, h) = CEILING;
+        cases.push((format!("busy{n}_{w}x{h}"), scene, w, h));
+    }
 
     let mut group = c.benchmark_group("render_floor");
-    for (label, scene) in [("busy", &busy), ("idle", &idle)] {
-        for (w, h) in [(192u16, 160u16), (360, 240)] {
-            group.bench_function(format!("{label}12_{w}x{h}"), |b| {
-                let mut fctx = FloorCtx::new();
-                let mut buf = RgbBuffer::filled(0, 0, Rgb { r: 0, g: 0, b: 0 });
-                let mut coffee = CoffeeState::new();
-                let mut chitchat = HashMap::new();
-                let mut i = 0u32;
-                b.iter(|| {
-                    i = (i + 1) % SIM_WINDOW_FRAMES;
-                    render_floor(
-                        &mut fctx,
-                        &mut buf,
-                        &mut coffee,
-                        &mut chitchat,
-                        FrameInputs {
-                            scene,
-                            pack: &pack,
-                            theme,
-                            now: base + Duration::from_millis(u64::from(i) * FRAME_STEP_MS),
-                            size: Size { w, h },
-                            floor_meta: FloorMeta::ground(),
-                            active_pet: None,
-                            floor_pet: None,
-                            debug_walkable: false,
-                        },
-                    )
-                    .expect("layout")
-                });
+    for (name, scene, w, h) in cases {
+        group.bench_function(name, |b| {
+            let mut fctx = FloorCtx::new();
+            let mut buf = RgbBuffer::filled(0, 0, Rgb { r: 0, g: 0, b: 0 });
+            let mut coffee = CoffeeState::new();
+            let mut chitchat = HashMap::new();
+            let mut i = 0u32;
+            b.iter(|| {
+                i = (i + 1) % SIM_WINDOW_FRAMES;
+                render_floor(
+                    &mut fctx,
+                    &mut buf,
+                    &mut coffee,
+                    &mut chitchat,
+                    FrameInputs {
+                        scene,
+                        pack: &pack,
+                        theme,
+                        now: base + Duration::from_millis(u64::from(i) * FRAME_STEP_MS),
+                        size: Size { w, h },
+                        floor_meta: FloorMeta::ground(),
+                        active_pet: None,
+                        floor_pet: None,
+                        debug_walkable: false,
+                    },
+                )
+                .expect("layout")
             });
-        }
+        });
     }
     group.finish();
 }

--- a/crates/pixtuoid/src/floating/offscreen.rs
+++ b/crates/pixtuoid/src/floating/offscreen.rs
@@ -529,6 +529,8 @@ mod tests {
 
         // MEASURED buffers for the default 360×240 logical window. `office_scale`
         // ROUNDS, so this is NOT monotone in sf — no logical-side seed is sound.
+        // The sf-1.0 row is also what pins `render_frame.rs`'s `FLOATING_DEFAULT`
+        // copy of these constants: a change to either reds this row first.
         let measured = [
             (1.00_f64, (360u32, 240u32), 80usize),
             (1.25, (225, 150), 30),

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -271,9 +271,9 @@ Advisory backstops that surface risk but NEVER gate: `scripts/check_upstream_dri
 (wire-format drift); `just bench` (criterion render-path + wire-path benchmarks — local numbers are the
 authoritative ones, recorded in commit messages; the on-demand `bench.yml` mirrors
 `mutants.yml`'s advisory shape because shared-runner wall-clock is noise per criterion's own
-FAQ, while `codspeed.yml` runs the same benches instrumented per PR — instruction-count
-simulation, so runner noise doesn't apply — and posts trends via the CodSpeed app, still
-gating nothing); the `risk radar` PR workflow (`scripts/risk-radar.py`) — deterministic
+FAQ, while `codspeed.yml` runs the same benches instrumented per PR in two modes —
+instruction-count simulation, so runner noise doesn't apply, plus heap-allocation
+measurement — and posts trends via the CodSpeed app, still gating nothing); the `risk radar` PR workflow (`scripts/risk-radar.py`) — deterministic
 path matching that posts the documented blast-radius escalations as a sticky PR comment so
 prose-only escalation can't be silently skipped (#198); and `just comment-lint`'s ast-grep
 arm, whose npm install keeps it in advisory `ci-supplemental` where a registry outage cannot

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -268,7 +268,7 @@ definition in `scripts/openclaw-live-e2e.sh`, where someone about to hoist them
 is already looking.
 
 Advisory backstops that surface risk but NEVER gate: `scripts/check_upstream_drift.py`
-(wire-format drift); `just bench` (criterion render-path benchmarks — local numbers are the
+(wire-format drift); `just bench` (criterion render-path + wire-path benchmarks — local numbers are the
 authoritative ones, recorded in commit messages; the on-demand `bench.yml` mirrors
 `mutants.yml`'s advisory shape because shared-runner wall-clock is noise per criterion's own
 FAQ, while `codspeed.yml` runs the same benches instrumented per PR — instruction-count

--- a/justfile
+++ b/justfile
@@ -338,7 +338,8 @@ test *args:
 # bench.yml runs the same recipe on-demand, advisory-only: shared-runner
 # wall-clock is noise (criterion's own FAQ), so no benchmark ever gates.
 # `render_frame` costs a FRAME, `decode_reduce` costs an EVENT; codspeed.yml
-# instruments both. Filter forwards: `just bench 360` runs only the 360x240
+# instruments both. Filter forwards to both targets, and a filter matching
+# nothing in one of them is not an error: `just bench 360` runs every 360x240
 # case, `just bench hook` only the hook-transport fold.
 [group('rust')]
 [doc('Render-path + wire-path criterion benchmarks; forwards a filter')]

--- a/justfile
+++ b/justfile
@@ -334,14 +334,17 @@ test *args:
         cargo test --workspace {{ args }}
     fi
 
-# Render-path benchmarks — LOCAL statistical numbers (criterion). CI's
+# Frame + wire benchmarks — LOCAL statistical numbers (criterion). CI's
 # bench.yml runs the same recipe on-demand, advisory-only: shared-runner
 # wall-clock is noise (criterion's own FAQ), so no benchmark ever gates.
-# Filter forwards: `just bench 360` runs only the 360x240 case.
+# `render_frame` costs a FRAME, `decode_reduce` costs an EVENT; codspeed.yml
+# instruments both. Filter forwards: `just bench 360` runs only the 360x240
+# case, `just bench hook` only the hook-transport fold.
 [group('rust')]
-[doc('Render-path criterion benchmarks; forwards a filter')]
+[doc('Render-path + wire-path criterion benchmarks; forwards a filter')]
 bench *args:
     cargo bench -p pixtuoid-scene --bench render_frame -- {{ args }}
+    cargo bench -p pixtuoid-core --bench decode_reduce -- {{ args }}
 
 # Feature-combination check — every feature subset must compile. Catches code
 # that silently only builds with `native` on (the wasm core builds without it).


### PR DESCRIPTION
## Summary

Turns the CodSpeed integration from one curve into actual coverage: adds the
README badge, two benchmark axes it couldn't see (occupancy, and the wire path),
and the memory instrument alongside simulation.

The starting question was "can we bench a bigger, real-monitor buffer?" —
measuring first killed that idea and pointed at better ones.

**Size is the saturated axis.** #900 measured 2.814x the time for 2.812x the
pixels; this branch reproduces it (192x160 -> 360x240 at 12 agents: 192.7 ->
547.4 us, 2.84x). And there is nowhere bigger to go: `office_scale` pins the
floating window's office buffer near `OFFICE_TARGET_H = 180`, so a *bigger*
display renders a *smaller* buffer.

| window (physical px) | scale | office buffer |
|---|---|---|
| 360x240 default | 1 | **360x240** |
| 1080p full | 6 | 320x180 |
| 5K 5120x2880 | 16 | 320x180 |

360x240 is `FLOATING_DEFAULT_W/H`, the scale-1 case, and the largest buffer any
painter ever produces. A third larger size would be a redundant point on a
straight line.

**Occupancy is what actually varies.** At a fixed 360x240, 12 -> 32 -> 64 agents
costs 547.4 -> 584.1 -> 719.4 us — **+31% at constant pixel count**, all of it
per-agent work (z-sort, routing, chitchat) the pixel curve cannot express.

**The wire had no coverage at all.** `cargo codspeed build` only ever built
`pixtuoid-scene`, so the decode->reduce half — per EVENT, not per FRAME — was
untracked. New `pixtuoid-core/benches/decode_reduce.rs` drives `harness::Drive`
(the one pipeline, so it cannot measure a decoder production doesn't use) over
both transports: 200 turns of JSONL 566 us, hooks 492 us.

**Memory instrument.** Simulation was already the CPU metric (instructions +
cache/memory access patterns), so heap allocation was the unmeasured axis — and
it is the one this repo argues about by hand. #900 refuted the "scratch buffers
on `FloorCtx`" proposal with a throwaway `#[ignore]`d test that no longer
exists, while the render path still clones the full buffer twice per frame.

## Related issue

n/a — follow-on tooling for the benchmarks #900 measured by hand.

## Type of change

- [x] Refactor / chore

## How I tested it

- `just preflight` — exit 0, 3060 tests passed (run twice; again by the pre-push hook).
- `just check-windows` — exit 0. Not in preflight, and this diff adds a **new bench target** that `--all-targets` builds on a platform local preflight is blind to.
- `just risk-radar-test` — exit 0, twice; this diff moves root `CLAUDE.md` prose, whose anchor gate is CI-only.
- `just lint` — exit 0 with all seven workflow-relevant arms confirmed green (zizmor, actions, ci-obs, composites, prose, links, guides).
- `node scripts/gen-readme.mjs --check` — exit 0, run *before* trusting the README edit (generated sections are install/features/tools; the badge row is hand-maintained).
- Benchmarks run locally for shape (1s warm-up / 3s measurement), numbers above.

Three things verified rather than reasoned about, because each could have
silently produced a meaningless benchmark:

1. **The 12-agent cases are unchanged.** The busy/idle mix is now proportional
   (n/2 active, n/6 waiting) instead of hardcoded index ranges. At n=12 that
   resolves to the same 6/2/4 split — asserted against the old rule before the
   change landed, so the existing four benchmarks keep their CodSpeed history
   instead of resetting it.
2. **The crowds actually seat.** A 360x240 floor lays out 80 desks; confirmed
   32/32 and 64/64 reaching `SimFrame.characters` before trusting the numbers.
3. **The new bench's guards have teeth.** `assert_clean` + registered/wire_events
   are the negative control. Corrupting one synthesized line makes it panic with
   "1 line(s) are not valid JSON" rather than quietly benchmarking the decoder's
   error path. Confirmed by doing exactly that, then reverting.

No production behavior changes, so there is no new-behavior test to add — the
checklist item below is left unticked rather than ticked vacuously.

## Visual verification

- [x] Not a visual change.

## Checklist

- [x] I read the relevant `CLAUDE.md` (root + `pixtuoid-core`, `pixtuoid-scene`, and the tests guide).
- [ ] New behavior has a test — **n/a, no production behavior**; the new bench carries its own negative-controlled guards (above).
- [x] No `unwrap()` in non-test code; the benches use `.expect()` on dev-only targets, matching the existing `render_frame.rs`.
- [x] No new `println!`/`eprintln!` on a production path.
- [x] Docs updated in the same commit — root `CLAUDE.md`, `docs/CONTRIBUTING.md`, and the `codspeed.yml`/`bench.yml` headers no longer describe the old single-mode, scene-only shape.
- [x] Checked against the recurring pitfalls — see the note below.
- [x] `just preflight` passes locally.

### Pitfall check — one live hit worth reviewer attention

Pitfall 2 (parallel-implementation drift): the bench's `CEILING = (360, 240)`
is a second copy of `pixtuoid`'s `FLOATING_DEFAULT_W/H`, with no bridge test
pinning them equal. It genuinely cannot be single-sourced — the DAG runs
`pixtuoid-scene <- pixtuoid`, so a scene bench cannot import the binary's
config — which is exactly the cross-crate case the magic-number rule says to
pin with a test or `debug_assert!`. I left it as a documented pairing in the
const's comment instead, on the grounds that a benchmark *parameter* is not a
contract and drift degrades representativeness rather than correctness. Flagging
it rather than burying it: if a reviewer wants the pin, it belongs in
`pixtuoid`'s test tree asserting against the literal.

Pitfalls 1, 3, 6 are n/a (no text slicing, no decode-boundary change, no
denylist). Pitfall 4 is addressed by the negative control above. Pitfall 5:
every addition is wired in the same diff — the core bench into both `just bench`
and `codspeed.yml`'s `-p` list, and `machete` confirms the new dev-dep is used.

### On the two upstream facts this leans on

`cargo codspeed build -p A -p B` and `mode: simulation,memory` are **not** in
CodSpeed's docs, which document a single flag and omit the rest. Both were
verified against source rather than assumed: `package: Vec<String>` with
`#[arg(short, long)]` and `--measurement-mode` as `ArgAction::Append` +
`value_delimiter = ','` in `cargo-codspeed`'s clap definitions, and `mode`
documented as comma-separated in the action's own `action.yml`.

The `timeout-minutes: 30 -> 45` bump is **a hedge, not a measurement**.
Measurement runs per mode, but the action forwards `--mode=` to CodSpeed's
distributed runner binary, so the exact multiplier isn't derivable from source
the way the flag semantics were. Worth tightening once the first run reports.

One note on the README badge: it is a **static logo chip**, not a metric.
CodSpeed serves one shared endpoint payload and has no per-repo `badge.json`
(verified — `esphome/esphome`'s 404s too, as a negative control), so unlike the
codecov and CI badges beside it, this one never changes value and never goes
red. Its value is the link: the dashboard is public, so it takes visitors
straight to the flamegraphs.

## AI assistance

- [x] This PR was written/heavily-assisted by an AI agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQULEd97BBLcYgYwGM3VDi
