### PR TITLE
chore(ci): the audit's tail — policy diet, one gate list, advisory symmetry

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -4,10 +4,11 @@ name: codspeed
 # modes: `simulation` counts weighted instructions (not wall-clock, so
 # shared-runner noise doesn't apply — <1% variance; the same setup ruff/uv
 # run) and `memory` counts heap allocations. ADVISORY by construction like
-# bench.yml/mutants.yml: nothing `needs:` it and it is not a required check —
-# trend evidence, never a gate. Reports need the CodSpeed GitHub App installed
-# on the repo; auth is OIDC (`id-token: write`, job-scoped per this repo's
-# convention — see ci-tests.yml's "Declared, not inherited"), no token secret.
+# bench.yml/mutants.yml: nothing `needs:` it, it is not a required check, and
+# both action steps are `continue-on-error` — trend evidence, never a gate.
+# Reports need the CodSpeed GitHub App installed on the repo; auth is OIDC
+# (`id-token: write`, job-scoped per this repo's convention — see ci-tests.yml's
+# "Declared, not inherited"), no token secret.
 # Steps follow CodSpeed's documented criterion workflow; moonrepo/setup-rust
 # installs cargo-codspeed via binstall (revisit if taiki-e/install-action adds
 # it).
@@ -52,9 +53,14 @@ jobs:
           channel: stable
           cache-target: release
           bins: cargo-codspeed
+      # Deliberately NOT continue-on-error: a bench that won't build is a
+      # broken build, not a perf trend.
       - name: Build instrumented benchmarks
         run: cargo codspeed build -p pixtuoid-scene -p pixtuoid-core
+      # Non-required is not enough: a red step still reaches mergeStateStatus
+      # (#964 sat gated on a red simulation while memory was already forgiven).
       - uses: CodSpeedHQ/action@v5
+        continue-on-error: true
         with:
           mode: simulation
           run: cargo codspeed run

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ cargo run --release --example snapshot -- /tmp/snap.png   # render TUI to PNG
 - Real wire bytes ride ONE pipeline: `pixtuoid_core::harness::Drive` (dev-only `harness` feature). A driver keyed off anything but the source's registry row registers NOTHING.
 - Fixtures are RECORDED, never composed (`just capture-fixture` — BILLED); every scenario declares `provenance.json`. Rules: [`fixtures/README.md`](crates/pixtuoid-core/tests/sources/fixtures/README.md). `just corpus-all` censuses local corpora; `just fixture-age` is advisory/local.
 - Visual verification for sprite work: snapshot example → `scripts/crop-snapshot.py` → READ the PNG; loop in `.claude/skills/beautify-decoration/SKILL.md`.
-- CI-only gates preflight can't see: semver · api-surface · doc-check · coverage/smoke · gen-check · gen-readme-check · npm-check · check-windows · insta snapshots. Details: [`CONTRIBUTING.md`](docs/CONTRIBUTING.md#ci-gates).
+- CI-only gates preflight can't see (a green preflight is NOT a green PR): [`CONTRIBUTING.md#ci-gates`](docs/CONTRIBUTING.md#ci-gates) lists them and what each catches.
 - On-demand advisory (never gates): `just mutants`, `just coverage`, `just bench`, CodSpeed.
 - Hooks: `git config core.hooksPath .githooks` once per clone; `just setup-tools` installs cargo tools (incl. rust-analyzer — without it the agent LSP degrades to grep).
 - Release: `just bump X.Y.Z` stops before the tag; pushing the tag IS the publish (crates.io + npm + homebrew autobump) and stays a human step. [`CONTRIBUTING.md`](docs/CONTRIBUTING.md#releasing).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -44,7 +44,10 @@ does not mean a green PR:
   deny) plus the doctests nextest skips.
 - **coverage/smoke · gen-check · gen-readme-check · npm-check** — committed
   media, README and npm manifest freshness.
