### PR TITLE
fix(e2e): scrub git's repo-relocating env before the throwaway workspace repo

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -126,6 +126,7 @@ jobs:
       - run: just drift-selftest
       - run: just env-paths
       - run: just tuidrive-selftest
+      - run: just e2e-scrub-selftest
       - run: just star-history-selftest
       # `just fixture-metadata` is NOT here: it became Rust tests in #929, so it
       # already rides `just test` in windows-test, macos-test and coverage —

--- a/justfile
+++ b/justfile
@@ -316,6 +316,7 @@ lint:
     run links   just links               & pids+=($!)
     run drift   just drift-selftest       & pids+=($!)
     run tuidrive just tuidrive-selftest   & pids+=($!)
+    run e2escrub just e2e-scrub-selftest  & pids+=($!)
     run starhist just star-history-selftest & pids+=($!)
     run fixpii  just fixture-pii          & pids+=($!)
     run piiself just fixture-pii-selftest & pids+=($!)
@@ -1279,6 +1280,16 @@ drift-selftest:
 [doc("Self-test the TUI capture driver's pure logic")]
 tuidrive-selftest:
     python3 scripts/lib/tuidrive.py --selftest
+
+# `e2e_init_repo`'s env scrub. A git hook exports GIT_DIR/GIT_INDEX_FILE into
+# every child and those OUTRANK `git -C <dir>`, so an unscrubbed helper COMMITS
+# to the developer's real repo while printing nothing (#893, twice). The suite
+# runs the naive form first and proves it corrupts, so a scrub that stopped
+# scrubbing cannot pass. Hermetic: one mktemp -d, no network, no real repo.
+[group('meta')]
+[doc("Self-test the e2e helper's git env scrub")]
+e2e-scrub-selftest:
+    bash scripts/lib/e2e-common-selftest.sh
 
 # The README star chart's renderer — bitmap font, axes, paging. (Its copied
 # office colours are pinned from Rust: scene's `tests/readme_chart_palette.rs`.)

--- a/scripts/lib/e2e-common-selftest.sh
+++ b/scripts/lib/e2e-common-selftest.sh
@@ -6,6 +6,14 @@
 # Everything happens inside one `mktemp -d`; the real repo is never a target.
 set -uo pipefail
 
+# A LINKED worktree's pre-push exports GIT_DIR (a plain checkout's does not), and
+# `just lint` reaches this file from pre-push — so without this the fixture setup
+# below builds no repo of its own and commits into the developer's: #893, inside
+# the file that pins #893. It has to happen HERE, before anything builds a repo;
+# the suite's own GIT_* exports come later and are unaffected.
+# shellcheck disable=SC2046  # githooks(5)'s own idiom — the list must word-split
+unset $(git rev-parse --local-env-vars)
+
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
 . "$here/e2e-common.sh"
@@ -93,6 +101,11 @@ printf 'stray\n' >"$scrubbed/NOTE.txt"
 head_before=$(head_of_real)
 e2e_init_repo "$scrubbed" >/dev/null 2>&1
 
+# Both sides of the next check read `head_of_real`, so an absent fixture repo
+# would compare empty to empty and pass — the exact state a leaked GIT_DIR
+# produces, which is when that check most needs to fire.
+check "the fixture repo has a HEAD to compare against" \
+    test -n "$head_before"
 check "e2e_init_repo does not commit to the REAL repo" \
     test "$(head_of_real)" = "$head_before"
 check "e2e_init_repo leaves the real repo's index untouched" \

