### PR TITLE
fix(tests): an indented wrapped `Pinned by` claim is no longer skipped silently

### DIFF
--- a/crates/pixtuoid-core/tests/pinned_by_claims.rs
+++ b/crates/pixtuoid-core/tests/pinned_by_claims.rs
@@ -4,10 +4,10 @@
 //! existed.
 //!
 //! Two gaps, neither currently harbouring an orphan — widen before trusting it
-//! further: the walk is `.rs` under `crates/`, so the claims in `desk.sprite`
-//! and `add-source.prompt.md` go unchecked; and `declared` is a raw text scan,
-//! so `fn foo` written in prose counts as a declaration. It checks the name
-//! EXISTS, never that the test pins the claim.
+//! further: the walk is `.rs` under `crates/`, so a claim anywhere else — a
+//! sprite header, a prompt, `docs/` — goes unchecked; and `declared` is a raw
+//! text scan, so `fn foo` written in prose counts as a declaration. It checks
+//! the name EXISTS, never that the test pins the claim.
 //!
 //! Reads sibling crates at runtime, so it is workspace-only and sits in
 //! `Cargo.toml`'s `exclude`.
@@ -38,13 +38,6 @@ fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
     }
 }
 
-/// The identifier a `Pinned by` claim names, if the line makes one.
-///
-/// Matched on text with comment leaders collapsed to a space first: a claim
-/// wrapped across two `///` lines is exactly the shape a line-at-a-time matcher
-/// passes silently, so the wrap has to be gone before the scan. The collapse
-/// anchors at column 0 — an indented leader survives it and the claim is
-/// skipped, which is why the module doc lists that as a gap.
 /// Collapse the comment leaders so a wrapped claim reads as one string.
 ///
 /// Indentation is stripped per line first: anchoring the replace at column 0
@@ -60,6 +53,11 @@ fn flatten_wrapped_comments(src: &str) -> String {
         .replace("\n//", " ")
 }
 
+/// The identifier a `Pinned by` claim names, if the line makes one.
+///
+/// Matched on text with comment leaders collapsed to a space first: a claim
+/// wrapped across two `///` lines is exactly the shape a line-at-a-time matcher
+/// passes silently, so the wrap has to be gone before the scan.
 fn claims_in(text: &str) -> Vec<String> {
     let mut out = Vec::new();
     let mut rest = text;
@@ -141,9 +139,12 @@ fn the_claim_scanner_fires_on_an_orphan_and_stays_silent_on_a_real_one() {
         ["some_test_name"]
     );
     assert_eq!(
-        claims_in("/// Pinned by  `wrapped_across_lines`."),
+        claims_in(&flatten_wrapped_comments(
+            "/// Pinned by\n/// `wrapped_across_lines`."
+        )),
         ["wrapped_across_lines"],
-        "a claim whose leaders were collapsed must still match"
+        "a wrapped claim must survive the REAL collapse — the old hand-flattened \
+         fixture never exercised it, which is how the column-0 gap stayed hidden"
     );
     assert_eq!(
         claims_in("/// pinned by [`bracketed_link`]"),
@@ -154,7 +155,7 @@ fn the_claim_scanner_fires_on_an_orphan_and_stays_silent_on_a_real_one() {
             "    // Pinned by\n    // `indented_wrapped_name`.\n    for x in y {"
         )),
         ["indented_wrapped_name"],
-        "an INDENTED wrapped claim is the live shape at install/mod.rs — \
+        "an INDENTED wrapped claim is a live shape in the tree — \
          a column-0-anchored collapse skips it silently"
     );
     assert!(claims_in("/// Pinned by the shared harness.").is_empty());

--- a/crates/pixtuoid-core/tests/pinned_by_claims.rs
+++ b/crates/pixtuoid-core/tests/pinned_by_claims.rs
@@ -3,12 +3,11 @@
 //! `escalated_permission_is_detected_by_the_exported_pair`, which had never
 //! existed.
 //!
-//! Three gaps, none currently harbouring an orphan — widen before trusting it
+//! Two gaps, neither currently harbouring an orphan — widen before trusting it
 //! further: the walk is `.rs` under `crates/`, so the claims in `desk.sprite`
