### PR TITLE
chore(ci): tier B of the CI audit — the release cache pair and the site-node composite

### DIFF
--- a/.github/actions/setup-site-node/action.yml
+++ b/.github/actions/setup-site-node/action.yml
@@ -1,24 +1,27 @@
 name: 'Setup Site Node'
 description: 'Node + pinned npm + npm ci + Playwright Chromium for the Astro site'
 
+inputs:
+  node-version:
+    description: 'The one authority for the Node major; feeds setup-node and the output below'
+    default: '26'
+
 outputs:
   node-version:
-    description: 'The Node major the site builds with (pages.yml forwards it to withastro/action)'
-    value: ${{ steps.versions.outputs.node }}
+    description: 'The Node major in effect — withastro/action runs its own Node setup and would otherwise pick a different major'
+    value: ${{ inputs.node-version }}
 
 runs:
   using: 'composite'
   steps:
-    - id: versions
-      shell: bash
-      run: echo "node=26" >> "$GITHUB_OUTPUT"
     - uses: actions/setup-node@v7
       with:
-        node-version: ${{ steps.versions.outputs.node }}
+        node-version: ${{ inputs.node-version }}
         cache: npm
         cache-dependency-path: site/package-lock.json
-    # Node 26's bundled npm predates the complete allowScripts toolchain, so
-    # match packageManager before npm ci or install-script policy goes unenforced.
+    # The pinned Node major's bundled npm predates the complete allowScripts
+    # toolchain, so match packageManager before npm ci or install-script policy
+    # goes unenforced.
     - name: Install pinned npm
       shell: bash
       run: npm install --global npm@12.0.1 # zizmor: ignore[adhoc-packages] exact packageManager bootstrap before the lockfile install
@@ -31,9 +34,9 @@ runs:
       with:
         path: ~/.cache/ms-playwright
         key: playwright-${{ runner.os }}-${{ hashFiles('site/package-lock.json') }}
-    # rehype-mermaid renders the mermaid blocks with a headless Chromium, so it
-    # must be installed BEFORE `check`/`build` (check-then-install is what broke
-    # pages.yml). The shell is named explicitly so a cache holding
+    # rehype-mermaid renders the mermaid blocks with a headless Chromium, so
+    # the install must stay INSIDE this composite, ahead of every caller's
+    # `check`/`build`. The shell is named explicitly so a cache holding
     # chromium-but-not-the-shell can't skip it.
     - name: Install Chromium for the diagrams
       shell: bash

--- a/.github/actions/setup-site-node/action.yml
+++ b/.github/actions/setup-site-node/action.yml
@@ -1,0 +1,41 @@
+name: 'Setup Site Node'
+description: 'Node + pinned npm + npm ci + Playwright Chromium for the Astro site'
+
+outputs:
+  node-version:
+    description: 'The Node major the site builds with (pages.yml forwards it to withastro/action)'
+    value: ${{ steps.versions.outputs.node }}
+
+runs:
+  using: 'composite'
+  steps:
+    - id: versions
+      shell: bash
+      run: echo "node=26" >> "$GITHUB_OUTPUT"
+    - uses: actions/setup-node@v7
+      with:
+        node-version: ${{ steps.versions.outputs.node }}
+        cache: npm
+        cache-dependency-path: site/package-lock.json
+    # Node 26's bundled npm predates the complete allowScripts toolchain, so
+    # match packageManager before npm ci or install-script policy goes unenforced.
+    - name: Install pinned npm
+      shell: bash
+      run: npm install --global npm@12.0.1 # zizmor: ignore[adhoc-packages] exact packageManager bootstrap before the lockfile install
+    - name: Install site dependencies
+      shell: bash
+      working-directory: site
+      run: npm ci
+    - name: Cache Playwright Chromium
+      uses: actions/cache@v6
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ hashFiles('site/package-lock.json') }}
+    # rehype-mermaid renders the mermaid blocks with a headless Chromium, so it
+    # must be installed BEFORE `check`/`build` (check-then-install is what broke
+    # pages.yml). The shell is named explicitly so a cache holding
+    # chromium-but-not-the-shell can't skip it.
+    - name: Install Chromium for the diagrams
+      shell: bash
+      working-directory: site
+      run: npx playwright install --with-deps chromium chromium-headless-shell

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,35 +30,11 @@ jobs:
           # checkout silently falls back to Cargo.toml
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-node@v7
-        with:
-          node-version: 26
-          cache: npm
-          cache-dependency-path: site/package-lock.json
-      # Node 26's bundled npm predates the complete allowScripts toolchain, so
-      # match packageManager before npm ci or install-script policy goes unenforced.
-      - name: Install pinned npm
-        working-directory: ${{ github.workspace }}
-        run: npm install --global npm@12.0.1 # zizmor: ignore[adhoc-packages] exact packageManager bootstrap before the lockfile install
-      - name: Cache Playwright Chromium
-        uses: actions/cache@v6
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('site/package-lock.json') }}
-      - name: Install site dependencies
-        working-directory: site
-        run: npm ci
+      - uses: ./.github/actions/setup-site-node
+        id: site-node
       - name: Audit site dependencies
         working-directory: site
         run: npm run audit
