### PR TITLE
chore(ci): tier A of the CI audit — composites, caches, and one-authority pins

### DIFF
--- a/.github/actions/packaging-build/action.yml
+++ b/.github/actions/packaging-build/action.yml
@@ -10,10 +10,7 @@ runs:
         prefix-key: v1-rust
         # rust-cache isolates by OS, so one shared-key is safe across platforms.
         shared-key: packaging-build
-    - name: Install ALSA headers (Linux only)
-      if: runner.os == 'Linux'
-      shell: bash
-      run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+    - uses: ./.github/actions/setup-alsa
     - name: cargo install --locked (both binaries, default features)
       shell: bash
       run: |

--- a/.github/actions/require-jobs/action.yml
+++ b/.github/actions/require-jobs/action.yml
@@ -1,0 +1,24 @@
+name: 'Require Jobs'
+description: 'Fails unless every needed job succeeded — skipped and cancelled red too'
+
+inputs:
+  results:
+    description: 'toJSON(needs) of the calling aggregator job'
+    required: true
+  label:
+    description: 'Failure-message prefix naming the group'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - shell: bash
+      env:
+        RESULTS: ${{ inputs.results }}
+        LABEL: ${{ inputs.label }}
+      run: |
+        failures="$(jq -r 'to_entries[] | select(.value.result != "success") | "\(.key)=\(.value.result)"' <<< "$RESULTS")"
+        if [[ -n "$failures" ]]; then
+          echo "::error::${LABEL}: ${failures//$'\n'/, }"
+          exit 1
+        fi

--- a/.github/actions/require-jobs/action.yml
+++ b/.github/actions/require-jobs/action.yml
@@ -17,6 +17,12 @@ runs:
         RESULTS: ${{ inputs.results }}
         LABEL: ${{ inputs.label }}
       run: |
+        # `required: true` on an input is advisory — a caller that omits it
+        # hands us an empty string, and an empty needs-map would pass vacuously.
+        if [[ -z "$RESULTS" || "$RESULTS" == "{}" ]]; then
+          echo "::error::${LABEL:-require-jobs}: no job results — the caller must pass results: toJSON(needs)"
+          exit 1
+        fi
         failures="$(jq -r 'to_entries[] | select(.value.result != "success") | "\(.key)=\(.value.result)"' <<< "$RESULTS")"
         if [[ -n "$failures" ]]; then
           echo "::error::${LABEL}: ${failures//$'\n'/, }"

--- a/.github/actions/setup-alsa/action.yml
+++ b/.github/actions/setup-alsa/action.yml
@@ -1,0 +1,25 @@
+name: 'Setup ALSA'
+description: 'Installs the ALSA headers the default-on audio feature needs on Linux'
+
+runs:
+  using: 'composite'
+  steps:
+    # rodio/cpal (the default-on `audio` feature) needs ALSA headers to BUILD on
+    # Linux (#633) — alsa-sys's build script PANICS when pkg-config can't find
+    # them. Bound flaky hosted-runner mirrors and retry the complete apt
+    # operation (the smoke job's ffmpeg envelope).
+    - name: Install ALSA headers
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        apt_opts=(-o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30)
+        for attempt in 1 2 3; do
+          if sudo apt-get update "${apt_opts[@]}" \
+            && sudo apt-get install -y "${apt_opts[@]}" libasound2-dev; then
+            exit 0
+          fi
+          echo "ALSA install attempt $attempt failed; retrying in $((attempt * 15))s..." >&2
+          sleep "$((attempt * 15))"
+        done
+        echo "ALSA install failed after 3 attempts" >&2
+        exit 1

--- a/.github/actions/setup-alsa/action.yml
+++ b/.github/actions/setup-alsa/action.yml
@@ -4,10 +4,10 @@ description: 'Installs the ALSA headers the default-on audio feature needs on Li
 runs:
   using: 'composite'
   steps:
-    # rodio/cpal (the default-on `audio` feature) needs ALSA headers to BUILD on
-    # Linux (#633) — alsa-sys's build script PANICS when pkg-config can't find
-    # them. Bound flaky hosted-runner mirrors and retry the complete apt
-    # operation (the smoke job's ffmpeg envelope).
+    # alsa-sys's build script PANICS when pkg-config can't find the headers
+    # (#633), so this rides every Linux job that compiles the workspace. The
+    # retry bounds flaky hosted-runner mirrors and re-runs the complete apt
+    # operation.
     - name: Install ALSA headers
       if: runner.os == 'Linux'
       shell: bash

--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -35,9 +35,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      # The default-on audio feature must compile through ALSA on Linux.
-      - name: Install ALSA headers
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+      - uses: ./.github/actions/setup-alsa
       - uses: ./.github/actions/setup-cargo-just
       - uses: taiki-e/install-action@cargo-hack
       - run: just hack
@@ -103,12 +101,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Require every build job to pass
-        env:
-          RESULTS: ${{ toJSON(needs) }}
-        run: |
-          failures="$(jq -r 'to_entries[] | select(.value.result != "success") | "\(.key)=\(.value.result)"' <<< "$RESULTS")"
-          if [[ -n "$failures" ]]; then
-            echo "::error::Required build job failed: ${failures//$'\n'/, }"
-            exit 1
-          fi
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/require-jobs
+        with:
+          results: ${{ toJSON(needs) }}
+          label: "Required build job failed"

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -31,9 +31,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      # The default-on audio feature compiles through ALSA on Linux.
-      - name: Install ALSA headers
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+      - uses: ./.github/actions/setup-alsa
       - uses: ./.github/actions/setup-cargo-just
         with:
           components: clippy
@@ -78,7 +76,19 @@ jobs:
           persist-credentials: false
       # Lychee is not manifest-managed by install-action, so its documented
       # cargo-binstall fallback installs our pinned version.
