### PR TITLE
feat(omp): every profile gets a desk — one watcher per profile sessions root

### DIFF
--- a/api/pixtuoid-core.txt
+++ b/api/pixtuoid-core.txt
@@ -524,9 +524,13 @@ impl !core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::source::manager
 impl !core::panic::unwind_safe::UnwindSafe for pixtuoid_core::source::manager::SourceManager
 pub mod pixtuoid_core::source::omp
 pub struct pixtuoid_core::source::omp::OmpSource
+pub pixtuoid_core::source::omp::OmpSource::profile_sessions_roots: alloc::vec::Vec<std::path::PathBuf>
+pub pixtuoid_core::source::omp::OmpSource::rescan: pixtuoid_core::source::omp::OmpProfileEnumerate
+pub pixtuoid_core::source::omp::OmpSource::rescan_interval: core::time::Duration
 pub pixtuoid_core::source::omp::OmpSource::sessions_root: std::path::PathBuf
 impl pixtuoid_core::source::omp::OmpSource
 pub fn pixtuoid_core::source::omp::OmpSource::default_paths() -> Self
+pub fn pixtuoid_core::source::omp::OmpSource::single_root(std::path::PathBuf) -> Self
 impl pixtuoid_core::Source for pixtuoid_core::source::omp::OmpSource
 pub fn pixtuoid_core::source::omp::OmpSource::name(&self) -> &str
 pub async fn pixtuoid_core::source::omp::OmpSource::run(alloc::boxed::Box<Self>, pixtuoid_core::TaggedSender) -> anyhow::Result<()>
@@ -535,8 +539,8 @@ impl core::marker::Send for pixtuoid_core::source::omp::OmpSource
 impl core::marker::Sync for pixtuoid_core::source::omp::OmpSource
 impl core::marker::Unpin for pixtuoid_core::source::omp::OmpSource
 impl core::marker::UnsafeUnpin for pixtuoid_core::source::omp::OmpSource
-impl core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::source::omp::OmpSource
-impl core::panic::unwind_safe::UnwindSafe for pixtuoid_core::source::omp::OmpSource
+impl !core::panic::unwind_safe::RefUnwindSafe for pixtuoid_core::source::omp::OmpSource
+impl !core::panic::unwind_safe::UnwindSafe for pixtuoid_core::source::omp::OmpSource
 pub const pixtuoid_core::source::omp::SOURCE_NAME: &str
 pub fn pixtuoid_core::source::omp::decode_omp_hook_payload(&serde_json::value::Value) -> anyhow::Result<alloc::vec::Vec<pixtuoid_core::source::AgentEvent>>
 pub fn pixtuoid_core::source::omp::decode_omp_line(&str, &str, serde_json::value::Value) -> anyhow::Result<alloc::vec::Vec<pixtuoid_core::source::AgentEvent>>
@@ -544,6 +548,7 @@ pub fn pixtuoid_core::source::omp::omp_agent_dir() -> std::path::PathBuf
 pub fn pixtuoid_core::source::omp::omp_extensions_dir() -> std::path::PathBuf
 pub fn pixtuoid_core::source::omp::omp_id_from_path(&std::path::Path) -> alloc::string::String
 pub fn pixtuoid_core::source::omp::omp_sessions_dir() -> std::path::PathBuf
+pub type pixtuoid_core::source::omp::OmpProfileEnumerate = alloc::sync::Arc<(dyn core::ops::function::Fn() -> alloc::vec::Vec<std::path::PathBuf> + core::marker::Send + core::marker::Sync)>
 pub mod pixtuoid_core::source::openclaw
 pub const pixtuoid_core::source::openclaw::SOURCE_NAME: &str
 pub fn pixtuoid_core::source::openclaw::decode_openclaw_hook_payload(&serde_json::value::Value) -> anyhow::Result<pixtuoid_core::source::daemon::DecodedPresence>

--- a/api/pixtuoid-core.txt
+++ b/api/pixtuoid-core.txt
@@ -525,12 +525,9 @@ impl !core::panic::unwind_safe::UnwindSafe for pixtuoid_core::source::manager::S
 pub mod pixtuoid_core::source::omp
 pub struct pixtuoid_core::source::omp::OmpSource
 pub pixtuoid_core::source::omp::OmpSource::profile_sessions_roots: alloc::vec::Vec<std::path::PathBuf>
-pub pixtuoid_core::source::omp::OmpSource::rescan: pixtuoid_core::source::omp::OmpProfileEnumerate
-pub pixtuoid_core::source::omp::OmpSource::rescan_interval: core::time::Duration
 pub pixtuoid_core::source::omp::OmpSource::sessions_root: std::path::PathBuf
 impl pixtuoid_core::source::omp::OmpSource
 pub fn pixtuoid_core::source::omp::OmpSource::default_paths() -> Self
-pub fn pixtuoid_core::source::omp::OmpSource::single_root(std::path::PathBuf) -> Self
 impl pixtuoid_core::Source for pixtuoid_core::source::omp::OmpSource
 pub fn pixtuoid_core::source::omp::OmpSource::name(&self) -> &str
 pub async fn pixtuoid_core::source::omp::OmpSource::run(alloc::boxed::Box<Self>, pixtuoid_core::TaggedSender) -> anyhow::Result<()>
@@ -547,6 +544,7 @@ pub fn pixtuoid_core::source::omp::decode_omp_line(&str, &str, serde_json::value
 pub fn pixtuoid_core::source::omp::omp_agent_dir() -> std::path::PathBuf
 pub fn pixtuoid_core::source::omp::omp_extensions_dir() -> std::path::PathBuf
 pub fn pixtuoid_core::source::omp::omp_id_from_path(&std::path::Path) -> alloc::string::String
+pub fn pixtuoid_core::source::omp::omp_profile_sessions_dirs() -> alloc::vec::Vec<std::path::PathBuf>
 pub fn pixtuoid_core::source::omp::omp_sessions_dir() -> std::path::PathBuf
 pub type pixtuoid_core::source::omp::OmpProfileEnumerate = alloc::sync::Arc<(dyn core::ops::function::Fn() -> alloc::vec::Vec<std::path::PathBuf> + core::marker::Send + core::marker::Sync)>
 pub mod pixtuoid_core::source::openclaw

--- a/crates/pixtuoid-core/src/source/jsonl/mod.rs
+++ b/crates/pixtuoid-core/src/source/jsonl/mod.rs
@@ -179,8 +179,8 @@ pub struct JsonlWatcher {
 }
 
 const DEFAULT_INITIAL_WINDOW: Duration = Duration::from_secs(3600);
-/// The watcher's poll backstop — also the cadence omp's profile rescan rides,
-/// so "how often we look at the filesystem" has one authority.
+/// The watcher's poll backstop — also the cadence profile rescans ride, so
+/// "how often we look at the filesystem" has one authority.
 pub(crate) const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Test-only seam: forces every `JsonlWatcher` in this process onto a polling

--- a/crates/pixtuoid-core/src/source/jsonl/mod.rs
+++ b/crates/pixtuoid-core/src/source/jsonl/mod.rs
@@ -179,7 +179,9 @@ pub struct JsonlWatcher {
 }
 
 const DEFAULT_INITIAL_WINDOW: Duration = Duration::from_secs(3600);
-const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(60);
+/// The watcher's poll backstop — also the cadence omp's profile rescan rides,
+/// so "how often we look at the filesystem" has one authority.
+pub(crate) const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Test-only seam: forces every `JsonlWatcher` in this process onto a polling
 /// backend (`notify::PollWatcher`) at `interval`, instead of the native

--- a/crates/pixtuoid-core/src/source/mod.rs
+++ b/crates/pixtuoid-core/src/source/mod.rs
@@ -270,10 +270,11 @@ impl AgentEvent {
     }
 }
 