-      # Chromium must be installed BEFORE `npm run check`: `astro check` renders
-      # /architecture's ```mermaid block via rehype-mermaid (headless Playwright),
-      # and a browserless render takes the deploy red at check:docs. Name
-      # `chromium-headless-shell` too, so a cache holding chromium-but-not-the-shell
-      # can't skip it.
-      - name: Install Chromium for the diagram
-        working-directory: site
-        run: npx playwright install --with-deps chromium chromium-headless-shell
       - name: Lint site
         working-directory: site
         run: npm run lint
@@ -72,7 +48,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           path: ./site
-          node-version: 26
+          node-version: ${{ steps.site-node.outputs.node-version }}
           # DON'T re-enable the action's Astro build cache: its bare
           # `astro-cache-<os>-` restore-key prefix means a deploy that once
           # rendered /architecture EMPTY caches that empty <Content /> and every

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,7 +5,7 @@ on:
   # silently lags its own source.
   push:
     branches: [main]
-    paths: ['site/**', 'Cargo.toml', 'docs/CONFIGURATION.md', 'docs/ARCHITECTURE.md', 'docs/CONTRIBUTING.md', 'docs/PARALLEL-DELIVERY.md', '.github/workflows/pages.yml']
+    paths: ['site/**', 'Cargo.toml', 'docs/CONFIGURATION.md', 'docs/ARCHITECTURE.md', 'docs/CONTRIBUTING.md', 'docs/PARALLEL-DELIVERY.md', '.github/workflows/pages.yml', '.github/actions/setup-site-node/**']
   workflow_dispatch:
 
 # Least-privilege: the build job runs third-party code (npm postinstall
@@ -56,9 +56,9 @@ jobs:
           # ```mermaid block. Cost of `false` is a cold content-layer rebuild.
           cache: false
           # PIN npm: v6's detection otherwise falls back to pnpm, whose fresh
-          # install resolves a DIFFERENT Playwright than the Chromium installed
-          # above, so rehype-mermaid's render of /architecture fails and silently
-          # ships an EMPTY page.
+          # install resolves a DIFFERENT Playwright than the Chromium
+          # setup-site-node installed, so rehype-mermaid's render of
+          # /architecture fails and silently ships an EMPTY page.
           package-manager: npm
           # Assert every doc page rendered a body IN the action's own context,
           # before it uploads: rehype-mermaid can collapse a doc's <Content /> to

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,9 +104,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2 # zizmor: ignore[cache-poisoning] PR caches are merge-ref scoped; stable tags are ancestry-gated to main
         with:
           prefix-key: v1-rust
-          # shared-key, not key: the deb job rebuilds the same target with the
-          # same flags, and per-job derived keys made it a second cold cross
-          # build per tag.
+          # One key for the pair: a re-run of a failed deb leg (aarch64, the one
+          # target both jobs build, same flags) restores this cache instead of
+          # repeating the cross build. A FRESH tag still pays both cold: the
+          # jobs start together, and a tag's caches are scoped to that tag.
           shared-key: release-${{ matrix.target }}
 
       - uses: ./.github/actions/setup-just
@@ -178,6 +179,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2 # zizmor: ignore[cache-poisoning] PR caches are merge-ref scoped; stable tags are ancestry-gated to main
         with:
           prefix-key: v1-rust
+          # Paired with the build job's shared-key — the rationale lives there.
           shared-key: release-${{ matrix.target }}
 
       - uses: ./.github/actions/setup-just

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2 # zizmor: ignore[cache-poisoning] PR caches are merge-ref scoped; stable tags are ancestry-gated to main
         with:
           prefix-key: v1-rust
