### PR TITLE
feat(omp): the stamped pid arms — prompt exits, first-moment focus

### DIFF
--- a/crates/pixtuoid-core/src/source/hook/mod.rs
+++ b/crates/pixtuoid-core/src/source/hook/mod.rs
@@ -192,9 +192,9 @@ fn pid_bind_target(ev: &AgentEvent) -> Option<(AgentId, bool)> {
 }
 
 /// The batch's bind targets, at most one per agent: a payload must not
-/// corroborate its own pid. No decoder pairs two bind-target events for one
-/// agent today (activity events are not bind targets), so this is a FORWARD
-/// guard — pinned by `a_batch_yields_one_bind_target_per_agent`.
+/// corroborate its own pid. omp pairs `SessionStart` + `Identity` in its
+/// session batches (activity events are not bind targets), so the collapse is
+/// load-bearing — pinned by `a_batch_yields_one_bind_target_per_agent`.
 fn bind_targets(evs: &[AgentEvent]) -> std::collections::BTreeMap<AgentId, bool> {
     evs.iter().filter_map(pid_bind_target).collect()
 }
@@ -372,7 +372,14 @@ mod tests {
                 "{source} Identity must stay pid: None"
             );
         }
-        for source in ["opencode", "cursor", "codewhale", "hermes", "reasonix"] {
+        for source in [
+            "opencode",
+            "cursor",
+            "codewhale",
+            "hermes",
+            "reasonix",
+            "omp",
+        ] {
             let mut evs = vec![AgentEvent::Identity {
                 agent_id: AgentId::from_parts(source, "ses_t"),
                 source: source.into(),
@@ -389,9 +396,9 @@ mod tests {
     }
 
     /// The guard `handle_conn` relies on: a batch yields at most ONE sighting per
-    /// agent, so a payload can never corroborate its own pid. No decoder pairs
-    /// two bind-target events today, so this pins the FORWARD guard directly —
-    /// the handle_conn-level test cannot, it would pass with the dedupe deleted.
+    /// agent, so a payload can never corroborate its own pid. Pinned directly
+    /// (the handle_conn-level test would pass with the dedupe deleted); omp's
+    /// session batches exercise it for real, the live pin below.
     #[test]
     fn a_batch_yields_one_bind_target_per_agent() {
         let id = AgentId::from_parts("cursor", "sess-A");
@@ -420,6 +427,34 @@ mod tests {
             bind_targets(&batch).get(&id),
             Some(&true),
             "cursor is ShimStamp — its pid is a guess and needs corroborating"
+        );
+    }
+
+    /// omp is the first decoder that really pairs `SessionStart` + `Identity`
+    /// in one batch, so the collapse the guard above pinned synthetically is
+    /// now load-bearing — and a PluginStamp pid needs no corroboration.
+    #[test]
+    fn an_omp_session_batch_pairs_start_and_identity_and_binds_once_trusted() {
+        let evs = crate::source::omp::decode_omp_hook_payload(&serde_json::json!({
+            "type": "session_start",
+            "sessionFile": "/h/.omp/agent/sessions/-repo/2026-08-30T01-00-00-000Z_01a00000-0000-7000-8000-000000000001.jsonl",
+            "sessionId": "01a00000-0000-7000-8000-000000000001",
+            "cwd": "/repo",
+        }))
+        .unwrap();
+        assert!(
+            matches!(
+                &evs[..],
+                [AgentEvent::SessionStart { .. }, AgentEvent::Identity { .. }]
+            ),
+            "the pair this test exists for: {evs:?}"
+        );
+        let targets = bind_targets(&evs);
+        assert_eq!(targets.len(), 1, "the pair must collapse to one sighting");
+        assert_eq!(
+            targets.values().next(),
+            Some(&false),
+            "a PluginStamp pid is the CLI's own — no corroboration"
         );
     }
 

--- a/crates/pixtuoid-core/src/source/hook/mod.rs
+++ b/crates/pixtuoid-core/src/source/hook/mod.rs
@@ -169,7 +169,11 @@ impl Drop for UndeliveredEvents {
 /// one fact ("is this source's `_pid` trustworthy") with two consumers. A
 /// `TranscriptProbe` source is excluded on its own terms: its pid comes from the
 /// CLI's own registry via `jsonl::liveness`, which drives its own exit watch, so
-/// binding here would only offer a second, weaker answer.
+/// binding here would only offer a second, weaker answer. omp carries BOTH
+/// reapers and no precedence is enforced: on an abrupt kill this watch usually
+/// ends the slot first, and the jsonl exit path's trailing rows then land on
+/// an exiting slot as no-ops — accepted, a duplicate `SessionEnd` is a
+/// documented reducer no-op.
 fn pid_bind_target(ev: &AgentEvent) -> Option<(AgentId, bool)> {
     use crate::source::registry::FocusChannel;
     let (agent_id, source) = match ev {
@@ -456,6 +460,28 @@ mod tests {
             targets.values().next(),
             Some(&false),
             "a PluginStamp pid is the CLI's own — no corroboration"
+        );
+
+        // The switch batch: End(prev) is no bind target, and the current id's
+        // Start+Identity pair still collapses to one trusted sighting.
+        let evs = crate::source::omp::decode_omp_hook_payload(&serde_json::json!({
+            "type": "session_switch",
+            "sessionFile": "/h/.omp/agent/sessions/-repo/2026-08-30T01-00-00-000Z_01a00000-0000-7000-8000-000000000002.jsonl",
+            "previousSessionFile": "/h/.omp/agent/sessions/-repo/2026-08-30T01-00-00-000Z_01a00000-0000-7000-8000-000000000001.jsonl",
+            "sessionId": "01a00000-0000-7000-8000-000000000002",
+            "cwd": "/repo",
+        }))
+        .unwrap();
+        assert_eq!(
+            evs.len(),
+            3,
+            "End(prev) + Start(cur) + Identity(cur): {evs:?}"
+        );
+        let targets = bind_targets(&evs);
+        assert_eq!(
+            (targets.len(), targets.values().next()),
+            (1, Some(&false)),
+            "one trusted sighting for the current id, none for the ended one"
         );
     }
 

--- a/crates/pixtuoid-core/src/source/hook/mod.rs
+++ b/crates/pixtuoid-core/src/source/hook/mod.rs
@@ -194,7 +194,8 @@ fn pid_bind_target(ev: &AgentEvent) -> Option<(AgentId, bool)> {
 /// The batch's bind targets, at most one per agent: a payload must not
 /// corroborate its own pid. omp pairs `SessionStart` + `Identity` in its
 /// session batches (activity events are not bind targets), so the collapse is
-/// load-bearing — pinned by `a_batch_yields_one_bind_target_per_agent`.
+/// load-bearing — pinned by `a_batch_yields_one_bind_target_per_agent` and
+/// `an_omp_session_batch_pairs_start_and_identity_and_binds_once_trusted`.
 fn bind_targets(evs: &[AgentEvent]) -> std::collections::BTreeMap<AgentId, bool> {
     evs.iter().filter_map(pid_bind_target).collect()
 }
@@ -203,8 +204,8 @@ fn bind_targets(evs: &[AgentEvent]) -> std::collections::BTreeMap<AgentId, bool>
 /// batch — the per-source decoders never see the envelope key, so this single
 /// patch point IS the whole focus-jump wiring.
 ///
-/// The gate is the registry's [`FocusChannel`] capability, shared with
-/// `focus::resolve_pid`. `TranscriptProbe` sources (CC/Codex) are skipped: the
+/// The gate is the registry's [`FocusChannel`] capability. `TranscriptProbe`
+/// sources are skipped: the
 /// shim's resolved pid is the nearest non-shell ancestor, not necessarily the CLI,
 /// and a stamped stale pid would shadow the probe's recycle guard in
 /// `resolve_pid`. The kernel start marker (#527, so the
@@ -397,8 +398,8 @@ mod tests {
 
     /// The guard `handle_conn` relies on: a batch yields at most ONE sighting per
     /// agent, so a payload can never corroborate its own pid. Pinned directly
-    /// (the handle_conn-level test would pass with the dedupe deleted); omp's
-    /// session batches exercise it for real, the live pin below.
+    /// (the handle_conn-level test would pass with the dedupe deleted); the
+    /// live pin is `an_omp_session_batch_pairs_start_and_identity_and_binds_once_trusted`.
     #[test]
     fn a_batch_yields_one_bind_target_per_agent() {
         let id = AgentId::from_parts("cursor", "sess-A");
@@ -797,8 +798,8 @@ mod tests {
     /// The #896 shape at this seam: ONE payload carrying a `_pid`, then that pid
     /// dies. A single sighting of a shim-guessed pid must end nothing. (The
     /// batch-dedupe guard itself is pinned by `a_batch_yields_one_bind_target_per_agent`
-    /// — this test would pass with the dedupe deleted, because no decoder emits
-    /// two bind-target events for one agent today.)
+    /// and exercised for real by omp's paired session batches —
+    /// `an_omp_session_batch_pairs_start_and_identity_and_binds_once_trusted`.)
     #[tokio::test]
     async fn handle_conn_a_single_sighting_dying_ends_nothing() {
         let (tx, mut rx) = tokio::sync::mpsc::channel::<(Transport, AgentEvent)>(8);

--- a/crates/pixtuoid-core/src/source/hook/pid_watch.rs
+++ b/crates/pixtuoid-core/src/source/hook/pid_watch.rs
@@ -1,4 +1,5 @@
-//! Liveness for HOOK-ONLY sources whose shim can supply the agent CLI's pid.
+//! Liveness for sources whose hook plane supplies the agent CLI's pid —
+//! hook-only CLIs, plus omp, whose in-process bridge stamps its own pid.
 //!
 //! A hook-only source has no tailable transcript and therefore none of the JSONL
 //! watcher's liveness ladder; its ONLY exit signal is the best-effort

--- a/crates/pixtuoid-core/src/source/omp.rs
+++ b/crates/pixtuoid-core/src/source/omp.rs
@@ -890,7 +890,11 @@ pub fn decode_omp_hook_payload(v: &Value) -> Result<Vec<AgentEvent>> {
     let identity = || AgentEvent::identity(agent_id, SOURCE_NAME, key.clone(), cwd());
 
     match ty {
-        HOOK_SESSION_START => Ok(vec![session_start()]),
+        // The trailing `identity()` on every session arm is the pid carrier:
+        // the router stamps only Identity events, and the slot must be armed
+        // from BIRTH — before any approval — for focus and the abrupt-exit
+        // watch to cover a bridge-only (never-persisted) session.
+        HOOK_SESSION_START => Ok(vec![session_start(), identity()]),
         // previous == current is the in-place branch REWRITE — an End+Start
         // pair there would walk the sprite out for its own rewrite.
         HOOK_SESSION_SWITCH | HOOK_SESSION_BRANCH => {
@@ -912,6 +916,7 @@ pub fn decode_omp_hook_payload(v: &Value) -> Result<Vec<AgentEvent>> {
                 }
             }
             evs.push(session_start());
+            evs.push(identity());
             Ok(evs)
         }
         HOOK_SESSION_SHUTDOWN => Ok(vec![AgentEvent::SessionEnd {
@@ -2432,7 +2437,7 @@ mod tests {
                 session_id,
                 cwd,
                 parent_id,
-            }] => {
+            }, AgentEvent::Identity { pid: None, .. }] => {
                 assert_eq!(*agent_id, hook_id(HOOK_ROOT));
                 assert_eq!(source, "omp");
                 assert_eq!(session_id, &hook_key(HOOK_ROOT));
@@ -2456,7 +2461,7 @@ mod tests {
                 session_id,
                 parent_id,
                 ..
-            }] => {
+            }, AgentEvent::Identity { .. }] => {
                 let key = hook_key(&child);
                 assert_eq!(*agent_id, AgentId::from_parts("omp", &key));
                 assert_eq!(session_id, &key);
@@ -2477,7 +2482,7 @@ mod tests {
                 agent_id,
                 session_id,
                 ..
-            }] => {
+            }, AgentEvent::Identity { .. }] => {
                 assert_eq!(
                     *agent_id,
                     AgentId::from_parts("omp", "01a05668-057f-7559-8fed-f28ff062e3ca")
@@ -2526,7 +2531,7 @@ mod tests {
                 as_child: false,
             }, AgentEvent::SessionStart {
                 agent_id: started, ..
-            }] => {
+            }, AgentEvent::Identity { .. }] => {
                 assert_eq!(*ended, hook_id(prev));
                 assert_eq!(*started, hook_id(HOOK_ROOT));
             }
@@ -2543,7 +2548,10 @@ mod tests {
             "sessionId": "01a05668-057f-7559-8fed-f28ff062e3ca", "cwd": "/repo",
         }));
         assert!(
-            matches!(&evs[..], [AgentEvent::SessionStart { .. }]),
+            matches!(
+                &evs[..],
+                [AgentEvent::SessionStart { .. }, AgentEvent::Identity { .. }]
+            ),
             "same-path branch must not End: {evs:?}"
         );
     }
@@ -2658,7 +2666,7 @@ mod tests {
         }))
         .unwrap();
         assert!(
-            matches!(&evs[..], [AgentEvent::SessionStart { agent_id, .. }]
+            matches!(&evs[..], [AgentEvent::SessionStart { agent_id, .. }, AgentEvent::Identity { .. }]
                 if *agent_id == hook_id(HOOK_ROOT)),
             "expected the ClaimsAll route: {evs:?}"
         );
@@ -2676,7 +2684,7 @@ mod tests {
             "sessionId": "x", "cwd": "/repo",
         }));
         match &evs[..] {
-            [AgentEvent::SessionStart { agent_id, .. }] => {
+            [AgentEvent::SessionStart { agent_id, .. }, AgentEvent::Identity { .. }] => {
                 assert_eq!(
                     *agent_id,
                     AgentId::from_parts("omp", &omp_id_from_path(Path::new(&folded)))

--- a/crates/pixtuoid-core/src/source/omp.rs
+++ b/crates/pixtuoid-core/src/source/omp.rs
@@ -562,9 +562,10 @@ pub(crate) const DECODED_EXIT_MARKER: &str = SESSION_EXIT;
 
 /// Appended on every clean teardown, SIGINT/SIGTERM included; its reason/kind is
 /// ignored, because every kind ("normal"|"signal"|"fatal"|"process_exit") IS an
-/// end. Skipped when the session never produced an assistant message, and SIGKILL
-/// writes nothing — both fall to the stale-sweep, except that the bridge's
-/// `session_shutdown` ends the empty session outright.
+/// end. Skipped when the session never produced an assistant message (the
+/// bridge's `session_shutdown` ends that one outright), and SIGKILL writes
+/// nothing — with the bridge `HookPidWatch` catches it; without, the
+/// stale-sweep.
 const SESSION_EXIT: &str = "session_exit";
 
 /// The turn role carrying tool calls. Its `model` is read BARE, never the
@@ -857,6 +858,11 @@ pub(crate) const DECODED_HOOK_EVENTS: &[&str] = &[
 /// upstream `reason` (`"new" | "resume" | "fork"`) is deliberately dropped —
 /// the End+Start pair keys on `previousSessionFile` alone, identically for
 /// all three.
+///
+/// The start/switch/branch arms trail an [`AgentEvent::Identity`]: the router
+/// stamps pids onto Identity events only, and the focus stamp must arm from
+/// BIRTH to cover a bridge-only (never-persisted) session — the exit watch
+/// needs no help, `SessionStart` is already a bind target.
 pub fn decode_omp_hook_payload(v: &Value) -> Result<Vec<AgentEvent>> {
     let Some(obj) = v.as_object() else {
         return Ok(vec![]);
@@ -890,10 +896,8 @@ pub fn decode_omp_hook_payload(v: &Value) -> Result<Vec<AgentEvent>> {
     let identity = || AgentEvent::identity(agent_id, SOURCE_NAME, key.clone(), cwd());
 
     match ty {
-        // The trailing `identity()` on every session arm is the pid carrier:
-        // the router stamps only Identity events, and the slot must be armed
-        // from BIRTH — before any approval — for focus and the abrupt-exit
-        // watch to cover a bridge-only (never-persisted) session.
+        // The trailing `identity()` is the focus-pid carrier (the declaration
+        // doc owns the story).
         HOOK_SESSION_START => Ok(vec![session_start(), identity()]),
         // previous == current is the in-place branch REWRITE — an End+Start
         // pair there would walk the sprite out for its own rewrite.

--- a/crates/pixtuoid-core/src/source/registry.rs
+++ b/crates/pixtuoid-core/src/source/registry.rs
@@ -793,15 +793,15 @@ const OMP: SourceDescriptor = SourceDescriptor {
             // AND the child persists its own parent-linked transcript.
             delegations_are_hook_silent: false,
         },
-        // omp holds a lifetime append fd on its session file, so the same
-        // `live_omp_session_ids` snapshot that vouches liveness also names the
-        // pid (`omp_pid_for_session`). The bridge extension DOES stamp `_pid`,
-        // and this channel discards it (recycle-guard rationale, #527-class);
-        // the stamp ships anyway so the wire shape is already right if a
-        // plugin-stamp channel ever lands. Known boundary: a bridge-only slot
-        // (pre-persist, or an empty session) has no transcript for the probe,
-        // so a focus click on it is a silent no-op.
-        focus: FocusChannel::TranscriptProbe,
+        // The bridge extension runs IN-PROCESS, so its stamped `process.pid`
+        // IS omp's own — PluginStamp trust, recycle-guarded by the router's
+        // start marker (#527). This also puts omp on `HookPidWatch`, so an
+        // abruptly killed omp leaves promptly instead of waiting out the
+        // stale-sweep, and a bridge-only (never-persisted) session is
+        // focusable from birth. Under `--no-extensions` no stamp arrives and
+        // focus falls back to the append-fd probe (`omp_pid_for_session` —
+        // the focus dispatch tries it by source name, not by this channel).
+        focus: FocusChannel::PluginStamp,
     },
 };
 

--- a/crates/pixtuoid-core/src/source/registry.rs
+++ b/crates/pixtuoid-core/src/source/registry.rs
@@ -749,8 +749,8 @@ const GROK: SourceDescriptor = SourceDescriptor {
 /// at `<omp_sessions_dir>/<encoded-cwd>/<ts>_<uuid>.jsonl`; the bridge
 /// extension (`pixtuoid/src/install/omp_extension.ts`, auto-discovered from the agent
 /// dir's `extensions/`) forwards what the transcript can never carry —
-/// pre-persist presence, empty-session shutdown, and the approval wait
-/// (#951). Both transports key on the sessionFile stem chain
+/// pre-persist presence, empty-session shutdown, the approval wait, and the
+/// process's own `_pid` (#951). Both transports key on the sessionFile stem chain
 /// ([`omp::omp_id_from_path`]), so they mint ONE AgentId per session — the
 /// grok same-key pattern. Under `omp --no-extensions`, or with the bridge
 /// broken or absent, the transcript path IS the old transcript-only source.
@@ -779,8 +779,9 @@ const OMP: SourceDescriptor = SourceDescriptor {
         caps: SourceCaps {
             // The `session_exit` entry is appended + flushed on every clean
             // teardown incl. SIGINT/SIGTERM (and the bridge fires
-            // `session_shutdown` even for empty sessions the entry skips);
-            // SIGKILL falls to the stale-sweep.
+            // `session_shutdown` even for empty sessions the entry skips).
+            // SIGKILL: with the bridge, `HookPidWatch` ends the stamped pid's
+            // sessions promptly; without it, the stale-sweep.
             has_exit_signal: true,
             // The header `SessionStart` decodes once per transcript life. A
             // `--resume` fires the bridge's `session_start` on the SAME id
@@ -793,14 +794,15 @@ const OMP: SourceDescriptor = SourceDescriptor {
             // AND the child persists its own parent-linked transcript.
             delegations_are_hook_silent: false,
         },
-        // The bridge extension runs IN-PROCESS, so its stamped `process.pid`
-        // IS omp's own — PluginStamp trust, recycle-guarded by the router's
-        // start marker (#527). This also puts omp on `HookPidWatch`, so an
-        // abruptly killed omp leaves promptly instead of waiting out the
-        // stale-sweep, and a bridge-only (never-persisted) session is
-        // focusable from birth. Under `--no-extensions` no stamp arrives and
-        // focus falls back to the append-fd probe (`omp_pid_for_session` —
-        // the focus dispatch tries it by source name, not by this channel).
+        // The bridge extension runs IN-PROCESS (upstream: extensions share
+        // the runtime), so its stamped `process.pid` IS omp's own —
+        // PluginStamp trust. The router stamps the kernel start marker; the
+        // click-time compare refuses a recycled pid (#527). The flip also
+        // puts omp on `HookPidWatch` (prompt exits) and makes a bridge-only,
+        // never-persisted session focusable from birth. Stamp-less shapes —
+        // `--no-extensions`, a session predating the bridge install — still
+        // focus through the append-fd probe: `resolve_pid` dispatches by
+        // source name and reads no channel.
         focus: FocusChannel::PluginStamp,
     },
 };

--- a/crates/pixtuoid-core/src/state/reducer/mod.rs
+++ b/crates/pixtuoid-core/src/state/reducer/mod.rs
@@ -682,9 +682,14 @@ impl Reducer {
             // unknown-cwd flag must not keep `STALE_UNKNOWN_CWD_TIMEOUT` armed.
             slot.unknown_cwd = false;
         } else if !self.corr.hook_session_end_tombstoned(agent_id, now)
+            // The child ledger too (#244-w2): an Identity carries no parent, so
+            // without this an omp session batch whose parented Start the ledger
+            // just refused would re-register the ended child PARENTLESS one
+            // event later. A never-child id is never in the ledger, so the
+            // Reasonix parentless resurrect keeps registering.
+            && !self.corr.child_recently_ended(agent_id, now)
             && self.register_slot(scene, agent_id, ctx, None, now)
         {
-            // Only the #242 tombstone is consulted, NOT the child ledger.
             if let Some(slot) = scene.agents.get_mut(&agent_id) {
                 slot.unknown_cwd = false;
                 if pid.is_some() {

--- a/crates/pixtuoid-core/tests/reducer/child_ledger.rs
+++ b/crates/pixtuoid-core/tests/reducer/child_ledger.rs
@@ -234,6 +234,79 @@ fn apply_hook_payload(
     }
 }
 
+/// omp's session batches trail an Identity behind the parented Start; when
+/// the child ledger refuses that Start, the parent-less Identity one event
+/// later must not re-register the ended child as an orphan (the ledger's
+/// window would otherwise be one event wide for omp).
+#[test]
+fn a_trailing_identity_cannot_revive_the_child_its_start_was_refused_for() {
+    use pixtuoid_core::state::reducer::EXIT_GRACE_WINDOW;
+    use serde_json::json;
+    let mut scene = SceneState::uniform(4);
+    let mut r = Reducer::new();
+    let root_file = "/h/.omp/agent/sessions/-repo/2026-08-30T01-00-00-000Z_01a00000-0000-7000-8000-0000000000aa.jsonl";
+    let child_file = "/h/.omp/agent/sessions/-repo/2026-08-30T01-00-00-000Z_01a00000-0000-7000-8000-0000000000aa/Alpha.jsonl";
+    let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+
+    apply_hook_payload(
+        &mut r,
+        &mut scene,
+        json!({
+            "type": "session_start", "sessionFile": root_file,
+            "sessionId": "x", "cwd": "/repo", "_pixtuoid_source": "omp",
+        }),
+        t0,
+    );
+    apply_hook_payload(
+        &mut r,
+        &mut scene,
+        json!({
+            "type": "session_start", "sessionFile": child_file,
+            "sessionId": "y", "cwd": "/repo", "_pixtuoid_source": "omp",
+        }),
+        t0 + Duration::from_secs(1),
+    );
+    let child = *scene
+        .agents
+        .keys()
+        .find(|id| {
+            scene.agents[id].session_id.contains("alpha")
+                || scene.agents[id].session_id.contains("Alpha")
+        })
+        .expect("child registered");
+    let stop = t0 + Duration::from_secs(2);
+    apply_hook_payload(
+        &mut r,
+        &mut scene,
+        json!({
+            "type": "session_shutdown", "sessionFile": child_file,
+            "sessionId": "y", "cwd": "/repo", "_pixtuoid_source": "omp",
+        }),
+        stop,
+    );
+    r.tick(
+        &mut scene,
+        stop + EXIT_GRACE_WINDOW + Duration::from_secs(1),
+    );
+    assert!(!scene.agents.contains_key(&child), "child GC'd");
+
+    // Within the ledger window, PAST the 5s tombstone: the batch's Start is
+    // refused, and the trailing Identity must be refused with it.
+    apply_hook_payload(
+        &mut r,
+        &mut scene,
+        json!({
+            "type": "session_start", "sessionFile": child_file,
+            "sessionId": "y", "cwd": "/repo", "_pixtuoid_source": "omp",
+        }),
+        stop + Duration::from_secs(30),
+    );
+    assert!(
+        !scene.agents.contains_key(&child),
+        "the parent-less trailing Identity revived the ledger-refused child"
+    );
+}
+
 #[test]
 fn late_parented_restart_of_an_ended_child_is_gated_by_the_child_ledger() {
     use pixtuoid_core::state::reducer::EXIT_GRACE_WINDOW;

--- a/crates/pixtuoid-core/tests/sources/omp/mod.rs
+++ b/crates/pixtuoid-core/tests/sources/omp/mod.rs
@@ -110,7 +110,8 @@ fn a_resumed_session_re_registers_after_its_earlier_end() {
 
 /// A task run under the bridge: the parent AND the in-process child each fire
 /// their own lifecycle, the child keyed by the NESTED file so both transports
-/// mint one id, parent-linked by path, both stamped with the ONE omp pid.
+/// mint one id, parent-linked by path, both payloads carrying the ONE omp
+/// `_pid` on the wire.
 #[test]
 fn a_task_round_is_two_linked_lifecycles_under_one_pid() {
     let evs = events("task-recorded");
@@ -287,7 +288,8 @@ fn a_recorded_switch_ends_the_previous_session_and_starts_the_current() {
             AgentEvent::SessionStart { agent_id, .. } if *agent_id == cur_id => "start-cur",
             AgentEvent::SessionEnd { agent_id, .. } if *agent_id == prev_id => "end-prev",
             AgentEvent::SessionEnd { agent_id, .. } if *agent_id == cur_id => "end-cur",
-            // The pid carrier behind each session arm (see the decoder).
+            // The pid carrier behind each session arm
+            // (`decode_omp_hook_payload`'s doc owns the story).
             AgentEvent::Identity { agent_id, .. } if *agent_id == cur_id => "identity-cur",
             AgentEvent::Identity { agent_id, .. } if *agent_id == prev_id => "identity-prev",
             other => panic!("unexpected event in the switch round: {other:?}"),

--- a/crates/pixtuoid-core/tests/sources/omp/mod.rs
+++ b/crates/pixtuoid-core/tests/sources/omp/mod.rs
@@ -306,6 +306,6 @@ fn a_recorded_switch_ends_the_previous_session_and_starts_the_current() {
             "identity-cur",
             "end-cur",
         ],
-        "the switch decodes as End(previous) + Start(current)"
+        "the switch decodes as End(previous) + Start(current), each session arm trailing its Identity"
     );
 }

--- a/crates/pixtuoid-core/tests/sources/omp/mod.rs
+++ b/crates/pixtuoid-core/tests/sources/omp/mod.rs
@@ -287,13 +287,23 @@ fn a_recorded_switch_ends_the_previous_session_and_starts_the_current() {
             AgentEvent::SessionStart { agent_id, .. } if *agent_id == cur_id => "start-cur",
             AgentEvent::SessionEnd { agent_id, .. } if *agent_id == prev_id => "end-prev",
             AgentEvent::SessionEnd { agent_id, .. } if *agent_id == cur_id => "end-cur",
+            // The pid carrier behind each session arm (see the decoder).
+            AgentEvent::Identity { agent_id, .. } if *agent_id == cur_id => "identity-cur",
+            AgentEvent::Identity { agent_id, .. } if *agent_id == prev_id => "identity-prev",
             other => panic!("unexpected event in the switch round: {other:?}"),
         })
         .map(str::to_string)
         .collect();
     assert_eq!(
         kinds,
-        ["start-prev", "end-prev", "start-cur", "end-cur"],
+        [
+            "start-prev",
+            "identity-prev",
+            "end-prev",
+            "start-cur",
+            "identity-cur",
+            "end-cur",
+        ],
         "the switch decodes as End(previous) + Start(current)"
     );
 }

--- a/crates/pixtuoid/src/doctor.rs
+++ b/crates/pixtuoid/src/doctor.rs
@@ -629,8 +629,9 @@ struct DoctorReport {
     /// `None` = probe disabled (non-standard projects root).
     cc_registry: Option<(std::path::PathBuf, bool)>,
     codex_sessions: (std::path::PathBuf, bool),
-    /// The other two `TranscriptProbe` roots. Each is source-specific — omp's is
-    /// the resolved sessions dir, grok's a registry FILE — so each needs its own
+    /// The other two probe roots (omp's probe is the stamp-less FALLBACK since
+    /// the PluginStamp flip). Each is source-specific — omp's is the resolved
+    /// sessions dir, grok's a registry FILE — so each needs its own
     /// hand-written row, pinned by `every_focusable_source_appears_in_the_focus_category`.
     omp_sessions: (std::path::PathBuf, bool),
     grok_registry: (std::path::PathBuf, bool),
@@ -734,7 +735,8 @@ fn collect_roots() -> Vec<RootStatus> {
         .collect()
 }
 
-/// The four hand-written `TranscriptProbe` roots, resolved exactly as the probe resolves
+/// The four hand-written probe roots (three `TranscriptProbe` + omp's
+/// stamp-less fallback), resolved exactly as the probe resolves
 /// them so the report cannot claim a root the probe would not use. grok's is a registry
 /// FILE, not a directory. DEFAULT resolution throughout: a `--projects-root` /
 /// `--codex-sessions-root` override changes the RUNNING app, but doctor deliberately
@@ -1182,16 +1184,16 @@ fn focus_category(r: &DoctorReport, ink: &Ink) -> Category {
     let om_prefix = prefix_of(pixtuoid_core::source::omp::SOURCE_NAME);
     if r.omp_sessions.1 {
         details.push(format!(
-            "{DETAIL_INDENT}{om_prefix}\u{b7}omp — append-fd probe {} {}",
+            "{DETAIL_INDENT}{om_prefix}\u{b7}omp — append-fd probe (stamp-less fallback) {} {}",
             ink.ok("\u{2713}"),
             r.omp_sessions.0.display()
         ));
     } else {
-        problem = true;
+        // Not a problem row since the PluginStamp flip: the stamped pid is the
+        // primary channel, this probe only covers stamp-less shapes.
         details.push(format!(
-            "{DETAIL_INDENT}{om_prefix}\u{b7}omp — append-fd probe {} {} (focus no-ops until omp \
-             writes it)",
-            ink.bad("\u{2717} missing"),
+            "{DETAIL_INDENT}{om_prefix}\u{b7}omp — append-fd probe (stamp-less fallback) {} {}",
+            ink.warn("\u{2717} missing"),
             r.omp_sessions.0.display()
         ));
     }
@@ -1418,6 +1420,10 @@ mod tests {
         assert!(
             s.contains("opencode") && s.contains("plugin-stamped"),
             "plugin stampers listed separately: {s}"
+        );
+        assert!(
+            s.contains("om\u{b7}omp — append-fd probe (stamp-less fallback)"),
+            "omp keeps its fallback-probe row beside the stamp census: {s}"
         );
         assert!(
             s.contains("cursor") && s.contains("shim-stamped `_pid`"),

--- a/crates/pixtuoid/src/doctor.rs
+++ b/crates/pixtuoid/src/doctor.rs
@@ -1222,7 +1222,8 @@ fn focus_category(r: &DoctorReport, ink: &Ink) -> Category {
             continue;
         };
         // Daemons aren't click-focusable agents; the TranscriptProbe sources
-        // got their own probe rows above.
+        // got their own probe rows above (omp appears in BOTH: its probe row
+        // is the stamp-less fallback, this census line the primary channel).
         if d.is_daemon() || d.focus_channel() == FocusChannel::TranscriptProbe {
             continue;
         }

--- a/crates/pixtuoid/src/focus/mod.rs
+++ b/crates/pixtuoid/src/focus/mod.rs
@@ -113,13 +113,11 @@ pub(crate) fn resolve_pid(
     // The probe FNS stay here in the binary: the registry const table compiles to
     // wasm and cannot hold a native-only fn pointer. The name match uses the
     // registry consts, not literals — a source rename must not silently drop an
-    // arm to `_ => None`.
-    use pixtuoid_core::source::registry::FocusChannel;
-    let channel = pixtuoid_core::source::registry::descriptor_for(&slot.source)
-        .map_or(FocusChannel::Unsupported, |d| d.focus_channel());
-    if channel != FocusChannel::TranscriptProbe {
-        return None;
-    }
+    // arm to `_ => None`. Deliberately NO FocusChannel read: a channel gate
+    // ahead of the match severed omp's probe the day it became PluginStamp
+    // (its stamp-less shapes — `--no-extensions`, a session predating the
+    // bridge install — resolve only here), and an arm-less source falls to
+    // `_ => None` without one.
     match slot.source.as_ref() {
         s if s == pixtuoid_core::source::claude_code::SOURCE_NAME => paths
             .cc_projects_root
@@ -370,7 +368,9 @@ mod tests {
     fn transcript_probe_sources_all_have_a_resolve_arm() {
         // Lockstep pin: marking a new source `TranscriptProbe` in the registry
         // REQUIRES wiring a probe arm in `resolve_pid` — extend BOTH, then add
-        // its name here.
+        // its name here. omp stays listed while PluginStamp: its arm is the
+        // stamp-less fallback, reachable because `resolve_pid` reads no
+        // channel.
         use pixtuoid_core::source::registry::FocusChannel;
         let wired = [
             pixtuoid_core::source::claude_code::SOURCE_NAME,

--- a/crates/pixtuoid/src/install/omp_extension.ts
+++ b/crates/pixtuoid/src/install/omp_extension.ts
@@ -50,9 +50,8 @@ export default function (pi: any) {
       if (typeof ev?.toolName === "string") payload.toolName = ev.toolName
       if (typeof ev?.reason === "string") payload.reason = ev.reason
       if (typeof ev?.approved === "boolean") payload.approved = ev.approved
-      // The omp process pid (extensions run in-process). Rust DISCARDS it
-      // today (omp's focus channel is the transcript probe), but stamping it
-      // keeps the wire shape right for a plugin-stamp channel.
+      // The omp process pid (extensions run in-process) — the PluginStamp
+      // channel: focus and the abrupt-exit watch ride it.
       payload._pid = typeof process !== "undefined" ? process.pid : undefined
       // Buffer stdin: no writable stream, no EPIPE window.
       const proc = Bun.spawn([HOOK_PATH, "--source", "omp"], {

--- a/crates/pixtuoid/src/version.rs
+++ b/crates/pixtuoid/src/version.rs
@@ -73,10 +73,10 @@ pub(crate) fn release_notes(version: &str) -> Option<&'static [&'static str]> {
         // `match` brace would silently break if the indentation ever shifted.
         // [bump-inject-here]
         "0.18.0" => Some(&[
-            "Oh My Pi can now connect — a tiny bridge extension makes its approval prompts show as real waits, brand-new sessions walk in before their first reply, and an abandoned empty session leaves promptly instead of idling for half an hour",
+            "Oh My Pi can now connect — a tiny bridge extension makes its approval prompts show as real waits, brand-new sessions walk in before their first reply, and a call seen by both the hook and the transcript counts once",
             "Approvals read true — the wait names exactly the tool call it gates, an approval returns the desk to work, a denial clears it, and parallel prompts each keep their own gate",
-            "One call, one count — the same tool call seen by both a hook and the transcript no longer double-increments the desk tally, however far apart the two land",
             "Every omp profile gets a desk — sessions under any profile's tree are watched, including profiles created while pixtuoid runs",
+            "omp sprites know their process — a killed omp leaves promptly, and a click brings its terminal forward from the first moment",
         ]),
         "0.17.0" => Some(&[
             "`pixtuoid doctor` is one report — sources, install health, CLI versions and decode drift, categorized and colorized, each row carrying the thing to run next",


### PR DESCRIPTION
#951's last piece: the bridge's `_pid` stamp arms — prompt exits and first-moment focus. Closes #951.

## What

The extension runs in-process (upstream: extensions share the runtime), so the `_pid` it has stamped since slice 1 is omp's own pid — `PluginStamp` trust.

- **Registry flip** `TranscriptProbe → PluginStamp`: the router stamps omp's `Identity` events (recycle-guarded at click time by the #527 start-marker compare) and `HookPidWatch` binds every session sighting — an abruptly killed omp leaves promptly instead of waiting out the stale-sweep.
- **Every session arm (start/switch/branch) trails an `Identity`** — the focus-pid carrier — so the slot is armed from birth: a bridge-only, never-persisted session is focusable before its first approval, closing the old row's known boundary. The exit watch needed no help (`SessionStart` was already a bind target).
- **`resolve_pid` reads no `FocusChannel` any more** (review round 1): the channel gate ahead of the name match severed omp's append-fd fallback the moment the row flipped — every stamp-less shape (`--no-extensions`, sessions predating the bridge install) lost focus while the new comment claimed otherwise. The coupling is deleted rather than detected: the source-name match is the whole dispatch, arm-less sources fall to `_ => None`. The enum slot was answering three questions (stamp trust, exit-watch arming, probe dispatch); omp is the first source where the answers differ, and the third consumer no longer asks.
- **The trailing `Identity` respects the child ledger** (review round 1, teeth-verified): it carries no parent, so a child the ledger just refused could have re-registered parentless one event later; `apply_identity`'s register branch now consults `child_recently_ended` too. Reasonix's parentless resurrect is unaffected — a never-child id is never in the ledger.
- **Doctor** tells the hybrid story: the omp probe row is the stamp-less-fallback fact (no longer a problem flag), pinned beside the plugin-stamp census line.

## Review (two-lens gate)

3 lenses: REQUEST-CHANGES ×3, all on the two convergent HIGHs above — both fixed in round 1; round 2 folded the design lens's late tail (dual-reaper precedence documented on `pid_bind_target`, the three-event switch batch joins the live bind pin). The in-process claim was fetched from upstream this session (extension-loading doc: "not sandboxed (same process/runtime)"); recorded slice-1 fixtures carry `"_pid"` on session payloads. All suites green (3225); semver/api-surface/doc-check verified clean by the correctness lens.

## Surfaced to owner

- The load-bearing in-process claim has no drift row of its own; an upstream move to workers would also break the extension loudly through the four existing `OMP_EXT_*` anchors.
- `Drive::hooks` bypasses `patch_identity_pids`/`bind_targets`, so no recorded payload reaches `handle_conn` in tests (the unit + live-pin layer covers the gating).
- `Bindings` grows one armed entry per `/new` until the omp pid dies (opencode-shaped; the eventual `take` is a no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6LG4b2iq2tRHvJ3AhFXDU
