### PR TITLE
fix(dsh): a truthy non-list insert row is refused loud; null passes as upstream's own no-op

### DIFF
--- a/crates/pixtuoid/src/install/dsh.rs
+++ b/crates/pixtuoid/src/install/dsh.rs
@@ -132,6 +132,28 @@ fn mount_row(plugin: &str) -> YamlOwned {
     YamlOwned::Mapping(row)
 }
 
+/// A row whose `insert:` is not a list: dsh's own patch apply
+/// (`cordis-plugin-include`'s `applyEntryPatches`, 0.1.1-rc.2 installed lib)
+/// spreads the value into an array push, so a mapping here throws at boot —
+/// and every function below would otherwise silently not-see an entry inside
+/// it. Refuse loud instead.
+fn malformed_insert(rows: &[YamlOwned]) -> bool {
+    rows.iter().any(|r| {
+        matches!(r, YamlOwned::Mapping(m)
+            if matches!(m.get(&ystr("insert")), Some(v) if !matches!(v, YamlOwned::Sequence(_))))
+    })
+}
+
+fn refuse_malformed(rows: &[YamlOwned]) -> Result<()> {
+    if malformed_insert(rows) {
+        bail!(
+            "cordis.patch.yml has an `insert:` that is not a list — dsh itself \
+             throws on that shape at boot; fix the row by hand before connecting"
+        );
+    }
+    Ok(())
+}
+
 /// Is this patch-list entry OUR mount entry (`id: pixtuoid`)?
 ///
 /// Ownership is an ENTRY, never a row: one `insert:` op may batch several
@@ -199,6 +221,7 @@ pub(crate) fn merge_install(content: &str, _hook_cmd: &str) -> Result<MergeOutco
     let plugin = plugin_path()?;
     let plugin = plugin.to_str().context("plugin path is not UTF-8")?;
     let rows = parse_rows(content)?;