+      # Keyed on this workflow file: a version bump edits it, so the cache can
+      # never serve a stale binary; any other ci-lint edit just costs one warm
+      # rebuild.
+      - name: Cache the Go-built tools
+        id: go-tools
+        uses: actions/cache@v6
+        with:
+          path: ~/go/bin
+          key: go-tools-${{ runner.os }}-${{ hashFiles('.github/workflows/ci-lint.yml') }}
+      - name: Expose Go tool binaries
+        run: echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
       - name: Install workflow lint + policy tools
+        if: steps.go-tools.outputs.cache-hit != 'true'
         run: |
           go install mvdan.cc/sh/v3/cmd/shfmt@v3.13.1
           go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
@@ -88,7 +98,6 @@ jobs:
           # the OPA binary owns both.
           go install github.com/open-policy-agent/opa@v1.18.2
           go install github.com/open-policy-agent/regal@v0.42.0
-          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
       - name: Install the JSON Schema validator
         run: pipx install check-jsonschema==0.37.4
       - uses: taiki-e/install-action@v2
@@ -142,9 +151,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      # The default-on audio feature must compile through ALSA on Linux.
-      - name: Install ALSA headers
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+      - uses: ./.github/actions/setup-alsa
       # No rust-cache on purpose: it would key the runner's stable compiler,
       # while the MSRV recipe installs the exact rust-version toolchain.
       - uses: ./.github/actions/setup-just
@@ -222,9 +229,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      # The default-on audio feature must compile through ALSA on Linux.
-      - name: Install ALSA headers
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+      - uses: ./.github/actions/setup-alsa
       - uses: ./.github/actions/setup-cargo-just
       - run: just doc-check
 
@@ -237,12 +242,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Require every lint job to pass
-        env:
-          RESULTS: ${{ toJSON(needs) }}
-        run: |
-          failures="$(jq -r 'to_entries[] | select(.value.result != "success") | "\(.key)=\(.value.result)"' <<< "$RESULTS")"
-          if [[ -n "$failures" ]]; then
-            echo "::error::Required lint job failed: ${failures//$'\n'/, }"
-            exit 1
-          fi
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/require-jobs
+        with:
+          results: ${{ toJSON(needs) }}
+          label: "Required lint job failed"

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -74,11 +74,11 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      # Lychee is not manifest-managed by install-action, so its documented
-      # cargo-binstall fallback installs our pinned version.
       # Keyed on this workflow file: a version bump edits it, so the cache can
-      # never serve a stale binary; any other ci-lint edit just costs one warm
-      # rebuild.
+      # never serve a stale binary; any other ci-lint edit costs one cold
+      # reinstall. ~/go/bin is spelled, not derived: GOPATH is the runner
+      # default, and deriving it here while the cache stores a literal is how
+      # a hit could restore binaries to a directory that is not on PATH.
       - name: Cache the Go-built tools
         id: go-tools
         uses: actions/cache@v6
@@ -86,7 +86,7 @@ jobs:
           path: ~/go/bin
           key: go-tools-${{ runner.os }}-${{ hashFiles('.github/workflows/ci-lint.yml') }}
       - name: Expose Go tool binaries
-        run: echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+        run: echo "$HOME/go/bin" >> "$GITHUB_PATH"
       - name: Install workflow lint + policy tools
         if: steps.go-tools.outputs.cache-hit != 'true'
         run: |
@@ -100,6 +100,8 @@ jobs:
           go install github.com/open-policy-agent/regal@v0.42.0
       - name: Install the JSON Schema validator
         run: pipx install check-jsonschema==0.37.4
+      # Lychee is not manifest-managed by install-action, so its documented
+      # cargo-binstall fallback installs our pinned version.
       - uses: taiki-e/install-action@v2
         with:
           tool: lychee@0.24.2,zizmor@1.30.0
@@ -215,6 +217,8 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-binstall
+      # The justfile's API_PUBLIC_API is the authority; api-surface-check
+      # asserts this copy against it before reading a golden.
       - name: Install cargo-public-api (pinned to match the committed goldens)
         run: cargo binstall -y cargo-public-api@0.52.0
       - uses: ./.github/actions/setup-just

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -72,9 +72,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      # The default-on audio feature must compile through ALSA on Linux.
-      - name: Install ALSA headers
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+      - uses: ./.github/actions/setup-alsa
       - uses: ./.github/actions/setup-cargo-just
         with:
           components: llvm-tools-preview
@@ -170,9 +168,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      # Snapshot tests compile the default-on audio feature on Linux.
-      - name: Install ALSA headers
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+      - uses: ./.github/actions/setup-alsa
       - uses: ./.github/actions/setup-cargo-just
       - uses: taiki-e/install-action@cargo-nextest
       - uses: taiki-e/install-action@cargo-insta
@@ -189,9 +185,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      # The release build compiles the default-on audio feature on Linux.
-      - name: Install ALSA headers
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+      - uses: ./.github/actions/setup-alsa
       - uses: ./.github/actions/setup-cargo-just
       - name: Build release binaries + examples
         run: just build --release --bins --examples
@@ -256,12 +250,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Require every test job to pass
-        env:
-          RESULTS: ${{ toJSON(needs) }}
-        run: |
-          failures="$(jq -r 'to_entries[] | select(.value.result != "success") | "\(.key)=\(.value.result)"' <<< "$RESULTS")"
-          if [[ -n "$failures" ]]; then
-            echo "::error::Required test job failed: ${failures//$'\n'/, }"
-            exit 1
-          fi
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/require-jobs
+        with:
+          results: ${{ toJSON(needs) }}
+          label: "Required test job failed"

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -202,8 +202,8 @@ jobs:
         with:
           node-version: 22
       - name: Install ffmpeg