-- **check-windows** — msvc cross-lint on every PR.
+- **windows-check / windows-test** — msvc cross-lint on every PR, and the
+  full suite on a real Windows runner.
+- **wasm-check** — the wasm32 build plus committed-`site/public/wasm/`
+  freshness (`just gen-wasm-check`).
 - **snapshots** — `cargo insta`; fails on a pending OR orphan `.snap`, the rot
   plain `cargo test` can't see.
 - **hygiene** — the same `just lint` recipes preflight runs (its CI job exists

--- a/docs/PARALLEL-DELIVERY.md
+++ b/docs/PARALLEL-DELIVERY.md
@@ -39,7 +39,8 @@ the Raycast extension. The cross-area contract is `pixtuoid … --json`
 Schemas, the Raycast extension generates its TS types from them (CI-checked
 fresh), and where no schema tool fits, golden/snapshot tests make a contract
 change a reviewable PR diff (`gen-check`). Per-area gates verify
-independently — `just preflight` + semver + gen-check (Rust),
+independently — `just preflight` + the
+[CI-only gates](CONTRIBUTING.md#ci-gates) (Rust),
 `just site-check` (site), `tsc` + `eslint` (Raycast) — and each area's house
 rules live in its own `CLAUDE.md`.
 

--- a/integrations/raycast/CLAUDE.md
+++ b/integrations/raycast/CLAUDE.md
@@ -9,7 +9,7 @@ this consumer sits in: [`../../docs/PARALLEL-DELIVERY.md`](../../docs/PARALLEL-D
 
 > **You are in the TS consumer, not the Rust producer.** The workspace
 > `CLAUDE.md` still loads above this file — but its Rust house rules
-> (TDD-in-Rust, `cargo`/`clippy`, `just preflight`, `semver`, `gen-check`)
+> (TDD-in-Rust, `cargo`/`clippy`, `just preflight`, the crate CI gates)
 > **do not apply here**. This is a Node project; the gates are `tsc` + `eslint`.
 > Don't run `cargo` anything for a change scoped to this directory.
 

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -1339,6 +1339,10 @@ deny contains msg if {
 	)
 }
 
+# CodeQL pins only SILENT drift: trigger coverage, the schedule, the language
+# matrix, the analysis-step census. Value-pins (permissions, concurrency,
+# runner, timeout) are absent on purpose — escalation is zizmor's beat, a
+# dropped permission reds the SARIF upload, a cancelled analysis self-heals.
 deny contains msg if {
 	object.get(codeql, ["on", "push", "branches"], null) != ["main"]
 	msg := sprintf("%s must run on pushes to main", [codeql_workflow_path])
@@ -1355,46 +1359,6 @@ deny contains msg if {
 deny contains msg if {
 	not has_weekly_codeql_schedule
 	msg := sprintf("%s must retain its weekly schedule", [codeql_workflow_path])
-}
-
-deny contains msg if {
-	object.get(codeql, ["permissions", "actions"], null) != "read"
-	msg := sprintf("%s must grant actions: read", [codeql_workflow_path])
-}
-
-deny contains msg if {
-	object.get(codeql, ["permissions", "contents"], null) != "read"
-	msg := sprintf("%s must grant contents: read", [codeql_workflow_path])
-}
-
-deny contains msg if {
-	object.get(codeql, ["permissions", "packages"], null) != "read"
-	msg := sprintf("%s must grant packages: read", [codeql_workflow_path])
-}
-
-deny contains msg if {
-	object.get(codeql, ["permissions", "security-events"], null) != "write"
-	msg := sprintf("%s must grant security-events: write", [codeql_workflow_path])
-}
-
-deny contains msg if {
-	object.get(codeql, ["concurrency", "group"], null) != "codeql-${{ github.ref }}"
-	msg := sprintf("%s must group concurrency by ref", [codeql_workflow_path])
-}
-
-deny contains msg if {
-	object.get(codeql, ["concurrency", "cancel-in-progress"], null) != "${{ github.event_name == 'pull_request' }}"
-	msg := sprintf("%s must cancel only superseded pull-request runs", [codeql_workflow_path])
-}
-
-deny contains msg if {
-	object.get(codeql_job, "runs-on", null) != "ubuntu-latest"
-	msg := sprintf("%s analyze job must use ubuntu-latest", [codeql_workflow_path])
-}
-
-deny contains msg if {
-	object.get(codeql_job, "timeout-minutes", null) != 30
-	msg := sprintf("%s analyze job must keep timeout-minutes: 30", [codeql_workflow_path])
 }
 
 deny contains msg if {

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -6,7 +6,7 @@ docs, demo media all flow in from outside `site/`. Parent guide: the workspace
 [`../CLAUDE.md`](../CLAUDE.md). Human detail: [`README.md`](README.md).
 
 > **You are in the Astro consumer, not the Rust producer.** Rust house rules
-> (`cargo`/`clippy`, `just preflight`, `semver`, `gen-check`) do not apply to a
+> (`cargo`/`clippy`, `just preflight`, the crate CI gates) do not apply to a
 > site-only change. The gates here are `just site-check` (+ `just site-fmt`)
 > and `just site-e2e`.
 


### PR DESCRIPTION
The 2026-09 CI audit's tail — three maintenance items, none touching runtime behavior of the test/build pipeline. Net **−26 lines**.

- **Policy diet**: the eight CodeQL value-pins go (permissions ×4, concurrency ×2, runs-on, timeout) — each pinned a value a reviewed workflow edit changes anyway, adding a second edit site with no drift-catch; escalation stays zizmor's beat, reduction fails loud on its own, a cancelled analysis self-heals. All structural pins stay (trigger coverage, the owner-pinned `on.pull_request` exact-null, schedule, language matrix, step counts, MSRV derivation). The boundary is written once, on the surviving CodeQL block. −40 rego lines, conftest 114 → 106.
- **One gate list**: `CONTRIBUTING.md#ci-gates` is the sole enumeration; CLAUDE.md, PARALLEL-DELIVERY, the raycast guide, and site/CLAUDE.md point at it. The sole authority itself was wrong in two places — `check-windows` is really `windows-check`/`windows-test`, and `wasm-check` was missing entirely.
- **CodSpeed is advisory in fact, not just in name**: the simulation step joins memory under `continue-on-error` (a red simulation gated #964 through the merge protocol's `mergeStateStatus` check while policy calls CodSpeed never-gating); the build step's deliberate non-forgiveness is stated.

**Re-scoped from the first cut**: the deterministic cache-prune job (push-on-`Cargo.lock`, superseded `v1-rust` generations) moves to its own PR: #976. It was the one new feature riding this cleanup and carried ~190 of its 216 added lines; it goes out byte-for-byte as reviewed here (two lenses + bot HIGH/MEDIUM folded).

Gates: `just ci-observability` (119 rego, 106 conftest), CI-pinned `conftest fmt --check`, actionlint, zizmor, lychee. No Rust touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZwwXpHPsUoRP5kx6EJDza
