### PR TITLE
chore(ci): deterministic cache pruning — superseded main-ref rust generations go on a lockfile bump

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,24 +1,36 @@
 name: cache cleanup
 
-# PR caches can evict useful main caches once the repository hits its size limit.
-# Runs in the base context so fork PRs clean up too — never checkout or execute
-# pull-request content here.
+# Two prunes under one grant shape: closed-PR caches (run in the base
+# context, so fork PRs clean up too) and superseded main-ref rust
+# generations. Never checkout or execute pull-request content here.
 on:
   pull_request_target: # zizmor: ignore[dangerous-triggers] no checkout or PR-code execution; policy pins the cache-only job
     types: [closed]
+  # A lockfile bump strands the previous rust cache generation on the main
+  # ref; deleting it deterministically beats the LRU lottery at the 10 GB
+  # ceiling. Toolchain bumps are out of scope in both directions: they don't
+  # touch Cargo.lock, and the rustc hash is inside the family key, so a bump
+  # forks a NEW family rather than superseding the old one.
+  push:
+    branches: [main]
+    paths: [Cargo.lock]
 
-permissions:
-  actions: write
+# Per-job grants: with more than one job, a workflow-level write is
+# zizmor's excessive-permissions class.
+permissions: {}
 
 concurrency:
-  group: cache-cleanup-${{ github.event.pull_request.number }}
+  group: cache-cleanup-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false
 
 jobs:
   closed-pr:
     name: closed PR
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      actions: write
     env:
       GH_TOKEN: ${{ github.token }}
       GH_REPO: ${{ github.repository }}
@@ -28,3 +40,45 @@ jobs:
         run: |
           gh cache delete --all --ref "$PR_REF" --succeed-on-no-caches
           echo "Cache cleanup completed for \`$PR_REF\` (no caches is a successful no-op)." >> "$GITHUB_STEP_SUMMARY"
+
+  stale-generations:
+    name: stale rust generations
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - name: Delete superseded main-ref rust caches
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Stripping the last segment reproduces rust-cache's own restoreKey
+          # boundary (key = prefix-sharedkey-OS-arch-envhash-LOCKHASH), so a
+          # family is (job, OS, toolchain) and only lockfile generations
+          # compete inside it. A key with a non-hex tail becomes its own
+          # one-element family and is never deleted — the failure direction
+          # is under-prune, never over-prune. Keep each family's newest
+          # entry; this run races the build creating its successor, so the
+          # superseded generation survives until the NEXT bump — the
+          # invariant is at most two generations per family, not one.
+          # An assignment propagates a pipeline failure under pipefail (a
+          # process substitution would swallow it); --limit 300 is an order
+          # of magnitude past what the 10 GB ceiling can hold.
+          ids=$(
+            gh cache list --ref refs/heads/main --limit 300 --json id,key,createdAt \
+              | jq -r '[.[] | select(.key | startswith("v1-rust-"))]
+                  | group_by(.key | sub("-[0-9a-f]+$"; ""))
+                  | map(sort_by(.createdAt) | .[:-1][])
+                  | .[].id'
+          )
+          pruned=0
+          for id in $ids; do
+            # LRU can evict between list and delete — a benign race.
+            gh cache delete "$id" || echo "::warning::cache $id already gone"
+            pruned=$((pruned + 1))
+          done
+          echo "Pruned $pruned stale rust cache generation(s) on refs/heads/main." >> "$GITHUB_STEP_SUMMARY"

--- a/policy/ci-observability/action_behavior_test.sh
+++ b/policy/ci-observability/action_behavior_test.sh
@@ -5,6 +5,7 @@ CODECOV_ACTION_FILE="${CODECOV_ACTION_FILE:-.github/actions/upload-codecov/actio
 CODEQL_WORKFLOW_FILE="${CODEQL_WORKFLOW_FILE:-.github/workflows/codeql.yml}"
 CLAUDE_REVIEW_WORKFLOW_FILE="${CLAUDE_REVIEW_WORKFLOW_FILE:-.github/workflows/claude-readonly-review.yml}"
 CI_LINT_WORKFLOW_FILE="${CI_LINT_WORKFLOW_FILE:-.github/workflows/ci-lint.yml}"
