### PR TITLE
chore(ci): CodeQL drops rust/cleartext-logging — every hit is a test assert

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Explicit: implicit detection can omit languages in a multi-language repo.
+        # Implicit detection can drop a language in a multi-language repo.
         language: [actions, javascript-typescript, python, rust]
     steps:
       - uses: actions/checkout@v7
@@ -69,23 +69,13 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-          # Rust supports only the no-build extractor; the interpreted languages
-          # in this matrix use the same mode.
+          # Rust has only the no-build extractor; the other three share the mode.
           build-mode: none
-          # `rust/cleartext-logging` is a name heuristic (`maybeAccountInfo` in
-          # github/codeql shared/concepts/codeql/concepts/internal/
-          # SensitiveDataHeuristics.qll, fetched 2026-09-01) that reads every
-          # `*_session_id` as a credential. Here a session id is an agent CLI's
-          # local key, hashed into `AgentId` at the decode boundary, and every
-          # alert to date is a test's failure message echoing one. The tests
-          # cannot be carved out: extraction covers every Cargo target
-          # (`CARGO_ALL_TARGETS`, policy-pinned) and `paths-ignore` cannot split
-          # an inline `#[cfg(test)]` module from its file. What the filter
-          # forgoes: the query's sinks are prints and panics, never `tracing`
-          # (the `log-injection` rows in github/codeql
-          # rust/ql/lib/codeql/rust/frameworks/log.model.yml, same fetch), so a
-          # session id reaching CLI output would go unflagged — the same
-          # misclassification, not a leak.
+          # `rust/cleartext-logging` reads every `*_session_id` as a credential
+          # (its `maybeAccountInfo` name heuristic); here it is an agent CLI's
+          # local key, and every alert to date was a test's failure message
+          # echoing one. `paths-ignore` cannot carve an inline `#[cfg(test)]`
+          # module out of its file, so the exclusion is per-query.
           config: |
             query-filters:
               - exclude:
@@ -96,14 +86,11 @@ jobs:
         uses: github/codeql-action/analyze@v4
         with:
           category: /language:${{ matrix.language }}
-          # Rust defers its upload until the extraction-health gate below passes: a
-          # degraded extraction yields FEWER alerts, so uploading first publishes a
-          # security tab that looks CLEANER than reality. Only Rust defers —
-          # upstream notes `never` complicates debugging.
+          # Rust uploads only after the health gate below: a degraded extraction
+          # yields FEWER alerts, so an early upload looks cleaner than reality.
           upload: ${{ matrix.language == 'rust' && 'never' || 'always' }}
 
-      # The action stays green even when extractor diagnostics affect most files,
-      # so enforce a threshold off CodeQL's own SARIF metrics.
+      # The action stays green under heavy extractor diagnostics; gate on the SARIF metrics.
       - name: Verify Rust extraction health
         if: ${{ matrix.language == 'rust' }}
         shell: bash
@@ -150,8 +137,6 @@ jobs:
             exit 1
           fi
 
-      # Only the SARIF the gate above vouched for: a failed gate skips this step, so
-      # no analysis reaches the security tab unless it was healthy enough to trust.
       - name: Upload Rust analysis
         if: ${{ matrix.language == 'rust' }}
         uses: github/codeql-action/upload-sarif@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -72,6 +72,20 @@ jobs:
           # Rust supports only the no-build extractor; the interpreted languages
           # in this matrix use the same mode.
           build-mode: none
+          # `rust/cleartext-logging` has no production sink to reach here: the
+          # workspace has no `log` crate, print macros are banned off production
+          # paths, and CodeQL ships no `tracing` model (github/codeql
+          # rust/ql/lib/codeql/rust/frameworks/, 2026-09-01), so its only sinks
+          # left are `panic!`/`assert!` messages. Every alert it has raised was a
+          # `#[cfg(test)]` assert printing a decoded event whose `*_session_id`
+          # source tripped the `session.?(id|key)` name heuristic
+          # (shared/concepts/codeql/concepts/internal/SensitiveDataHeuristics.qll).
+          # Those tests are extracted on purpose (`CARGO_ALL_TARGETS`, policy-pinned)
+          # and `paths-ignore` cannot split an inline test module from its file.
+          config: |
+            query-filters:
+              - exclude:
+                  id: rust/cleartext-logging
 
       - name: Analyze
         id: analyze

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -72,16 +72,20 @@ jobs:
           # Rust supports only the no-build extractor; the interpreted languages
           # in this matrix use the same mode.
           build-mode: none