-        # Bound flaky hosted-runner mirrors and retry the complete apt operation;
-        # do not pipe the version command through head under pipefail.
+        # setup-alsa's mirror-retry envelope, for a package that composite
+        # doesn't own; do not pipe the version command through head under pipefail.
         run: |
           apt_opts=(-o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30)
           for attempt in 1 2 3; do

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -26,8 +26,11 @@ on:
       - "Cargo.lock"
       - ".github/workflows/codspeed.yml"
 
-permissions:
-  contents: read
+concurrency:
+  group: codspeed-${{ github.ref }}
+  # Same rule as ci.yml: never cancel an in-flight main run — that is the trend
+  # point; stacked PR pushes cancel.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   codspeed:

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -28,9 +28,12 @@ on:
 
 concurrency:
   group: codspeed-${{ github.ref }}
-  # Same rule as ci.yml: never cancel an in-flight main run — that is the trend
-  # point; stacked PR pushes cancel.
+  # Same rule as ci.yml: never cancel an in-flight main run — it IS the trend
+  # point.
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
 
 jobs:
   codspeed:

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -21,8 +21,8 @@ jobs:
           fetch-depth: 0 # `--in-diff` needs the merge base in history
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
-      # cargo-mutants' baseline build dies before testing a single mutant
-      # without the ALSA headers.
+      # cargo-mutants builds its baseline with DEFAULT features — it needs
+      # ALSA even where a reader assumes the flag-stripped release shape.
       - uses: ./.github/actions/setup-alsa
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -21,10 +21,9 @@ jobs:
           fetch-depth: 0 # `--in-diff` needs the merge base in history
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
-      # cargo-mutants builds a baseline with DEFAULT features, which pull rodio ->
-      # cpal -> ALSA headers; without them it dies before testing a single mutant.
-      - name: Install ALSA headers
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+      # cargo-mutants' baseline build dies before testing a single mutant
+      # without the ALSA headers.
+      - uses: ./.github/actions/setup-alsa
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: v1-rust # match setup-cargo-just's default cache namespace

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -45,17 +45,17 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('site/package-lock.json') }}
-      # Chromium must be installed BEFORE `npm run check`: `astro check` renders
-      # /architecture's ```mermaid block via rehype-mermaid (headless Playwright),
-      # and a browserless render takes the deploy red at check:docs. Name
-      # `chromium-headless-shell` too, so a cache holding chromium-but-not-the-shell
-      # can't skip it.
       - name: Install site dependencies
         working-directory: site
         run: npm ci
       - name: Audit site dependencies
         working-directory: site
         run: npm run audit
+      # Chromium must be installed BEFORE `npm run check`: `astro check` renders
+      # /architecture's ```mermaid block via rehype-mermaid (headless Playwright),
+      # and a browserless render takes the deploy red at check:docs. Name
+      # `chromium-headless-shell` too, so a cache holding chromium-but-not-the-shell
+      # can't skip it.
       - name: Install Chromium for the diagram
         working-directory: site
         run: npx playwright install --with-deps chromium chromium-headless-shell

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,10 +271,11 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
-      # `cargo publish` BUILDS each crate to verify it, and default features pull
-      # Without the headers the loop irreversibly publishes the earlier crates,
-      # then fails to compile pixtuoid — stranding the release half-published at
-      # a version that can never be reused.
+      # `cargo publish` BUILDS each crate to verify it, and default features
+      # pull rodio -> cpal -> the ALSA headers. Without them the loop
+      # irreversibly publishes the earlier crates, then fails to compile
+      # pixtuoid — stranding the release half-published at a version that can
+      # never be reused.
       - uses: ./.github/actions/setup-alsa
       - uses: Swatinem/rust-cache@v2 # zizmor: ignore[cache-poisoning] PR caches are merge-ref scoped; stable tags are ancestry-gated to main
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,7 @@ jobs:
           # Full history for the tag-on-main ancestry check below.
           fetch-depth: 0
           persist-credentials: false
-      # rodio/cpal (the default-on `audio` feature) needs ALSA headers to BUILD on
-      # Linux (#633) — alsa-sys's build script PANICS when pkg-config can't find them.
-      - name: Install ALSA headers
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+      - uses: ./.github/actions/setup-alsa
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
@@ -58,7 +55,7 @@ jobs:
           # so it validates against the base version.
           TAG_VERSION="${GITHUB_REF_NAME#v}"
           TAG_VERSION="${TAG_VERSION%%-*}"
-          CARGO_VERSION=$(grep -m1 '^version' Cargo.toml | cut -d'"' -f2)
+          CARGO_VERSION=$(just workspace-version)
           if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
             echo "::error::Tag ${GITHUB_REF_NAME} does not match Cargo.toml version ${CARGO_VERSION}"
             exit 1
@@ -120,9 +117,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y musl-tools
 
       - name: Build
-        # Linux artifacts build WITHOUT the audio feature: musl can't link ALSA
-        # statically and the aarch64 cross image has no ALSA headers (#633).
-        run: just build-target ${{ matrix.target }} "${{ matrix.cross || 'false' }}" "${{ contains(matrix.target, 'linux') && '--no-default-features' || '' }}"
+        run: just build-target ${{ matrix.target }} "${{ matrix.cross || 'false' }}"
 
       - name: Package (Unix)
         if: runner.os != 'Windows'
@@ -192,9 +187,7 @@ jobs:
         uses: taiki-e/install-action@cargo-deb
 
       - name: Build
-        # Linux artifacts build WITHOUT the audio feature: musl can't link ALSA
-        # statically and the aarch64 cross image has no ALSA headers (#633).
-        run: just build-target ${{ matrix.target }} "${{ matrix.cross || 'false' }}" "${{ contains(matrix.target, 'linux') && '--no-default-features' || '' }}"
+        run: just build-target ${{ matrix.target }} "${{ matrix.cross || 'false' }}"
 
       - name: Build .deb packages
         run: just deb ${{ matrix.target }}
