### PR TITLE
fix(drift): repin the dsh session anchor, ledger codex retained_context and grok hook_run_started

### DIFF
--- a/scripts/check_upstream_drift.py
+++ b/scripts/check_upstream_drift.py
@@ -569,6 +569,11 @@ GROK_XAI_KNOWN_OMITTED: dict[str, str] = {
     "subagent_progress": "cumulative per-child totals (turns, tool calls); "
     "summing a running total into the delta-accumulating reducer double-counts "
     "(codex's `token_count_emits_fresh_usage_from_last_reading` is the precedent)",
+    "hook_run_started": "grok's pager spinner phase — 'the turn is blocked on "
+    "an awaited hook batch that just started' (notification.rs:571-582); its "
+    "END is `hook_execution`, which decodes to nothing except session_end, so an "
+    "ActivityStart here would strand the session Active (codex's "
+    "`local_shell_call` precedent)",
 }
 
 

--- a/scripts/check_upstream_drift.py
+++ b/scripts/check_upstream_drift.py
@@ -555,7 +555,7 @@ CODEX_KNOWN_OMITTED: dict[str, str] = {
     "Started/Closed bracket the voice layer, speech segments are content no "
     "decoder reads, and `BemItemPromoted` re-presents items already decoded "
     "from `response_item` (upstream: 'sparse, model-invisible facts')",
-    "retained_context": "host-only, model-invisible guardian records "
+    "retained_context": "host-only, model-invisible records "
     "(history/src/retained_context.rs: 'Sparse, model-invisible updates. Only "
     "the host may produce these records.'); the sole variant `verified_answer` "
     "is authorization evidence — no lifecycle, activity, model or token signal. "
@@ -569,11 +569,12 @@ GROK_XAI_KNOWN_OMITTED: dict[str, str] = {
     "subagent_progress": "cumulative per-child totals (turns, tool calls); "
     "summing a running total into the delta-accumulating reducer double-counts "
     "(codex's `token_count_emits_fresh_usage_from_last_reading` is the precedent)",
-    "hook_run_started": "grok's pager spinner phase — 'the turn is blocked on "
-    "an awaited hook batch that just started' (notification.rs:571-582); its "
-    "END is `hook_execution`, which decodes to nothing except session_end, so an "
-    "ActivityStart here would strand the session Active (codex's "
-    "`local_shell_call` precedent)",
+    "hook_run_started": "never in the transcript: upstream emits it through "
+    "`send_xai_notification_transient` (session/acp_session_impl/hook_dispatch.rs), "
+    "which only forwards to the live client and never appends to updates.jsonl, "
+    "the file this decoder reads. A pager spinner phase — 'the turn is blocked on "
+    "an awaited hook batch that just started' (extensions/notification.rs) — whose "
+    "end `hook_execution` decodes to nothing but session_end",
 }
 
 

--- a/scripts/check_upstream_drift.py
+++ b/scripts/check_upstream_drift.py
@@ -302,7 +302,7 @@ ANCHORS: dict[str, Anchor] = {
     CODEX_PROTOCOL_URL: Anchor(r"pub enum HookEventName\b", "`HookEventName`"),
     CODEX_ROLLOUT_ITEM_URL: Anchor(r"pub enum RolloutItem\b", "`RolloutItem`"),
     DSH_RUNTIME_TYPES_URL: Anchor(r"'agent/pre-step'", "`agent/pre-step`"),
-    DSH_SESSION_TYPES_URL: Anchor(r"'assistant/chunk'", "`assistant/chunk`"),
+    DSH_SESSION_TYPES_URL: Anchor(r"export interface SessionEventMap\b", "`SessionEventMap`"),
     DSH_APPROVAL_TYPES_URL: Anchor(r"ApprovalRequestId", "`ApprovalRequestId`"),
     DSH_SESSION_INDEX_URL: Anchor(r"'session/created'", "`session/created`"),
     GROK_HOOK_URL: Anchor(r"pub enum HookEventName\b", "`HookEventName`"),
@@ -555,6 +555,11 @@ CODEX_KNOWN_OMITTED: dict[str, str] = {
     "Started/Closed bracket the voice layer, speech segments are content no "
     "decoder reads, and `BemItemPromoted` re-presents items already decoded "
     "from `response_item` (upstream: 'sparse, model-invisible facts')",
+    "retained_context": "host-only, model-invisible guardian records "
+    "(history/src/retained_context.rs: 'Sparse, model-invisible updates. Only "
+    "the host may produce these records.'); the sole variant `verified_answer` "
+    "is authorization evidence — no lifecycle, activity, model or token signal. "
+    "Sibling of `turn_context` by suffix only",
 }
 
 

--- a/scripts/check_upstream_drift_selftest.py
+++ b/scripts/check_upstream_drift_selftest.py
@@ -109,7 +109,7 @@ ANCHOR_SAMPLES: dict[str, str] = {
         'export interface ToolApprovalRequestedEvent { type: "tool_approval_requested"; }\n',
     d.OMP_SESSION_MANAGER_URL: 'getSessionFile(): string | undefined {\n',
     d.DSH_RUNTIME_TYPES_URL: "    'agent/pre-step'(payload: {}): void\n",
-    d.DSH_SESSION_TYPES_URL: "  'assistant/chunk': { delta: string }\n",
+    d.DSH_SESSION_TYPES_URL: "export interface SessionEventMap {\n  'assistant/message': { text: string }\n}\n",
     d.DSH_APPROVAL_TYPES_URL: "export type ApprovalRequestId = string\n",
     d.DSH_SESSION_INDEX_URL: "  register('session/created', header)\n",
     d.OMP_EXT_DISCOVERY_URL:
@@ -1254,7 +1254,7 @@ def test_every_source_check_fires_on_a_vanish_and_stays_silent_otherwise() -> No
             ("dsh_plugin_events", str, lambda ns: {
                 d.DSH_RUNTIME_TYPES_URL: "'agent/pre-step'\n"
                 + "\n".join(f"'{n}'" for n in ns),
-                d.DSH_SESSION_TYPES_URL: "'assistant/chunk'\n",
+                d.DSH_SESSION_TYPES_URL: "export interface SessionEventMap {\n",
                 d.DSH_APPROVAL_TYPES_URL: "ApprovalRequestId\n",
                 d.DSH_SESSION_INDEX_URL: "'session/created'\n"}),
             ("copilot", str, lambda ns: {


### PR DESCRIPTION
## Summary

Both items of #981, plus one that landed after it was filed. No decoder changes — every fix is in the drift watcher's own ledger/anchors, and `check_upstream_drift.py` now exits 0 against live upstream.

## Related issue

Closes #981

## Type of change

- [x] Refactor / chore

## What each item turned out to be

**dsh `assistant/chunk` — a stale watcher anchor, not a broken plugin.** This was the trap the issue warned about, and it was a real upstream reshape rather than a moved declaration: dsh's session format v2 dropped `assistant/chunk` as a top-level event (`.agents/notes/implemented/architecture/2026-09-01-v2-embedded-assistant-streams.md`: *"Session format v2 has no top-level `assistant/chunk` event"*), and `packages/core/session/src/types.ts:88` now declares `SESSION_FORMAT_VERSION = 3`. The bundled `dsh_plugin.mjs` was never affected — it listens for `assistant/message`, the v2 replacement — and all nine of its events still resolve across the four pinned docs (checked by hand). The watcher's anchor aborted that check before it could run. Repinned to the declaration that owns the keys, `export interface SessionEventMap {` (`types.ts:269`), matching the owner-grade form the Codex rows use; an event-key anchor is a sibling of the names it guards and can vanish independently, which is exactly what happened. The v3 canonical-envelope note adds `surfaceOp` to `assistant/message` / `tool/result` — additive; `dsh.rs` has a `_ =>` arm and reads none of it.

**Codex `retained_context` — ledgered, not decoded.** `RolloutItem` gained `RetainedContext(RetainedContextEvent)` (`history/src/lib.rs:134`). Upstream's own doc reads *"Sparse, model-invisible updates. Only the host may produce these records."* (`history/src/retained_context.rs:124`) — the same reason `realtime_item` is already in `CODEX_KNOWN_OMITTED`. Sole variant `verified_answer` is authorization evidence: no lifecycle, activity, model, or token signal. The `_context` kinship with `turn_context` is lexical.

**grok `hook_run_started` — ledgered (new since the issue).** `SessionUpdate` gained `HookRunStarted` (`xai-grok-shell/src/extensions/notification.rs`): grok's own pager spinner phase — *"the turn is blocked on an awaited hook batch that just started"*. The reason it is ledgered rather than decoded, fetched from the whole upstream tree: upstream emits it through `send_xai_notification_transient` (`session/acp_session_impl/hook_dispatch.rs`), whose body only `forward_fire_and_forget()`s to the live client and never appends to `updates.jsonl` — unlike `send_xai_notification`, which appends with `AppendDurability::Buffered`. This decoder reads `updates.jsonl`, so the tag cannot appear in it. (The review fold replaced an earlier reason — that decoding the start would strand the session Active — which the repo's own `turn_completed → ActivityEnd` test refutes.)

Owner rule applied throughout: only the latest version of each CLI is supported, so there is no dual anchor for the v1 dsh name and nothing to fall back to.

## How I tested it

- `just drift-selftest`: 0 (baseline on main was also 0).
- `just drift-selftest` and live `python3 scripts/check_upstream_drift.py` re-run after the review fold (`a143060e`): 0 and **0** — `No drift. Every name we depend on is present upstream.` (was 1 with the three items).
- Every upstream `path:line` above was fetched this session, not recalled; the dsh search was over the whole upstream tree via code search, not one plausible file.

## Surfaced — owner's call, not grown into this PR

- `DSH_RUNTIME_TYPES_URL` (`'agent/pre-step'`) and `DSH_SESSION_INDEX_URL` (`'session/created'`) are the same fragile event-key anchor class that just bit here. Both still resolve today. Converting them is **not** a small follow-up: their upstream owners are ambient `declare module '@deepseek-ai/cordis' { interface Events {` augmentations with no unique exportable name, so an owner-grade anchor needs a multi-line pattern — a gate-shape change, its own PR. Related pre-existing nit: those two rows plus `ApprovalRequestId` sit under the `# owner-grade:` label at `check_upstream_drift.py:299` but are identity-grade by the file's own definition; moving them under the `# identity-grade:` label is a pure reorder.
- A `*_KNOWN_OMITTED` key that upstream later removes is never reported (the sweeps compute `upstream - mine - ledger`), so a dead ledger row is inert forever. A stale-ledger guard is its own small PR.
- Candidate one-line bullet for `CLAUDE.md` Conventions: *Only the latest released version of each agent CLI is supported — no fallback arms, no dual-listening for an old event name beside its replacement.*
- grok's `verified_version` lagged the installed CLI (0.2.102 vs 1.0.25); re-recorded in #988.

## Visual verification

- [x] Not a visual change.

## Checklist

- [x] I read the relevant `CLAUDE.md`.
- [x] New behavior has a test — the selftest fixtures embed the new anchor; the ledger entries are exercised by the existing sibling-sweep tests.
- [x] No `unwrap()` in non-test code.
- [x] No new `println!`/`eprintln!` on a production path.
- [x] Docs updated in the same commit — the ledger values are their own WHY.
- [x] Checked against the recurring pitfalls (#793: do not change a decoder on a probe failure alone — none changed).
- [ ] `just preflight` — runs on push via pre-push.

## AI assistance

- [x] This PR was written/heavily-assisted by an AI agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B875vtxMVrdmypiEZgDNSX
