### PR TITLE
fix(deps): remove ttf-parser from the graph, retiring the last deny ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,12 @@ updates:
       - dependency-name: "x11rb"
         update-types:
           ["version-update:semver-minor", "version-update:semver-major"]
+      # winit's default set is copied verbatim into crates/pixtuoid/Cargo.toml and
+      # cargo cannot subtract one default, so a bump ADDING a default silently
+      # drops a backend — a Linux runtime failure no gate catches. Bump by hand.
+      - dependency-name: "winit"
+        update-types:
+          ["version-update:semver-minor", "version-update:semver-major"]
     cooldown:
       default-days: 7
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,6 +1201,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "font-types"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64eb721ca85a34323425f4041adc5d82704d3782d5f8f03793bc012419dce23"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1738,14 +1747,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.19"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
+checksum = "8d8f1ea3f21fd3405dcaf6c9b5c1630af9afc422d9073ea39c5f6d6c772e08ed"
 dependencies = [
  "bitflags 2.13.1",
  "libc",
  "plain",
- "redox_syscall 0.9.1",
+ "redox_syscall 0.9.3",
 ]
 
 [[package]]
@@ -2676,7 +2685,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 name = "pixtuoid"
 version = "0.18.0"
 dependencies = [
- "ab_glyph",
+ "ab_glyph_rasterizer",
  "anyhow",
  "chrono",
  "clap",
@@ -2697,6 +2706,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "skrifa",
  "snapbox",
  "softbuffer",
  "tempfile",
@@ -3161,6 +3171,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "read-fonts"
+version = "0.43.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "005c8acf251756c478b0bf402885bfd88a1476020c4c7e6060edc1aa68da38ea"
+dependencies = [
+ "bytemuck",
+ "font-types",
+ "once_cell",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3180,9 +3201,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07507be7b4a5f9f26eeb41eeaebb1f5a7ff29dfb29739facc21d35bf8b11c21e"
+checksum = "d678d17679829e73d371e96880897e98fee2ded7acc0a50bdf8af2affa4b2fe5"
 dependencies = [
  "bitflags 2.13.1",
 ]
@@ -3580,6 +3601,16 @@ name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "skrifa"
+version = "0.46.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4febebda507fb889c545a37a135517769d1391941013561292897961d1887d6"
+dependencies = [
+ "bytemuck",
+ "read-fonts",
+]
 
 [[package]]
 name = "slab"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,6 @@
 version = 4
 
 [[package]]
-name = "ab_glyph"
-version = "0.2.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2"
-dependencies = [
- "ab_glyph_rasterizer",
- "owned_ttf_parser",
-]
-
-[[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2490,15 +2480,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
-name = "owned_ttf_parser"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
-dependencies = [
- "ttf-parser",
-]
-
-[[package]]
 name = "palette"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3419,9 +3400,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec"
 dependencies = [
- "ab_glyph",
  "log",
- "memmap2",
  "smithay-client-toolkit",
  "tiny-skia",
 ]
@@ -4158,12 +4137,6 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
-
-[[package]]
-name = "ttf-parser"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
 name = "typenum"

--- a/crates/pixtuoid/Cargo.toml
+++ b/crates/pixtuoid/Cargo.toml
@@ -21,11 +21,16 @@ path = "src/main.rs"
 [dependencies]
 pixtuoid-core  = { path = "../pixtuoid-core", version = "0.18.0" }
 pixtuoid-scene = { path = "../pixtuoid-scene", version = "0.18.0" }
-# AA text rasterizer (Monaspace Neon) for the binary's pixel surfaces. Its
-# per-pixel coverage callback (`OutlinedGlyph::draw`) suits our callback-based
-# `aa_text::draw_text_at` better than fontdue's raw-bitmap API. Binary-only: the
-# wasm-compiled engine never sees it, and renders text as a DOM overlay instead.
-ab_glyph = "0.2"
+# AA text rasterizer (Monaspace Neon) for the binary's pixel surfaces, SPLIT in
+# two on purpose: skrifa parses the face and emits outlines, ab_glyph_rasterizer
+# turns those outlines into per-pixel coverage. The pair was `ab_glyph`, whose
+# parsing half pulls the unmaintained ttf-parser (RUSTSEC-2026-0192, #440); its
+# rasterizing half is dependency-free and is the one kept, so the coverage the
+# committed stills were rendered with does not change. Rejected alternatives are
+# on `aa_text`'s module doc. Binary-only: the wasm-compiled engine never sees
+# this, and renders text as a DOM overlay instead.
+skrifa = "0.46"
+ab_glyph_rasterizer = "0.1"
 tokio              = { workspace = true, features = ["rt-multi-thread", "macros", "signal", "sync", "time", "net", "fs", "io-util"] }
 ratatui            = { workspace = true }
 # Terminal graphics (kitty/iTerm2/SIXEL) for the cutaway profile — capability

--- a/crates/pixtuoid/Cargo.toml
+++ b/crates/pixtuoid/Cargo.toml
@@ -67,7 +67,22 @@ open               = "5"
 # The `pixtuoid floating` desktop window (binary-only — pixtuoid-core stays
 # window-free): winit is the frameless always-on-top window + main-thread event
 # loop, softbuffer the CPU blit of the office RgbBuffer into it (no GPU).
-winit              = "0.30"
+#
+# The feature list is winit's own default set with ONE substitution, so dropping
+# `default-features` must keep the other four verbatim — a missing one is a
+# Linux RUNTIME failure (no backend), not a build error. The substitution:
+# `wayland-csd-adwaita` -> `-notitle`, which is the same sctk-adwaita decoration
+# minus its optional `ab_glyph` title-text renderer. That font stack was pure
+# weight here — `window.rs` builds with `with_decorations(false)`, so the
+# titlebar it draws into never exists — and it was the second of the two paths
+# putting the unmaintained ttf-parser in the graph (RUSTSEC-2026-0192, #440).
+winit = { version = "0.30", default-features = false, features = [
+    "rwh_06",
+    "x11",
+    "wayland",
+    "wayland-dlopen",
+    "wayland-csd-adwaita-notitle",
+] }
 softbuffer         = "0.4"
 clap_complete = "4.6.5"
 clap_mangen = "0.3.0"

--- a/crates/pixtuoid/Cargo.toml
+++ b/crates/pixtuoid/Cargo.toml
@@ -21,14 +21,10 @@ path = "src/main.rs"
 [dependencies]
 pixtuoid-core  = { path = "../pixtuoid-core", version = "0.18.0" }
 pixtuoid-scene = { path = "../pixtuoid-scene", version = "0.18.0" }
-# AA text rasterizer (Monaspace Neon) for the binary's pixel surfaces, SPLIT in
-# two on purpose: skrifa parses the face and emits outlines, ab_glyph_rasterizer
-# turns those outlines into per-pixel coverage. The pair was `ab_glyph`, whose
-# parsing half pulls the unmaintained ttf-parser (RUSTSEC-2026-0192, #440); its
-# rasterizing half is dependency-free and is the one kept, so the coverage the
-# committed stills were rendered with does not change. Rejected alternatives are
-# on `aa_text`'s module doc. Binary-only: the wasm-compiled engine never sees
-# this, and renders text as a DOM overlay instead.
+# AA text rasterizer (Monaspace Neon) for the binary's pixel surfaces, split in
+# two on purpose — the WHY, and the rejected whole-stack alternatives, are on
+# `aa_text`'s module doc. Binary-only: the wasm-compiled engine never sees this,
+# and renders text as a DOM overlay instead.
 skrifa = "0.46"
 ab_glyph_rasterizer = "0.1"
 tokio              = { workspace = true, features = ["rt-multi-thread", "macros", "signal", "sync", "time", "net", "fs", "io-util"] }
@@ -53,9 +49,9 @@ serde              = { workspace = true }
 serde_json         = { workspace = true, features = ["preserve_order"] }
 toml               = { workspace = true }
 toml_edit          = { workspace = true }
-# YAML parse+emit for the Hermes install target. The maintained yaml-rust
-# successor (serde_yaml/serde_yml are both abandoned); it data-preserves a user's
-# other config keys on merge but does NOT round-trip comments.
+# YAML parse+emit for the Hermes install target — the maintained yaml-rust
+# successor, serde_yaml and serde_yml both being abandoned. It data-preserves a
+# user's other config keys on merge but does NOT round-trip comments.
 saphyr             = "0.0.12"
 anyhow             = { workspace = true }
 tracing            = { workspace = true }
@@ -68,14 +64,11 @@ open               = "5"
 # window-free): winit is the frameless always-on-top window + main-thread event
 # loop, softbuffer the CPU blit of the office RgbBuffer into it (no GPU).
 #
-# The feature list is winit's own default set with ONE substitution, so dropping
-# `default-features` must keep the other four verbatim — a missing one is a
-# Linux RUNTIME failure (no backend), not a build error. The substitution:
-# `wayland-csd-adwaita` -> `-notitle`, which is the same sctk-adwaita decoration
-# minus its optional `ab_glyph` title-text renderer. That font stack was pure
-# weight here — `window.rs` builds with `with_decorations(false)`, so the
-# titlebar it draws into never exists — and it was the second of the two paths
-# putting the unmaintained ttf-parser in the graph (RUSTSEC-2026-0192, #440).
+# This is winit's own default set with ONE substitution, so dropping
+# `default-features` must keep every other default verbatim — a missing one is a
+# Linux RUNTIME failure (no backend), not a build error. The substitution
+# `wayland-csd-adwaita` -> `-notitle` drops only that decoration's `ab_glyph`
+# title-text renderer, which `with_decorations(false)` never draws into.
 winit = { version = "0.30", default-features = false, features = [
     "rwh_06",
     "x11",
@@ -103,10 +96,10 @@ audio = ["dep:rodio"]
 # `ratatui-image` pulls icy_sixel -> quantette -> rayon unconditionally (no
 # feature of its own drops the sixel backend), so a work-stealing thread pool
 # enters a tokio binary, and on Windows a SECOND binding family (`windows 0.58`
-# beside the existing 0.62) with its proc-macro crates. 27 transitive crates in
-# total, and every one of them reaches `cargo install` and homebrew-core's
-# from-source build. Off is a build whose `doctor` reports the capability as
-# unqueryable, which is what every non-graphics terminal already gets.
+# beside the existing 0.62) with its proc-macro crates. Every one of those
+# transitive crates reaches `cargo install` and homebrew-core's from-source
+# build. Off is a build whose `doctor` reports the capability as unqueryable,
+# which is what every non-graphics terminal already gets.
 graphics = ["dep:ratatui-image"]
 
 # termios/poll for the truecolor preflight's DECRQSS terminal query (term.rs).

--- a/crates/pixtuoid/src/aa_text.rs
+++ b/crates/pixtuoid/src/aa_text.rs
@@ -12,14 +12,10 @@
 //! render glyph MUST be Monaspace-covered, never a second face; the gate is
 //! `office_symbol_vocabulary_is_fully_covered`.
 //!
-//! TWO crates, not one: [`skrifa`] parses the face and emits outlines,
-//! [`ab_glyph_rasterizer`] turns an outline into coverage. Both halves were
-//! `ab_glyph`, whose parsing half pulls the unmaintained ttf-parser
-//! (RUSTSEC-2026-0192, #440) while its rasterizing half depends on nothing — so
-//! only the parser was replaced. Keeping the rasterizer is what makes the AA
-//! curve, and therefore every committed still, survive the swap untouched; a
-//! whole-stack move (`swash`, or `skrifa` + `zeno`) would have shifted every
-//! edge for no gain.
+//! The committed stills are pinned to [`ab_glyph_rasterizer`]'s AA curve, so
+//! only the PARSER moved to [`skrifa`] (`ab_glyph`'s pulled the unmaintained
+//! ttf-parser, RUSTSEC-2026-0192, #440). A whole-stack move (`swash`, or
+//! `skrifa` + `zeno`) would shift every edge and reshoot every still.
 //!
 //! Surface-agnostic: [`draw_text_at`] hands each lit pixel's coverage to a
 //! `put(x, y, coverage)` closure, so every caller applies its own pixel-format
@@ -38,19 +34,9 @@ use skrifa::{FontRef, GlyphId, MetadataProvider};
 /// License text in `fonts/OFL-Monaspace.txt`.
 const FONT_BYTES: &[u8] = include_bytes!("../fonts/MonaspaceNeon-SemiBold.otf");
 
-static FONT: LazyLock<FontRef<'static>> =
-    LazyLock::new(|| FontRef::new(FONT_BYTES).expect("bundled Monaspace Neon OTF must parse"));
-
-/// The face's derived lookup structures, built once.
-///
-/// skrifa keeps these separate from the font data so a caller can retain them,
-/// and a caller should: [`MetadataProvider::charmap`] re-runs cmap subtable
-/// SELECTION on every call, so building one per character — which is how this
-/// module first read — makes glyph lookup cost a table scan.
-///
-/// Sizing is not baked in. Metrics are held in font units and scaled by
-/// [`px_per_unit`] at the call, so one instance serves every `px` the office
-/// asks for.
+/// The face's derived lookup structures, built once: [`MetadataProvider::charmap`]
+/// re-runs cmap subtable SELECTION on every call, so one per character would cost
+/// a table scan. Held unscaled — [`px_per_unit`] scales at the call site.
 struct Face {
     charmap: Charmap<'static>,
     outlines: OutlineGlyphCollection<'static>,
@@ -60,7 +46,8 @@ struct Face {
 }
 
 static FACE: LazyLock<Face> = LazyLock::new(|| {
-    let font: &'static FontRef<'static> = &FONT;
+    // Every field borrows FONT_BYTES, not `font`, so the FontRef is local.
+    let font = FontRef::new(FONT_BYTES).expect("bundled Monaspace Neon OTF must parse");
     let m = font.metrics(Size::unscaled(), LocationRef::default());
     Face {
         charmap: font.charmap(),
@@ -70,15 +57,9 @@ static FACE: LazyLock<Face> = LazyLock::new(|| {
     }
 });
 
-/// Pixels per font unit at `px`, where `px` spans ascent−descent — NOT the em
-/// square, which for this face is a different number (1000 units against 1155).
-///
-/// That is the contract every call site was measured against (`LABEL_FONT_PX`,
-/// `CELL_FONT_PX`, the `--proof` panel's sizes), so it is converted here rather
-/// than re-tuned at ~40 call sites. It also means metrics are read unscaled and
-/// scaled here, instead of instancing the face at a ppem: same linear map for an
-/// unhinted outline, and it keeps `gen-check`'s zero-threshold pixel diff green
-/// across the swap instead of costing a `just gen` reshoot.
+/// Pixels per font unit at `px`, where `px` spans ascent−descent, NOT the em
+/// square — the two differ for this face. Every call site's size constant was
+/// picked against that convention, so it is converted here rather than re-tuned.
 fn px_per_unit(px: f32) -> f32 {
     let (ascent, descent, _) = FACE.v_metrics;
     px / (ascent - descent)
@@ -132,12 +113,10 @@ enum Seg {
 
 /// Collects a glyph's outline and the control-point bounds of what it emitted.
 ///
-/// Bounds and geometry come from ONE [`OutlineGlyph::draw`] pass because
-/// [`Rasterizer`] is sized at construction; skrifa's own `ControlBoundsPen`
-/// would mean drawing the glyph twice. Control bounds are looser than the true
-/// outline box, which costs a few all-zero coverage rows and nothing else: the
-/// absolute pixel a sample lands on is `origin + rasterizer coord`, and a larger
-/// box shifts both terms by the same integer.
+/// Bounds and geometry come from ONE draw pass because [`Rasterizer`] is sized
+/// at construction; skrifa's `ControlBoundsPen` would draw the glyph twice.
+/// Control points can only widen the box, and a wider box is inert: a sample's
+/// absolute pixel is `origin + rasterizer coord`, so both shift by one integer.
 #[derive(Default)]
 struct OutlineCollector {
     segs: Vec<Seg>,
@@ -247,11 +226,17 @@ fn draw_outline(
     let Some((min_x, min_y, max_x, max_y)) = collector.bounds else {
         return;
     };
+    // Round the SCALED offset against the pen's fraction and re-add its integer
+    // part, never `pen + offset` — that sum loses the offset's low bits once the
+    // pen is large, moving a whole device pixel (`ab_glyph`'s `px_bounds` does
+    // the same, for the same reason).
+    let (x_trunc, x_fract) = (pen_x.trunc(), pen_x.fract());
+    let (y_trunc, y_fract) = (baseline_y.trunc(), baseline_y.fract());
     // y flips here: the outline's max_y is the glyph's TOP, the smaller device row.
-    let ox = (pen_x + min_x * k).floor();
-    let oy = (baseline_y - max_y * k).floor();
-    let w = ((pen_x + max_x * k).ceil() - ox) as usize;
-    let h = ((baseline_y - min_y * k).ceil() - oy) as usize;
+    let ox = (min_x * k + x_fract).floor() + x_trunc;
+    let oy = (-(max_y * k) + y_fract).floor() + y_trunc;
+    let w = ((max_x * k + x_fract).ceil() + x_trunc - ox) as usize;
+    let h = ((-(min_y * k) + y_fract).ceil() + y_trunc - oy) as usize;
     if w == 0 || h == 0 {
         return;
     }
@@ -309,6 +294,15 @@ mod tests {
             "AA glyph has anti-aliased (partial-coverage) edges"
         );
         assert!(advance > 0, "returns the advance width");
+    }
+
+    #[test]
+    fn an_open_contour_is_closed_before_rasterizing() {
+        // `B` has an open contour; `a` and `M` above do not, and widening this
+        // to the vocabulary would false-alarm on `◷`'s overlapping ones.
+        let mut max_cov = 0.0f32;
+        draw_text_at("B", 0, 0, 24.0, |_x, _y, cov| max_cov = max_cov.max(cov));
+        assert!(max_cov <= 1.0, "open contour leaked winding: {max_cov}");
     }
 
     #[test]

--- a/crates/pixtuoid/src/aa_text.rs
+++ b/crates/pixtuoid/src/aa_text.rs
@@ -38,9 +38,8 @@ use skrifa::{FontRef, GlyphId, MetadataProvider};
 /// License text in `fonts/OFL-Monaspace.txt`.
 const FONT_BYTES: &[u8] = include_bytes!("../fonts/MonaspaceNeon-SemiBold.otf");
 
-static FONT: LazyLock<FontRef<'static>> = LazyLock::new(|| {
-    FontRef::new(FONT_BYTES).expect("bundled Monaspace Neon OTF must parse")
-});
+static FONT: LazyLock<FontRef<'static>> =
+    LazyLock::new(|| FontRef::new(FONT_BYTES).expect("bundled Monaspace Neon OTF must parse"));
 
 /// The face's derived lookup structures, built once.
 ///

--- a/crates/pixtuoid/src/aa_text.rs
+++ b/crates/pixtuoid/src/aa_text.rs
@@ -1,6 +1,6 @@
 //! Shared anti-aliased text rasterizer (Monaspace Neon) for the binary's pixel
-//! surfaces — the floating window's name badges + wall board and the snapshot
-//! example's cell text + `--proof` panel.
+//! surfaces — the floating window's name badges + wall board, and the examples'
+//! cell text, `--proof` panel and cutaway.
 //!
 //! Kept BINARY-side on purpose: `pixtuoid-scene` also compiles to wasm for the
 //! web hero, so it stays font-dep-free — no font parser, no embedded font, no

--- a/crates/pixtuoid/src/aa_text.rs
+++ b/crates/pixtuoid/src/aa_text.rs
@@ -3,8 +3,8 @@
 //! example's cell text + `--proof` panel.
 //!
 //! Kept BINARY-side on purpose: `pixtuoid-scene` also compiles to wasm for the
-//! web hero, so it stays font-dep-free — no `ab_glyph`, no embedded font, no wasm
-//! bundle bloat.
+//! web hero, so it stays font-dep-free — no font parser, no embedded font, no
+//! wasm bundle bloat.
 //!
 //! ONE face by DESIGN. Monaspace Neon natively covers the office's FULL symbol
 //! vocabulary (`★ ◐ ⬢ ▮ ▯ ↳ ◷ ▤`), which JetBrains Mono does not — not even the
@@ -12,21 +12,78 @@
 //! render glyph MUST be Monaspace-covered, never a second face; the gate is
 //! `office_symbol_vocabulary_is_fully_covered`.
 //!
+//! TWO crates, not one: [`skrifa`] parses the face and emits outlines,
+//! [`ab_glyph_rasterizer`] turns an outline into coverage. Both halves were
+//! `ab_glyph`, whose parsing half pulls the unmaintained ttf-parser
+//! (RUSTSEC-2026-0192, #440) while its rasterizing half depends on nothing — so
+//! only the parser was replaced. Keeping the rasterizer is what makes the AA
+//! curve, and therefore every committed still, survive the swap untouched; a
+//! whole-stack move (`swash`, or `skrifa` + `zeno`) would have shifted every
+//! edge for no gain.
+//!
 //! Surface-agnostic: [`draw_text_at`] hands each lit pixel's coverage to a
 //! `put(x, y, coverage)` closure, so every caller applies its own pixel-format
 //! blend — all through [`blend_channel`], the one blend curve.
 
 use std::sync::LazyLock;
 
-use ab_glyph::{point, Font, FontRef, GlyphId, PxScale, ScaleFont};
+use ab_glyph_rasterizer::{point, Point, Rasterizer};
+use skrifa::charmap::Charmap;
+use skrifa::instance::{LocationRef, Size};
+use skrifa::metrics::GlyphMetrics;
+use skrifa::outline::{DrawSettings, OutlineGlyphCollection, OutlinePen};
+use skrifa::{FontRef, GlyphId, MetadataProvider};
 
 /// SemiBold is the weight picked by eye for these small-size pixel surfaces.
 /// License text in `fonts/OFL-Monaspace.txt`.
 const FONT_BYTES: &[u8] = include_bytes!("../fonts/MonaspaceNeon-SemiBold.otf");
 
 static FONT: LazyLock<FontRef<'static>> = LazyLock::new(|| {
-    FontRef::try_from_slice(FONT_BYTES).expect("bundled Monaspace Neon OTF must parse")
+    FontRef::new(FONT_BYTES).expect("bundled Monaspace Neon OTF must parse")
 });
+
+/// The face's derived lookup structures, built once.
+///
+/// skrifa keeps these separate from the font data so a caller can retain them,
+/// and a caller should: [`MetadataProvider::charmap`] re-runs cmap subtable
+/// SELECTION on every call, so building one per character — which is how this
+/// module first read — makes glyph lookup cost a table scan.
+///
+/// Sizing is not baked in. Metrics are held in font units and scaled by
+/// [`px_per_unit`] at the call, so one instance serves every `px` the office
+/// asks for.
+struct Face {
+    charmap: Charmap<'static>,
+    outlines: OutlineGlyphCollection<'static>,
+    metrics: GlyphMetrics<'static>,
+    /// Vertical metrics in font units: ascent, descent (negative), line gap.
+    v_metrics: (f32, f32, f32),
+}
+
+static FACE: LazyLock<Face> = LazyLock::new(|| {
+    let font: &'static FontRef<'static> = &FONT;
+    let m = font.metrics(Size::unscaled(), LocationRef::default());
+    Face {
+        charmap: font.charmap(),
+        outlines: font.outline_glyphs(),
+        metrics: font.glyph_metrics(Size::unscaled(), LocationRef::default()),
+        v_metrics: (m.ascent, m.descent, m.leading),
+    }
+});
+
+/// Pixels per font unit at `px`, where `px` spans ascent−descent — NOT the em
+/// square, which for this face is a different number (1000 units against 1155).
+///
+/// That is the contract every call site was measured against (`LABEL_FONT_PX`,
+/// `CELL_FONT_PX`, the `--proof` panel's sizes), so it is converted here rather
+/// than re-tuned at ~40 call sites. It also means metrics are read unscaled and
+/// scaled here, instead of instancing the face at a ppem: same linear map for an
+/// unhinted outline, and it keeps `gen-check`'s zero-threshold pixel diff green
+/// across the swap instead of costing a `just gen` reshoot.
+fn px_per_unit(px: f32) -> f32 {
+    let (ascent, descent, _) = FACE.v_metrics;
+    px / (ascent - descent)
+}
 
 /// Linear per-channel coverage blend of `fg` over `bg` — THE one blend curve
 /// every AA-text surface composites with, so a future curve change (e.g.
@@ -37,26 +94,109 @@ pub fn blend_channel(bg: u8, fg: u8, cov: f32) -> u8 {
     (bg as f32 + (fg as f32 - bg as f32) * a).round() as u8
 }
 
+/// The face's glyph for `ch`, falling back to `.notdef` on a cmap miss — so an
+/// uncovered char still advances by the tofu box rather than collapsing the run.
+fn glyph_id(ch: char) -> GlyphId {
+    FACE.charmap.map(ch).unwrap_or(GlyphId::NOTDEF)
+}
+
 /// Whether the face covers `ch` with a real glyph (not `.notdef`). Callers with a
 /// non-text fallback gate on this so an uncovered symbol renders as the fallback,
 /// never tofu.
 pub fn has_glyph(ch: char) -> bool {
-    FONT.glyph_id(ch) != GlyphId(0)
+    glyph_id(ch) != GlyphId::NOTDEF
 }
 
 /// Summing real advances, rather than `chars × one advance`, stays correct even
 /// for a future proportional face.
 pub fn text_width(s: &str, px: f32) -> i32 {
-    let sf = FONT.as_scaled(PxScale::from(px));
+    let k = px_per_unit(px);
     s.chars()
-        .map(|c| sf.h_advance(sf.glyph_id(c)))
+        .map(|c| FACE.metrics.advance_width(glyph_id(c)).unwrap_or(0.0) * k)
         .sum::<f32>()
         .round() as i32
 }
 
 pub fn line_height(px: f32) -> i32 {
-    let sf = FONT.as_scaled(PxScale::from(px));
-    (sf.ascent() - sf.descent() + sf.line_gap()).round() as i32
+    let (ascent, descent, leading) = FACE.v_metrics;
+    let k = px_per_unit(px);
+    // `descent` is negative below the baseline, so subtracting it adds depth.
+    ((ascent - descent + leading) * k).round() as i32
+}
+
+/// One outline segment in FONT UNITS, y-UP from the baseline.
+enum Seg {
+    Line(Point, Point),
+    Quad(Point, Point, Point),
+    Cubic(Point, Point, Point, Point),
+}
+
+/// Collects a glyph's outline and the control-point bounds of what it emitted.
+///
+/// Bounds and geometry come from ONE [`OutlineGlyph::draw`] pass because
+/// [`Rasterizer`] is sized at construction; skrifa's own `ControlBoundsPen`
+/// would mean drawing the glyph twice. Control bounds are looser than the true
+/// outline box, which costs a few all-zero coverage rows and nothing else: the
+/// absolute pixel a sample lands on is `origin + rasterizer coord`, and a larger
+/// box shifts both terms by the same integer.
+#[derive(Default)]
+struct OutlineCollector {
+    segs: Vec<Seg>,
+    /// `None` until the first point — a glyph like the space has no outline.
+    bounds: Option<(f32, f32, f32, f32)>,
+    start: Point,
+    last: Point,
+}
+
+impl OutlineCollector {
+    fn see(&mut self, p: Point) {
+        self.bounds = Some(match self.bounds {
+            None => (p.x, p.y, p.x, p.y),
+            Some((x0, y0, x1, y1)) => (x0.min(p.x), y0.min(p.y), x1.max(p.x), y1.max(p.y)),
+        });
+    }
+}
+
+impl OutlinePen for OutlineCollector {
+    fn move_to(&mut self, x: f32, y: f32) {
+        let p = point(x, y);
+        self.see(p);
+        self.start = p;
+        self.last = p;
+    }
+
+    fn line_to(&mut self, x: f32, y: f32) {
+        let p = point(x, y);
+        self.see(p);
+        self.segs.push(Seg::Line(self.last, p));
+        self.last = p;
+    }
+
+    fn quad_to(&mut self, cx: f32, cy: f32, x: f32, y: f32) {
+        let (c, p) = (point(cx, cy), point(x, y));
+        self.see(c);
+        self.see(p);
+        self.segs.push(Seg::Quad(self.last, c, p));
+        self.last = p;
+    }
+
+    fn curve_to(&mut self, cx0: f32, cy0: f32, cx1: f32, cy1: f32, x: f32, y: f32) {
+        let (c0, c1, p) = (point(cx0, cy0), point(cx1, cy1), point(x, y));
+        self.see(c0);
+        self.see(c1);
+        self.see(p);
+        self.segs.push(Seg::Cubic(self.last, c0, c1, p));
+        self.last = p;
+    }
+
+    fn close(&mut self) {
+        // The rasterizer accumulates winding along explicit edges, so the
+        // contour's closing edge has to be one — skrifa leaves it implicit.
+        if self.last != self.start {
+            self.segs.push(Seg::Line(self.last, self.start));
+        }
+        self.last = self.start;
+    }
 }
 
 /// Rasterize `s` in the AA face at pixel size `px`, top-left at `(x, top_y)`,
@@ -70,23 +210,64 @@ pub fn draw_text_at(
     px: f32,
     mut put: impl FnMut(i32, i32, f32),
 ) -> i32 {
-    let scale = PxScale::from(px);
-    let sf = FONT.as_scaled(scale);
-    let baseline_y = top_y as f32 + sf.ascent();
+    let k = px_per_unit(px);
+    let (ascent, _, _) = FACE.v_metrics;
+    let baseline_y = top_y as f32 + ascent * k;
     let mut cursor_x = x as f32;
     for ch in s.chars() {
-        let gid = sf.glyph_id(ch);
-        let glyph = gid.with_scale_and_position(scale, point(cursor_x, baseline_y));
-        if let Some(outlined) = FONT.outline_glyph(glyph) {
-            let bounds = outlined.px_bounds();
-            let (ox, oy) = (bounds.min.x.round() as i32, bounds.min.y.round() as i32);
-            outlined.draw(|gx, gy, coverage| {
-                put(ox + gx as i32, oy + gy as i32, coverage);
-            });
+        let gid = glyph_id(ch);
+        if let Some(glyph) = FACE.outlines.get(gid) {
+            let mut collector = OutlineCollector::default();
+            // A malformed charstring yields no outline; the run must still
+            // advance, so a draw error is skipped rather than propagated.
+            if glyph
+                .draw(
+                    DrawSettings::unhinted(Size::unscaled(), LocationRef::default()),
+                    &mut collector,
+                )
+                .is_ok()
+            {
+                draw_outline(&collector, k, cursor_x, baseline_y, &mut put);
+            }
         }
-        cursor_x += sf.h_advance(gid);
+        cursor_x += FACE.metrics.advance_width(gid).unwrap_or(0.0) * k;
     }
     (cursor_x - x as f32).round() as i32
+}
+
+/// Scale `collector`'s font-unit outline by `k`, flip it onto the device grid at
+/// `(pen_x, baseline_y)`, and hand every covered pixel to `put` in absolute
+/// coordinates.
+fn draw_outline(
+    collector: &OutlineCollector,
+    k: f32,
+    pen_x: f32,
+    baseline_y: f32,
+    put: &mut impl FnMut(i32, i32, f32),
+) {
+    let Some((min_x, min_y, max_x, max_y)) = collector.bounds else {
+        return;
+    };
+    // y flips here: the outline's max_y is the glyph's TOP, the smaller device row.
+    let ox = (pen_x + min_x * k).floor();
+    let oy = (baseline_y - max_y * k).floor();
+    let w = ((pen_x + max_x * k).ceil() - ox) as usize;
+    let h = ((baseline_y - min_y * k).ceil() - oy) as usize;
+    if w == 0 || h == 0 {
+        return;
+    }
+    let (off_x, off_y) = (pen_x - ox, baseline_y - oy);
+    let dev = |p: &Point| point(p.x * k + off_x, off_y - p.y * k);
+    let mut r = Rasterizer::new(w, h);
+    for seg in &collector.segs {
+        match seg {
+            Seg::Line(p0, p1) => r.draw_line(dev(p0), dev(p1)),
+            Seg::Quad(p0, p1, p2) => r.draw_quad(dev(p0), dev(p1), dev(p2)),
+            Seg::Cubic(p0, p1, p2, p3) => r.draw_cubic(dev(p0), dev(p1), dev(p2), dev(p3)),
+        }
+    }
+    let (ox, oy) = (ox as i32, oy as i32);
+    r.for_each_pixel_2d(|gx, gy, coverage| put(ox + gx as i32, oy + gy as i32, coverage));
 }
 
 #[cfg(test)]

--- a/crates/pixtuoid/src/aa_text.rs
+++ b/crates/pixtuoid/src/aa_text.rs
@@ -115,8 +115,9 @@ enum Seg {
 ///
 /// Bounds and geometry come from ONE draw pass because [`Rasterizer`] is sized
 /// at construction; skrifa's `ControlBoundsPen` would draw the glyph twice.
-/// Control points can only widen the box, and a wider box is inert: a sample's
-/// absolute pixel is `origin + rasterizer coord`, so both shift by one integer.
+/// Control points can only widen the box, which costs zero-coverage `put` calls
+/// and nothing else: a sample's absolute pixel is `origin + rasterizer coord`,
+/// and widening shifts both terms by the SAME integer.
 #[derive(Default)]
 struct OutlineCollector {
     segs: Vec<Seg>,
@@ -178,8 +179,9 @@ impl OutlinePen for OutlineCollector {
 }
 
 /// Rasterize `s` in the AA face at pixel size `px`, top-left at `(x, top_y)`,
-/// calling `put(px_x, px_y, coverage)` for every lit pixel (`coverage` ∈ `[0,1]`
-/// is the AA grayscale strength). Returns the total advance width, so a caller
+/// calling `put(px_x, px_y, coverage)` for every pixel of each glyph's box —
+/// `coverage` ∈ `[0,1]` is the AA grayscale strength, and is 0 where uncovered,
+/// so callers that write unconditionally must gate on it. Returns the advance, so a caller
 /// placing a second run needn't recompute it via [`text_width`].
 pub fn draw_text_at(
     s: &str,

--- a/crates/pixtuoid/src/aa_text.rs
+++ b/crates/pixtuoid/src/aa_text.rs
@@ -216,6 +216,11 @@ pub fn draw_text_at(
 /// Scale `collector`'s font-unit outline by `k`, flip it onto the device grid at
 /// `(pen_x, baseline_y)`, and hand every covered pixel to `put` in absolute
 /// coordinates.
+///
+/// Each edge of the box rounds the SCALED offset against the pen's fraction and
+/// re-adds its integer part, never `pen + offset`: that sum drops the offset's
+/// low bits whenever it lands within an ulp of an integer, moving the box a whole
+/// device pixel on either axis. `ab_glyph`'s `px_bounds` split it the same way.
 fn draw_outline(
     collector: &OutlineCollector,
     k: f32,
@@ -226,10 +231,6 @@ fn draw_outline(
     let Some((min_x, min_y, max_x, max_y)) = collector.bounds else {
         return;
     };
-    // Round the SCALED offset against the pen's fraction and re-add its integer
-    // part, never `pen + offset` — that sum loses the offset's low bits once the
-    // pen is large, moving a whole device pixel (`ab_glyph`'s `px_bounds` does
-    // the same, for the same reason).
     let (x_trunc, x_fract) = (pen_x.trunc(), pen_x.fract());
     let (y_trunc, y_fract) = (baseline_y.trunc(), baseline_y.fract());
     // y flips here: the outline's max_y is the glyph's TOP, the smaller device row.

--- a/crates/pixtuoid/src/audio/mod.rs
+++ b/crates/pixtuoid/src/audio/mod.rs
@@ -117,7 +117,7 @@ impl AudioController {
         Self::new_with(muted, volume, config_path, respawn)
     }
 
-    /// [`new`] with the boot-spawn injected, so a test can pin the boot decision
+    /// [`Self::new`] with the boot-spawn injected, so a test can pin the boot decision
     /// without opening an output device. `pub(crate)` for the same reason it
     /// exists: `tui`'s key-action tests need an UNMUTED controller, and an
     /// unmuted `new` boot-spawns the real device.

--- a/crates/pixtuoid/src/audio/sink.rs
+++ b/crates/pixtuoid/src/audio/sink.rs
@@ -1,6 +1,6 @@
 //! The playback seam: `AudioSink` is the ONE device boundary, so everything above
 //! it is device-free and tests (or CI runners with no sound card) ride
-//! [`NullSink`].
+//! `NullSink` — `cfg(test)`-only, so it cannot be an intra-doc link.
 
 use std::sync::Arc;
 

--- a/crates/pixtuoid/src/audio/sink.rs
+++ b/crates/pixtuoid/src/audio/sink.rs
@@ -1,6 +1,6 @@
 //! The playback seam: `AudioSink` is the ONE device boundary, so everything above
 //! it is device-free and tests (or CI runners with no sound card) ride
-//! `NullSink` — `cfg(test)`-only, so it cannot be an intra-doc link.
+//! `NullSink`.
 
 use std::sync::Arc;
 

--- a/crates/pixtuoid/src/tui/tui_renderer/mod.rs
+++ b/crates/pixtuoid/src/tui/tui_renderer/mod.rs
@@ -367,7 +367,7 @@ impl<B: Backend<Error: Send + Sync + 'static>> TuiRenderer<B> {
         }
     }
     /// Composite two floors sliding in/out during a `FloorTransition`. `nf` is the
-    /// live floor count from [`render`].
+    /// live floor count from [`Self::render`].
     fn render_transition(
         &mut self,
         scene: &SceneState,

--- a/deny.toml
+++ b/deny.toml
@@ -10,10 +10,8 @@ all-features = true
 # behind a green run. Needs cargo-deny 0.20.2 (what cargo-deny-action@v2.1.1 pins);
 # an older cargo-deny rejects the whole file over this key.
 unused-ignored-advisory = "deny"
-# No advisory is ignored. The last one (RUSTSEC-2026-0192, ttf-parser
-# unmaintained) was retired by removing the crate instead of the warning: both
-# routes to it were cut in #440 — `aa_text` parses with skrifa now, and winit
-# takes `wayland-csd-adwaita-notitle`.
+# The last entry (RUSTSEC-2026-0192, ttf-parser) was retired in #440 by removing
+# the crate rather than the warning — both routes to it were cut.
 ignore = []
 
 [licenses]

--- a/deny.toml
+++ b/deny.toml
@@ -10,16 +10,11 @@ all-features = true
 # behind a green run. Needs cargo-deny 0.20.2 (what cargo-deny-action@v2.1.1 pins);
 # an older cargo-deny rejects the whole file over this key.
 unused-ignored-advisory = "deny"
-# #440 tracks dropping this ignore, but there is no upstream release to wait for:
-# RUSTSEC-2026-0192 is `informational = "unmaintained"` with `patched = []`. It
-# clears only when ab_glyph moves off ttf-parser, or when we drop ab_glyph.
-ignore = [
-    # ttf-parser (unmaintained) enters by TWO routes — our own `ab_glyph` dep in
-    # src/aa_text.rs, and `sctk-adwaita <- winit` for the Wayland CSD titlebar —
-    # so winit moving off ab_glyph would NOT clear this row. Neither route takes
-    # attacker input: both parse a compiled-in or local system font.
-    "RUSTSEC-2026-0192",
-]
+# No advisory is ignored. The last one (RUSTSEC-2026-0192, ttf-parser
+# unmaintained) was retired by removing the crate instead of the warning: both
+# routes to it were cut in #440 — `aa_text` parses with skrifa now, and winit
+# takes `wayland-csd-adwaita-notitle`.
+ignore = []
 
 [licenses]
 allow = [

--- a/deny.toml
+++ b/deny.toml
@@ -10,8 +10,6 @@ all-features = true
 # behind a green run. Needs cargo-deny 0.20.2 (what cargo-deny-action@v2.1.1 pins);
 # an older cargo-deny rejects the whole file over this key.
 unused-ignored-advisory = "deny"
-# The last entry (RUSTSEC-2026-0192, ttf-parser) was retired in #440 by removing
-# the crate rather than the warning — both routes to it were cut.
 ignore = []
 
 [licenses]


### PR DESCRIPTION
## Summary

Cuts both routes that put the unmaintained `ttf-parser` (RUSTSEC-2026-0192) in the dependency graph, so `deny.toml`'s last `[advisories] ignore` entry can go: `aa_text` parses with `skrifa` instead of `ab_glyph`, and `winit` takes `wayland-csd-adwaita-notitle` instead of the `ab_glyph`-backed CSD titlebar it never draws.

## Related issue

Closes #440

## Type of change

- [x] Refactor / chore

## How I tested it

**Dependency graph** — `ttf-parser` is absent on `x86_64-unknown-linux-gnu`, `aarch64-apple-darwin` and `x86_64-pc-windows-msvc` under `--all-features` (the graph `deny.toml` configures). Net lockfile churn is three out (`ttf-parser`, `owned_ttf_parser`, `ab_glyph`) and three in (`skrifa`, `read-fonts`, `font-types`); the new crates are `MIT OR Apache-2.0` and `Apache-2.0`, both already in the `[licenses] allow` list.

**Pixel identity** — the reason `ab_glyph_rasterizer` is kept rather than moving the whole stack. Two layers of evidence:

1. *Unit* — a differential oracle dumped every coverage sample the public API emits, run against both implementations. **At 8-bit output the streams are identical (max blend delta `0`)**, which is what every consumer sees.

   An earlier revision of this section claimed **max f32 coverage delta `0.000e+00`**. That was measured on too coarse a grid (4 sizes × 6 origins, none past ~1024) and is **false as written** — review widened it and found a real divergence: this port had collapsed `ab_glyph`'s trunc/fract pen split into `pen + offset`, equal in exact arithmetic but not in f32. Wherever `pen + coord·k` lands within one f32 ulp of an integer the offset's low bits vanish and the box origin moves a whole device pixel — on **both** axes, so it reaches down to `pen_x` 0 through the baseline term, and fires in ~0.0156% of (glyph, size, pen, baseline) combinations. Concretely, at `pen_x` 2047.6804 with a scaled offset of 6.3196507 the exact sum 2054.0000705719 rounds to `2054.0`, so `ceil` gives 2054 where the split gives 2055. Measured before the fix: max coverage delta `1.77e-5`, 250,034 pixels lit only by the old path, 15,541 of 99,553,428 swept origins disagreeing — all of it inert at 8 bits (`8.23e-5 × 255 = 0.021` against a 0.5 flip threshold), which is why the stills never moved. **`ab_glyph`'s split is now restored**, so the streams agree in f32 too rather than merely below the rounding threshold.
2. *End-to-end* — every pixel-gated committed artifact reproducible without the media venv re-renders byte-identical:

   | artifact | `aa_text` path |
   |---|---|
   | `docs/images/reference-screenshot.png` | TUI cell text (`encode.rs`, 14.7px) |
   | `docs/images/reference-night.png` | same |
   | `site/public/demos/proof-poster.png` | `--proof` panel (`proof.rs`) |
   | `site/public/demos/proof-tall-poster.png` | same |

   Those cover both call paths, so `gen-check`'s zero-threshold diff needs no reshoot and no media is committed here.

**Tests / lint** — `cargo test -p pixtuoid --lib`: 1005 passed. The one failure, `onboarding_overlay_renders_roster_and_hint`, is a pre-existing `--no-default-features` artifact (it asserts the audio offer; this environment cannot install ALSA headers) and fails identically on the base commit. `cargo clippy -p pixtuoid --all-targets`: clean.

**Since verified locally** (the gates the authoring environment could not install): `cargo deny check advisories` and `bans licenses sources` on cargo-deny **0.20.2**, the exact CI pin — both exit 0 with `ignore = []` under `unused-ignored-advisory = "deny"`. `cargo machete`: 0. `TZ=UTC scripts/gen-media.py --check`: 0, every committed artifact in sync at threshold 0, re-run after the pen-split fix. Full `just preflight` (lint → clippy → hack → test) passes via pre-push: 3,252 tests, 0 failures.

## Notes on the approach

`ab_glyph` is two crates: a parsing half (`owned_ttf_parser` → `ttf-parser`) and a rasterizing half (`ab_glyph_rasterizer`) that depends on nothing but an optional `libm`. Only the parser is the advisory's subject, so only the parser is replaced — keeping the rasterizer is what holds the AA curve, and therefore the committed stills, unchanged. `swash` or `skrifa` + `zeno` would have moved every anti-aliased edge for no gain.

Two constants of the old API had to be preserved deliberately:

- **Size convention.** `ab_glyph` sized text so `px` spans ascent−descent; skrifa's `Size` is ppem, and for this face those differ (1000 units against 1155). `px_per_unit` converts, rather than re-tuning ~40 call sites.
- **Bounds.** Control-point bounds are looser than the outline box `ab_glyph` sized its rasterizer with. That costs a few all-zero coverage rows and nothing else — the absolute pixel a sample lands on is `origin + rasterizer coord`, and a larger box shifts both terms by the same integer.

Performance, measured on an 11-char label: `draw_text_at` 20.4µs → 30.5µs (skrifa validates CFF charstrings harder, matching the numbers on the upstream ab-glyph skrifa port), against a 33.3ms frame the whole text pass now takes 1.24% of, up from 0.82%. `text_width` goes the other way, 0.30µs → 0.17µs, because `Charmap` is now held instead of rebuilt per character — `MetadataProvider::charmap()` re-runs cmap subtable selection on every call.

`winit` dropping `default-features` means its other four defaults are listed verbatim; a missing one is a Linux runtime failure (no backend), not a build error.

## Visual verification

- [x] Not a visual change — it is a rendering-stack change whose verification is the pixel identity above: the four committed stills that exercise `aa_text` re-render byte-for-byte, so there is nothing to look at.

## Checklist

- [x] I read the relevant `CLAUDE.md` (root + `crates/pixtuoid/`).
- [x] New behavior has a test — no new behavior; the existing `aa_text` tests are the regression net and the byte-exactness check above is the evidence for the swap.
- [x] No `unwrap()` in non-test code; errors propagate via `anyhow`/`thiserror`.
- [x] No new `println!`/`eprintln!` on a production path.
- [x] Docs updated in the same commit — the rationale lives on `aa_text`'s module doc and the two `Cargo.toml` declarations; no module structure or public API changed.
- [x] Checked against the recurring pitfalls.
- [ ] `just preflight` passes locally — **could not run**: `cargo-deny`, `cargo-hack`, `cargo-machete` are unavailable in this environment (see above). Everything reachable here (`cargo test`, `cargo clippy --all-targets`) is green.

## AI assistance

- [x] This PR was written/heavily-assisted by an AI agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEqEB4zXiPhLSbwGLqMJM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01AEqEB4zXiPhLSbwGLqMJM9)_