@@ -282,8 +275,7 @@ jobs:
       # rodio -> cpal -> ALSA headers. Without these the loop irreversibly publishes
       # the earlier crates, then fails to compile pixtuoid — stranding the release
       # half-published at a version that can never be reused.
-      - name: Install ALSA headers
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+      - uses: ./.github/actions/setup-alsa
       - uses: Swatinem/rust-cache@v2 # zizmor: ignore[cache-poisoning] PR caches are merge-ref scoped; stable tags are ancestry-gated to main
         with:
           prefix-key: v1-rust

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,9 +272,9 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       # `cargo publish` BUILDS each crate to verify it, and default features pull
-      # rodio -> cpal -> ALSA headers. Without these the loop irreversibly publishes
-      # the earlier crates, then fails to compile pixtuoid — stranding the release
-      # half-published at a version that can never be reused.
+      # Without the headers the loop irreversibly publishes the earlier crates,
+      # then fails to compile pixtuoid — stranding the release half-published at
+      # a version that can never be reused.
       - uses: ./.github/actions/setup-alsa
       - uses: Swatinem/rust-cache@v2 # zizmor: ignore[cache-poisoning] PR caches are merge-ref scoped; stable tags are ancestry-gated to main
         with:

--- a/justfile
+++ b/justfile
@@ -33,12 +33,13 @@ PUBLISHED_CRATES := "pixtuoid-core pixtuoid-scene"
 SHELL_SOURCES := "scripts/lib/*.sh .githooks/* policy/ci-observability/*.sh"
 
 # The nightly the api-surface goldens are pinned to (rustdoc JSON is
-# nightly-only). Self-installed by `_api-nightly`, which also asserts the
-# [`API_PUBLIC_API`] pin — ci-lint.yml installs its own copy of that version,
-# and silent divergence churned goldens before the assert existed.
+# nightly-only). Provisioned by `_api-toolchain`.
 API_NIGHTLY := "nightly-2026-07-22"
 
-# The cargo-public-api the api/ goldens are reproducible against.
+# The cargo-public-api the api/ goldens are reproducible against — tool-exact:
+# a different version rewrites them all. ci-lint.yml installs its own copy;
+# `_api-toolchain` asserts the pair, so divergence fails loud instead of
+# churning goldens.
 API_PUBLIC_API := "0.52.0"
 
 # List available recipes.
@@ -425,7 +426,7 @@ semver:
 # public surface changes.
 [group('rust')]
 [doc('Regenerate the api/<crate>.txt public-API goldens (cargo-public-api + pinned nightly)')]
-api-surface: _api-nightly
+api-surface: _api-toolchain
     #!/usr/bin/env bash
     set -euo pipefail
     # cargo-public-api only honors RUSTUP_TOOLCHAIN when the invoked `cargo` is
@@ -440,7 +441,7 @@ api-surface: _api-nightly
 
 [group('rust')]
 [doc("Fail if a published crate's public API drifted from the api/ goldens (CI-only)")]
-api-surface-check: _api-nightly
+api-surface-check: _api-toolchain
     #!/usr/bin/env bash
     set -euo pipefail
     # See `api-surface`: force the rustup proxy cargo so RUSTUP_TOOLCHAIN is honored.
@@ -457,18 +458,21 @@ api-surface-check: _api-nightly
     done
     exit "$fail"
 
-# Self-provision the api-surface pinned nightly (rustdoc JSON is nightly-only) if
-# it isn't already installed — the same idempotent posture as setup-tools. The
-# minimal profile carries rustdoc (bundled with rustc), all cargo-public-api
-# needs to build the crate's rustdoc JSON.
+# Both halves of the goldens' reproducibility contract: refuse a mismatched
+# cargo-public-api, then self-provision the pinned nightly (rustdoc JSON is
+# nightly-only) if it isn't already installed. The minimal profile carries
+# rustdoc (bundled with rustc), all cargo-public-api needs.
 [private]
-_api-nightly:
+_api-toolchain:
     #!/usr/bin/env bash
     set -euo pipefail
-    # Goldens are tool-exact: a different cargo-public-api rewrites them all.
     have="$(cargo public-api --version 2>/dev/null | awk '{print $NF}' || true)"
-    if [ "${have:-missing}" != "{{ API_PUBLIC_API }}" ]; then
-        echo "error: cargo-public-api ${have:-missing} installed, goldens need {{ API_PUBLIC_API }} (just setup-tools)" >&2
+    if [ -z "$have" ]; then
+        echo "error: cargo-public-api not installed — goldens need {{ API_PUBLIC_API }} (just setup-tools)" >&2
+        exit 1
+    fi
+    if [ "$have" != "{{ API_PUBLIC_API }}" ]; then
+        echo "error: cargo-public-api $have installed, goldens need {{ API_PUBLIC_API }} (just setup-tools)" >&2
         exit 1
     fi
     command -v rustup >/dev/null || { echo "rustup not found — install {{API_NIGHTLY}} manually for api-surface" >&2; exit 1; }
@@ -696,14 +700,16 @@ replay fixture delay="3":
 #   just build --release                      # release
 #   just build --release --bins --examples    # what ci-tests.yml's smoke job builds
 [group('rust')]
-[doc('Print the workspace version — the one authority for tag/packaging checks')]
-workspace-version:
-    @grep -m1 '^version' Cargo.toml | cut -d'"' -f2
-
-[group('rust')]
 [doc('Compile the workspace; forwards args (e.g. --release --bins --examples)')]
 build *args:
     cargo build --workspace {{ args }}