-/// The on-disk root a source resolves, through the SAME `default_paths()` the
-/// driver calls — a second copy of the resolution is the #880 defect one layer
-/// up. `None` = no single root (a daemon is port-keyed; a hook-only CLI's
-/// config root lives with its install target).
+/// The PRIMARY on-disk root a source resolves, through the SAME
+/// `default_paths()` the driver calls — a second copy of the resolution is the
+/// #880 defect one layer up. `None` = no such root (a daemon is port-keyed; a
+/// hook-only CLI's config root lives with its install target). omp watches
+/// further profile roots beyond this one (`omp_profile_sessions_dirs`).
 ///
 /// LOCKSTEP with [`registry::SourceDescriptor::home_env`]: a row declaring an
 /// override with no arm here fails

--- a/crates/pixtuoid-core/src/source/omp.rs
+++ b/crates/pixtuoid-core/src/source/omp.rs
@@ -1,6 +1,8 @@
 //! Oh My Pi (`omp`, omp.sh) source. Watches the omp session transcripts
-//! (`<omp_sessions_dir>/<encoded-cwd>/<ts>_<uuid>.jsonl`) via `JsonlWatcher`;
-//! [`omp_sessions_dir`] owns every axis of that root. omp has no shell-hook
+//! (`<sessions-root>/<encoded-cwd>/<ts>_<uuid>.jsonl`) via one `JsonlWatcher`
+//! per root: [`omp_sessions_dir`] owns every axis of the primary root, and
+//! `omp_profile_sessions_dirs` adds every OTHER profile's (each profile keeps
+//! its own sessions tree). omp has no shell-hook
 //! seam — its hooks are in-process TS extension modules — so the hook plane
 //! is a pixtuoid-owned bridge extension
 //! (`pixtuoid/src/install/omp_extension.ts`) whose payloads
@@ -23,7 +25,7 @@ mod native;
 #[cfg(feature = "native")]
 pub(crate) use native::live_omp_session_ids_for_focus;
 #[cfg(feature = "native")]
-pub use native::OmpSource;
+pub use native::{OmpProfileEnumerate, OmpSource};
 
 /// The Oh My Pi (omp) source's registry name (its `SourceDescriptor.name`).
 pub const SOURCE_NAME: &str = "omp";
@@ -225,6 +227,59 @@ fn resolve_omp_sessions_dir(
     // The flatten lives here: with XDG the base REPLACES `<…>/agent`, it does
     // not sit under it.
     xdg.unwrap_or(agent_dir).join("sessions")
+}
+
+/// Sessions dirs of every OTHER profile — the roots the primary
+/// [`omp_sessions_dir`] resolution does not cover. Enumerated from the
+/// `profiles/` child of the base config root, each derived with the SAME
+/// precedence as the selected profile (its own `agent` dir; the XDG arm
+/// flattens `agent/` away where its candidate exists). The env-selected
+/// profile is excluded: its dir IS the primary root. Sorted so the watcher
+/// set is deterministic.
+pub(crate) fn omp_profile_sessions_dirs() -> Vec<PathBuf> {
+    let env = with_omp_dotenv(&OmpEnv::from_process(), &|p| {
+        std::fs::read_to_string(p).ok()
+    });
+    omp_profile_sessions_dirs_resolved(
+        &env,
+        cfg!(any(target_os = "linux", target_os = "macos")),
+        &|p| p.exists(),
+        &|profiles| {
+            let Ok(entries) = std::fs::read_dir(profiles) else {
+                return Vec::new();
+            };
+            entries
+                .filter_map(|e| e.ok())
+                .filter(|e| e.file_type().is_ok_and(|t| t.is_dir()))
+                .filter_map(|e| e.file_name().into_string().ok())
+                .collect()
+        },
+    )
+}
+
+fn omp_profile_sessions_dirs_resolved(
+    env: &OmpEnv,
+    xdg_platform: bool,
+    exists: &dyn Fn(&Path) -> bool,
+    list_profiles: &dyn Fn(&Path) -> Vec<String>,
+) -> Vec<PathBuf> {
+    let Some(base) = omp_config_root(env, None) else {
+        return Vec::new();
+    };
+    let primary = resolve_omp_sessions_dir(env, xdg_platform, exists);
+    let mut names = list_profiles(&base.join("profiles"));
+    names.sort();
+    names
+        .iter()
+        .filter_map(|p| {
+            let agent = omp_config_root(env, Some(p))?.join("agent");
+            let xdg = xdg_platform
+                .then(|| xdg_app_root(env.xdg_data_home.as_deref(), Some(p), exists))
+                .flatten();
+            Some(xdg.unwrap_or(agent).join("sessions"))
+        })
+        .filter(|d| *d != primary)
+        .collect()
 }
 
 /// `resolveIf`: `$XDG_DATA_HOME/omp` (or its `profiles/<name>` child) when that
@@ -1876,6 +1931,69 @@ mod tests {
             resolve_omp_agent_dir(&profiled),
             PathBuf::from("/home/u/.omp/profiles/work/agent"),
             "a named profile derives its own agent dir"
+        );
+    }
+
+    #[test]
+    fn profile_enumeration_derives_each_profiles_sessions_dir() {
+        let env = OmpEnv {
+            home: Some("/home/u".into()),
+            config_dir_name: None,
+            omp_profile: None,
+            pi_profile: None,
+            pi_profile_live: None,
+            agent_dir: None,
+            xdg_data_home: Some("/xdg".into()),
+        };
+        let list = |p: &Path| {
+            assert_eq!(
+                p,
+                Path::new("/home/u/.omp/profiles"),
+                "enumerates the profiles dir"
+            );
+            vec!["play".to_string(), "work".to_string()]
+        };
+        // XDG exists only for `work`, so `work` gets the flattened shape and
+        // `play` the standard profile agent shape.
+        let exists = |p: &Path| p == Path::new("/xdg/omp/profiles/work");
+        assert_eq!(
+            omp_profile_sessions_dirs_resolved(&env, true, &exists, &list),
+            vec![
+                PathBuf::from("/home/u/.omp/profiles/play/agent/sessions"),
+                PathBuf::from("/xdg/omp/profiles/work/sessions"),
+            ]
+        );
+    }
+
+    #[test]
+    fn profile_enumeration_skips_the_selected_profile_and_survives_no_profiles_dir() {
+        let mut env = OmpEnv {
+            home: Some("/home/u".into()),
+            config_dir_name: None,
+            omp_profile: Some("work".into()),
+            pi_profile: None,
+            pi_profile_live: None,
+            agent_dir: None,
+            xdg_data_home: None,
+        };
+        let none = |_: &Path| false;
+        // `work` is the PRIMARY root (env-selected); only `other` is extra.
+        let list = |_: &Path| vec!["work".to_string(), "other".to_string()];
+        assert_eq!(
+            omp_profile_sessions_dirs_resolved(&env, false, &none, &list),
+            vec![PathBuf::from("/home/u/.omp/profiles/other/agent/sessions")]
+        );
+        // No profiles dir at all -> nothing to add.
+        let empty = |_: &Path| Vec::new();
+        assert_eq!(
+            omp_profile_sessions_dirs_resolved(&env, false, &none, &empty),
+            Vec::<PathBuf>::new()
+        );
+        // An unresolvable home enumerates nothing rather than panicking.
+        env.home = None;
+        assert_eq!(
+            omp_profile_sessions_dirs_resolved(&env, false, &none, &list),
+            Vec::<PathBuf>::new()
         );
     }
 