--- a/scripts/lib/e2e-common-selftest.sh
+++ b/scripts/lib/e2e-common-selftest.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Proves `e2e_init_repo`'s env scrub by running the NAIVE form first and showing
+# it corrupts. Without that negative control this file would pass against a
+# scrub that does nothing, which is the exact failure mode #893 shipped twice.
+#
+# Everything happens inside one `mktemp -d`; the real repo is never a target.
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+. "$here/e2e-common.sh"
+
+fails=0
+# Takes the message, then the command to run — never `$?`, which after a `[ ]`
+# reports the condition and is overwritten by the next one (SC2319).
+check() {
+    local msg="$1"
+    shift
+    if "$@"; then
+        printf '  ok   %s\n' "$msg"
+    else
+        printf '  FAIL %s\n' "$msg" >&2
+        fails=$((fails + 1))
+    fi
+}
+
+root=$(mktemp -d)
+trap 'rm -rf "$root"' EXIT
+
+# The stand-in for the developer's real repo — what a hook's exported GIT_DIR
+# points at, and what must stay untouched.
+real="$root/real"
+mkdir -p "$real"
+git init -q "$real"
+printf 'keep\n' >"$real/tracked.txt"
+git -C "$real" add tracked.txt
+git -C "$real" -c user.email=t@t -c user.name=t commit -qm base
+
+# What a git hook exports into every child it spawns. `git -C <dir>` does NOT
+# override these. GIT_WORK_TREE is pinned too: without it an unscrubbed `add -A`
+# resolves the work tree from the CWD, which makes what it stages depend on
+# where the suite was invoked — and the index assertion below then passes or
+# fails by accident rather than by the scrub.
+export GIT_DIR="$real/.git"
+export GIT_INDEX_FILE="$real/.git/index"
+export GIT_WORK_TREE="$real"
+
+staged_in_real() {
+    git --git-dir="$real/.git" --work-tree="$real" \
+        diff --cached --name-only 2>/dev/null | wc -l | tr -d ' '
+}
+
+# HEAD, not the index: an unscrubbed `e2e_init_repo` ends in `commit`, which
+# lands the stolen files as a REAL COMMIT and leaves `diff --cached` clean
+# again. Keyed on the index alone this suite passed against the mutation that
+# removes the scrub — the commit is the damage, so the commit is the assertion.
+head_of_real() {
+    git --git-dir="$real/.git" rev-parse HEAD 2>/dev/null
+}
+
+# git's own list must relocate the repo and nothing else: stripping a transport
+# or identity var would break a caller that set it deliberately.
+scrub_list_is_narrow() {
+    local list
+    list=$(git rev-parse --local-env-vars)
+    ! grep -qx 'GIT_SSH_COMMAND' <<<"$list" &&
+        ! grep -qx 'GIT_COMMITTER_NAME' <<<"$list"
+}
+
+# Bait INSIDE the real work tree, staged by any unscrubbed `add -A`. Both halves
+# below read the same file: the `reset` between them unstages without deleting.
+# Without it each half would pass or fail on whether the real repo happened to be
+# dirty rather than on the scrub — verified by mutation.
+printf 'bait\n' >"$real/BAIT.txt"
+
+# --- negative control: the naive form, which is what this helper replaced -----
+naive="$root/naive-ws"
+mkdir -p "$naive"
+printf 'stray\n' >"$naive/NOTE.txt"
+git init -q "$naive" 2>/dev/null
+git -C "$naive" add -A 2>/dev/null
+naive_staged=$(staged_in_real)
+check "the naive form stages into the REAL repo (negative control fires)" \
+    test "$naive_staged" -gt 0
+
+# Undo whatever the naive form did, so the scrubbed run starts clean.
+git --git-dir="$real/.git" --work-tree="$real" reset -q
+
+# --- the helper under test ---------------------------------------------------
+scrubbed="$root/scrubbed-ws"
+mkdir -p "$scrubbed"
+printf 'stray\n' >"$scrubbed/NOTE.txt"
+head_before=$(head_of_real)
+e2e_init_repo "$scrubbed" >/dev/null 2>&1
+
+check "e2e_init_repo does not commit to the REAL repo" \
+    test "$(head_of_real)" = "$head_before"
+check "e2e_init_repo leaves the real repo's index untouched" \
+    test "$(staged_in_real)" -eq 0
+check "e2e_init_repo created the workspace's OWN repo" \
+    test -d "$scrubbed/.git"
+workspace_repo_has_a_commit() {
+    git --git-dir="$scrubbed/.git" --work-tree="$scrubbed" \
+        log --oneline -1 >/dev/null 2>&1
+}
+check "the workspace repo carries its init commit" workspace_repo_has_a_commit
+check "git's own list carries no transport/identity vars to over-strip" \
+    scrub_list_is_narrow
+
+if [ "$fails" -eq 0 ]; then
+    echo "e2e-common-selftest: OK"
+else
+    echo "e2e-common-selftest: $fails FAILED" >&2
+    exit 1
+fi