+
+# packaging-build/action.yml keeps its own just-free parse of the same line —
+# that composite deliberately never installs just (see ci-builds.yml).
+[group('rust')]
+[doc("Print the workspace version — release.yml's tag check and `just bump` read it")]
+workspace-version:
+    @grep -m1 '^version' Cargo.toml | cut -d'"' -f2
 
 # Cross-compile a release build for ONE target triple (release.yml's build
 # matrix). Pass `true` for targets that need the Docker-backed `cross` toolchain
@@ -729,9 +735,9 @@ build-target target cross="false":
     # Every LINUX artifact builds --no-default-features (musl can't link ALSA
     # statically; the aarch64 cross image has no ALSA headers), so prebuilt
     # Linux binaries ship SILENT and Linux audio is a from-source feature
-    # (#633; see docs/CONFIGURATION.md). Derived here, not passed: the flag is
-    # a property of the target, and the two callers restating it drifted apart
-    # from this WHY once already.
+    # (#633; see docs/CONFIGURATION.md). Derived here, not passed: the flag
+    # is a property of the target. $flags stays UNQUOTED below — quoting the
+    # empty non-Linux case would pass cargo an empty positional arg.
     flags=""
     case "{{ target }}" in
     *linux*) flags="--no-default-features" ;;
@@ -1175,8 +1181,7 @@ verify: preflight site-check gen-check
 setup-tools:
     #!/usr/bin/env bash
     set -euo pipefail
-    # cargo-public-api is PINNED (the `just api-surface` goldens are reproducible
-    # only against an exact tool + nightly pair — see the api-surface recipe).
+    # cargo-public-api rides API_PUBLIC_API — the tool-exact story lives there.
     tools=(cargo-nextest cargo-machete cargo-deny cargo-hack cargo-semver-checks cargo-edit cargo-insta lychee cargo-public-api@{{ API_PUBLIC_API }})
     if command -v cargo-binstall &>/dev/null; then
         cargo binstall -y "${tools[@]}"

--- a/justfile
+++ b/justfile
@@ -33,9 +33,13 @@ PUBLISHED_CRATES := "pixtuoid-core pixtuoid-scene"
 SHELL_SOURCES := "scripts/lib/*.sh .githooks/* policy/ci-observability/*.sh"
 
 # The nightly the api-surface goldens are pinned to (rustdoc JSON is
-# nightly-only). Self-installed by `_api-nightly`; CI + setup-tools pin
-# cargo-public-api 0.52.0 to match. Bump both together or the golden churns.
+# nightly-only). Self-installed by `_api-nightly`, which also asserts the
+# [`API_PUBLIC_API`] pin — ci-lint.yml installs its own copy of that version,
+# and silent divergence churned goldens before the assert existed.
 API_NIGHTLY := "nightly-2026-07-22"
+
+# The cargo-public-api the api/ goldens are reproducible against.
+API_PUBLIC_API := "0.52.0"
 
 # List available recipes.
 default:
@@ -461,6 +465,12 @@ api-surface-check: _api-nightly
 _api-nightly:
     #!/usr/bin/env bash
     set -euo pipefail
+    # Goldens are tool-exact: a different cargo-public-api rewrites them all.
+    have="$(cargo public-api --version 2>/dev/null | awk '{print $NF}' || true)"
+    if [ "${have:-missing}" != "{{ API_PUBLIC_API }}" ]; then
+        echo "error: cargo-public-api ${have:-missing} installed, goldens need {{ API_PUBLIC_API }} (just setup-tools)" >&2
+        exit 1
+    fi
     command -v rustup >/dev/null || { echo "rustup not found — install {{API_NIGHTLY}} manually for api-surface" >&2; exit 1; }
     rustup toolchain list | grep -q '{{API_NIGHTLY}}' && exit 0
     echo "installing {{API_NIGHTLY}} (api-surface needs nightly rustdoc JSON)…" >&2
@@ -686,6 +696,11 @@ replay fixture delay="3":
 #   just build --release                      # release
 #   just build --release --bins --examples    # what ci-tests.yml's smoke job builds
 [group('rust')]
+[doc('Print the workspace version — the one authority for tag/packaging checks')]
+workspace-version:
+    @grep -m1 '^version' Cargo.toml | cut -d'"' -f2
+
+[group('rust')]
 [doc('Compile the workspace; forwards args (e.g. --release --bins --examples)')]
 build *args:
     cargo build --workspace {{ args }}
@@ -694,11 +709,11 @@ build *args:
 # matrix). Pass `true` for targets that need the Docker-backed `cross` toolchain
 # (CI installs it via taiki-e/install-action@cross). `cross` is validated rather
 # than defaulted because callers pass it POSITIONALLY: an unquoted, unset
-# matrix.cross expands to nothing, and the collapse slid `flags` into this slot
-# on both Linux legs that omit the key — pinned by the arg-shift case below.
+# matrix.cross once slid the next argument into this slot on both Linux legs
+# that omit the key — pinned by the arg-shift case below.
 [group('rust')]
 [doc('Cross-compile a release for ONE target triple (release.yml build matrix)')]
-build-target target cross="false" flags="":
+build-target target cross="false":
     #!/usr/bin/env bash
     set -euo pipefail
     use_cross="{{ cross }}"
@@ -711,14 +726,20 @@ build-target target cross="false" flags="":
         exit 1
         ;;
     esac
-    # flags: extra cargo flags — release.yml passes --no-default-features for
-    # every LINUX artifact (musl can't link ALSA statically; the aarch64 cross
-    # image has no ALSA headers), so prebuilt Linux binaries ship SILENT and
-    # Linux audio is a from-source feature (#633; see docs/CONFIGURATION.md).
+    # Every LINUX artifact builds --no-default-features (musl can't link ALSA
+    # statically; the aarch64 cross image has no ALSA headers), so prebuilt
+    # Linux binaries ship SILENT and Linux audio is a from-source feature
+    # (#633; see docs/CONFIGURATION.md). Derived here, not passed: the flag is
+    # a property of the target, and the two callers restating it drifted apart
+    # from this WHY once already.
+    flags=""
+    case "{{ target }}" in
+    *linux*) flags="--no-default-features" ;;
+    esac
     if [ "$use_cross" = "true" ]; then