+    refuse_malformed(&rows)?;
     let wanted = mount_row(plugin);
     if our_entries(&rows).len() == 1 && rows.contains(&wanted) {
         return Ok(MergeOutcome {
@@ -219,6 +242,7 @@ pub(crate) fn merge_install(content: &str, _hook_cmd: &str) -> Result<MergeOutco
 /// saphyr — the hermes target's documented trade).
 pub(crate) fn merge_uninstall(content: &str) -> Result<MergeOutcome> {
     let rows = parse_rows(content)?;
+    refuse_malformed(&rows)?;
     let (kept, removed) = strip_our_entries(&rows);
     if removed == 0 {
         return Ok(MergeOutcome {
@@ -247,6 +271,14 @@ pub(crate) fn verify_schema(content: &str) -> SchemaParse {
         shim: ShimRef::Unknown,
         ..Default::default()
     };
+    if malformed_insert(&rows) {
+        parse.issues.push(
+            "an `insert:` row is not a list — dsh throws on that shape at \
+             boot; fix cordis.patch.yml by hand"
+                .to_string(),
+        );
+        return parse;
+    }
     match ours.len() {
         0 => parse
             .issues
@@ -498,6 +530,27 @@ mod tests {
     fn merge_refuses_a_non_list_config_rather_than_rewriting_it() {
         assert!(merge_install("just: a mapping\n", "/unused").is_err());
         assert!(merge_uninstall("just: a mapping\n").is_err());
+    }
+
+    #[test]
+    fn a_mapping_shaped_insert_is_refused_loud_not_silently_unseen() {
+        let _env = crate::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let home = tempfile::tempdir().unwrap();
+        std::env::set_var("DSH_HOME", home.path());
+        // dsh's own patch apply spreads `insert` into an array push, so this
+        // hand-written shape throws upstream at boot; every path here must
+        // say so rather than treat the row as invisible.
+        let mapping = "- insert:\n    id: pixtuoid\n    name: /old/pixtuoid-dsh.mjs\n";
+        assert!(merge_install(mapping, "/unused").is_err());
+        assert!(merge_uninstall(mapping).is_err());
+        let v = verify_schema(mapping);
+        assert!(
+            v.issues.iter().any(|i| i.contains("is not a list")),
+            "{v:?}"
+        );
+        std::env::remove_var("DSH_HOME");
     }
 
     #[test]

--- a/crates/pixtuoid/src/install/dsh.rs
+++ b/crates/pixtuoid/src/install/dsh.rs
@@ -132,23 +132,29 @@ fn mount_row(plugin: &str) -> YamlOwned {
     YamlOwned::Mapping(row)
 }
 
-/// A row whose `insert:` is not a list: dsh's own patch apply
-/// (`cordis-plugin-include`'s `applyEntryPatches`, 0.1.1-rc.2 installed lib)
-/// spreads the value into an array push, so a mapping here throws at boot —
-/// and every function below would otherwise silently not-see an entry inside
-/// it. Refuse loud instead.
+/// A row whose `insert:` is a truthy non-list: dsh's own patch apply
+/// spreads the value into an array push
+/// (`@deepseek-ai/cordis-plugin-include` 1.0.7, vendored in dsh 0.1.1-rc.2
+/// — `vendor/include/src/index.ts:94`, read 2026-09-01), so it throws at
+/// boot — and a mapping could HOLD an entry `our_entries`/
+/// `strip_our_entries` would silently not-see. Refuse loud instead. A NULL
+/// `insert:` passes: upstream's truthiness gate skips it, an override row
+/// (`- id: x` + `enabled: false`) carries one legitimately, and a null can
+/// hide nothing.
 fn malformed_insert(rows: &[YamlOwned]) -> bool {
     rows.iter().any(|r| {
         matches!(r, YamlOwned::Mapping(m)
-            if matches!(m.get(&ystr("insert")), Some(v) if !matches!(v, YamlOwned::Sequence(_))))
+            if matches!(m.get(&ystr("insert")),
+                Some(v) if !matches!(v, YamlOwned::Sequence(_) | YamlOwned::Value(ScalarOwned::Null))))
     })
 }
 
 fn refuse_malformed(rows: &[YamlOwned]) -> Result<()> {
     if malformed_insert(rows) {
         bail!(
-            "cordis.patch.yml has an `insert:` that is not a list — dsh itself \
-             throws on that shape at boot; fix the row by hand before connecting"
+            "cordis.patch.yml has an `insert:` that is not a list — dsh's patch \
+             apply spreads it into an array push, so neither dsh nor pixtuoid \
+             can read the entries there; fix the row by hand first"
         );
     }
     Ok(())
@@ -216,7 +222,8 @@ fn strip_our_entries(rows: &[YamlOwned]) -> (Vec<YamlOwned>, usize) {
 /// `changed` is a semantic diff: exactly one of our entries, already a row
 /// of its own at the wanted path → no rewrite. Anything else — a stale
 /// path, a batched entry, duplicates — strips every one of our entries and
-/// mounts one fresh standalone row.
+/// mounts one fresh standalone row; a non-list `insert:` is refused first
+/// ([`malformed_insert`]).
 pub(crate) fn merge_install(content: &str, _hook_cmd: &str) -> Result<MergeOutcome> {
     let plugin = plugin_path()?;
     let plugin = plugin.to_str().context("plugin path is not UTF-8")?;
@@ -271,10 +278,14 @@ pub(crate) fn verify_schema(content: &str) -> SchemaParse {
         shim: ShimRef::Unknown,
         ..Default::default()
     };
+    // The one early return in an accumulate-into-issues fn: ours.len() is
+    // not trustworthy here — a mapping-shaped row can HOLD our entry, so
+    // falling through would report "no mount entry" about an entry that is
+    // in the file.
     if malformed_insert(&rows) {
         parse.issues.push(
-            "an `insert:` row is not a list — dsh throws on that shape at \
-             boot; fix cordis.patch.yml by hand"
+            "an `insert:` row is not a list — dsh cannot apply it and pixtuoid \
+             cannot read it; fix cordis.patch.yml by hand"
                 .to_string(),
         );
         return parse;
@@ -539,17 +550,26 @@ mod tests {
             .unwrap_or_else(|e| e.into_inner());
         let home = tempfile::tempdir().unwrap();
         std::env::set_var("DSH_HOME", home.path());
-        // dsh's own patch apply spreads `insert` into an array push, so this
-        // hand-written shape throws upstream at boot; every path here must
-        // say so rather than treat the row as invisible.
+        // Message-anchored (the openclaw refusal-test standard): a different
+        // error passing `is_err()` for the wrong reason must not count.
         let mapping = "- insert:\n    id: pixtuoid\n    name: /old/pixtuoid-dsh.mjs\n";
-        assert!(merge_install(mapping, "/unused").is_err());
-        assert!(merge_uninstall(mapping).is_err());
+        let err = merge_install(mapping, "/unused").unwrap_err();
+        assert!(err.to_string().contains("is not a list"), "{err}");
+        let err = merge_uninstall(mapping).unwrap_err();
+        assert!(err.to_string().contains("is not a list"), "{err}");
         let v = verify_schema(mapping);
         assert!(
             v.issues.iter().any(|i| i.contains("is not a list")),
             "{v:?}"
         );
+        // A NULL insert is upstream's own falsy no-op (a legitimate
+        // override row carries one) and can hide nothing — it passes
+        // through preserved, never refused.
+        let over = "- id: timer\n  insert:\n  enabled: false\n";
+        let ok = merge_install(over, "/unused").unwrap();
+        assert!(ok.changed, "our row still mounts beside it");
+        assert!(ok.content.contains("timer"), "{}", ok.content);
+        assert!(verify_schema(&ok.content).issues.is_empty());
         std::env::remove_var("DSH_HOME");
     }
 

--- a/crates/pixtuoid/src/install/dsh.rs
+++ b/crates/pixtuoid/src/install/dsh.rs
@@ -137,15 +137,24 @@ fn mount_row(plugin: &str) -> YamlOwned {
 /// (`@deepseek-ai/cordis-plugin-include` 1.0.7, vendored in dsh 0.1.1-rc.2
 /// — `vendor/include/src/index.ts:94`, read 2026-09-01), so it throws at
 /// boot — and a mapping could HOLD an entry `our_entries`/
-/// `strip_our_entries` would silently not-see. Refuse loud instead. A NULL
-/// `insert:` passes: upstream's truthiness gate skips it, an override row
-/// (`- id: x` + `enabled: false`) carries one legitimately, and a null can
-/// hide nothing.
+/// `strip_our_entries` would silently not-see. Refuse loud instead. A
+/// JS-FALSY scalar (`null`/`false`/`0`/`""`) passes: upstream's truthiness
+/// gate skips it before the spread, an override row (`- id: x` +
+/// `enabled: false`) carries a null one legitimately, and no scalar can
+/// hide an entry.
 fn malformed_insert(rows: &[YamlOwned]) -> bool {
+    fn falsy(v: &YamlOwned) -> bool {
+        matches!(
+            v,
+            YamlOwned::Value(ScalarOwned::Null)
+                | YamlOwned::Value(ScalarOwned::Boolean(false))
+                | YamlOwned::Value(ScalarOwned::Integer(0))
+        ) || matches!(v, YamlOwned::Value(ScalarOwned::String(s)) if s.is_empty())
+    }
     rows.iter().any(|r| {
         matches!(r, YamlOwned::Mapping(m)
             if matches!(m.get(&ystr("insert")),
-                Some(v) if !matches!(v, YamlOwned::Sequence(_) | YamlOwned::Value(ScalarOwned::Null))))
+                Some(v) if !matches!(v, YamlOwned::Sequence(_)) && !falsy(v)))
     })
 }
 
@@ -562,14 +571,23 @@ mod tests {
             v.issues.iter().any(|i| i.contains("is not a list")),
             "{v:?}"
         );
-        // A NULL insert is upstream's own falsy no-op (a legitimate
-        // override row carries one) and can hide nothing — it passes
-        // through preserved, never refused.
-        let over = "- id: timer\n  insert:\n  enabled: false\n";
-        let ok = merge_install(over, "/unused").unwrap();
-        assert!(ok.changed, "our row still mounts beside it");
-        assert!(ok.content.contains("timer"), "{}", ok.content);
-        assert!(verify_schema(&ok.content).issues.is_empty());
+        // A JS-falsy insert is upstream's own no-op (a legitimate override
+        // row carries a null one) and no scalar can hide an entry — falsy
+        // shapes pass through preserved, never refused.
+        for over in [
+            "- id: timer\n  insert:\n  enabled: false\n",
+            "- insert: false\n",
+            "- insert: 0\n",
+            "- insert: ''\n",
+        ] {
+            let ok = merge_install(over, "/unused").unwrap();
+            assert!(ok.changed, "our row still mounts beside {over:?}");
+            assert!(verify_schema(&ok.content).issues.is_empty(), "{over:?}");
+        }
+        // A TRUTHY scalar still refuses: upstream spreads it (a number
+        // throws at boot; a string spreads into per-char garbage entries).
+        let err = merge_install("- insert: 42\n", "/unused").unwrap_err();
+        assert!(err.to_string().contains("is not a list"), "{err}");
         std::env::remove_var("DSH_HOME");
     }
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -106,7 +106,11 @@ our release never builds. Two consequences:
   `crates/pixtuoid/src/sources_cli.rs`,
   `crates/pixtuoid-core/src/source/claude_code.rs`.
 
-Preempt BrewTestBot: submit the bump PR yourself right after tagging.
+Do not try to preempt BrewTestBot: the formula is on homebrew-core's
+autobump list, so `brew bump-formula-pr pixtuoid` refuses by policy and the
+bot opens the PR itself within ~3 hours of the tag. Watch THAT PR's CI — its
+default-features from-source build is the one configuration our release never
+builds — and intervene only if it reds.
 Publishing uses **OIDC trusted publishing** — CI carries no registry tokens;
 the per-crate/per-package Trusted Publishers must exist before the tag
 ([#216](https://github.com/IvanWng97/pixtuoid/issues/216)).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -108,9 +108,9 @@ our release never builds. Two consequences:
 
 Do not try to preempt BrewTestBot: the formula is on homebrew-core's
 autobump list, so `brew bump-formula-pr pixtuoid` refuses by policy and the
-bot opens the PR itself within ~3 hours of the tag. Watch THAT PR's CI — its
-default-features from-source build is the one configuration our release never
-builds — and intervene only if it reds.
+bot opens the PR itself within ~3 hours of the tag. Watch THAT PR's CI and
+intervene only if it reds.
+
 Publishing uses **OIDC trusted publishing** — CI carries no registry tokens;
 the per-crate/per-package Trusted Publishers must exist before the tag
 ([#216](https://github.com/IvanWng97/pixtuoid/issues/216)).


### PR DESCRIPTION
Closes out the last surfaced item from the #971/#972 reviews, plus one dead doc line.

- **A truthy non-list `insert:` row is refused loud** by `merge_install`, `merge_uninstall`, and `verify_schema` — previously invisible to all three (verify said "no mount entry" about an entry sitting in the file; uninstall returned `changed: false` with pixtuoid still mounted). Grounded in the shipped bytes: dsh's own patch apply spreads the value into an array push (`@deepseek-ai/cordis-plugin-include` 1.0.7, vendored in dsh 0.1.1-rc.2, `vendor/include/src/index.ts:94`), so a mapping there throws at boot — and a mapping can HOLD our entry, which is what made the silent blindness dangerous.
- **A null `insert:` passes through untouched**: upstream's truthiness gate skips it, and an override row (`- id: x` + `enabled: false`) carries one legitimately — refusing it would have bricked connect/disconnect for a config dsh boots happily (the review's one lens collision, decided by upstream's own gate).
- **CONTRIBUTING**: the "preempt BrewTestBot" advice is dead — the formula is autobumped and `brew bump-formula-pr` refuses by policy (hit live at the 0.18.0 release; the bot's own PR merged within the hour). The doc now says to watch the bot PR's CI instead.

Review: two lenses (both APPROVE), all findings folded with dispositions in the fold commit; one pre-existing item surfaced there (`sources.rs` flips `connected` before `uninstall_target` runs — shared across targets).

`just preflight` green ×2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6LG4b2iq2tRHvJ3AhFXDU