-          key: ${{ matrix.target }}
+          # shared-key, not key: the deb job rebuilds the same target with the
+          # same flags, and per-job derived keys made it a second cold cross
+          # build per tag.
+          shared-key: release-${{ matrix.target }}
 
       - uses: ./.github/actions/setup-just
 
@@ -175,7 +178,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2 # zizmor: ignore[cache-poisoning] PR caches are merge-ref scoped; stable tags are ancestry-gated to main
         with:
           prefix-key: v1-rust
-          key: deb-${{ matrix.target }}
+          shared-key: release-${{ matrix.target }}
 
       - uses: ./.github/actions/setup-just
 

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -29,26 +29,7 @@ jobs:
           # checkout silently falls back to Cargo.toml
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-node@v7
-        with:
-          node-version: 26
-          cache: npm
-          cache-dependency-path: site/package-lock.json
-      # Node 26's bundled npm predates the complete allowScripts toolchain, so
-      # match packageManager before npm ci or install-script policy goes unenforced.
-      - name: Install pinned npm
-        working-directory: ${{ github.workspace }}
-        run: npm install --global npm@12.0.1 # zizmor: ignore[adhoc-packages] exact packageManager bootstrap before the lockfile install
-      - run: npm ci
-      - name: Cache Playwright Chromium
-        uses: actions/cache@v6
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('site/package-lock.json') }}
-      # rehype-mermaid needs a headless Chromium, installed BEFORE `check`/`build`
-      # (both render it; check-then-install is what broke pages.yml). The shell is
-      # named explicitly so a cache holding chromium-but-not-the-shell can't skip it.
-      - run: npx playwright install --with-deps chromium chromium-headless-shell
+      - uses: ./.github/actions/setup-site-node
       - run: npm run format:check
       - run: npm run lint
       - run: npm run check

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -5,7 +5,7 @@ on:
   # be a redundant 2nd Astro build. README drift is gated by ci-lint.yml's
   # `readme` job instead, so README.md is deliberately absent from the paths.
   pull_request:
-    paths: ['site/**', 'Cargo.toml', 'docs/CONFIGURATION.md', 'docs/ARCHITECTURE.md', 'docs/CONTRIBUTING.md', 'docs/PARALLEL-DELIVERY.md', '.github/workflows/site.yml', '.github/workflows/pages.yml']
+    paths: ['site/**', 'Cargo.toml', 'docs/CONFIGURATION.md', 'docs/ARCHITECTURE.md', 'docs/CONTRIBUTING.md', 'docs/PARALLEL-DELIVERY.md', '.github/workflows/site.yml', '.github/workflows/pages.yml', '.github/actions/setup-site-node/**']
 
 permissions:
   contents: read

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -280,9 +280,8 @@ dependency_audit_steps(path, job_name) := [step |
 	effective_working_directory(job, step) == "site"
 ]
 