-        cross build --release --target "{{ target }}" {{ flags }}
+        cross build --release --target "{{ target }}" $flags
     else
-        cargo build --release --target "{{ target }}" {{ flags }}
+        cargo build --release --target "{{ target }}" $flags
     fi
 
 # Package the .deb for ONE already-built target (release.yml's deb job, hence
@@ -1020,7 +1041,7 @@ bump version:
     if ! git diff --quiet || ! git diff --cached --quiet; then
         echo "error: uncommitted changes — commit or stash before bumping" >&2; exit 1; fi
 
-    cur="$(grep -m1 '^version' Cargo.toml | cut -d'"' -f2)"
+    cur="$(just workspace-version)"
 
     # 3. must be strictly newer than the current version
     if [[ "$ver" == "$cur" || "$(printf '%s\n%s\n' "$cur" "$ver" | sort -V | tail -1)" != "$ver" ]]; then
@@ -1156,7 +1177,7 @@ setup-tools:
     set -euo pipefail
     # cargo-public-api is PINNED (the `just api-surface` goldens are reproducible
     # only against an exact tool + nightly pair — see the api-surface recipe).
-    tools=(cargo-nextest cargo-machete cargo-deny cargo-hack cargo-semver-checks cargo-edit cargo-insta lychee cargo-public-api@0.52.0)
+    tools=(cargo-nextest cargo-machete cargo-deny cargo-hack cargo-semver-checks cargo-edit cargo-insta lychee cargo-public-api@{{ API_PUBLIC_API }})
     if command -v cargo-binstall &>/dev/null; then
         cargo binstall -y "${tools[@]}"
     else

--- a/policy/ci-observability/action_behavior_test.sh
+++ b/policy/ci-observability/action_behavior_test.sh
@@ -345,8 +345,8 @@ printf '%s\n' \
     >"$fake_bin/gh"
 chmod +x "$fake_bin/gh"
 
-# One publisher invocation over the shared fixture env; cases vary only the
-# review body and the head pair.
+# The head pair is parameterized for the one stale-review case; everything
+# else varies only the review body.
 run_publisher() {
     local review_json="$1"
     local fake_head="${2:-abc123}"

--- a/policy/ci-observability/action_behavior_test.sh
+++ b/policy/ci-observability/action_behavior_test.sh
@@ -345,17 +345,26 @@ printf '%s\n' \
     >"$fake_bin/gh"
 chmod +x "$fake_bin/gh"
 
+# One publisher invocation over the shared fixture env; cases vary only the
+# review body and the head pair.
+run_publisher() {
+    local review_json="$1"
+    local fake_head="${2:-abc123}"
+    local expected_head="${3:-abc123}"
+    PATH="$fake_bin:$PATH" \
+        FAKE_PR_HEAD="$fake_head" \
+        PUBLISHED_COMMENT="$published_comment" \
+        EXPECTED_HEAD_SHA="$expected_head" \
+        PR_NUMBER="42" \
+        REPOSITORY="owner/repo" \
+        REVIEW_JSON="$review_json" \
+        REVIEW_MARKER="claude-auto-review" \
+        REVIEW_TITLE="Claude Review" \
+        bash -c "$publisher_script"
+}
+
 valid_review='{"summary":"No correctness findings.","findings":[]}'
-PATH="$fake_bin:$PATH" \
-    FAKE_PR_HEAD="abc123" \
-    PUBLISHED_COMMENT="$published_comment" \
-    EXPECTED_HEAD_SHA="abc123" \
-    PR_NUMBER="42" \
-    REPOSITORY="owner/repo" \
-    REVIEW_JSON="$valid_review" \
-    REVIEW_MARKER="claude-auto-review" \
-    REVIEW_TITLE="Claude Review" \
-    bash -c "$publisher_script" ||
+run_publisher "$valid_review" ||
     fail "Claude publisher rejected a valid zero-finding review"
 [[ -s "$published_comment" ]] ||
     fail "Claude publisher posted no review body"
@@ -366,16 +375,7 @@ published_content="$(<"$published_comment")"
     fail "Claude publisher omitted the zero-finding count"
 
 multi_review='{"summary":"Two verified findings.","findings":[{"severity":"HIGH","path":"src/lib.rs","line":7,"body":"Primary invariant violation."},{"severity":"MEDIUM","path":"tests/review.rs","line":11,"body":"Missing refusal-path coverage."}]}'
-PATH="$fake_bin:$PATH" \
-    FAKE_PR_HEAD="abc123" \
-    PUBLISHED_COMMENT="$published_comment" \
-    EXPECTED_HEAD_SHA="abc123" \
-    PR_NUMBER="42" \
-    REPOSITORY="owner/repo" \
-    REVIEW_JSON="$multi_review" \
-    REVIEW_MARKER="claude-auto-review" \
-    REVIEW_TITLE="Claude Review" \
-    bash -c "$publisher_script" ||
+run_publisher "$multi_review" ||
     fail "Claude publisher rejected a valid multi-finding review"
 published_content="$(<"$published_comment")"
 [[ "$published_content" == *"**Findings: 2** (1 high, 1 medium)"* ]] ||
@@ -390,44 +390,17 @@ expected_location="\`src/lib.rs:7\`"
 # "the bot never posted", not "the bot was blocked", and the merge gate silently
 # becomes unsatisfiable for every finding on those files.
 variant_review='{"summary":"One finding on a density variant.","findings":[{"severity":"MEDIUM","path":"crates/pixtuoid-scene/sprites/default/desk@4x.sprite","line":6,"body":"Header names a scheme that does not exist."}]}'
-PATH="$fake_bin:$PATH" \
-    FAKE_PR_HEAD="abc123" \
-    PUBLISHED_COMMENT="$published_comment" \
-    EXPECTED_HEAD_SHA="abc123" \
-    PR_NUMBER="42" \
-    REPOSITORY="owner/repo" \
-    REVIEW_JSON="$variant_review" \
-    REVIEW_MARKER="claude-auto-review" \
-    REVIEW_TITLE="Claude Review" \
-    bash -c "$publisher_script" ||
+run_publisher "$variant_review" ||
     fail "Claude publisher rejected a finding on an '@' density-variant path"
 published_content="$(<"$published_comment")"
 [[ "$published_content" == *"\`crates/pixtuoid-scene/sprites/default/desk@4x.sprite:6\`"* ]] ||
     fail "Claude publisher omitted the density-variant finding location"
 
-if PATH="$fake_bin:$PATH" \
-    FAKE_PR_HEAD="new-head" \
-    PUBLISHED_COMMENT="$published_comment" \
-    EXPECTED_HEAD_SHA="old-head" \
-    PR_NUMBER="42" \
-    REPOSITORY="owner/repo" \
-    REVIEW_JSON="$valid_review" \
-    REVIEW_MARKER="claude-auto-review" \
-    REVIEW_TITLE="Claude Review" \
-    bash -c "$publisher_script" >/dev/null 2>&1; then
+if run_publisher "$valid_review" new-head old-head >/dev/null 2>&1; then
     fail "Claude publisher accepted a stale review"
 fi
 
-if PATH="$fake_bin:$PATH" \
-    FAKE_PR_HEAD="abc123" \
-    PUBLISHED_COMMENT="$published_comment" \
-    EXPECTED_HEAD_SHA="abc123" \
-    PR_NUMBER="42" \
-    REPOSITORY="owner/repo" \
-    REVIEW_JSON='{"summary":' \
-    REVIEW_MARKER="claude-auto-review" \
-    REVIEW_TITLE="Claude Review" \
-    bash -c "$publisher_script" >/dev/null 2>&1; then
+if run_publisher '{"summary":' >/dev/null 2>&1; then
     fail "Claude publisher accepted malformed JSON"
 fi
 
@@ -444,16 +417,7 @@ oversized_findings="$(
         ]
     }'
 )"