-          # `rust/cleartext-logging` has no production sink to reach here: the
-          # workspace has no `log` crate, print macros are banned off production
-          # paths, and CodeQL ships no `tracing` model (github/codeql
-          # rust/ql/lib/codeql/rust/frameworks/, 2026-09-01), so its only sinks
-          # left are `panic!`/`assert!` messages. Every alert it has raised was a
-          # `#[cfg(test)]` assert printing a decoded event whose `*_session_id`
-          # source tripped the `session.?(id|key)` name heuristic
-          # (shared/concepts/codeql/concepts/internal/SensitiveDataHeuristics.qll).
-          # Those tests are extracted on purpose (`CARGO_ALL_TARGETS`, policy-pinned)
-          # and `paths-ignore` cannot split an inline test module from its file.
+          # `rust/cleartext-logging` is a name heuristic (`maybeAccountInfo` in
+          # github/codeql shared/concepts/codeql/concepts/internal/
+          # SensitiveDataHeuristics.qll, fetched 2026-09-01) that reads every
+          # `*_session_id` as a credential. Here a session id is an agent CLI's
+          # local key, hashed into `AgentId` at the decode boundary, and every
+          # alert to date is a test's failure message echoing one. The tests
+          # cannot be carved out: extraction covers every Cargo target
+          # (`CARGO_ALL_TARGETS`, policy-pinned) and `paths-ignore` cannot split
+          # an inline `#[cfg(test)]` module from its file. What the filter
+          # forgoes: the query's sinks are prints and panics, never `tracing`
+          # (the `log-injection` rows in github/codeql
+          # rust/ql/lib/codeql/rust/frameworks/log.model.yml, same fetch), so a
+          # session id reaching CLI output would go unflagged — the same
+          # misclassification, not a leak.
           config: |
             query-filters:
               - exclude:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -65,7 +65,9 @@ does not mean a green PR:
   when the model job fails or declines, because absence otherwise renders as
   a pass (#809). `claude.yml` refuses fork PR heads.
 - **CodeQL** stays the advanced workflow (`codeql.yml`): explicit languages,
-  Rust's `none` build mode fed the MSRV toolchain, a SARIF health gate.
+  Rust's `none` build mode fed the MSRV toolchain, a SARIF health gate, and an
+  inline query filter dropping `rust/cleartext-logging` (its only reachable
+  sinks here are test asserts — the WHY sits on the init step).
 
 ## Releasing
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -66,8 +66,7 @@ does not mean a green PR:
   a pass (#809). `claude.yml` refuses fork PR heads.
 - **CodeQL** stays the advanced workflow (`codeql.yml`): explicit languages,
   Rust's `none` build mode fed the MSRV toolchain, a SARIF health gate, and an
-  inline query filter dropping `rust/cleartext-logging` (its only reachable
-  sinks here are test asserts — the WHY sits on the init step).
+  inline query filter dropping `rust/cleartext-logging` (WHY on the init step).
 
 ## Releasing
 


### PR DESCRIPTION
## Summary

CodeQL's `rust/cleartext-logging` is excluded via an inline `config:` on the init step. The query is a name heuristic (`maybeAccountInfo` in `shared/concepts/codeql/concepts/internal/SensitiveDataHeuristics.qll`) that reads every `*_session_id` as a credential. Here a session id is an agent CLI's local key, hashed into `AgentId` at the decode boundary, and every alert the rule has raised (47: 35 open, 11 dismissed "used in tests" on 2026-07-26 and 08-31, 1 fixed) is a test's failure message echoing one — 32 inside `#[cfg(test)]` modules, 3 under `tests/`. Dismissals are per-location, so each new test file re-raised the class.

What the filter forgoes: the query's sinks are prints and panics (the `log-injection` rows in `rust/ql/lib/codeql/rust/frameworks/log.model.yml`), never `tracing`, which CodeQL does not model. The exclusion is repo-wide, so it also forgoes the heuristic's other name classes (`maybePassword`, `maybeSecret`, `maybeCertificate`, `maybePrivate`): a future credential-shaped value reaching a print macro would go unflagged. Today no production crate holds one — every credential-shaped identifier in the tree sits in test code — and a session id reaching CLI output would be the same misclassification, not a leak. The day a source needs an API key, re-enable the query or add a barrier model for the `*_session_id` helpers instead. Alternatives: `CARGO_ALL_TARGETS` is policy-pinned, `paths-ignore` is file-level (would clear 3 of 35), a barrier model pack is a per-function list every new source must extend. No Rego pin in this PR: removing the filter or an upstream id rename both return the alerts in the Security tab after the next `main` scan (a PR's CodeQL check counts only alerts in changed code, so the PR itself stays green); widening the exclude list would be silent. Whether that earns a policy pin is the owner's call as its own small PR (the review gate forbids new gates inside a fix round).

Positive control: the PR-ref Rust analysis reports 24 rules / 0 results against main's 25 / 36; the other three languages are unchanged. The 35 open alerts close as "no longer detected" on the first `main` scan after merge.

## Related issue

n/a

## Type of change

- [x] Refactor / chore

## How I tested it

- `just actionlint`, `just zizmor`, `just ci-observability` (119 Rego unit tests + 114 conftest checks) — exit 0.
- The `config:` block parsed with `yq` and the filter id read back as `rust/cleartext-logging`.
- `query-filters: - exclude: id:` and the init step's `config` input are the documented forms (`init/action.yml` at v4 lines 96-98; docs.github.com "customizing your advanced setup for code scanning", fetched 2026-09-01).
- Code-scanning analyses on the PR merge ref vs main (see positive control above).

## Visual verification (required for sprite / rendering changes)

- [x] Not a visual change.

## Checklist

- [x] I read the relevant `CLAUDE.md`.
- [x] No `unwrap()` in non-test code.
- [x] No new `println!`/`eprintln!` on a production path.
- [x] Docs updated in the same commit (`docs/CONTRIBUTING.md` CodeQL bullet).
- [x] `just preflight` passes locally (pre-push hook).

## AI assistance

- [x] This PR was written/heavily-assisted by an AI agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WND5MmFHuVxDpJ2JNEZo4u