-//! and `add-source.prompt.md` go unchecked; the collapse below anchors at
-//! column 0, so an INDENTED wrapped claim is skipped silently; and `declared`
-//! is a raw text scan, so `fn foo` written in prose counts as a declaration.
-//! It checks the name EXISTS, never that the test pins the claim.
+//! and `add-source.prompt.md` go unchecked; and `declared` is a raw text scan,
+//! so `fn foo` written in prose counts as a declaration. It checks the name
+//! EXISTS, never that the test pins the claim.
 //!
 //! Reads sibling crates at runtime, so it is workspace-only and sits in
 //! `Cargo.toml`'s `exclude`.
@@ -46,6 +45,21 @@ fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
 /// passes silently, so the wrap has to be gone before the scan. The collapse
 /// anchors at column 0 — an indented leader survives it and the claim is
 /// skipped, which is why the module doc lists that as a gap.
+/// Collapse the comment leaders so a wrapped claim reads as one string.
+///
+/// Indentation is stripped per line first: anchoring the replace at column 0
+/// left an indented leader intact, and the claim wrapped under it was skipped
+/// silently (this file's module doc used to list that as a known gap).
+fn flatten_wrapped_comments(src: &str) -> String {
+    src.lines()
+        .map(str::trim_start)
+        .collect::<Vec<_>>()
+        .join("\n")
+        .replace("\n///", " ")
+        .replace("\n//!", " ")
+        .replace("\n//", " ")
+}
+
 fn claims_in(text: &str) -> Vec<String> {
     let mut out = Vec::new();
     let mut rest = text;
@@ -93,12 +107,11 @@ fn every_pinned_by_claim_names_a_function_that_exists() {
                 declared.insert(name);
             }
         }
-        // Collapse the comment leaders so a wrapped claim reads as one string.
-        let flat = src
-            .replace("\n///", " ")
-            .replace("\n//!", " ")
-            .replace("\n//", " ");
-        claims.extend(claims_in(&flat).into_iter().map(|n| (path.clone(), n)));
+        claims.extend(
+            claims_in(&flatten_wrapped_comments(&src))
+                .into_iter()
+                .map(|n| (path.clone(), n)),
+        );
     }
 
     assert!(
@@ -135,6 +148,14 @@ fn the_claim_scanner_fires_on_an_orphan_and_stays_silent_on_a_real_one() {
     assert_eq!(
         claims_in("/// pinned by [`bracketed_link`]"),
         ["bracketed_link"]
+    );
+    assert_eq!(
+        claims_in(&flatten_wrapped_comments(
+            "    // Pinned by\n    // `indented_wrapped_name`.\n    for x in y {"
+        )),
+        ["indented_wrapped_name"],
+        "an INDENTED wrapped claim is the live shape at install/mod.rs — \
+         a column-0-anchored collapse skips it silently"
     );
     assert!(claims_in("/// Pinned by the shared harness.").is_empty());
     assert!(


### PR DESCRIPTION
Closes the one machine-checkable gap `pinned_by_claims.rs`'s own module doc listed: the comment-leader collapse anchored at column 0, so an **indented** wrapped `Pinned by` claim survived the collapse and was skipped silently. The tree already had one live instance riding the gap — `install/mod.rs:144`, whose named function happens to exist, but nothing was checking.

## The fix

Indentation is stripped per line before the collapse (`flatten_wrapped_comments`, extracted so the negative control can exercise it directly).

## TDD trail

1. Negative control gained the indented-wrap case → **red** (the exact live shape from `install/mod.rs`).
2. Per-line `trim_start` before the collapse → green.
3. Mutation — re-anchor the collapse at column 0 → the control **reds again**.
4. Real-tree sweep stays green: the newly covered claims all name real functions.

Module doc updated in the same commit: three gaps → two (the `.rs`-only walk and the prose-declaration scan remain, both still without a live orphan).

`cargo test -p pixtuoid-core --test pinned_by_claims` 0 · fmt 0 · clippy 0 · preflight on push 3174 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4W4HtEmnF7Bu8jsqafJML