-if PATH="$fake_bin:$PATH" \
-    FAKE_PR_HEAD="abc123" \
-    PUBLISHED_COMMENT="$published_comment" \
-    EXPECTED_HEAD_SHA="abc123" \
-    PR_NUMBER="42" \
-    REPOSITORY="owner/repo" \
-    REVIEW_JSON="$oversized_findings" \
-    REVIEW_MARKER="claude-auto-review" \
-    REVIEW_TITLE="Claude Review" \
-    bash -c "$publisher_script" >/dev/null 2>&1; then
+if run_publisher "$oversized_findings" >/dev/null 2>&1; then
     fail "Claude publisher accepted more than five findings"
 fi
 
@@ -461,30 +425,12 @@ oversized_summary="$(
     jq -n --arg summary "$(printf 's%.0s' {1..8001})" \
         '{summary: $summary, findings: []}'
 )"
-if PATH="$fake_bin:$PATH" \
-    FAKE_PR_HEAD="abc123" \
-    PUBLISHED_COMMENT="$published_comment" \
-    EXPECTED_HEAD_SHA="abc123" \
-    PR_NUMBER="42" \
-    REPOSITORY="owner/repo" \
-    REVIEW_JSON="$oversized_summary" \
-    REVIEW_MARKER="claude-auto-review" \
-    REVIEW_TITLE="Claude Review" \
-    bash -c "$publisher_script" >/dev/null 2>&1; then
+if run_publisher "$oversized_summary" >/dev/null 2>&1; then
     fail "Claude publisher accepted an oversized summary"
 fi
 
 unsafe_path_review='{"summary":"finding","findings":[{"severity":"HIGH","path":"../outside","line":1,"body":"bad"}]}'
