### PR TITLE
docs: the three operational guides drop what the code already states

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,11 +9,11 @@ in nested guides, auto-loaded when you touch their tree:
 - [`crates/pixtuoid/CLAUDE.md`](crates/pixtuoid/CLAUDE.md) — the binary: install, runtime, cli, config, multi-floor. (+ [`src/tui/CLAUDE.md`](crates/pixtuoid/src/tui/CLAUDE.md): the terminal painter.)
 - [`integrations/raycast/CLAUDE.md`](integrations/raycast/CLAUDE.md), [`site/CLAUDE.md`](site/CLAUDE.md) — the non-Rust `--json` consumers; their gates are `tsc`/`eslint` / `just site-check`, not cargo.
 
-**What the guides hold.** A nested `CLAUDE.md` says what its crate IS, plus
-the cross-file couplings no declaration can own (site's build inputs, Raycast's
-`package.json` facts). Everything else a change needs — the constraint that looks
-like a bug, the WHY, the test that pins it — is on the declaration it
-constrains: read the item's doc comment before changing it.
+**What the guides hold.** A nested `CLAUDE.md` says what its crate IS, plus the
+facts no declaration can own (site's build inputs, Raycast's `package.json`
+rules, `tests/`'s directory-to-binary layout). Everything else a change needs —
+the constraint that looks like a bug, the WHY, the test that pins it — is on
+the declaration it constrains: read the item's doc comment before changing it.
 
 **A third consumer lives outside this repo**: homebrew-core's `pixtuoid`
 formula asserts exact CLI output (`test do`) and needs `pixtuoid man` /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,8 +10,8 @@ in nested guides, auto-loaded when you touch their tree:
 - [`integrations/raycast/CLAUDE.md`](integrations/raycast/CLAUDE.md), [`site/CLAUDE.md`](site/CLAUDE.md) — the non-Rust `--json` consumers; their gates are `tsc`/`eslint` / `just site-check`, not cargo.
 
 **What the guides hold.** A nested `CLAUDE.md` says what its crate IS, plus the
-facts no declaration can own (site's build inputs, Raycast's `package.json`
-rules, `tests/`'s directory-to-binary layout). Everything else a change needs —
+facts no single declaration can own: cross-file workflows, comment-less
+manifests, and directory-shape rules. Everything else a change needs —
 the constraint that looks like a bug, the WHY, the test that pins it — is on
 the declaration it constrains: read the item's doc comment before changing it.
 
@@ -104,16 +104,15 @@ Repo skills (committed): `two-lens-review`, `beautify-decoration`,
 ## Ownership by crate
 
 Don't "fix" documented design — the constraint is on the declaration. Who owns
-what: **core** owns session
-lifecycle/identity (registration, dedup, first-sight, liveness ladder,
-subagent parenting, feature boundaries) · **scene** owns look/motion (palette
-recolor by RGB equality, walk timing, footprints, sky/light invariants,
-reachability) · **binary** owns install/runtime wiring (config rewriting,
-desk growth, boot order, doctor, daemon announce-only) · **tui** owns the
-flush (popup geometry, hit-test ladders, key dispatch). Terminal cell aspect
-drives sprite design: the half-block ▀ technique assumes ~1:2 cells, so sprites
-past ~16×16 px break on taller-cell terminals; bundled character sprites max at
-8×12 px.
+what: **core** owns session lifecycle/identity (registration, dedup,
+first-sight, liveness ladder, subagent parenting, feature boundaries) ·
+**scene** owns look/motion (palette recolor by RGB equality, walk timing,
+footprints, sky/light invariants, reachability) · **binary** owns
+install/runtime wiring (config rewriting, desk growth, boot order, doctor,
+daemon announce-only) · **tui** owns the flush (popup geometry, hit-test
+ladders, key dispatch). Terminal cell aspect drives sprite design: the
+half-block ▀ technique assumes ~1:2 cells, so sprites past ~16×16 px break on
+taller-cell terminals; bundled character sprites max at 8×12 px.
 
 ## Things NOT to do
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,9 @@ in nested guides, auto-loaded when you touch their tree:
 - [`crates/pixtuoid/CLAUDE.md`](crates/pixtuoid/CLAUDE.md) — the binary: install, runtime, cli, config, multi-floor. (+ [`src/tui/CLAUDE.md`](crates/pixtuoid/src/tui/CLAUDE.md): the terminal painter.)
 - [`integrations/raycast/CLAUDE.md`](integrations/raycast/CLAUDE.md), [`site/CLAUDE.md`](site/CLAUDE.md) — the non-Rust `--json` consumers; their gates are `tsc`/`eslint` / `just site-check`, not cargo.
 
-**What the guides hold.** A nested `CLAUDE.md` says what its crate IS. The
-three that also carry operational content — `pixtuoid-core/tests/`, Raycast,
-site — keep it INLINE there. Everything else a change needs — the constraint that looks
+**What the guides hold.** A nested `CLAUDE.md` says what its crate IS, plus
+the cross-file couplings no declaration can own (site's build inputs, Raycast's
+`package.json` facts). Everything else a change needs — the constraint that looks
 like a bug, the WHY, the test that pins it — is on the declaration it
 constrains: read the item's doc comment before changing it.
 
@@ -101,9 +101,10 @@ Repo skills (committed): `two-lens-review`, `beautify-decoration`,
 5. **The hook shim never blocks CC** — always exit 0 silently; the 200 ms send bound is watchdog-enforced on both platforms. Shim coverage is child-process level only.
 6. **Walkable mask = ground footprint only**; sprite size never moves a sim position — fitting the frame is the painter's job (`keep_sprite_on_canvas`), not the sim's (#912).
 
-## Sharp edges (cross-crate ownership)
+## Ownership by crate
 
-Don't "fix" documented design. Ownership by crate: **core** owns session
+Don't "fix" documented design — the constraint is on the declaration. Who owns
+what: **core** owns session
 lifecycle/identity (registration, dedup, first-sight, liveness ladder,
 subagent parenting, feature boundaries) · **scene** owns look/motion (palette
 recolor by RGB equality, walk timing, footprints, sky/light invariants,

--- a/crates/pixtuoid-core/Cargo.toml
+++ b/crates/pixtuoid-core/Cargo.toml
@@ -13,7 +13,9 @@ categories.workspace   = true
 # Workspace-only tests that reach outside the crate for a sibling file absent
 # from the published tarball — shipping them would make `cargo test` fail on the
 # .crate. Runtime reads need excluding too: they spare the publish build-verify
-# but not `cargo test` on an extracted crate.
+# but not `cargo test` on an extracted crate. They stay FLAT for the same reason:
+# a grouped binary's submodule cannot be excluded on its own — the parent `mod`
+# then fails on the extracted crate.
 exclude                = [
     "tests/pinned_by_claims.rs",
     "tests/socket_path_parity.rs",

--- a/crates/pixtuoid-core/Cargo.toml
+++ b/crates/pixtuoid-core/Cargo.toml
@@ -13,9 +13,8 @@ categories.workspace   = true
 # Workspace-only tests that reach outside the crate for a sibling file absent
 # from the published tarball — shipping them would make `cargo test` fail on the
 # .crate. Runtime reads need excluding too: they spare the publish build-verify
-# but not `cargo test` on an extracted crate. They stay FLAT for the same reason:
-# a grouped binary's submodule cannot be excluded on its own — the parent `mod`
-# then fails on the extracted crate.
+# but not `cargo test` on an extracted crate. They stay FLAT so they can be
+# excluded at all: a grouped binary's submodule cannot be excluded on its own.
 exclude                = [
     "tests/pinned_by_claims.rs",
     "tests/socket_path_parity.rs",

--- a/crates/pixtuoid-core/tests/CLAUDE.md
+++ b/crates/pixtuoid-core/tests/CLAUDE.md
@@ -2,7 +2,9 @@
 
 Integration tests organized **by capability/layer**; the per-CLI dimension
 lives where the actual variation is — the source fixtures. 9 test binaries
-(each top-level `tests/*.rs` or `tests/<area>/main.rs` is one binary):
+(each top-level `tests/*.rs` or `tests/<area>/main.rs` is one binary — a
+multi-file area MUST be `<area>/main.rs`, because a top-level `<area>.rs` is a
+crate root whose `mod foo;` resolves to a SIBLING `tests/foo.rs`):
 
 ```
 tests/
@@ -39,7 +41,7 @@ tests/
 ├── render/main.rs       blit + format (+ sprite fixtures)
 └── socket_path_parity.rs · supported_sources_manifest.rs ·
     proof_fixture_disjointness.rs · pinned_by_claims.rs
-                         FLAT + publish-excluded (sharp edge below)
+                         FLAT + publish-excluded (see Cargo.toml's `exclude`)
 ```
 
 Data scopes to the binary that reads it — a module-owned fixture lives with
@@ -76,25 +78,3 @@ under `sources/fixtures/` would be mis-scanned.
 3. **Only for unique behavior** (subagent hooks, custom lifecycle): a
    `tests/sources/<cli>/` module registered in `sources/main.rs`. Plain CLIs
    (antigravity, reasonix) need none.
-
-## Known sharp edges
-
-- **The four FLAT tests stay flat and publish-excluded.** Each reads a
-  sibling outside this crate (`site/src/sources.json`, `Statusline.astro`,
-  the shim's `paths.rs`, the whole `crates/` tree), so all four sit in
-  `Cargo.toml`'s `exclude` and the published tarball builds without them; a grouped binary's submodule
-  can't be individually excluded (the parent `mod` fails on the extracted crate).
-- **A multi-file binary is `tests/<area>/main.rs`, NOT `tests/<area>.rs`** — a
-  top-level `area.rs` is a crate root whose `mod foo;` resolves to a SIBLING
-  `tests/foo.rs`. (nextest runs each `#[test]` in its own process either way.)
-- **`conformance.rs` asserts every dir under `sources/fixtures/` is a
-  registered source with exactly one transcript/hook file → one AgentId** —
-  single-owner multi-payload fixtures would be mis-scanned and panic; they
-  co-locate with their module instead.
-- **insta names = `<binary>__<module>__<explicit-name>`**; decoded bodies hash
-  an `AgentId` from the fixture path relative to `fixtures_root()`, so moving
-  the tree is snapshot-safe iff the per-source suffix is preserved.
-- **Windows parity twins:** `transport/pipe.rs` and the shim's
-  `tests/shim_pipe.rs` are `#[cfg(windows)]` twins of the socket tests, run
-  only on the `windows-test` job — a behavior pinned on one platform's
-  transport stays pinned on the other's twin.

--- a/crates/pixtuoid-core/tests/transport/pipe.rs
+++ b/crates/pixtuoid-core/tests/transport/pipe.rs
@@ -1,5 +1,5 @@
-//! The named-pipe twin of `socket.rs`, run only by the `windows-test` job: a
-//! behavior pinned on one platform's transport stays pinned on the other's.
+//! The named-pipe twin of `socket.rs`, compiled only on Windows: mirror here any
+//! behavior pinned there. Nothing enforces the parity, and the rosters differ.
 #![cfg(windows)]
 
 use std::time::Duration;

--- a/crates/pixtuoid-core/tests/transport/pipe.rs
+++ b/crates/pixtuoid-core/tests/transport/pipe.rs
@@ -1,3 +1,5 @@
+//! The named-pipe twin of `socket.rs`, run only by the `windows-test` job: a
+//! behavior pinned on one platform's transport stays pinned on the other's.
 #![cfg(windows)]
 
 use std::time::Duration;

--- a/crates/pixtuoid-core/tests/transport/socket.rs
+++ b/crates/pixtuoid-core/tests/transport/socket.rs
@@ -1,3 +1,6 @@
+//! The Unix-socket twin of `pipe.rs`, compiled only on Unix: mirror there any
+//! behavior pinned here. The Windows half never compiles on a macOS box, so
+//! only CI will tell you it drifted.
 #![cfg(unix)]
 use std::time::Duration;
 

--- a/crates/pixtuoid-hook/tests/shim.rs
+++ b/crates/pixtuoid-hook/tests/shim.rs
@@ -1,6 +1,7 @@
 #![cfg(unix)]
 //! Integration tests for the hook shim BINARY's I/O contract (invariant #5:
-//! "always exit 0, never block CC").
+//! "always exit 0, never block CC"). `shim_pipe.rs` is the Windows twin —
+//! mirror there any behavior pinned here.
 
 use std::io::{Read, Write};
 use std::os::unix::net::UnixListener;

--- a/crates/pixtuoid-hook/tests/shim_pipe.rs
+++ b/crates/pixtuoid-hook/tests/shim_pipe.rs
@@ -1,5 +1,5 @@
-//! The named-pipe twin of `shim.rs`, run only by the `windows-test` job: a
-//! behavior pinned on one platform's transport stays pinned on the other's.
+//! The named-pipe twin of `shim.rs`, compiled only on Windows: mirror here any
+//! behavior pinned there. Nothing enforces the parity, and the rosters differ.
 #![cfg(windows)]
 
 use std::io::Write;

--- a/crates/pixtuoid-hook/tests/shim_pipe.rs
+++ b/crates/pixtuoid-hook/tests/shim_pipe.rs
@@ -1,3 +1,5 @@
+//! The named-pipe twin of `shim.rs`, run only by the `windows-test` job: a
+//! behavior pinned on one platform's transport stays pinned on the other's.
 #![cfg(windows)]
 
 use std::io::Write;

--- a/integrations/raycast/CLAUDE.md
+++ b/integrations/raycast/CLAUDE.md
@@ -47,14 +47,15 @@ binary's version; `OutcomeRow`'s doc comment in `crates/pixtuoid/src/sources.rs`
 owns that rule.)
 
 **A republish may still be owed.** The split (`e21ec7f0`, 2026-07-02) landed
-AFTER the last publish marker in history (`b870d8ba`, 2026-06-19), so the
-version in the store was built against the folded `failed: <msg>` form: it
-prefix-strips, and renders a bare `failed` toast with the reason dropped. The
-parse in `src/` is already correct, so a republish is the whole fix. Whether one
-has happened since is not checkable from this repo — read the store listing
-before assuming it is clear.
+AFTER the local `ray publish` marker `__raycast_latest_publish_ext/pixtuoid__`
+(`b870d8ba`, 2026-06-19), so the version in the store was built against the
+folded `failed: <msg>` form: it prefix-strips, and renders a bare `failed` toast
+with the reason dropped. The parse in `src/` is already correct, so a republish
+is the whole fix. That tag is never pushed, so a fresh clone has no copy — check
+your own, then the listing at `raycast.com/IvanWng97/pixtuoid`, before assuming
+it is clear.
 
-## Toolchain and audit policy
+## Toolchain policy
 
 `package.json` cannot carry a comment, so these live here.
 
@@ -65,15 +66,12 @@ before assuming it is clear.
   (dependabot bumps minors within it — `.github/dependabot.yml` ignores only
   the major). `@raycast/api`'s exact peer is a warning-level mismatch npm
   tolerates under the committed lockfile, not a hard pin the manifest must
-  equal. `ray build` type-checks with its OWN bundled tsc, so `tsconfig.json`
-  must stay parseable by BOTH that and the local TS.
-- **`npm run audit` is plain `npm audit --audit-level=low`.** It was a
-  per-advisory allow-list script until its one entry cleared. `npm audit` has
-  no per-advisory ignore, so if an unfixable advisory recurs, restore that
-  script from history rather than lowering `--audit-level`, which blinds a
-  whole severity band to hide one id. Unfixable is realistic: the last one
-  arrived through a five-deep chain we own no link of, and the override that
-  would have patched it made audit green over code that throws (#792).
+  equal. `ray build` type-checks with its OWN bundled tsc (5.6 as of api
+  1.104.21), so `tsconfig.json` must stay parseable by BOTH that and the local
+  TS: the TS 6 migration was `moduleResolution: "Bundler"` + an explicit
+  `types: ["node"]` (TS 6.0 stopped auto-including `node_modules/@types`);
+  `ignoreDeprecations: "6.0"` would have broken `ray build` (TS 5.x rejects the
+  value).
 
 ## Gates
 

--- a/integrations/raycast/CLAUDE.md
+++ b/integrations/raycast/CLAUDE.md
@@ -41,49 +41,39 @@ generated — eslint/prettier-ignored, never hand-edit them. This is
 (The `source_status_json_shape` / `outcome_row_json_shape` byte tests still pin
 the exact wire JSON; `OutcomeRow` is `{id, outcome, message?}` — a bare machine
 token plus an optional failure-detail field, split from the old folded
-`failed: <msg>` form back when this in-repo copy was the only consumer — see
-the sharp edge below and `OutcomeRow`'s own doc comment in
-`crates/pixtuoid/src/sources.rs`.)
+`failed: <msg>` form back when this in-repo copy was the only consumer. The
+wire is PUBLISHED — installed store copies parse it independently of the
+binary's version; `OutcomeRow`'s doc comment in `crates/pixtuoid/src/sources.rs`
+owns that rule.)
 
-## Sharp edges (don't be surprised by these)
+**A republish may still be owed.** The split (`e21ec7f0`, 2026-07-02) landed
+AFTER the last publish marker in history (`b870d8ba`, 2026-06-19), so the
+version in the store was built against the folded `failed: <msg>` form: it
+prefix-strips, and renders a bare `failed` toast with the reason dropped. The
+parse in `src/` is already correct, so a republish is the whole fix. Whether one
+has happened since is not checkable from this repo — read the store listing
+before assuming it is clear.
 
-- **A non-zero CLI exit DISCARDS stdout in the usual `execFile` path** — but the
-  CLI still printed a JSON array. Recover it from `err.stdout` in the bridge; a
-  toast-only error path is dead code (the failed approach). The `--json` outcome
-  rows arrive even on a partial failure.
-- **The `binaryPath` preference is RE-READ on every call**, not cached — only
-  the PATH auto-detect is memoized. A user who fixes the pref mid-session
-  shouldn't have to relaunch.
+## Toolchain and audit policy
+
+`package.json` cannot carry a comment, so these live here.
+
 - **Toolchain bumps must stay within what Raycast DECLARES — check the peers,
   don't guess.** `eslint`/`typescript` are gated by `@raycast/eslint-config`'s
   peerDependencies (2.2.0 declares `eslint ^10`, `typescript <6.1.0` — so
   eslint 10 + TS 6.0 are in-range); `@types/node` stays on the `22.x` MAJOR
   (dependabot bumps minors within it — `.github/dependabot.yml` ignores only
-  the major — so the manifest floats at `^22.x`, currently `^22.20.1`).
-  `@raycast/api`'s exact peer (22.19.17; Raycast's runtime is Node 22) is a
-  warning-level mismatch npm tolerates under the committed lockfile, not a hard
-  pin the manifest must equal. And
-  `ray build` type-checks with its OWN bundled tsc (5.6 as of api 1.104.21),
-  so `tsconfig.json` must stay parseable by BOTH that and the local TS: the
-  TS 6 migration was `moduleResolution: "Bundler"` + an explicit
-  `types: ["node"]` (TS 6.0 stopped auto-including `node_modules/@types`);
-  `ignoreDeprecations: "6.0"` would have broken `ray build` (TS 5.x rejects
-  the value).
-- **`OutcomeRow.outcome` ∈ `connected | disconnected | failed`** (bare tokens)
-  for the single-id `connect`/`disconnect` the extension calls; `no_op` is
-  emitted only by `pixtuoid sources set` (the declarative reconcile this
-  extension never invokes). Failure detail rides in the optional `message`
-  field (present exactly when `outcome === "failed"`) — match tokens exactly,
-  no prefix-stripping. This clean split was made ASSUMING the in-repo extension
-  was the ONLY consumer. **It was not** — the last `ray publish` marker
-  (`__raycast_latest_publish_ext/pixtuoid__` → b870d8ba, 2026-06-19) PREDATES
-  the split (e21ec7f0, 2026-07-02), so the break shipped to the store: what
-  users have installed still prefix-strips `failed: <msg>` and renders a bare
-  `failed` toast with the real reason dropped. A republish clears that; the
-  parse in `src/` is already correct. **Treat the wire as PUBLISHED from here
-  on** (`raycast.com/IvanWng97/pixtuoid`) — installed copies parse it
-  independently of the binary's version, so any further wire change needs a
-  version handshake, not a flag-day edit.
+  the major). `@raycast/api`'s exact peer is a warning-level mismatch npm
+  tolerates under the committed lockfile, not a hard pin the manifest must
+  equal. `ray build` type-checks with its OWN bundled tsc, so `tsconfig.json`
+  must stay parseable by BOTH that and the local TS.
+- **`npm run audit` is plain `npm audit --audit-level=low`.** It was a
+  per-advisory allow-list script until its one entry cleared. `npm audit` has
+  no per-advisory ignore, so if an unfixable advisory recurs, restore that
+  script from history rather than lowering `--audit-level`, which blinds a
+  whole severity band to hide one id. Unfixable is realistic: the last one
+  arrived through a five-deep chain we own no link of, and the override that
+  would have patched it made audit green over code that throws (#792).
 
 ## Gates
 

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -30,28 +30,19 @@ build, and every one sits in the `site.yml` / `pages.yml` path filters:
   edit), both workflow path filters, `lighthouserc.json`, and the smoke
   viewport table.
 
-**Mermaid renders at build AND during `astro check`** (why CI installs
-Chromium, BEFORE `npm run check`). A version-mismatched Chromium/Playwright
-collapses `<Content />` to an empty article WITHOUT failing the build, and
-`withastro/action`'s cross-run Astro cache can then serve the empty page back
-forever — hence `pages.yml` pins `package-manager: npm` (#680) and
-`cache: false` (#682). All three historical causes are gated by
-`config/assert-docs-rendered.mjs` (`check:docs`, in `verify` AND the deploy
-build-cmd): every doc `<article>` has a body and `/architecture` keeps its
-`<svg>` — a collapsed render reddens, never deploys.
+**Mermaid renders at build AND during `astro check`** — which is why CI
+installs Chromium BEFORE `npm run check`. The silent-empty-render class it
+opens is gated by `config/assert-docs-rendered.mjs` (`check:docs`), whose
+header owns the mechanism; `pages.yml`'s two pins carry their own.
 
 **Docs shell**: the doc routes (the `DOCS` manifest in `consts.ts` is the
 roster) mount the Statusline doc variant (no PR feed fetch); `Docs.astro`'s
 sidebar reads the one `FLOORS` manifest.
 Blockquotes promote to terminal callouts (`config/rehype-callouts.mjs`,
-unit-tested, registered AFTER `rehypeRepoLinks`). **SHARP EDGE — the callout
-window is a `--screen` panel inside `.prose`, so every `.prose <tag>` colour
-rule beats the ink the callout hands down** (direct match beats inheritance).
-Each such rule needs a twin at `.docs :global(.callout__body <tag>)`, and the
-twin must OUTWEIGH the prose rule — count the specificity, including
-theme-prefixed globals that tie (source order then decides) and second-type
-selectors that outweigh. The smoke suite's callout AA sweep is the proof;
-add a `.prose` colour rule ⇒ add its twin and let the sweep grade it.
+unit-tested, registered AFTER `rehypeRepoLinks`). Adding a `.prose` colour rule
+needs a twin under `.callout__body` — the specificity arithmetic and its
+theme-prefixed tie are on the rule itself in `Docs.astro`, and the smoke
+suite's callout AA sweep grades it.
 
 ## Single-sourced content
 
@@ -60,20 +51,13 @@ Every generated artifact, manifest seam, and rendered-copy sharp edge:
 
 ## CSP (hash-based, two coordinated halves in astro.config.mjs)
 
-Astro 7's `security.csp` owns policy + resource lists; the `cspInlineHashes()`
-`astro:build:done` hook re-derives inline-script hashes from the BUILT html
-(Astro doesn't hash template `is:inline` scripts — verified vs 7.0.5) and
-HOISTS the `<meta>` directly after `<meta charset>` (a meta CSP governs only
-what follows it; Astro emits it below the scripts it hashes). The pure
-transform `rewriteCspMeta` lives in `config/csp-hashes.mjs`, unit-tested.
-Rules: adding/editing an `is:inline` script needs NO manual CSP step;
-hand-written `public/*.js` loaded by URL rides `script-src 'self'`;
-`style-src` keeps `'unsafe-inline'` and must stay hash-free (inline style
-ATTRIBUTES — mermaid SVG, `style={}` — can't be hashed; one hash disables
-unsafe-inline for the directive; keep Prism class-based highlighting, not
-Shiki). `astro dev` serves NO CSP — regressions surface in `just site-e2e`'s
-console watchdog, not dev.
-
+`cspInlineHashes()` in `astro.config.mjs` owns the WHY; `config/csp-hashes.mjs`
+owns the parse. The rules a page author needs: an `is:inline` script needs NO
+manual CSP step; a hand-written `public/*.js` loaded by URL rides
+`script-src 'self'`; `style-src` must stay hash-free (one hash disables
+unsafe-inline for the directive, and inline style ATTRIBUTES cannot be hashed —
+so keep Prism's class-based highlighting, not Shiki). `astro dev` serves NO
+CSP; regressions surface in `just site-e2e`'s console watchdog.
 ## Dev server (agent-driving)
 
 `just site-dev-bg` daemonizes (`astro dev --background`, polls the dev-only

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -58,6 +58,7 @@ manual CSP step; a hand-written `public/*.js` loaded by URL rides
 unsafe-inline for the directive, and inline style ATTRIBUTES cannot be hashed —
 so keep Prism's class-based highlighting, not Shiki). `astro dev` serves NO
 CSP; regressions surface in `just site-e2e`'s console watchdog.
+
 ## Dev server (agent-driving)
 
 `just site-dev-bg` daemonizes (`astro dev --background`, polls the dev-only

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -155,10 +155,11 @@ function rehypeRepoLinks() {
 }
 
 // Astro's built-in CSP (`security.csp` below) does NOT hash template-level
-// `is:inline` scripts — the only kind this site has — it appends style hashes
-// (which make browsers IGNORE the 'unsafe-inline' Shiki/mermaid needs), and it
-// emits its <meta> BELOW scripts the layout already wrote, which a meta policy
-// does not govern. This hook closes all three from the BUILT html.
+// `is:inline` scripts (verified vs Astro 7.0.5) — the only kind this site has —
+// it appends style hashes (which make browsers IGNORE the 'unsafe-inline'
+// Shiki/mermaid needs), and it emits its <meta> BELOW scripts the layout
+// already wrote, which a meta policy does not govern. This hook closes all
+// three from the BUILT html.
 function cspInlineHashes() {
   return {
     name: 'csp-inline-hashes',


### PR DESCRIPTION
Follow-on to #956. That PR moved the per-crate sharp edges onto their declarations and deleted the `SHARP-EDGES.md` / `WHERE-TO-LOOK.md` siblings. The three guides that carry **operational** content — `tests/`, Raycast, site — kept theirs inline and were out of its scope. This is that scope.

**−97 / +58 across four guides**, plus two files that gained a header they never had.

## The method, and where it caught me

Every deleted clause was checked by **opening the declaration it claims to live on**, not by grepping for the symbol. That distinction matters: the same shortcut produced a wrong deletion in #956 (a `backup_once` doc that duplicated `sibling`'s, which I only found in round 4).

Three clauses turned out **not** to be duplicates. They are handled, not dropped:

| Clause | Why it survived |
|---|---|
| **The multi-file test binary rule** — `<area>/main.rs`, never `<area>.rs`, because a top-level `<area>.rs` is a crate root whose `mod foo;` resolves to a **sibling** `tests/foo.rs` | Nothing in the tree stated it, and no declaration can own a fact about **directory layout**. Kept in the guide, folded onto the line it qualifies. |
| **The Windows parity twins** | `transport/pipe.rs` and `shim_pipe.rs` each opened with a bare `#![cfg(windows)]` and **no header at all**. Each now names its twin. |
| **The outstanding Raycast republish** | Gone entirely. Restored, and split by what is checkable — see below. |

## The Raycast republish, split by verifiability

The old text asserted a store state. Verified from git: the wire split (`e21ec7f0`, 2026-07-02) **is** a descendant of the last publish marker (`b870d8ba`, 2026-06-19), so the version built for the store predates the split and still prefix-strips `failed: <msg>`.

Not verifiable from this repo: whether a republish has since cleared it. The guide now says so explicitly rather than asserting a state I cannot check — per `CLAUDE.md`'s "external-surface claims are fetched, not remembered".

## Verified as genuinely duplicated (destination read, not grepped)

- `assert-docs-rendered.mjs`'s header owns the silent-empty-render class
- `astro.config.mjs`'s `cspInlineHashes()` owns all three CSP mechanisms
- **`Docs.astro:296` carries the callout specificity arithmetic in more detail than the guide did** — the (0,3,1) vs (0,1,1) weights, the theme-prefixed exact tie that only source order breaks, and the (0,4,2) twin. The guide only gestured at it.
- `runPixtuoid`'s comment owns the `err.stdout` recovery
- `resolveBinary`'s doc owns the re-read-every-call rule
- `contract-outcome.ts` owns the PUBLISHED-wire rule

## Additions

- `Cargo.toml`'s `exclude` gains the clause explaining why the four tests stay **flat** (a grouped binary's submodule cannot be excluded on its own).
- The Raycast guide gains the `npm audit` policy — it has nowhere else to go, since `package.json` cannot carry a comment, and the guide now says that.

## Why a fresh branch

Branched off `main`, not rebased from `refactor/guides-to-code`. That branch predates #956's round-3 and round-4 fixes, so landing it would have **reverted seven of them** — including the trim that had turned *"No in-tree JSONL path emits Identity today … not dead code"* into the false *"No path emits this today"*.

## Gates

`preflight` green (3174) · `just links` 98 unique / **0 errors** · `rustfmt --check` clean.

One gap named rather than hidden: the two edited `.rs` files are `#![cfg(windows)]`, so **preflight on darwin never compiles them**. Their syntax was checked separately (`rustfmt --check` parses both; a minimal `//!`-before-`#![cfg]` fixture compiles under `rustc`). CI's `windows-check` is the real gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017WdFnoFgpKUZdQtqQY5w5F


---

## Census completion (round-1 review)

The list above enumerated 9 clause-groups; the diff deletes 11. The two the
body never named — both verified to survive, so neither is a lost fact:

| Clause | Where it survives |
|---|---|
| `conformance.rs`'s one-`AgentId` bullet | `conformance.rs:1-13` |
| the insta-naming bullet | `fixtures/README.md:147-158`; the concrete name form is retained at `tests/CLAUDE.md:28` |

A reviewer should be able to check a census, not reconstruct the population.