--- a/crates/pixtuoid-core/src/source/omp.rs
+++ b/crates/pixtuoid-core/src/source/omp.rs
@@ -1,8 +1,7 @@
 //! Oh My Pi (`omp`, omp.sh) source. Watches the omp session transcripts
 //! (`<sessions-root>/<encoded-cwd>/<ts>_<uuid>.jsonl`) via one `JsonlWatcher`
-//! per root: [`omp_sessions_dir`] owns every axis of the primary root, and
-//! `omp_profile_sessions_dirs` adds every OTHER profile's (each profile keeps
-//! its own sessions tree). omp has no shell-hook
+//! per root: [`omp_sessions_dir`] owns every axis of the primary root,
+//! [`omp_profile_sessions_dirs`] adds every other profile's. omp has no shell-hook
 //! seam — its hooks are in-process TS extension modules — so the hook plane
 //! is a pixtuoid-owned bridge extension
 //! (`pixtuoid/src/install/omp_extension.ts`) whose payloads
@@ -165,6 +164,13 @@ fn resolve_profile(env: &OmpEnv) -> Option<String> {
 }
 
 /// `getProfileConfigRoot` — `<home>/<PI_CONFIG_DIR|.omp>[/profiles/<profile>]`.
+/// The fixed path segments of a profile's tree, named once — `dirs.ts` joins
+/// these literals, and a silent rename upstream is the drift class
+/// `EXTENSIONS_SUBDIR` already guards its own segment against.
+const PROFILES_SUBDIR: &str = "profiles";
+/// The agent-dir segment under a config root (flattened away by the XDG arm).
+const AGENT_SUBDIR: &str = "agent";
+
 fn omp_config_root(env: &OmpEnv, profile: Option<&str>) -> Option<PathBuf> {
     let name = env
         .config_dir_name
@@ -173,7 +179,7 @@ fn omp_config_root(env: &OmpEnv, profile: Option<&str>) -> Option<PathBuf> {
         .unwrap_or(".omp");
     let root = node_join(env.home.as_deref()?, name);
     Some(match profile {
-        Some(p) => root.join("profiles").join(p),
+        Some(p) => root.join(PROFILES_SUBDIR).join(p),
         None => root,
     })
 }
@@ -185,14 +191,14 @@ fn omp_config_root(env: &OmpEnv, profile: Option<&str>) -> Option<PathBuf> {
 /// parent's `setProfile` exported it rather than the user choosing it.
 fn resolve_omp_agent_dir_parts(env: &OmpEnv) -> Option<(PathBuf, bool, Option<String>)> {
     let profile = resolve_profile(env);
-    let default_agent = omp_config_root(env, profile.as_deref())?.join("agent");
+    let default_agent = omp_config_root(env, profile.as_deref())?.join(AGENT_SUBDIR);
     if profile.is_some() {
         return Some((default_agent, true, profile));
     }
     let override_dir = env.agent_dir.clone().filter(|v| {
         let derived = normalize_profile_name(env.pi_profile_live.as_deref())
             .and_then(|p| omp_config_root(env, Some(&p)))
-            .map(|r| r.join("agent"));
+            .map(|r| r.join(AGENT_SUBDIR));
         derived.is_none_or(|d| *v != d)
     });
     match override_dir {
@@ -209,7 +215,7 @@ fn resolve_omp_agent_dir(env: &OmpEnv) -> PathBuf {
     resolve_omp_agent_dir_parts(env)
         .map(|(d, _, _)| d)
         // Keeps the pre-#880 shape: an unresolvable home is already `/tmp`-rooted.
-        .unwrap_or_else(|| crate::platform::user_home().join(".omp").join("agent"))
+        .unwrap_or_else(|| crate::platform::user_home().join(".omp").join(AGENT_SUBDIR))
 }
 
 /// `getSessionsDir()` = `agentSubdir(undefined, "sessions", "data")`.
@@ -235,8 +241,10 @@ fn resolve_omp_sessions_dir(
 /// precedence as the selected profile (its own `agent` dir; the XDG arm
 /// flattens `agent/` away where its candidate exists). The env-selected
 /// profile is excluded: its dir IS the primary root. Sorted so the watcher
-/// set is deterministic.
-pub(crate) fn omp_profile_sessions_dirs() -> Vec<PathBuf> {
+/// set is deterministic. Only the SELECTED profile's `.env` files overlay the
+/// env (upstream freezes the resolver per process the same way), so another
+/// profile's own `.env` relocations are unseen here.
+pub fn omp_profile_sessions_dirs() -> Vec<PathBuf> {
     let env = with_omp_dotenv(&OmpEnv::from_process(), &|p| {
         std::fs::read_to_string(p).ok()
     });
@@ -267,12 +275,18 @@ fn omp_profile_sessions_dirs_resolved(
         return Vec::new();
     };
     let primary = resolve_omp_sessions_dir(env, xdg_platform, exists);
-    let mut names = list_profiles(&base.join("profiles"));
+    // Through the same validator omp applies: a dir failing its name regex (or
+    // a stray `default`) is one omp can never select, and enumerating it would
+    // make the watcher MATERIALIZE junk roots via its create_dir_all.
+    let mut names: Vec<String> = list_profiles(&base.join(PROFILES_SUBDIR))
+        .iter()
+        .filter_map(|n| normalize_profile_name(Some(n)))
+        .collect();
     names.sort();
     names
         .iter()
         .filter_map(|p| {
-            let agent = omp_config_root(env, Some(p))?.join("agent");
+            let agent = omp_config_root(env, Some(p))?.join(AGENT_SUBDIR);
             let xdg = xdg_platform
                 .then(|| xdg_app_root(env.xdg_data_home.as_deref(), Some(p), exists))
                 .flatten();
@@ -294,7 +308,7 @@ fn xdg_app_root(
 ) -> Option<PathBuf> {
     let app_root = node_join(xdg_data_home?, "omp");
     let candidate = match profile {
-        Some(p) => app_root.join("profiles").join(p),
+        Some(p) => app_root.join(PROFILES_SUBDIR).join(p),
         None => app_root,
     };
     exists(&candidate).then_some(candidate)
@@ -1981,6 +1995,19 @@ mod tests {
         let list = |_: &Path| vec!["work".to_string(), "other".to_string()];
         assert_eq!(
             omp_profile_sessions_dirs_resolved(&env, false, &none, &list),
+            vec![PathBuf::from("/home/u/.omp/profiles/other/agent/sessions")]
+        );
+        // Names omp's own validator refuses — a stray `default` dir, a case
+        // violation — never become roots (the watcher would materialize them).
+        let junk = |_: &Path| {
+            vec![
+                "default".to_string(),
+                "Work".to_string(),
+                "other".to_string(),
+            ]
+        };
+        assert_eq!(
+            omp_profile_sessions_dirs_resolved(&env, false, &none, &junk),
             vec![PathBuf::from("/home/u/.omp/profiles/other/agent/sessions")]
         );
         // No profiles dir at all -> nothing to add.

--- a/crates/pixtuoid-core/src/source/omp/native.rs
+++ b/crates/pixtuoid-core/src/source/omp/native.rs
@@ -1,14 +1,21 @@
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Result;
 
 use super::{
-    decode_omp_line, omp_derive_label, omp_head_title, omp_id_from_path, omp_sessions_dir,
-    SOURCE_NAME,
+    decode_omp_line, omp_derive_label, omp_head_title, omp_id_from_path, omp_profile_sessions_dirs,
+    omp_sessions_dir, SOURCE_NAME,
 };
 use crate::source::decoder::parsed_tail_lines;
-use crate::source::jsonl::{JsonlWatcher, ProbeSnapshot};
+use crate::source::jsonl::{JsonlWatcher, ProbeSnapshot, DEFAULT_POLL_INTERVAL};
 use crate::source::{Source, TaggedSender};
+
+/// The profile-roots lister [`OmpSource::run`] re-invokes on its rescan tick,
+/// injectable so tests can grow the set without touching process env.
+pub type OmpProfileEnumerate = Arc<dyn Fn() -> Vec<PathBuf> + Send + Sync>;
 
 /// omp appends a `custom` entry `customType:"session_exit"` on every clean
 /// teardown, so a transcript that already ended carries that marker — the
@@ -23,19 +30,67 @@ fn omp_session_ended(tail: &[u8]) -> bool {
     })
 }
 
-/// Source that watches the omp sessions directory recursively.
+/// Source that watches the omp sessions directory recursively — the primary
+/// (env-selected) root plus every other profile's, since each profile keeps
+/// its own sessions tree and a session under any of them is a sprite.
 pub struct OmpSource {
-    /// The watched omp `sessions` root.
+    /// The watched primary omp `sessions` root.
     pub sessions_root: PathBuf,
+    /// The OTHER profiles' sessions roots, one watcher each. Filled by
+    /// [`Self::default_paths`]' enumeration; [`Self::run`]'s rescan appends
+    /// newcomers.
+    pub profile_sessions_roots: Vec<PathBuf>,
+    /// Re-lists the profile roots each rescan tick (a profile created mid-run
+    /// gains a watcher without a restart).
+    pub rescan: OmpProfileEnumerate,
+    /// How often [`Self::rescan`] runs; production stays on the watcher poll
+    /// authority, tests shrink it.
+    pub rescan_interval: Duration,
 }
 
 impl OmpSource {
-    /// Construct pointed at the default omp `sessions` root.
+    /// Construct pointed at the default omp `sessions` root, plus every other
+    /// profile's.
     pub fn default_paths() -> Self {
         Self {
+            profile_sessions_roots: omp_profile_sessions_dirs(),
+            rescan: Arc::new(omp_profile_sessions_dirs),
+            rescan_interval: DEFAULT_POLL_INTERVAL,
             sessions_root: omp_sessions_dir(),
         }
     }
+
+    /// A source over one root with no profile set — the test/replay shape.
+    pub fn single_root(sessions_root: PathBuf) -> Self {
+        Self {
+            sessions_root,
+            profile_sessions_roots: Vec::new(),
+            rescan: Arc::new(Vec::new),
+            rescan_interval: DEFAULT_POLL_INTERVAL,
+        }
+    }
+}
+
+/// One watcher over `root`, probe attached where the layout gate allows.
+fn spawn_watcher(
+    set: &mut tokio::task::JoinSet<Result<()>>,
+    started: &mut HashSet<PathBuf>,
+    root: PathBuf,
+    tx: TaggedSender,
+) {
+    let mut watcher = JsonlWatcher::new(
+        root.clone(),
+        SOURCE_NAME.to_string(),
+        decode_omp_line,
+        omp_session_ended,
+    )
+    .with_label_deriver(omp_derive_label)
+    .with_head_label(omp_head_title);
+    if let Some(probe_root) = omp_probe_root(&root) {
+        watcher = watcher.with_liveness_probe(Arc::new(move || live_omp_session_ids(&probe_root)));
+    }
+    started.insert(root);
+    set.spawn(watcher.run(tx));
 }
 
 impl Source for OmpSource {
@@ -44,19 +99,42 @@ impl Source for OmpSource {
     }
 
     async fn run(self: Box<Self>, tx: TaggedSender) -> Result<()> {
-        let mut watcher = JsonlWatcher::new(
-            self.sessions_root.clone(),
-            SOURCE_NAME.to_string(),
-            decode_omp_line,
-            omp_session_ended,
-        )
-        .with_label_deriver(omp_derive_label)
-        .with_head_label(omp_head_title);
-        if let Some(root) = omp_probe_root(&self.sessions_root) {
-            watcher = watcher
-                .with_liveness_probe(std::sync::Arc::new(move || live_omp_session_ids(&root)));
+        let Self {
+            sessions_root,
+            profile_sessions_roots,
+            rescan,
+            rescan_interval,
+        } = *self;
+        let mut set = tokio::task::JoinSet::new();
+        let mut started = HashSet::new();
+        spawn_watcher(&mut set, &mut started, sessions_root, tx.clone());
+        for root in profile_sessions_roots {
+            if !started.contains(&root) {
+                spawn_watcher(&mut set, &mut started, root, tx.clone());
+            }
         }
-        watcher.run(tx).await
+        loop {
+            tokio::select! {
+                _ = tokio::time::sleep(rescan_interval) => {
+                    for root in rescan() {
+                        if !started.contains(&root) {
+                            spawn_watcher(&mut set, &mut started, root, tx.clone());
+                        }
+                    }
+                }
+                Some(finished) = set.join_next() => {
+                    // Log-and-continue: one root failing must not silence the
+                    // rest. `started` keeps the entry, so a failed root is not
+                    // respawn-thrashed by the next rescan.
+                    if let Ok(Err(e)) = finished {
+                        tracing::warn!(source = SOURCE_NAME, error = %e, "omp watcher exited");
+                    }
+                    if set.is_empty() {
+                        return Ok(());
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -113,13 +191,18 @@ fn omp_probe_root_resolved(sessions_root: &Path, resolved_sessions: &Path) -> Op
         return None;
     }
     let parent = sessions_root.parent();
-    let parent_is_dot_omp_agent = parent.is_some_and(|p| {
-        p.file_name().and_then(|n| n.to_str()) == Some("agent")
-            && p.parent()
-                .and_then(|g| g.file_name())
-                .and_then(|n| n.to_str())
-                == Some(".omp")
-    });
+    let name_at = |depth: usize| {
+        let mut dir = parent;
+        for _ in 0..depth {
+            dir = dir.and_then(Path::parent);
+        }
+        dir.and_then(Path::file_name).and_then(|n| n.to_str())
+    };
+    let parent_is_dot_omp_agent = name_at(0) == Some("agent")
+        && (name_at(1) == Some(".omp")
+            // The profiles layout, held to the same rigor: every fixed segment
+            // of `.omp/profiles/<name>/agent/sessions` must be in place.
+            || (name_at(2) == Some("profiles") && name_at(3) == Some(".omp")));
     // Covers every relocating axis at once: this gate and `default_paths` call
     // the SAME `omp_sessions_dir()`, so they cannot disagree.
     let is_resolved_root = sessions_root == resolved_sessions;
@@ -135,6 +218,45 @@ fn omp_probe_root_resolved(sessions_root: &Path, resolved_sessions: &Path) -> Op
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn probe_root_accepts_the_profiles_layout_with_the_same_rigor() {
+        let home = tempfile::tempdir().unwrap();
+        let elsewhere = home.path().join("pi-coding-agent").join("sessions");
+
+        let profiled = home
+            .path()
+            .join(".omp")
+            .join("profiles")
+            .join("work")
+            .join("agent")
+            .join("sessions");
+        assert_eq!(
+            omp_probe_root_resolved(&profiled, &elsewhere),
+            Some(profiled.clone()),
+            "`.omp/profiles/<name>/agent/sessions` is first-party"
+        );
+
+        // Both outer segments must hold, or any `profiles/x/agent/sessions`
+        // replay tree would be vouched for.
+        let no_dot_omp = home
+            .path()
+            .join("work")
+            .join("profiles")
+            .join("x")
+            .join("agent")
+            .join("sessions");
+        assert_eq!(omp_probe_root_resolved(&no_dot_omp, &elsewhere), None);
+
+        let no_agent = home
+            .path()
+            .join(".omp")
+            .join("profiles")
+            .join("work")
+            .join("other")
+            .join("sessions");
+        assert_eq!(omp_probe_root_resolved(&no_agent, &elsewhere), None);
+    }
 
     #[test]
     fn probe_root_accepts_the_dot_omp_agent_layout_and_nothing_that_merely_resembles_it() {

--- a/crates/pixtuoid-core/src/source/omp/native.rs
+++ b/crates/pixtuoid-core/src/source/omp/native.rs
@@ -37,15 +37,20 @@ pub struct OmpSource {
     /// The watched primary omp `sessions` root.
     pub sessions_root: PathBuf,
     /// The OTHER profiles' sessions roots, one watcher each. Filled by
-    /// [`Self::default_paths`]' enumeration; [`Self::run`]'s rescan appends
-    /// newcomers.
+    /// [`Self::default_paths`]' enumeration.
     pub profile_sessions_roots: Vec<PathBuf>,
     /// Re-lists the profile roots each rescan tick (a profile created mid-run
     /// gains a watcher without a restart).
+    #[doc(hidden)]
     pub rescan: OmpProfileEnumerate,
     /// How often [`Self::rescan`] runs; production stays on the watcher poll
     /// authority, tests shrink it.
+    #[doc(hidden)]
     pub rescan_interval: Duration,
+    /// Roots here came from the resolver (never user-supplied), so every
+    /// watcher gets the fd probe without the replay-excluding layout gate.
+    /// Only [`Self::default_paths`] sets it.
+    first_party_roots: bool,
 }
 
 impl OmpSource {
@@ -57,25 +62,32 @@ impl OmpSource {
             rescan: Arc::new(omp_profile_sessions_dirs),
             rescan_interval: DEFAULT_POLL_INTERVAL,
             sessions_root: omp_sessions_dir(),
+            first_party_roots: true,
         }
     }
 
     /// A source over one root with no profile set — the test/replay shape.
+    #[doc(hidden)]
     pub fn single_root(sessions_root: PathBuf) -> Self {
         Self {
             sessions_root,
             profile_sessions_roots: Vec::new(),
             rescan: Arc::new(Vec::new),
             rescan_interval: DEFAULT_POLL_INTERVAL,
+            first_party_roots: false,
         }
     }
 }
 
-/// One watcher over `root`, probe attached where the layout gate allows.
+/// One watcher over `root`. A first-party root (resolver-enumerated, never
+/// user-supplied) gets the fd probe unconditionally; anything else goes
+/// through [`omp_probe_root`]'s replay-excluding gate. `started` keeps every
+/// root ever spawned, so a failed one is not respawn-thrashed by the rescan.
 fn spawn_watcher(
     set: &mut tokio::task::JoinSet<Result<()>>,
     started: &mut HashSet<PathBuf>,
     root: PathBuf,
+    first_party: bool,
     tx: TaggedSender,
 ) {
     let mut watcher = JsonlWatcher::new(
@@ -86,7 +98,12 @@ fn spawn_watcher(
     )
     .with_label_deriver(omp_derive_label)
     .with_head_label(omp_head_title);
-    if let Some(probe_root) = omp_probe_root(&root) {
+    let probe_root = if first_party {
+        Some(root.clone())
+    } else {
+        omp_probe_root(&root)
+    };
+    if let Some(probe_root) = probe_root {
         watcher = watcher.with_liveness_probe(Arc::new(move || live_omp_session_ids(&probe_root)));
     }
     started.insert(root);
@@ -104,33 +121,59 @@ impl Source for OmpSource {
             profile_sessions_roots,
             rescan,
             rescan_interval,
+            first_party_roots,
         } = *self;
         let mut set = tokio::task::JoinSet::new();
         let mut started = HashSet::new();
-        spawn_watcher(&mut set, &mut started, sessions_root, tx.clone());
+        let mut last_error = None;
+        spawn_watcher(
+            &mut set,
+            &mut started,
+            sessions_root,
+            first_party_roots,
+            tx.clone(),
+        );
         for root in profile_sessions_roots {
             if !started.contains(&root) {
-                spawn_watcher(&mut set, &mut started, root, tx.clone());
+                spawn_watcher(&mut set, &mut started, root, first_party_roots, tx.clone());
             }
         }
         loop {
             tokio::select! {
                 _ = tokio::time::sleep(rescan_interval) => {
-                    for root in rescan() {
+                    // Off the worker: the enumeration does blocking fs reads
+                    // (the liveness probes set the precedent).
+                    let listed = tokio::task::spawn_blocking({
+                        let rescan = rescan.clone();
+                        move || rescan()
+                    })
+                    .await;
+                    for root in listed.unwrap_or_default() {
                         if !started.contains(&root) {
-                            spawn_watcher(&mut set, &mut started, root, tx.clone());
+                            spawn_watcher(&mut set, &mut started, root, first_party_roots, tx.clone());
                         }
                     }
                 }
                 Some(finished) = set.join_next() => {
-                    // Log-and-continue: one root failing must not silence the
-                    // rest. `started` keeps the entry, so a failed root is not
-                    // respawn-thrashed by the next rescan.
-                    if let Ok(Err(e)) = finished {
-                        tracing::warn!(source = SOURCE_NAME, error = %e, "omp watcher exited");
+                    // Log-and-continue per root, but REMEMBER the failure: a
+                    // source watching nothing must reach the deaths surface
+                    // the user sees (#157), not only the log.
+                    match finished {
+                        Ok(Err(e)) => {
+                            tracing::warn!(source = SOURCE_NAME, error = %e, "omp watcher exited");
+                            last_error = Some(e);
+                        }
+                        Err(join) => {
+                            tracing::warn!(source = SOURCE_NAME, error = %join, "omp watcher task died");
+                            last_error = Some(join.into());
+                        }
+                        Ok(Ok(())) => {}
                     }
                     if set.is_empty() {
-                        return Ok(());
+                        return match last_error {
+                            Some(e) => Err(e),
+                            None => Ok(()),
+                        };
                     }
                 }
             }
@@ -191,18 +234,13 @@ fn omp_probe_root_resolved(sessions_root: &Path, resolved_sessions: &Path) -> Op
         return None;
     }
     let parent = sessions_root.parent();
-    let name_at = |depth: usize| {
-        let mut dir = parent;
-        for _ in 0..depth {
-            dir = dir.and_then(Path::parent);
-        }
-        dir.and_then(Path::file_name).and_then(|n| n.to_str())
-    };
-    let parent_is_dot_omp_agent = name_at(0) == Some("agent")
-        && (name_at(1) == Some(".omp")
-            // The profiles layout, held to the same rigor: every fixed segment
-            // of `.omp/profiles/<name>/agent/sessions` must be in place.
-            || (name_at(2) == Some("profiles") && name_at(3) == Some(".omp")));
+    let parent_is_dot_omp_agent = parent.is_some_and(|p| {
+        p.file_name().and_then(|n| n.to_str()) == Some("agent")
+            && p.parent()
+                .and_then(|g| g.file_name())
+                .and_then(|n| n.to_str())
+                == Some(".omp")
+    });
     // Covers every relocating axis at once: this gate and `default_paths` call
     // the SAME `omp_sessions_dir()`, so they cannot disagree.
     let is_resolved_root = sessions_root == resolved_sessions;
@@ -218,45 +256,6 @@ fn omp_probe_root_resolved(sessions_root: &Path, resolved_sessions: &Path) -> Op
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn probe_root_accepts_the_profiles_layout_with_the_same_rigor() {
-        let home = tempfile::tempdir().unwrap();
-        let elsewhere = home.path().join("pi-coding-agent").join("sessions");
-
-        let profiled = home
-            .path()
-            .join(".omp")
-            .join("profiles")
-            .join("work")
-            .join("agent")
-            .join("sessions");
-        assert_eq!(
-            omp_probe_root_resolved(&profiled, &elsewhere),
-            Some(profiled.clone()),
-            "`.omp/profiles/<name>/agent/sessions` is first-party"
-        );
-
-        // Both outer segments must hold, or any `profiles/x/agent/sessions`
-        // replay tree would be vouched for.
-        let no_dot_omp = home
-            .path()
-            .join("work")
-            .join("profiles")
-            .join("x")
-            .join("agent")
-            .join("sessions");
-        assert_eq!(omp_probe_root_resolved(&no_dot_omp, &elsewhere), None);
-
-        let no_agent = home
-            .path()
-            .join(".omp")
-            .join("profiles")
-            .join("work")
-            .join("other")
-            .join("sessions");
-        assert_eq!(omp_probe_root_resolved(&no_agent, &elsewhere), None);
-    }
 
     #[test]
     fn probe_root_accepts_the_dot_omp_agent_layout_and_nothing_that_merely_resembles_it() {

--- a/crates/pixtuoid-core/tests/watcher/sources.rs
+++ b/crates/pixtuoid-core/tests/watcher/sources.rs
@@ -367,6 +367,130 @@ async fn grok_source_run_emits_events_from_updates_jsonl() {
 // at <sessions_root>/<encoded-cwd>/<ts>_<uuid>/<taskId>.jsonl — the root keys on
 // its stem, the child on the stem CHAIN.
 #[tokio::test]
+async fn omp_source_run_watches_profile_roots_beside_the_primary() {
+    use pixtuoid_core::source::omp::OmpSource;
+    use pixtuoid_core::AgentId;
+
+    fast_watch();
+    let dir = TempDir::new().unwrap();
+    let primary = dir.path().join("agent").join("sessions");
+    let profile = dir
+        .path()
+        .join("profiles")
+        .join("work")
+        .join("agent")
+        .join("sessions");
+    const STEM: &str = "2026-07-09T08-00-00-000Z_0197f0aa-0000-7000-8000-000000000021";
+    let cwd_dir = profile.join("-dev-proj");
+    tokio::fs::create_dir_all(&primary).await.unwrap();
+    tokio::fs::create_dir_all(&cwd_dir).await.unwrap();
+    let transcript = cwd_dir.join(format!("{STEM}.jsonl"));
+
+    let (tx, mut rx) = mpsc::channel::<(Transport, AgentEvent)>(32);
+    let mut src = OmpSource::single_root(primary);
+    src.profile_sessions_roots = vec![profile];
+    let handle = tokio::spawn(async move { Box::new(src).run(tx).await });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    write_omp_header(&transcript, "0197f0aa-0000-7000-8000-000000000021").await;
+
+    let want = AgentId::from_parts("omp", &omp_watcher_key(&transcript));
+    assert!(
+        wait_for_session_start(&mut rx, want).await,
+        "a transcript under a PROFILE root must register like a primary one"
+    );
+    handle.abort();
+}
+
+#[tokio::test]
+async fn omp_source_rescan_hot_plugs_a_profile_created_mid_run() {
+    use pixtuoid_core::source::omp::OmpSource;
+    use pixtuoid_core::AgentId;
+
+    fast_watch();
+    let dir = TempDir::new().unwrap();
+    let primary = dir.path().join("agent").join("sessions");
+    tokio::fs::create_dir_all(&primary).await.unwrap();
+    let late_profile = dir
+        .path()
+        .join("profiles")
+        .join("late")
+        .join("agent")
+        .join("sessions");
+
+    // The rescan seam reports nothing until the test "creates" the profile.
+    let announced = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let feed = announced.clone();
+    let (tx, mut rx) = mpsc::channel::<(Transport, AgentEvent)>(32);
+    let mut src = OmpSource::single_root(primary);
+    src.rescan = std::sync::Arc::new(move || feed.lock().unwrap().clone());
+    src.rescan_interval = Duration::from_millis(50);
+    let handle = tokio::spawn(async move { Box::new(src).run(tx).await });
+
+    tokio::time::sleep(Duration::from_millis(80)).await;
+    const STEM: &str = "2026-07-09T08-00-00-000Z_0197f0aa-0000-7000-8000-000000000022";
+    let cwd_dir = late_profile.join("-dev-proj");
+    tokio::fs::create_dir_all(&cwd_dir).await.unwrap();
+    announced.lock().unwrap().push(late_profile.clone());
+    // Give the rescan a tick to bind the new root BEFORE the transcript lands,
+    // so registration cannot ride the initial scan of an already-known root.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    let transcript = cwd_dir.join(format!("{STEM}.jsonl"));
+    write_omp_header(&transcript, "0197f0aa-0000-7000-8000-000000000022").await;
+
+    let want = AgentId::from_parts("omp", &omp_watcher_key(&transcript));
+    assert!(
+        wait_for_session_start(&mut rx, want).await,
+        "a profile announced after startup must gain a watcher without a restart"
+    );
+    handle.abort();
+}
+
+/// The expected-id seam shared by the omp cases: the SAME fold + deriver the
+/// watcher uses, so a raw-case literal cannot pass on Unix and red only on
+/// windows-test.
+fn omp_watcher_key(p: &std::path::Path) -> String {
+    use pixtuoid_core::source::omp::omp_id_from_path;
+    omp_id_from_path(std::path::Path::new(
+        &pixtuoid_core::id::normalize_path_key(&p.to_string_lossy()),
+    ))
+}
+
+async fn write_omp_header(path: &std::path::Path, id: &str) {
+    let header = serde_json::json!({
+        "type": "session", "version": 3, "id": id,
+        "timestamp": "2026-07-09T08:00:00.000Z", "cwd": "/dev/proj"
+    });
+    let mut f = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .await
+        .unwrap();
+    f.write_all(format!("{header}\n").as_bytes()).await.unwrap();
+    f.flush().await.unwrap();
+}
+
+/// Drain until `want`'s SessionStart or a deadline; true on arrival.
+async fn wait_for_session_start(
+    rx: &mut mpsc::Receiver<(Transport, AgentEvent)>,
+    want: pixtuoid_core::AgentId,
+) -> bool {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    while tokio::time::Instant::now() < deadline {
+        match tokio::time::timeout(Duration::from_millis(200), rx.recv()).await {
+            Ok(Some((_, AgentEvent::SessionStart { agent_id, .. }))) if agent_id == want => {
+                return true
+            }
+            Ok(Some(_)) => {}
+            Ok(None) => return false,
+            Err(_) => {}
+        }
+    }
+    false
+}
+
+#[tokio::test]
 async fn omp_source_run_links_a_nested_subagent_to_its_root() {
     use pixtuoid_core::source::omp::OmpSource;
     use pixtuoid_core::AgentId;
@@ -382,31 +506,16 @@ async fn omp_source_run_links_a_nested_subagent_to_its_root() {
     let child_transcript = child_dir.join("Alpha.jsonl");
 
     let (tx, mut rx) = mpsc::channel::<(Transport, AgentEvent)>(32);
-    let src = OmpSource { sessions_root };
+    let src = OmpSource::single_root(sessions_root);
     let handle = tokio::spawn(async move { Box::new(src).run(tx).await });
 
     tokio::time::sleep(Duration::from_millis(50)).await;
 
-    let header = |id: &str| {
-        serde_json::json!({
-            "type": "session", "version": 3, "id": id,
-            "timestamp": "2026-07-09T08:00:00.000Z", "cwd": "/dev/proj"
-        })
-    };
     for (path, id) in [
         (&root_transcript, "0197f0aa-0000-7000-8000-000000000001"),
         (&child_transcript, "0197f0cc-0000-7000-8000-000000000003"),
     ] {
-        let mut f = tokio::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(path)
-            .await
-            .unwrap();
-        f.write_all(format!("{}\n", header(id)).as_bytes())
-            .await
-            .unwrap();
-        f.flush().await.unwrap();
+        write_omp_header(path, id).await;
     }
 
     // Expected ids must go through the SAME seam fold + deriver the watcher uses:
@@ -471,7 +580,7 @@ async fn omp_ended_transcript_is_gated_at_first_sight_and_a_live_one_seeds() {
         .unwrap();
 
         let (tx, mut rx) = mpsc::channel::<(Transport, AgentEvent)>(32);
-        let src = OmpSource { sessions_root };
+        let src = OmpSource::single_root(sessions_root);
         let handle = tokio::spawn(async move { Box::new(src).run(tx).await });
 
         let deadline =
@@ -538,7 +647,11 @@ async fn omp_oversized_first_sight_uses_the_head_title_through_source_wiring() {
     .unwrap();
 
     let (tx, mut rx) = mpsc::channel::<(Transport, AgentEvent)>(64);
-    let handle = tokio::spawn(async move { Box::new(OmpSource { sessions_root }).run(tx).await });
+    let handle = tokio::spawn(async move {
+        Box::new(OmpSource::single_root(sessions_root))
+            .run(tx)
+            .await
+    });
 
     let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
     let mut rename_seen_at = None;

--- a/crates/pixtuoid-core/tests/watcher/sources.rs
+++ b/crates/pixtuoid-core/tests/watcher/sources.rs
@@ -363,9 +363,6 @@ async fn grok_source_run_emits_events_from_updates_jsonl() {
     handle.abort();
 }
 
-// Layout: <sessions_root>/<encoded-cwd>/<ts>_<uuid>.jsonl with a subagent child
-// at <sessions_root>/<encoded-cwd>/<ts>_<uuid>/<taskId>.jsonl — the root keys on
-// its stem, the child on the stem CHAIN.
 #[tokio::test]
 async fn omp_source_run_watches_profile_roots_beside_the_primary() {
     use pixtuoid_core::source::omp::OmpSource;
@@ -443,7 +440,49 @@ async fn omp_source_rescan_hot_plugs_a_profile_created_mid_run() {
         wait_for_session_start(&mut rx, want).await,
         "a profile announced after startup must gain a watcher without a restart"
     );
+
+    // Re-announcing the SAME root must not disturb it: a later transcript
+    // still registers. (Watcher-count dedup itself is not observable here —
+    // one watcher already emits SessionStart twice, seed + decoded header.)
+    announced.lock().unwrap().push(late_profile.clone());
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    const STEM2: &str = "2026-07-09T08-00-00-000Z_0197f0aa-0000-7000-8000-000000000023";
+    let second = cwd_dir.join(format!("{STEM2}.jsonl"));
+    write_omp_header(&second, "0197f0aa-0000-7000-8000-000000000023").await;
+    let want2 = AgentId::from_parts("omp", &omp_watcher_key(&second));
+    assert!(
+        wait_for_session_start(&mut rx, want2).await,
+        "a re-announced root must keep registering new transcripts"
+    );
     handle.abort();
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn omp_source_run_reports_total_watch_failure_instead_of_swallowing_it() {
+    use pixtuoid_core::source::omp::OmpSource;
+    use std::os::unix::fs::PermissionsExt;
+
+    // Deliberately NOT fast_watch(): the forced PollWatcher tolerates a
+    // missing root (walk latches and warns), so only the native backend's
+    // watch() error can exercise the death path.
+    let dir = TempDir::new().unwrap();
+    let sealed = dir.path().join("sealed");
+    tokio::fs::create_dir(&sealed).await.unwrap();
+    let mut perms = std::fs::metadata(&sealed).unwrap().permissions();
+    perms.set_mode(0o000);
+    std::fs::set_permissions(&sealed, perms.clone()).unwrap();
+
+    let (tx, _rx) = mpsc::channel::<(Transport, AgentEvent)>(8);
+    let result = Box::new(OmpSource::single_root(sealed.join("sessions")))
+        .run(tx)
+        .await;
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&sealed, perms).unwrap();
+    assert!(
+        result.is_err(),
+        "every watcher failing must propagate to the deaths surface (#157), got Ok"
+    );
 }
 
 /// The expected-id seam shared by the omp cases: the SAME fold + deriver the
@@ -490,6 +529,9 @@ async fn wait_for_session_start(
     false
 }
 
+// Layout: <sessions_root>/<encoded-cwd>/<ts>_<uuid>.jsonl with a subagent child
+// at <sessions_root>/<encoded-cwd>/<ts>_<uuid>/<taskId>.jsonl — the root keys on
+// its stem, the child on the stem CHAIN.
 #[tokio::test]
 async fn omp_source_run_links_a_nested_subagent_to_its_root() {
     use pixtuoid_core::source::omp::OmpSource;
@@ -518,17 +560,8 @@ async fn omp_source_run_links_a_nested_subagent_to_its_root() {
         write_omp_header(path, id).await;
     }
 
-    // Expected ids must go through the SAME seam fold + deriver the watcher uses:
-    // a raw-case literal here passes on Unix and fails ONLY on windows-test,
-    // where the id-space is normalize_path_key-folded.
-    use pixtuoid_core::source::omp::omp_id_from_path;
-    let watcher_key = |p: &std::path::Path| {
-        omp_id_from_path(std::path::Path::new(
-            &pixtuoid_core::id::normalize_path_key(&p.to_string_lossy()),
-        ))
-    };
-    let root_id = AgentId::from_parts("omp", &watcher_key(&root_transcript));
-    let child_id = AgentId::from_parts("omp", &watcher_key(&child_transcript));
+    let root_id = AgentId::from_parts("omp", &omp_watcher_key(&root_transcript));
+    let child_id = AgentId::from_parts("omp", &omp_watcher_key(&child_transcript));
     let mut child_linked = false;
     let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
     while tokio::time::Instant::now() < deadline && !child_linked {

--- a/crates/pixtuoid/src/doctor.rs
+++ b/crates/pixtuoid/src/doctor.rs
@@ -1074,9 +1074,10 @@ fn drift_category(r: &DoctorReport, ink: &Ink) -> Category {
     }
 }
 
-/// One row per source with a single on-disk root. A FACT row, not an alarm — a
-/// missing root is normal for a CLI the user never runs, so the only alarm is
-/// missing WHILE that source's override is set (#880).
+/// One row per source with a PRIMARY on-disk root (omp may watch further
+/// profile roots this row does not list). A FACT row, not an alarm — a missing
+/// root is normal for a CLI the user never runs, so the only alarm is missing
+/// WHILE that source's override is set (#880).
 fn format_root_row(r: &RootStatus, ink: &Ink) -> String {
     let via = match r.env {
         Some((var, true)) => format!(" (via ${var})"),

--- a/crates/pixtuoid/src/focus/mod.rs
+++ b/crates/pixtuoid/src/focus/mod.rs
@@ -74,9 +74,10 @@ pub(crate) struct FocusPaths<'a> {
     /// — `focus_slot` resolves it from `grok_home()`; the field exists so tests
     /// inject it like the other two.
     pub grok_root: Option<&'a Path>,
-    /// omp's sessions root (`omp_sessions_dir()`) for the fd probe. Like
-    /// `grok_root` it has no CLI override — `focus_slot` derives it.
-    pub omp_sessions_root: Option<&'a Path>,
+    /// omp's sessions roots — the primary plus every profile's — for the fd
+    /// probe. Like `grok_root` there is no CLI override — `focus_slot`
+    /// derives them.
+    pub omp_sessions_roots: &'a [std::path::PathBuf],
 }
 
 /// Resolve the agent's OS pid. Precedence: the slot's cached pid (hook-family
@@ -130,8 +131,9 @@ pub(crate) fn resolve_pid(
             .grok_root
             .and_then(|d| pixtuoid_core::source::grok_pid_for_session(d, &slot.session_id)),
         s if s == pixtuoid_core::source::omp::SOURCE_NAME => paths
-            .omp_sessions_root
-            .and_then(|d| pixtuoid_core::source::omp_pid_for_session(d, &slot.session_id)),
+            .omp_sessions_roots
+            .iter()
+            .find_map(|d| pixtuoid_core::source::omp_pid_for_session(d, &slot.session_id)),
         _ => None,
     }
 }
@@ -144,12 +146,13 @@ pub(crate) fn focus_slot(
     roots: &(Option<std::path::PathBuf>, Option<std::path::PathBuf>),
 ) {
     let grok_home = pixtuoid_core::source::grok::grok_home();
-    let omp_sessions = pixtuoid_core::source::omp::omp_sessions_dir();
+    let mut omp_sessions = vec![pixtuoid_core::source::omp::omp_sessions_dir()];
+    omp_sessions.extend(pixtuoid_core::source::omp::omp_profile_sessions_dirs());
     let paths = FocusPaths {
         cc_projects_root: roots.0.as_deref(),
         codex_sessions_root: roots.1.as_deref(),
         grok_root: Some(&grok_home),
-        omp_sessions_root: Some(&omp_sessions),
+        omp_sessions_roots: &omp_sessions,
     };
     focus_agent(slot, &paths, &OsProcessTable, activate_os);
 }
@@ -307,7 +310,7 @@ mod tests {
         cc_projects_root: None,
         codex_sessions_root: None,
         grok_root: None,
-        omp_sessions_root: None,
+        omp_sessions_roots: &[],
     };
 
     fn empty_table() -> MockTable {

--- a/crates/pixtuoid/src/version.rs
+++ b/crates/pixtuoid/src/version.rs
@@ -76,6 +76,7 @@ pub(crate) fn release_notes(version: &str) -> Option<&'static [&'static str]> {
             "Oh My Pi can now connect — a tiny bridge extension makes its approval prompts show as real waits, brand-new sessions walk in before their first reply, and an abandoned empty session leaves promptly instead of idling for half an hour",
             "Approvals read true — the wait names exactly the tool call it gates, an approval returns the desk to work, a denial clears it, and parallel prompts each keep their own gate",
             "One call, one count — the same tool call seen by both a hook and the transcript no longer double-increments the desk tally, however far apart the two land",
+            "Every omp profile gets a desk — sessions under any profile's tree are watched, including profiles created while pixtuoid runs",
         ]),
         "0.17.0" => Some(&[
             "`pixtuoid doctor` is one report — sources, install health, CLI versions and decode drift, categorized and colorized, each row carrying the thing to run next",

--- a/scripts/lib/capture-omp-tui.py
+++ b/scripts/lib/capture-omp-tui.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-rr"""Drive omp's interactive TUI under a pty for `just capture-fixture`.
+r"""Drive omp's interactive TUI under a pty for `just capture-fixture`.
 
 The recorder can only run a command; omp's approval gates and /-commands need
 keystrokes, so this driver types them on a resilient schedule. Modes:


### PR DESCRIPTION
#951 slice 2, the roots half: every omp profile gets a desk. Pid-arming stays #951's last open piece, so this PR does not close the issue.

## What

omp keeps a sessions tree per profile; the watcher covered only the env-selected one, so a session under any other profile never became a sprite.

- **Enumeration** — `omp_profile_sessions_dirs` lists `profiles/*` under the base config root and derives each profile's sessions dir with the selected-profile precedence the resolver already encodes (own `agent` dir; the XDG arm flattens `agent/` away where its candidate exists), excluding the env-selected primary. Names go through `normalize_profile_name`, so a stray `default` dir or an invalid name can never be materialized as a root by the watcher's `create_dir_all`.
- **One watcher per root** — `OmpSource::run` drives a `JoinSet`, rescanning on the watcher poll authority (`spawn_blocking`, the liveness-probe precedent) so a profile created mid-run gains a watcher without a restart. One root failing logs and leaves the rest alive, but the failure is REMEMBERED: when every watcher is gone the error propagates to the deaths surface (#157) — pinned by a native-backend test on an unwatchable root.
- **First-party probes** — roots from `default_paths`' enumeration get the fd-liveness probe by construction (the layout gate exists to exclude user-supplied replay roots; a resolver-derived root never is one), so XDG- and `PI_CONFIG_DIR`-relocated profiles keep real liveness. `single_root` (the test/replay shape) stays gated.
- **Focus** — `FocusPaths` carries every omp root; clicking a profile sprite resolves its pid instead of silently no-oping under doctor's probe ✓.

## Review (two-lens gate)

3 lenses (correctness / design / whole-file comment audit): REQUEST-CHANGES ×2 on one HIGH — the first cut's log-and-continue loop swallowed total watch failure, regressing the #157 death-signal contract while multiplying its likeliest trigger (inotify watches × N roots). Fold `23bb5240` carries all dispositions: 7 FIXED (death signal, probe trust, focus re-scope, junk-name filter, blocking rescan, named path-segment consts + doc(hidden) seams, comment findings), 1 REFUTED (exact-start-count dedup teeth — one watcher emits SessionStart twice by design, seed + decoded header), 2 SURFACED below. Correctness lens ran eight gates itself, all exit 0 (including semver — the new pub fields are 0.x-major-class, absorbed by the unreleased 0.18.0 — and api-surface, doc-check, windows-structural).

## Surfaced to owner

- `JsonlWatcher::run` does `create_dir_all` on its root, so pixtuoid now materializes `profiles/<p>/agent/sessions` for profiles that never ran omp — pre-existing behavior for the primary root, multiplied by profile count.
- Only the selected profile's `.env` overlays enumeration (upstream freezes its resolver per process the same way); a profile relocating its own dirs via its own `.env` is unseen — documented on the fn.
- doctor/corpus census still reports the primary root only (the root row now says PRIMARY).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6LG4b2iq2tRHvJ3AhFXDU