-# The pinned bootstrap lives in the shared composite; each site workflow proves
-# it runs it by calling the composite un-conditioned, and the composite proves
-# it still performs the exact install.
+# The pinned bootstrap lives in the shared composite, which must still perform
+# the exact install.
 site_node_action_installs := [step |
 	action := documents[site_node_action_path]
 	steps := object.get(object.get(action, "runs", {}), "steps", [])
@@ -292,6 +291,8 @@ site_node_action_installs := [step |
 	object.get(step, "continue-on-error", false) == false
 ]
 
+# Each site workflow proves it runs the bootstrap by calling the composite
+# un-conditioned.
 site_node_call_steps(path, job_name) := [step |
 	workflow := documents[path]
 	jobs := object.get(workflow, "jobs", {})

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -72,11 +72,12 @@ lighthouse_workflow_path := ".github/workflows/site.yml"
 pages_workflow_path := ".github/workflows/pages.yml"
 site_package_path := "site/package.json"
 expected_dependency_audit := "npm audit --audit-level=low"
+site_node_action_path := ".github/actions/setup-site-node/action.yml"
+site_node_action_ref := "./.github/actions/setup-site-node"
 pinned_npm_version := "12.0.1"
 expected_package_manager := sprintf("npm@%s", [pinned_npm_version])
 expected_npm_engine := ">=12.0.0 <13"
 expected_npm_setup := sprintf("npm install --global npm@%s", [pinned_npm_version])
-github_workspace := "${{ github.workspace }}"
 
 expected_codecov_route(file, flag, report_type, condition) := {
 	"path": codecov_workflow_path,
@@ -279,7 +280,19 @@ dependency_audit_steps(path, job_name) := [step |
 	effective_working_directory(job, step) == "site"
 ]
 
-pinned_npm_setup_steps(path, job_name) := [step |
+# The pinned bootstrap lives in the shared composite; each site workflow proves
+# it runs it by calling the composite un-conditioned, and the composite proves
+# it still performs the exact install.
+site_node_action_installs := [step |
+	action := documents[site_node_action_path]
+	steps := object.get(object.get(action, "runs", {}), "steps", [])
+	some step in steps
+	object.get(step, "run", "") == expected_npm_setup
+	object.get(step, "if", null) == null
+	object.get(step, "continue-on-error", false) == false
+]
+
+site_node_call_steps(path, job_name) := [step |
 	workflow := documents[path]
 	jobs := object.get(workflow, "jobs", {})
 	job := object.get(jobs, job_name, {})
@@ -287,8 +300,7 @@ pinned_npm_setup_steps(path, job_name) := [step |
 	object.get(job, "continue-on-error", false) == false
 	steps := object.get(job, "steps", [])
 	some step in steps
-	object.get(step, "run", "") == expected_npm_setup
-	object.get(step, "working-directory", "") == github_workspace
+	object.get(step, "uses", "") == site_node_action_ref
 	object.get(step, "if", null) == null
 	object.get(step, "continue-on-error", false) == false
 ]
@@ -1213,13 +1225,18 @@ deny contains msg if {
 }
 
 deny contains msg if {
-	count(pinned_npm_setup_steps(lighthouse_workflow_path, "check")) != 1
-	msg := sprintf("%s must install %s exactly once", [lighthouse_workflow_path, expected_package_manager])
+	count(site_node_action_installs) != 1
+	msg := sprintf("%s must install %s exactly once", [site_node_action_path, expected_package_manager])
 }
 
 deny contains msg if {
-	count(pinned_npm_setup_steps(pages_workflow_path, "build")) != 1
-	msg := sprintf("%s must install %s exactly once", [pages_workflow_path, expected_package_manager])
+	count(site_node_call_steps(lighthouse_workflow_path, "check")) != 1
+	msg := sprintf("%s must run %s exactly once", [lighthouse_workflow_path, site_node_action_ref])
+}
+
+deny contains msg if {
+	count(site_node_call_steps(pages_workflow_path, "build")) != 1
+	msg := sprintf("%s must run %s exactly once", [pages_workflow_path, site_node_action_ref])
 }
 
 deny contains msg if {

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -265,7 +265,7 @@ test_pages_workflow_must_call_the_site_node_composite if {
 test_a_conditioned_site_node_call_does_not_count if {
 	fixture := {"documents": [{
 		"path": pages_workflow_path,
-		"contents": {"jobs": {"build": {"steps": [{"uses": "./.github/actions/setup-site-node", "if": "false"}]}}},
+		"contents": {"jobs": {"build": {"steps": [{"uses": site_node_action_ref, "if": "false"}]}}},
 	}]}
 	violations := deny with input as fixture
 	sprintf("%s must run %s exactly once", [pages_workflow_path, site_node_action_ref]) in violations

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -235,22 +235,40 @@ test_dependency_audit_script_is_pinned if {
 	sprintf("%s must keep scripts.audit at %q", [site_package_path, expected_dependency_audit]) in violations
 }
 
-test_site_workflow_installs_the_pinned_npm if {
+test_site_node_action_must_keep_the_pinned_install if {
 	fixture := {"documents": [{
-		"path": lighthouse_workflow_path,
-		"contents": {"jobs": {"check": {"steps": [{"run": "npm install --global npm@latest"}]}}},
+		"path": site_node_action_path,
+		"contents": {"runs": {"steps": [{"run": "npm install --global npm@latest"}]}},
 	}]}
 	violations := deny with input as fixture
-	sprintf("%s must install %s exactly once", [lighthouse_workflow_path, expected_package_manager]) in violations
+	sprintf("%s must install %s exactly once", [site_node_action_path, expected_package_manager]) in violations
 }
 
-test_pages_workflow_installs_the_pinned_npm if {
+test_site_workflow_must_call_the_site_node_composite if {
 	fixture := {"documents": [{
-		"path": pages_workflow_path,
-		"contents": {"jobs": {"build": {"steps": [{"run": "npm install --global npm@latest"}]}}},
+		"path": lighthouse_workflow_path,
+		"contents": {"jobs": {"check": {"steps": [{"run": "npm ci"}]}}},
 	}]}
 	violations := deny with input as fixture
-	sprintf("%s must install %s exactly once", [pages_workflow_path, expected_package_manager]) in violations
+	sprintf("%s must run %s exactly once", [lighthouse_workflow_path, site_node_action_ref]) in violations
+}
+
+test_pages_workflow_must_call_the_site_node_composite if {
+	fixture := {"documents": [{
+		"path": pages_workflow_path,
+		"contents": {"jobs": {"build": {"steps": [{"run": "npm ci"}]}}},
+	}]}
+	violations := deny with input as fixture
+	sprintf("%s must run %s exactly once", [pages_workflow_path, site_node_action_ref]) in violations
+}
+
+test_a_conditioned_site_node_call_does_not_count if {
+	fixture := {"documents": [{
+		"path": pages_workflow_path,
+		"contents": {"jobs": {"build": {"steps": [{"uses": "./.github/actions/setup-site-node", "if": "false"}]}}},
+	}]}
+	violations := deny with input as fixture
+	sprintf("%s must run %s exactly once", [pages_workflow_path, site_node_action_ref]) in violations
 }
 
 test_site_manifest_pins_the_npm_generation if {


### PR DESCRIPTION
Tier B of the CI audit (items 8-11), stacked on #966 — retarget to main after it merges.

## What

- **Release cache pair** — the build and deb jobs rebuild the one shared target (`aarch64-unknown-linux-gnu`, identical flags since #966's target-derived `--no-default-features`) into per-job caches; both now use `shared-key: release-<target>`. Honest scope, per review: a fresh tag still pays both cold (the jobs start together; tag caches are tag-scoped) — the wins are same-tag re-runs of a failed deb leg and one cache entry instead of two (cache is currently over the 10 GB ceiling).
- **`setup-site-node` composite** — pages.yml and site.yml shared ~20 verbatim lines of Node/npm/Playwright setup; the composite owns them. The Node major is a composite input (default 26) — one authority feeding `setup-node` and an output pages.yml forwards to `withastro/action` (which runs its own Node setup and would otherwise pick a different major). The ci-obs pin follows the moved step: the composite must keep the exact pinned npm install, and each workflow must call the composite un-conditioned exactly once. Both workflows' `paths:` lists now include the composite (review-caught: a composite-only change previously got zero runtime exercise).

## Dispositions of the audit's items 9-10

- **Item 9 (cache pressure)** — the shared-key halves release's footprint; the broader levers (Linux job `shared-key`/`save-if` consolidation) need restore-rate measurement first — most main-branch jobs build with *different* flag sets, and forcing a shared key across them thrashes. Surfaced with that caveat.
- **Item 10 (non-Rust PR skips)** — the CodeQL half is **REFUTED by mechanism**: `main.rego` pins `on.pull_request` to exact-null ("any filter lets some PR merge unanalyzed"); changing that is a security-policy decision, not a cleanup. The ci.yml step-level skip design (~400 runner-min/week) remains available but wants its own design-gated PR: a changes-filter job + `if:` on expensive steps, inverted default, aggregators and policy untouched. Say the word and it becomes PR 3.

## Review (two-lens gate)

3 lenses (correctness / design / whole-file comment audit): APPROVE-WITH-NITS ×2, REQUEST-CHANGES ×1 (both its HIGHs fixed — one on the parent branch as #966's round 2, one here). Fold `ec88fdd4`. Probe highlights: rust-cache `shared-key` semantics fetched from its README; every policy mutation fires the right deny (install deleted, call deleted, `if:` added — both levels); zizmor parses and still suppresses inside the composite; the deleted-outputs case is actionlint-caught while the input-shaped authority removes the dangling-id case structurally.

**Deploy-watch note**: `withastro/action` + the output forwarding live only in pages.yml, which never runs on PRs — watch the first main-push pages run's "setup node" step resolve Node 26 before trusting the chain end-to-end.

**Surfaced**: a bootstrap-before-`npm ci` ordering rule inside the composite (new gate — needs its own small PR if wanted); `lighthouse_workflow_path` naming debt (13 uses, site.yml's check job is 1-of-10 lighthouse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6LG4b2iq2tRHvJ3AhFXDU