-if PATH="$fake_bin:$PATH" \
-    FAKE_PR_HEAD="abc123" \
-    PUBLISHED_COMMENT="$published_comment" \
-    EXPECTED_HEAD_SHA="abc123" \
-    PR_NUMBER="42" \
-    REPOSITORY="owner/repo" \
-    REVIEW_JSON="$unsafe_path_review" \
-    REVIEW_MARKER="claude-auto-review" \
-    REVIEW_TITLE="Claude Review" \
-    bash -c "$publisher_script" >/dev/null 2>&1; then
+if run_publisher "$unsafe_path_review" >/dev/null 2>&1; then
     fail "Claude publisher accepted an unsafe finding path"
 fi
 

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -666,7 +666,7 @@ nested_manifest_needs(path) := {name |
 # the results it reads ARE the merge gate. Each reusable workflow already pins
 # its own nested job membership; nothing pinned the level above, where adding a
 # group and forgetting to gate it leaves the single required check green while
-# that group is free to fail. `supplemental` is advisory by design.
+# that group is free to fail.
 
 # A job-level `uses:` IS a reusable-workflow call — a job cannot carry both
 # `uses:` and `steps:`. Matching on the `./.github/workflows/` prefix instead
@@ -680,14 +680,11 @@ calls_a_reusable_workflow(job) if {
 
 ci_gate_job_key := "gate"
 
-ci_advisory_job_keys := {"supplemental"}
-
 ci_gate_job := object.get(ci_jobs, ci_gate_job_key, {})
 
 ci_group_job_keys contains name if {
 	some name, job in ci_jobs
 	calls_a_reusable_workflow(job)
-	not name in ci_advisory_job_keys
 }
 
 ci_gate_needs := {name | some name in object.get(ci_gate_job, "needs", [])}

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -1090,7 +1090,7 @@ deny contains msg if {
 	_ := documents[ci_workflow_path]
 	ci_gate_needs != ci_group_job_keys
 	msg := sprintf(
-		"%s %s must gate exactly the non-advisory group jobs %v, not %v",
+		"%s %s must gate exactly the group jobs %v, not %v",
 		[ci_workflow_path, ci_gate_job_key, ci_group_job_keys, ci_gate_needs],
 	)
 }

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -1036,7 +1036,7 @@ ci_gate_shipped_jobs := {
 
 ci_gate_membership_violations(violations) := [msg |
 	some msg in violations
-	contains(msg, "must gate exactly the non-advisory group jobs")
+	contains(msg, "must gate exactly the group jobs")
 ]
 
 ci_gate_unread_violations(violations) := [msg |

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -1024,7 +1024,6 @@ ci_gate_shipped_jobs := {
 	"lint": {"uses": "./.github/workflows/ci-lint.yml"},
 	"builds": {"uses": "./.github/workflows/ci-builds.yml"},
 	"tests": {"uses": "./.github/workflows/ci-tests.yml"},
-	"supplemental": {"uses": "./.github/workflows/ci-supplemental.yml"},
 	"gate": {
 		"needs": ["lint", "builds", "tests"],
 		"steps": [{"env": {
@@ -1084,19 +1083,6 @@ test_ci_gate_listing_a_group_it_never_reads_is_denied if {
 		}}],
 	}})
 	sprintf("%s %s must read needs.builds.result", [ci_workflow_path, ci_gate_job_key]) in deny with input as ci_gate_fixture(jobs)
-}
-
-test_ci_gate_need_on_the_advisory_group_is_denied if {
-	jobs := object.union(ci_gate_shipped_jobs, {"gate": {
-		"needs": ["lint", "builds", "tests", "supplemental"],
-		"steps": [{"env": {
-			"LINT_RESULT": "${{ needs.lint.result }}",
-			"BUILDS_RESULT": "${{ needs.builds.result }}",
-			"TESTS_RESULT": "${{ needs.tests.result }}",
-		}}],
-	}})
-	violations := deny with input as ci_gate_fixture(jobs)
-	count(ci_gate_membership_violations(violations)) == 1
 }
 
 ci_oidc_call_message(name) := sprintf(


### PR DESCRIPTION
Tier A of the CI audit (items 1-7): the mechanical, low-risk consolidations. Net −50 lines with two new composites; items 8-11 (cache tuning, non-Rust-PR skips, site/pages composite) follow in a second PR.

## What

- **`setup-alsa` composite** — 11 bare `apt-get install libasound2-dev` copies (4 comment variants, none retried) become one composite carrying the #633 WHY and the smoke job's mirror-retry envelope; the flake class costs a full 47-min re-run per occurrence.
- **`require-jobs` composite** — the three byte-identical jq aggregators share one shape (with a guard: a caller omitting `results:` fails loud instead of gating nothing — `required:` inputs are advisory per GitHub's own docs). ci.yml's gate deliberately keeps its hand-written env reads: the policy pins them (`must read needs.*.result`).
- **go-tools cache** — the hygiene job stops compiling five Go tools from source every run (148s of a 189s job); key hashes ci-lint.yml itself so a version bump can never serve a stale binary.
- **Three one-authority fixes** — the Linux `--no-default-features` flag derives inside `build-target` from the target; `just workspace-version` owns the version parse for the tag check and `just bump`; `API_PUBLIC_API` + a runtime assert in `_api-toolchain` pin the cargo-public-api pair so divergence fails loud instead of churning goldens.
- **Policy** — the dead `supplemental` exemption (job deleted in #956) goes, with its clause, fixture row, and test; the behavior test's seven publisher blocks share `run_publisher`.
- **Trivia** — codspeed gains the standard concurrency block (keeping the read floor); the Chromium-before-check comment moves onto the step it describes.

## Review (two-lens gate)

3 lenses (correctness / design / whole-file comment audit): APPROVE-WITH-NITS ×3 effectively; fold `d32afcb5` carries the dispositions — highlights: the vacuous-pass guard (probe-verified: actionlint accepts an omitted `results:`, jq exits 0 on empty), the "non-advisory" deny-message rot, the stolen `build` comment block, codspeed's lost permissions floor. All local gates green: preflight (3218 tests), ci-obs (117 rego + 113 conftest), actionlint, actionlint-composites, zizmor 1.30, shellcheck/shfmt, standalone behavior test.

**Tag-time-only surfaces** (release.yml never runs on a PR): `build-target`'s derivation and `just workspace-version` — exercised locally instead: native `just build-target aarch64-apple-darwin false` exit 0; the derivation replayed over all 7 matrix targets matches the deleted expression; `just workspace-version` → 0.18.0. Recommend one by-hand musl `build-target` before the next tag.

## Surfaced to owner (pre-existing / trades, one line each)

- `packaging-build/action.yml:41` keeps an independent, differently-implemented version parse (deliberately just-free; `cargo metadata --no-deps` could replace it if wanted).
- `release.yml`'s musl-tools install is still a bare un-retried apt call on the tag-only path (a generalized apt composite would collect it and the ffmpeg install).
- The three aggregators gained a checkout — a transient checkout failure now reds the merge-gate job (fail-closed, but a new network dependency).
- The go-tools cache populates only on a fully green hygiene job (actions/cache semantics); fork PRs read-only, degrade gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6LG4b2iq2tRHvJ3AhFXDU