+CACHE_CLEANUP_WORKFLOW_FILE="${CACHE_CLEANUP_WORKFLOW_FILE:-.github/workflows/cache-cleanup.yml}"
 
 fail() {
     echo "ci-observability behavior test: $*" >&2
@@ -513,3 +514,52 @@ absence_body="$(<"$absence_capture")"
 run_absence success
 [[ "$(<"$absence_capture")" == *"out of scope for the reviewer"* ]] ||
     fail "a declined review was reported as a failure"
+
+# ── cache-cleanup: the prune deletes exactly the superseded generations ──────
+# The rego rule pins only the job's shape; which ids the jq family logic
+# selects is asserted here: newest-per-family survives, a single-entry family
+# survives, a non-hex tail is its own family (under-prune direction), non-rust
+# keys are untouched, and one 404'd delete warns without aborting the rest.
+prune_script="$(workflow_step_script "$CACHE_CLEANUP_WORKFLOW_FILE" "Delete superseded main-ref rust caches")"
+prune_dir="$(mktemp -d)"
+prune_bin="$prune_dir/bin"
+mkdir -p "$prune_bin"
+prune_list="$prune_dir/cache_list.json"
+cat >"$prune_list" <<'JSON'
+[
+  {"id": 1, "key": "v1-rust-smoke-Linux-x64-aaaa-1111", "createdAt": "2026-08-01T00:00:00Z"},
+  {"id": 2, "key": "v1-rust-smoke-Linux-x64-aaaa-2222", "createdAt": "2026-09-01T00:00:00Z"},
+  {"id": 3, "key": "v1-rust-docs-Linux-x64-aaaa-2222", "createdAt": "2026-09-01T00:00:00Z"},
+  {"id": 4, "key": "v1-rust-odd-Linux-x64-tail", "createdAt": "2026-01-01T00:00:00Z"},
+  {"id": 5, "key": "playwright-Linux-abc123", "createdAt": "2026-01-01T00:00:00Z"},
+  {"id": 6, "key": "v1-rust-hack-Linux-x64-aaaa-1111", "createdAt": "2026-07-01T00:00:00Z"},
+  {"id": 7, "key": "v1-rust-hack-Linux-x64-aaaa-2222", "createdAt": "2026-08-01T00:00:00Z"},
+  {"id": 8, "key": "v1-rust-hack-Linux-x64-aaaa-3333", "createdAt": "2026-09-01T00:00:00Z"}
+]
+JSON
+# shellcheck disable=SC2016 # The generated stub reads its env when it runs.
+printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'set -euo pipefail' \
+    'if [[ "$1" == "cache" && "$2" == "list" ]]; then command cat "$CACHE_LIST_FILE"; exit 0; fi' \
+    'if [[ "$1" == "cache" && "$2" == "delete" ]]; then' \
+    '    printf "%s\n" "$3" >>"$DELETE_LOG"' \
+    '    if [[ "$3" == "6" ]]; then exit 1; fi' \
+    '    exit 0' \
+    'fi' \
+    'exit 1' \
+    >"$prune_bin/gh"
+chmod +x "$prune_bin/gh"
+prune_deletes="$prune_dir/deletes.log"
+: >"$prune_deletes"
+prune_summary="$prune_dir/summary.md"
+PATH="$prune_bin:$PATH" \
+    CACHE_LIST_FILE="$prune_list" \
+    DELETE_LOG="$prune_deletes" \
+    GITHUB_STEP_SUMMARY="$prune_summary" \
+    bash -c "$prune_script" ||
+    fail "prune aborted — a 404'd delete must warn and continue"
+[[ "$(sort -n "$prune_deletes" | tr '\n' ' ')" == "1 6 7 " ]] ||
+    fail "prune deleted the wrong ids: $(tr '\n' ' ' <"$prune_deletes")"
+[[ "$(<"$prune_summary")" == *"Pruned 3"* ]] ||
+    fail "prune summary did not report the attempted count"

--- a/policy/ci-observability/main.rego
+++ b/policy/ci-observability/main.rego
@@ -619,13 +619,24 @@ rust_health_summary_is_quantified(run) if {
 	contains(run, "Clean files")
 }
 
+# Both jobs are trigger-guarded on purpose: an unguarded `stale-generations`
+# runs on pull_request_target, handing a fork PR author a main-ref cache
+# deletion. The step counts and the empty `uses` keep either job from growing
+# an action that could execute PR content under that same grant.
 cache_cleanup_is_inert if {
 	workflow := documents[cache_cleanup_workflow_path]
-	workflow.permissions == {"actions": "write"}
-	workflow.on == {"pull_request_target": {"types": ["closed"]}}
+	workflow.permissions == {}
+
+	# Exact `types: [closed]`: any wider and the closed-pr job's `if` (event
+	# NAME only) would delete caches out from under still-open PRs. The push
+	# trigger's shape is deliberately unpinned — the prune script hardcodes
+	# its ref, so trigger drift there changes nothing this rule protects.
+	object.get(workflow, ["on", "pull_request_target"], null) == {"types": ["closed"]}
 	jobs := object.get(workflow, "jobs", {})
-	count(jobs) == 1
+	count(jobs) == 2
 	job := jobs["closed-pr"]
+	object.get(job, "permissions", null) == {"actions": "write"}
+	object.get(job, "if", "") == "github.event_name == 'pull_request_target'"
 	count(object.get(job, "steps", [])) == 1
 	step := job.steps[0]
 	object.get(step, "uses", "") == ""
@@ -633,6 +644,11 @@ cache_cleanup_is_inert if {
 	object.get(env, "PR_REF", "") == "refs/pull/${{ github.event.pull_request.number }}/merge"
 	run := object.get(step, "run", "")
 	contains(run, "gh cache delete --all --ref \"$PR_REF\" --succeed-on-no-caches")
+	prune := jobs["stale-generations"]
+	object.get(prune, "permissions", null) == {"actions": "write"}
+	object.get(prune, "if", "") == "github.event_name == 'push'"
+	count(object.get(prune, "steps", [])) == 1
+	object.get(prune.steps[0], "uses", "") == ""
 }
 
 has_weekly_codeql_schedule if {
@@ -938,7 +954,7 @@ deny contains msg if {
 deny contains msg if {
 	_ := documents[cache_cleanup_workflow_path]
 	not cache_cleanup_is_inert
-	msg := sprintf("%s pull_request_target job must remain cache-only and checkout-free", [cache_cleanup_workflow_path])
+	msg := sprintf("%s must keep both jobs inert: workflow-level permissions empty, each job trigger-guarded with its own actions:write, one step, no action", [cache_cleanup_workflow_path])
 }
 
 deny contains msg if {

--- a/policy/ci-observability/main_test.rego
+++ b/policy/ci-observability/main_test.rego
@@ -705,20 +705,65 @@ test_zizmor_block_scalar_invocation_still_needs_the_token if {
 	zizmor_token_message("hygiene") in violations
 }
 
-test_cache_cleanup_cannot_execute_pull_request_code if {
-	fixture := {"documents": [{
-		"path": cache_cleanup_workflow_path,
-		"contents": {
-			"on": {"pull_request_target": {"types": ["closed"]}},
+cache_cleanup_message := sprintf("%s must keep both jobs inert: workflow-level permissions empty, each job trigger-guarded with its own actions:write, one step, no action", [cache_cleanup_workflow_path])
+
+cache_cleanup_valid_contents := {
+	"on": {
+		"pull_request_target": {"types": ["closed"]},
+		"push": {"branches": ["main"], "paths": ["Cargo.lock"]},
+	},
+	"permissions": {},
+	"jobs": {
+		"closed-pr": {
+			"if": "github.event_name == 'pull_request_target'",
 			"permissions": {"actions": "write"},
-			"jobs": {"closed-pr": {
-				"env": {"PR_REF": "refs/pull/${{ github.event.pull_request.number }}/merge"},
-				"steps": [{"uses": "actions/checkout@v7"}],
-			}},
+			"env": {"PR_REF": "refs/pull/${{ github.event.pull_request.number }}/merge"},
+			"steps": [{"run": "gh cache delete --all --ref \"$PR_REF\" --succeed-on-no-caches"}],
 		},
-	}]}
-	violations := deny with input as fixture
-	sprintf("%s pull_request_target job must remain cache-only and checkout-free", [cache_cleanup_workflow_path]) in violations
+		"stale-generations": {
+			"if": "github.event_name == 'push'",
+			"permissions": {"actions": "write"},
+			"steps": [{"run": "gh cache list"}],
+		},
+	},
+}
+
+cache_cleanup_fixture(overrides) := {"documents": [{
+	"path": cache_cleanup_workflow_path,
+	"contents": object.union(cache_cleanup_valid_contents, overrides),
+}]}
+
+# object.union is shallow, so a job mutation carries the whole jobs map.
+cache_cleanup_with_job(name, job) := cache_cleanup_fixture({"jobs": object.union(cache_cleanup_valid_contents.jobs, {name: job})})
+
+# The mutation tests are only pins while the base is clean: without this, a
+# new rule condition the base doesn't satisfy makes every one of them fire
+# for the wrong reason.
+test_cache_cleanup_baseline_is_inert if {
+	violations := deny with input as cache_cleanup_fixture({})
+	not cache_cleanup_message in violations
+}
+
+test_cache_cleanup_cannot_execute_pull_request_code if {
+	violations := deny with input as cache_cleanup_with_job("closed-pr", {
+		"if": "github.event_name == 'pull_request_target'",
+		"permissions": {"actions": "write"},
+		"env": {"PR_REF": "refs/pull/${{ github.event.pull_request.number }}/merge"},
+		"steps": [{
+			"uses": "actions/checkout@v7",
+			"run": "gh cache delete --all --ref \"$PR_REF\" --succeed-on-no-caches",
+		}],
+	})
+	cache_cleanup_message in violations
+}
+
+test_cache_cleanup_prune_job_cannot_grow_an_action_step if {
+	violations := deny with input as cache_cleanup_with_job("stale-generations", {
+		"if": "github.event_name == 'push'",
+		"permissions": {"actions": "write"},
+		"steps": [{"uses": "actions/checkout@v7", "run": "gh cache list"}],
+	})
+	cache_cleanup_message in violations
 }
 
 test_claude_review_trigger_must_load_from_the_trusted_base if {


### PR DESCRIPTION
Split out of #974 so that PR stays a cleanup: this was the one new job riding it and carried ~190 of its 216 added lines. Carried here byte-for-byte as reviewed there (two lenses APPROVE-with-fixes, bot HIGH + MEDIUM folded).

**Deterministic cache pruning**: `cache-cleanup.yml` gains a push-on-`Cargo.lock` job pruning superseded `v1-rust` cache generations on the main ref (14 GB against the 10 GB ceiling today, 3.3 GB of it a dead lockfile generation) — the LRU lottery becomes an at-most-two-generations-per-family invariant. The family boundary is rust-cache's own `restoreKey`; a non-matching key can only under-prune. Fails loud (`shell: bash`, `set -euo pipefail`, command-substitution assignment — a process substitution swallows a failed `gh cache list` even under pipefail), tolerates the list→delete LRU race, and reports a count.

- zizmor's multi-job rule sinks the `actions: write` grant to job level; both jobs are trigger-guarded (an unguarded prune on `pull_request_target` would hand a fork PR author a main-ref cache deletion).
- The inert-workflow rego pin covers the two-job shape, rebuilt in the two-halves idiom: valid base, one mutation per test, negative-control baseline.
- The jq family logic has its behavior test in `action_behavior_test.sh`: newest-per-family survives, a single-entry family survives, a non-hex tail under-prunes, non-rust keys untouched, a 404'd delete warns without aborting.

Independent of #974 (no shared hunks; the diet touches only the CodeQL rules).

Gates: `just ci-observability` (121 rego, 114 conftest), CI-pinned `conftest fmt --check`, `action_behavior_test.sh`, actionlint, zizmor, shellcheck, shfmt. No Rust touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZwwXpHPsUoRP5kx6EJDza