--- a/scripts/lib/e2e-common.sh
+++ b/scripts/lib/e2e-common.sh
@@ -25,3 +25,25 @@ e2e_require_bin() {
 e2e_sandbox() {
     mktemp -d
 }
+
+# A throwaway git repo at $1, for the CLIs that refuse to act outside one.
+#
+# The scrub is the whole point. A git hook exports GIT_DIR and GIT_INDEX_FILE
+# into every child, and those OUTRANK `git -C <dir>` — so run from a hook, a
+# bare `git -C "$WS" add -A` stages the REAL repo while printing nothing (#893,
+# which landed twice). `just live-sources` is manual today, so nothing reaches
+# this from a hook; the scrub is what keeps that true for the next caller.
+#
+# The list comes from `git rev-parse --local-env-vars`, git's own answer, not a
+# GIT_* prefix match — that would also strip GIT_SSH_COMMAND and the
+# GIT_COMMITTER_* identity, neither of which relocates a repo.
+e2e_init_repo() {
+    local ws="$1" scrub
+    scrub=$(git rev-parse --local-env-vars | sed 's/^/-u /' | tr '\n' ' ')
+    # shellcheck disable=SC2086  # $scrub is a flag LIST and must word-split
+    env $scrub git init -q "$ws"
+    # shellcheck disable=SC2086
+    env $scrub git -C "$ws" add -A
+    # shellcheck disable=SC2086
+    env $scrub git -C "$ws" -c user.email=e2e@pixtuoid -c user.name=e2e commit -qm init
+}

--- a/scripts/lib/e2e-common.sh
+++ b/scripts/lib/e2e-common.sh
@@ -40,11 +40,13 @@ e2e_sandbox() {
 e2e_init_repo() {
     local ws="$1" scrub
     scrub=$(git rev-parse --local-env-vars | sed 's/^/-u /' | tr '\n' ' ')
-    # An empty list is indistinguishable from "nothing to scrub", so the git calls
-    # below would silently inherit the caller's GIT_DIR — the bug this guards.
+    # An empty list is the scrub silently NOT happening, not "nothing to scrub":
+    # `git init` would then land wherever an ambient GIT_DIR points, and exit 0.
+    # `exit 2` (not `return`) because no caller checks the status — matches
+    # `e2e_require_bin` above.
     if [ -z "$scrub" ]; then
-        printf 'e2e_init_repo: git rev-parse --local-env-vars gave nothing\n' >&2
-        return 1
+        echo "e2e_init_repo: git gave no --local-env-vars; refusing to init unscrubbed" >&2
+        exit 2
     fi
     # shellcheck disable=SC2086  # $scrub is a flag LIST and must word-split
     env $scrub git init -q "$ws"

--- a/scripts/lib/e2e-common.sh
+++ b/scripts/lib/e2e-common.sh
@@ -40,6 +40,12 @@ e2e_sandbox() {
 e2e_init_repo() {
     local ws="$1" scrub
     scrub=$(git rev-parse --local-env-vars | sed 's/^/-u /' | tr '\n' ' ')
+    # An empty list is indistinguishable from "nothing to scrub", so the git calls
+    # below would silently inherit the caller's GIT_DIR — the bug this guards.
+    if [ -z "$scrub" ]; then
+        printf 'e2e_init_repo: git rev-parse --local-env-vars gave nothing\n' >&2
+        return 1
+    fi
     # shellcheck disable=SC2086  # $scrub is a flag LIST and must word-split
     env $scrub git init -q "$ws"
     # shellcheck disable=SC2086

--- a/scripts/lib/tier-live-sources.sh
+++ b/scripts/lib/tier-live-sources.sh
@@ -75,9 +75,7 @@ printf 'pong\n' >"$WS/NOTE.txt"
 # A git repo, because several CLIs refuse to act outside one (codex: "Not inside
 # a trusted directory"). Cheaper than a per-CLI trust flag, and it is what a real
 # user's workspace looks like anyway.
-git init -q "$WS" 2>/dev/null
-git -C "$WS" add -A 2>/dev/null
-git -C "$WS" -c user.email=e2e@pixtuoid -c user.name=e2e commit -qm init 2>/dev/null
+e2e_init_repo "$WS"
 PIXPID=""
 CLIPID=""
 


### PR DESCRIPTION
Restores the guard #956 deleted, as a mechanism instead of a script.

## The hazard

`scripts/lib/tier-live-sources.sh` built its throwaway workspace with a bare `git init` / `git -C "$WS" add -A` / `commit`. A git hook exports `GIT_DIR` and `GIT_INDEX_FILE` into every child it spawns, and **those outrank `git -C <dir>`** — so run from a hook, that sequence does not touch `$WS` at all. It commits the developer's own tree into the developer's own repo. Exit 0, no output.

That is #893, which landed **twice** while printing a clean pass. `scripts/gitenv.py` held the guard until #956 deleted it along with the generator it served.

Measured, not reasoned — with `GIT_DIR` exported:

```
git init -q "$ws"      → exit 0, and $ws/.git is NOT created (it re-inits the real repo)
git -C "$ws" add -A    → exit 0, and stages the REAL repo's files
```

## No live trigger, and the PR says so

`.githooks/pre-push` runs `just preflight`; `preflight` is `lint clippy hack test`; `tier-live-sources.sh`'s only caller is the manual, billed `just live-sources` (justfile:673). **Nothing reaches those git calls from a hook today.** This keeps that true for the next caller rather than depending on it.

## The scrub

`e2e_init_repo` scrubs via `git rev-parse --local-env-vars` — git's own answer, 15 vars, fetched in-session rather than remembered. Deliberately **not** a `GIT_*` prefix match: that would also strip `GIT_SSH_COMMAND` and the `GIT_COMMITTER_*` identity, neither of which relocates a repo. The selftest pins that distinction.

## The selftest, and the hole mutation testing found in it

It runs the **naive form first and proves it corrupts**, so a scrub that stopped scrubbing cannot pass vacuously.

Two rounds of mutation testing (empty the scrub, the suite must red). The second round found a real hole in my own first version:

| | |
|---|---|
| **round 1** | keyed the safety assertion on the real repo's **index**. Under the mutation it **PASSED** — because the unscrubbed helper's third command is `commit`, which lands the stolen files as a real commit and leaves `diff --cached` clean again. The index is not the damage; the commit is. |
| **round 2** | assert on **HEAD**. The load-bearing check now reds under the mutation. The index check stays as belt-and-braces, with a comment saying it is *not* the one with teeth, and why. |

`GIT_WORK_TREE` is exported alongside the other two: without it an unscrubbed `add -A` resolves its work tree from the CWD, so what it stages depends on where the suite was invoked and the assertion passes or fails by accident.

Hermetic — one `mktemp -d`, no network, the real repo is never a target.

## Wiring

Both places, because one alone is a no-op:

- `just lint`'s fan-out (`✓ e2escrub`)
- **`ci-lint.yml`'s hygiene job** — that job enumerates each selftest as its own step, so the recipe alone would have run locally and never in CI.

## Gates

`preflight` green (3174) · `shellcheck -x` exit 0 · `shfmt-check` clean · `just lint` green · `actionlint` clean · **116 Rego CI-contract tests pass** on the workflow edit.

## Note

Supersedes the stale `fix/e2e-env-scrub` branch (uncommitted work in another worktree). Branched fresh off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017WdFnoFgpKUZdQtqQY5w5F
