### PR TITLE
release(0.17.0): curate the in-app notes to what this release actually shipped

### DIFF
--- a/crates/pixtuoid/src/version.rs
+++ b/crates/pixtuoid/src/version.rs
@@ -73,10 +73,10 @@ pub(crate) fn release_notes(version: &str) -> Option<&'static [&'static str]> {
         // `match` brace would silently break if the indentation ever shifted.
         // [bump-inject-here]
         "0.17.0" => Some(&[
-            "`validate-pack` now rejects a density variant whose size doesn't match the density its own name claims, and says so at load time too",
-            "Sprite packs may now DECLARE higher-density art — a `desk@4x` alongside `desk`. Nothing paints it yet: this release defines the contract so packs can be authored ahead of the renderer that will use it",
-            "`pixtuoid doctor` gained a `graphics:` row reporting what this terminal COULD paint, and `--graphics off` to skip the query",
-            "Otherwise groundwork: the office looks the same, but its SIZE and its RESOLUTION are now separate — so a later release can draw the same room in more detail instead of more desks",
+            "`pixtuoid doctor` is one report — sources, install health, CLI versions and decode drift, categorized and colorized, each row carrying the thing to run next",
+            "The office reads better — desks face each other across the pods, lamps take over after dark, and a plain 80x24 terminal lays out a real office again instead of refusing",
+            "A fuller band — a bass stem plus kalimba and vibraphone leads join the procedural lofi, over a wider jazz harmony",
+            "Painting a frame costs 45-57% less and is byte-for-byte identical: an idle 360x240 office went 1246 to 542us",
         ]),
         "0.16.0" => Some(&[
             "The office you can hear — press m for procedural lofi that builds with the bustle, plus typing, rain, door and appliance cues. Starts muted; + and - set volume",


### PR DESCRIPTION
Curates the in-app release notes for 0.17.0. **No version bump** — `Cargo.toml` is
already `0.17.0` from an earlier PR, and `just bump 0.17.0` refuses a version that
is not strictly newer than the current one, so this is the notes half only.

## Why

The `"0.17.0"` arm has sat in `version.rs` since the cutaway-groundwork PR, so the
notes users will see describe sprite density variants, `validate-pack` and a
`graphics:` row — four bullets about one PR out of the **sixty** this release
carries (`git log v0.16.0..main --first-parent` → 60, 688 files, +50.5k/−48.1k).

## What ships in the popup now

- `pixtuoid doctor` — one categorized, colorized report (#924)
- Layout and light — desks facing each other, lamps after dark, 80x24 laying out an
  office again (#889, #904, #923)
- A fuller band — bass stem, kalimba and vibraphone leads, wider jazz harmony (#886)
- Frame paint 45–57% cheaper, byte-identical (#918)

Numbers come from the commits, not estimates: `b14e56bb` measured idle 360x240 at
1246.3 → 541.9us and 192x160 at 483.9 → 263.9us.

## The band these notes have to sit inside

Two harness tests pull in opposite directions, and a first draft that satisfied one
broke the other:

| test | size | requires |
| --- | --- | --- |
| `the_shipped_release_notes_render_whole_on_a_classic_terminal` | 80x24 | notes must **not** overflow |
| `a_full_height_modal_never_covers_the_footer_row` | 37x24 (`min_terminal_size`) | notes **must** overflow |

The second uses the shipped notes as its full-height-modal fixture and states the
premise explicitly. Shortening the notes to four crisp lines fit both terminals and
silently removed that test's reason to exist — caught by running the whole suite
rather than the one test I had in mind. The committed four are verified at both
sizes.

`gen-check` rc=0: the HUD bakes `CARGO_PKG_VERSION` into the committed stills and
they already match 0.17.0, so no `just gen` is owed.

## Not included, deliberately

An upgrade nudge for **hermes** and **grok**. Both gained hook events in #929, so
every existing install of those two opens with `[✗] sources — 3 of 13 need
attention` and three `hooks are installed but BROKEN` banners until reconnected
from the Sources panel. There is no auto-repair, and no room for a fifth bullet
inside the band above. Verified by a runtime pass against a synthetic pre-0.17
config under an isolated `HERMES_HOME`: `pixtuoid connect hermes` adds the event
and clears the verdict, real configs untouched.

If it should reach users, the GitHub release body is the place — `release.yml`
generates it from git-cliff, and it can be edited after the tag.

## Gates

`test` 3135 passed, 2 skipped · `lint` rc=0 · `clippy` rc=0 · `gen-check` rc=0

## After merge

Tagging is the irreversible publish (crates.io + npm + a homebrew-core autobump,
with the tarball fetchable the instant the tag lands) and stays a human step:

```
git tag v0.17.0 && git push origin v0.17.0
```
