### PR TITLE
tests(#936): one fixture line-reader for the sources binary

### DIFF
--- a/crates/pixtuoid-core/tests/sources/captures.rs
+++ b/crates/pixtuoid-core/tests/sources/captures.rs
@@ -91,6 +91,19 @@ pub(crate) fn transcripts_in(dir: &Path) -> Vec<PathBuf> {
     out
 }
 
+/// A fixture's JSONL payload as its non-empty lines — THE line reader for every
+/// source test. One definition so a semantics change (a BOM skip, a `\r` trim
+/// for Windows checkouts) cannot reach one source's tests and miss its siblings;
+/// four diverging copies is how #936 happened.
+pub(crate) fn fixture_lines(path: &Path) -> Vec<String> {
+    std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
 pub(crate) fn sources_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/sources")
 }

--- a/crates/pixtuoid-core/tests/sources/captures.rs
+++ b/crates/pixtuoid-core/tests/sources/captures.rs
@@ -91,10 +91,9 @@ pub(crate) fn transcripts_in(dir: &Path) -> Vec<PathBuf> {
     out
 }
 
-/// A fixture's JSONL payload as its non-empty lines — THE line reader for every
-/// source test. One definition so a semantics change (a BOM skip, a `\r` trim
-/// for Windows checkouts) cannot reach one source's tests and miss its siblings;
-/// four diverging copies is how #936 happened.
+/// A fixture's JSONL payload as its non-empty lines — this binary's one line
+/// reader. One definition so a semantics change (a BOM skip, say) cannot reach
+/// one source's tests and miss its siblings (#936's diverging-copies class).
 pub(crate) fn fixture_lines(path: &Path) -> Vec<String> {
     std::fs::read_to_string(path)
         .unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
@@ -849,12 +848,8 @@ fn a_recorded_captures_claims_are_falsified_by_its_own_bytes() {
         let mut stamps: BTreeSet<String> = BTreeSet::new();
         let mut dates: BTreeSet<String> = BTreeSet::new();
         if let Some(hooks) = c.hook_payloads() {
-            for line in std::fs::read_to_string(&hooks)
-                .unwrap_or_else(|e| panic!("read {}: {e}", hooks.display()))
-                .lines()
-                .filter(|l| !l.trim().is_empty())
-            {
-                let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
+            for line in fixture_lines(&hooks) {
+                let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) else {
                     continue;
                 };
                 if let Some(src) = v.get("_pixtuoid_source").and_then(|s| s.as_str()) {
@@ -1052,12 +1047,8 @@ fn each_sources_tool_id_key_is_the_one_its_captures_carry() {
         let Some(want) = d.hook().map(|h| h.tool_id_key.wire_name()) else {
             continue;
         };
-        for line in std::fs::read_to_string(&hooks)
-            .unwrap_or_else(|e| panic!("read {}: {e}", hooks.display()))
-            .lines()
-            .filter(|l| !l.trim().is_empty())
-        {
-            let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
+        for line in fixture_lines(&hooks) {
+            let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) else {
                 continue;
             };
             for wrong in KEYS.iter().filter(|k| **k != want) {

--- a/crates/pixtuoid-core/tests/sources/claude/mod.rs
+++ b/crates/pixtuoid-core/tests/sources/claude/mod.rs
@@ -140,8 +140,7 @@ fn hook_parent_id() -> AgentId {
 /// bare shim with no env, so the decoder's claude-code default applies.
 fn captured_hook_events() -> Vec<AgentEvent> {
     super::captures::fixture_lines(
-        &std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("tests/sources/claude/fixtures/hook-payloads.jsonl"),
+        &super::captures::sources_root().join("claude/fixtures/hook-payloads.jsonl"),
     )
     .iter()
     .flat_map(|l| {

--- a/crates/pixtuoid-core/tests/sources/claude/mod.rs
+++ b/crates/pixtuoid-core/tests/sources/claude/mod.rs
@@ -139,17 +139,16 @@ fn hook_parent_id() -> AgentId {
 /// `_pixtuoid_source` — exactly like production, where CC's hook entry is the
 /// bare shim with no env, so the decoder's claude-code default applies.
 fn captured_hook_events() -> Vec<AgentEvent> {
-    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/sources/claude/fixtures/hook-payloads.jsonl");
-    std::fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
-        .lines()
-        .filter(|l| !l.trim().is_empty())
-        .flat_map(|l| {
-            let v: serde_json::Value = serde_json::from_str(l).expect("valid hook json");
-            decode_hook_payload(v).expect("captured CC subagent hook payload must decode")
-        })
-        .collect()
+    super::captures::fixture_lines(
+        &std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/sources/claude/fixtures/hook-payloads.jsonl"),
+    )
+    .iter()
+    .flat_map(|l| {
+        let v: serde_json::Value = serde_json::from_str(l).expect("valid hook json");
+        decode_hook_payload(v).expect("captured CC subagent hook payload must decode")
+    })
+    .collect()
 }
 
 fn start_parent(r: &mut Reducer, scene: &mut SceneState, now: SystemTime) {

--- a/crates/pixtuoid-core/tests/sources/codewhale/mod.rs
+++ b/crates/pixtuoid-core/tests/sources/codewhale/mod.rs
@@ -4,7 +4,6 @@
 //! CodeWhale's documented observer-hook wire (Hmbown/CodeWhale
 //! `crates/tui/src/hooks/config.rs` `HookEvent` + `docs/CONFIGURATION.md`).
 
-use std::path::Path;
 use std::time::SystemTime;
 
 use pixtuoid_core::source::decoder::decode_hook_payload;
@@ -18,8 +17,7 @@ const CHILD: &str = "agent_12345678";
 
 fn hook_events() -> Vec<AgentEvent> {
     super::captures::fixture_lines(
-        &Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("tests/sources/codewhale/fixtures/hook-payloads.jsonl"),
+        &super::captures::sources_root().join("codewhale/fixtures/hook-payloads.jsonl"),
     )
     .iter()
     .flat_map(|l| {

--- a/crates/pixtuoid-core/tests/sources/codewhale/mod.rs
+++ b/crates/pixtuoid-core/tests/sources/codewhale/mod.rs
@@ -17,17 +17,16 @@ const WORKSPACE: &str = "/Users/dev/cwproj";
 const CHILD: &str = "agent_12345678";
 
 fn hook_events() -> Vec<AgentEvent> {
-    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/sources/codewhale/fixtures/hook-payloads.jsonl");
-    std::fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
-        .lines()
-        .filter(|l| !l.trim().is_empty())
-        .flat_map(|l| {
-            let v: serde_json::Value = serde_json::from_str(l).expect("valid hook json");
-            decode_hook_payload(v).expect("CodeWhale hook payload must decode")
-        })
-        .collect()
+    super::captures::fixture_lines(
+        &Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/sources/codewhale/fixtures/hook-payloads.jsonl"),
+    )
+    .iter()
+    .flat_map(|l| {
+        let v: serde_json::Value = serde_json::from_str(l).expect("valid hook json");
+        decode_hook_payload(v).expect("CodeWhale hook payload must decode")
+    })
+    .collect()
 }
 
 #[test]

--- a/crates/pixtuoid-core/tests/sources/codex/mod.rs
+++ b/crates/pixtuoid-core/tests/sources/codex/mod.rs
@@ -7,7 +7,7 @@
 //! 0.135, gpt-5.5) and sanitized: synthetic UUIDs, generic cwd, the huge
 //! `last_assistant_message` truncated.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::SystemTime;
 
 use pixtuoid_core::source::decoder::decode_hook_payload;
@@ -21,8 +21,7 @@ const CHILD: &str = "01000000-0000-7000-8000-000000000002";
 
 fn captured_hook_events() -> Vec<AgentEvent> {
     super::captures::fixture_lines(
-        &Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("tests/sources/codex/fixtures/hook-payloads.jsonl"),
+        &super::captures::sources_root().join("codex/fixtures/hook-payloads.jsonl"),
     )
     .iter()
     .flat_map(|l| {

--- a/crates/pixtuoid-core/tests/sources/codex/mod.rs
+++ b/crates/pixtuoid-core/tests/sources/codex/mod.rs
@@ -20,17 +20,16 @@ const PARENT: &str = "01000000-0000-7000-8000-000000000001";
 const CHILD: &str = "01000000-0000-7000-8000-000000000002";
 
 fn captured_hook_events() -> Vec<AgentEvent> {
-    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/sources/codex/fixtures/hook-payloads.jsonl");
-    std::fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
-        .lines()
-        .filter(|l| !l.trim().is_empty())
-        .flat_map(|l| {
-            let v: serde_json::Value = serde_json::from_str(l).expect("valid hook json");
-            decode_hook_payload(v).expect("captured Codex hook payload must decode")
-        })
-        .collect()
+    super::captures::fixture_lines(
+        &Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/sources/codex/fixtures/hook-payloads.jsonl"),
+    )
+    .iter()
+    .flat_map(|l| {
+        let v: serde_json::Value = serde_json::from_str(l).expect("valid hook json");
+        decode_hook_payload(v).expect("captured Codex hook payload must decode")
+    })
+    .collect()
 }
 
 #[test]

--- a/crates/pixtuoid-core/tests/sources/conformance.rs
+++ b/crates/pixtuoid-core/tests/sources/conformance.rs
@@ -22,7 +22,7 @@ use pixtuoid_core::source::{registry, AgentEvent};
 // copies whose `read_dir` SWALLOWED errors where the other panics — an
 // unreadable capture dir made `wire_files()` empty, so the redaction rule
 // passed vacuously for it.
-use super::captures::{fixtures_root, sorted_dirs, transcripts_in};
+use super::captures::{fixture_lines, fixtures_root, sorted_dirs, transcripts_in};
 
 /// Hook-only-ness comes from the registry row, never a harness-side list — a
 /// second list could mark a JSONL source hook-only and pass the harness without
@@ -36,15 +36,6 @@ fn is_hook_only(source: &str) -> bool {
 /// apply (no agent slots).
 fn is_daemon(source: &str) -> bool {
     registry::descriptor_for(source).is_some_and(|d| d.is_daemon())
-}
-
-fn read_lines(path: &Path) -> Vec<String> {
-    std::fs::read_to_string(path)
-        .unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
-        .lines()
-        .map(str::to_string)
-        .filter(|l| !l.trim().is_empty())
-        .collect()
 }
 
 struct Decoded {
@@ -111,7 +102,7 @@ fn decode_fixture(source: &str, dir: &Path) -> Decoded {
                  SourceDescriptor row in source/registry.rs"
             )
         });
-        let driven = drive.lines(read_lines(transcript));
+        let driven = drive.lines(fixture_lines(transcript));
         driven.assert_clean(&format!("transcript {}", transcript.display()));
         driven
     });
@@ -120,7 +111,7 @@ fn decode_fixture(source: &str, dir: &Path) -> Decoded {
     // `{{TRANSCRIPT_PATH}}` lets a path-keyed hook (CC) line up with its
     // transcript; Codex carries it too, to prove it's ignored.
     let hook_lines: Vec<String> = if hooks_path.exists() {
-        read_lines(&hooks_path)
+        fixture_lines(&hooks_path)
             .into_iter()
             .map(|l| l.replace("{{TRANSCRIPT_PATH}}", &logical))
             .collect()
@@ -163,7 +154,7 @@ fn a_seeded_drive_coalesces_with_each_transcripts_own_decoder() {
             let driven = Drive::transcript_at(&source, &transcript)
                 .unwrap_or_else(|| panic!("{source}: no transcript decoder"))
                 .seeded()
-                .lines(read_lines(&transcript));
+                .lines(fixture_lines(&transcript));
             driven.assert_clean(&format!("seeded transcript {}", transcript.display()));
 
             let ids: BTreeSet<_> = driven.events.iter().map(AgentEvent::agent_id).collect();

--- a/crates/pixtuoid-core/tests/sources/cursor/mod.rs
+++ b/crates/pixtuoid-core/tests/sources/cursor/mod.rs
@@ -7,15 +7,13 @@
 //! declines to "fix": the flat render, and the `Task` id that never pairs.
 
 use std::collections::BTreeSet;
-use std::path::Path;
 
 use pixtuoid_core::harness::Drive;
 use pixtuoid_core::source::AgentEvent;
 
 fn lines() -> Vec<String> {
     super::captures::fixture_lines(
-        &Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("tests/sources/cursor/fixtures/hook-payloads.jsonl"),
+        &super::captures::sources_root().join("cursor/fixtures/hook-payloads.jsonl"),
     )
 }
 

--- a/crates/pixtuoid-core/tests/sources/cursor/mod.rs
+++ b/crates/pixtuoid-core/tests/sources/cursor/mod.rs
@@ -13,14 +13,10 @@ use pixtuoid_core::harness::Drive;
 use pixtuoid_core::source::AgentEvent;
 
 fn lines() -> Vec<String> {
-    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/sources/cursor/fixtures/hook-payloads.jsonl");
-    std::fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
-        .lines()
-        .filter(|l| !l.trim().is_empty())
-        .map(str::to_string)
-        .collect()
+    super::captures::fixture_lines(
+        &Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/sources/cursor/fixtures/hook-payloads.jsonl"),
+    )
 }
 
 /// The RAW envelopes, for the one assertion that is about the WIRE rather than

--- a/crates/pixtuoid-core/tests/sources/delegation/mod.rs
+++ b/crates/pixtuoid-core/tests/sources/delegation/mod.rs
@@ -4,15 +4,13 @@
 //! model-authored argument on an ordinary tool cannot spoof a delegation, seed
 //! `active_tasks`, and cascade a real child out on drain.
 
-use std::path::Path;
-
 use pixtuoid_core::harness::Drive;
 use pixtuoid_core::source::{AgentEvent, ToolDetail};
 
 fn lines(cli: &str, name: &str) -> Vec<String> {
     super::captures::fixture_lines(
-        &Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("tests/sources/delegation/fixtures")
+        &super::captures::sources_root()
+            .join("delegation/fixtures")
             .join(cli)
             .join(name),
     )

--- a/crates/pixtuoid-core/tests/sources/delegation/mod.rs
+++ b/crates/pixtuoid-core/tests/sources/delegation/mod.rs
@@ -10,16 +10,12 @@ use pixtuoid_core::harness::Drive;
 use pixtuoid_core::source::{AgentEvent, ToolDetail};
 
 fn lines(cli: &str, name: &str) -> Vec<String> {
-    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/sources/delegation/fixtures")
-        .join(cli)
-        .join(name);
-    std::fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
-        .lines()
-        .filter(|l| !l.trim().is_empty())
-        .map(str::to_string)
-        .collect()
+    super::captures::fixture_lines(
+        &Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/sources/delegation/fixtures")
+            .join(cli)
+            .join(name),
+    )
 }
 
 fn opencode_events() -> Vec<AgentEvent> {

--- a/crates/pixtuoid-core/tests/sources/grok/mod.rs
+++ b/crates/pixtuoid-core/tests/sources/grok/mod.rs
@@ -9,8 +9,6 @@
 //! parent's `subagent_start` names the child and the CHILD's own `subagent_stop`
 //! ends it.
 
-use std::path::Path;
-
 use pixtuoid_core::harness::{Drive, Driven};
 use pixtuoid_core::source::{AgentEvent, ToolDetail};
 use pixtuoid_core::AgentId;
@@ -20,8 +18,8 @@ const CHILD: &str = "01a006a6-0659-7690-a9cc-20da7c827b72";
 
 fn lines(name: &str) -> Vec<String> {
     super::captures::fixture_lines(
-        &Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("tests/sources/grok/fixtures")
+        &super::captures::sources_root()
+            .join("grok/fixtures")
             .join(name),
     )
 }

--- a/crates/pixtuoid-core/tests/sources/grok/mod.rs
+++ b/crates/pixtuoid-core/tests/sources/grok/mod.rs
@@ -19,15 +19,11 @@ const PARENT: &str = "01a006a5-e63d-7543-b1af-da3127a85c3b";
 const CHILD: &str = "01a006a6-0659-7690-a9cc-20da7c827b72";
 
 fn lines(name: &str) -> Vec<String> {
-    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/sources/grok/fixtures")
-        .join(name);
-    std::fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
-        .lines()
-        .filter(|l| !l.trim().is_empty())
-        .map(str::to_string)
-        .collect()
+    super::captures::fixture_lines(
+        &Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/sources/grok/fixtures")
+            .join(name),
+    )
 }
 
 fn hooks() -> Driven {


### PR DESCRIPTION
## Summary

Seven copies of "read a fixture's JSONL lines" → one `fixture_lines` in `captures.rs`, beside the tree helpers #929 already consolidated.

The issue named four; the class sweep found three more in the same binary (claude / codex / codewhale, inline ahead of their per-source decode) — and review found the final two hiding in the helper's own file, which the sweep's `grep -v captures.rs` had excluded. **Nine copies total, all routed through the one helper.** The map/filter order divergence the issue flagged has no semantic gap, so this is pure copy deletion, zero behavior.

Deliberately out of the class: `wire_to_pixels.rs` (other crate, cannot reach core's test-internal module), `proof_fixture_disjointness.rs` (its own test binary), the two examples. A shared test-util crate for one 8-line fn is the wrong trade.

Population census (the deletion-PR rule), re-measured at the fold head: the pattern has **5 hits** over `crates/` = the helper itself + the four adjudicated-out sites; base had 13. Wrappers stay (they name which fixture a test pins); paths derive from `captures::sources_root()`.

Gates: `just preflight` exit 0, 3,156 tests.

Closes #936

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ZsTZvLuSjSVJULz4VDPrS
