### PR TITLE
fix(drift): anchors that guard their own names, and three checks that could report green while dead

### DIFF
--- a/scripts/check_upstream_drift.py
+++ b/scripts/check_upstream_drift.py
@@ -954,12 +954,25 @@ def strip_rust_comments(body: str) -> str:
     return "".join(out)
 
 
+def fetch_all_anchored(targets: list[tuple[str, str]], report: Report) -> str | None:
+    """Every `(url, label)` joined, or `None` the moment one misses.
+
+    Where a checked name is declared in exactly one half, the UNION is the
+    document, so a single fetch failure must read as probe health and never as a
+    vanish. Counting survivors against a literal instead — `len(docs) == 2` beside
+    an inline 2-tuple — goes False on a fully successful run the day a third URL
+    joins the tuple, and the whole check then goes dark with no blind line and
+    exit 0 (the #454 shape the `exit_code` docstring names)."""
+    docs = [fetch_anchored(url, label, report) for url, label in targets]
+    return "\n".join(d for d in docs if d is not None) if all(docs) else None
+
+
 def report_stale_ledger(
     ledger_name: str,
     ledger: dict[str, str],
     upstream: set[str],
     enum_label: str,
-    report: "Report",
+    report: Report,
 ) -> None:
     """Report ledger rows naming a variant upstream no longer declares.
 
@@ -1569,13 +1582,10 @@ def run_checks(ours: OurNames, *, report: Report) -> None:
                         )
 
     if ours.omp_message_vocab is not None:
-        docs = [
-            t
-            for u in (OMP_AI_TYPES_URL, OMP_ASK_URL)
-            if (t := fetch_anchored(u, "omp message vocabulary", report)) is not None
-        ]
-        if len(docs) == 2:
-            joined = "\n".join(docs)
+        joined = fetch_all_anchored(
+            [(u, "omp message vocabulary") for u in (OMP_AI_TYPES_URL, OMP_ASK_URL)], report
+        )
+        if joined is not None:
             for name in sorted(ours.omp_message_vocab):
                 if f'"{name}"' not in joined:
                     report.add_breaking(
@@ -1611,14 +1621,16 @@ def run_checks(ours: OurNames, *, report: Report) -> None:
                 check_omp_title_fields(text, ours.omp_title_fields, report)
 
     if ours.dsh_plugin_events is not None:
-        docs = [
-            fetch_anchored(DSH_RUNTIME_TYPES_URL, "dsh agent runtime-types", report),
-            fetch_anchored(DSH_SESSION_TYPES_URL, "dsh session event types", report),
-            fetch_anchored(DSH_APPROVAL_TYPES_URL, "dsh approval types", report),
-            fetch_anchored(DSH_SESSION_INDEX_URL, "dsh session bus names", report),
-        ]
-        if all(d is not None for d in docs):
-            joined = "\n".join(d for d in docs if d is not None)
+        joined = fetch_all_anchored(
+            [
+                (DSH_RUNTIME_TYPES_URL, "dsh agent runtime-types"),
+                (DSH_SESSION_TYPES_URL, "dsh session event types"),
+                (DSH_APPROVAL_TYPES_URL, "dsh approval types"),
+                (DSH_SESSION_INDEX_URL, "dsh session bus names"),
+            ],
+            report,
+        )
+        if joined is not None:
             for name in sorted(ours.dsh_plugin_events):
                 if f"'{name}'" not in joined:
                     report.add_breaking(
@@ -1741,13 +1753,11 @@ def run_checks(ours: OurNames, *, report: Report) -> None:
                         )
 
     if ours.codex_escalation is not None:
-        docs = [
-            t
-            for u in (CODEX_PROTOCOL_URL, CODEX_MODELS_URL)
-            if (t := fetch_anchored(u, "Codex escalation names", report)) is not None
-        ]
-        if len(docs) == 2:
-            joined = "\n".join(docs)
+        joined = fetch_all_anchored(
+            [(u, "Codex escalation names") for u in (CODEX_PROTOCOL_URL, CODEX_MODELS_URL)],
+            report,
+        )
+        if joined is not None:
             for name in sorted(ours.codex_escalation):
                 if not re.search(rf"\b{re.escape(name)}\b", joined):
                     report.add_breaking(
@@ -1756,15 +1766,15 @@ def run_checks(ours: OurNames, *, report: Report) -> None:
                         f"so a codex session sits Active through every prompt."
                     )
 
-    # `CODEX_KNOWN_OMITTED` exempts a name from EITHER enum, so a stale-row check
-    # must see both before it can call a row dead — hence the union, and the count
-    # that proves both sweeps actually ran.
-    codex_seen: set[str] = set()
-    codex_swept = 0
-    for field, url, enum in (
+    # `CODEX_KNOWN_OMITTED` exempts a name from EITHER enum, hence the union, and
+    # only once every sweep ran (`report_stale_ledger`'s precondition).
+    codex_sibling_sweeps = (
         ("codex_response_item", CODEX_MODELS_URL, "ResponseItem"),
         ("codex_outers", CODEX_ROLLOUT_ITEM_URL, "RolloutItem"),
-    ):
+    )
+    codex_seen: set[str] = set()
+    codex_swept = 0
+    for field, url, enum in codex_sibling_sweeps:
         mine = getattr(ours, field)
         if mine is None:
             continue
@@ -1785,9 +1795,13 @@ def run_checks(ours: OurNames, *, report: Report) -> None:
                     f"we already decode, and source/codex.rs decodes it to nothing. "
                     f"Decode it, or add it to CODEX_KNOWN_OMITTED with the reason."
                 )
-    if codex_swept == 2:
+    if codex_swept == len(codex_sibling_sweeps):
         report_stale_ledger(
-            "CODEX_KNOWN_OMITTED", CODEX_KNOWN_OMITTED, codex_seen, "`ResponseItem`/`RolloutItem`", report
+            "CODEX_KNOWN_OMITTED",
+            CODEX_KNOWN_OMITTED,
+            codex_seen,
+            "`ResponseItem`/`RolloutItem`",
+            report,
         )
 
     if ours.grok_xai_method is not None:
@@ -1855,13 +1869,10 @@ def run_checks(ours: OurNames, *, report: Report) -> None:
                         )
 
     if ours.opencode is not None:
-        docs = [
-            t
-            for u in OPENCODE_EVENT_URLS
-            if (t := fetch_anchored(u, "opencode event inventory", report)) is not None
-        ]
-        if len(docs) == len(OPENCODE_EVENT_URLS):
-            joined = "\n".join(docs)
+        joined = fetch_all_anchored(
+            [(u, "opencode event inventory") for u in OPENCODE_EVENT_URLS], report
+        )
+        if joined is not None:
             for ev in sorted(ours.opencode - OPENCODE_TOLERATED):
                 if f'"{ev}"' not in joined:
                     report.add_breaking(

--- a/scripts/check_upstream_drift.py
+++ b/scripts/check_upstream_drift.py
@@ -372,6 +372,12 @@ class Report:
     review: list[str] = dataclasses.field(default_factory=list)
     blind: list[str] = dataclasses.field(default_factory=list)
     errors: list[str] = dataclasses.field(default_factory=list)
+    # One run's anchored fetches, keyed by URL. A document is upstream's answer
+    # for the whole run, and several checks legitimately read the same one — three
+    # read codex's protocol.rs — so without this a single dead pin spends three
+    # requests and files the SAME blind line three times under three labels, which
+    # the workflow then renders as repeated bullets in the issue it opens.
+    fetched: dict[str, str | None] = dataclasses.field(default_factory=dict)
 
     def add_breaking(self, line: str) -> None:
         self.breaking.append(line)
@@ -505,6 +511,9 @@ def fetch_anchored(url: str, label: str, report: Report) -> str | None:
     it are SKIPPED as probe health, not drift. An undeclared URL is reported and
     never RAISED: `run_checks` routes exceptions to the transient bucket, degrading
     "someone added an unproven sweep" to a green-run warning."""
+    if url in report.fetched:
+        return report.fetched[url]
+    report.fetched[url] = None
     anchor = ANCHORS.get(url)
     if anchor is None:
         report.add_blind(
@@ -531,6 +540,7 @@ def fetch_anchored(url: str, label: str, report: Report) -> str | None:
             "reported as drift.",
         )
         return None
+    report.fetched[url] = text
     return text
 
 

--- a/scripts/check_upstream_drift.py
+++ b/scripts/check_upstream_drift.py
@@ -1077,7 +1077,14 @@ def check_omp_extension_reads(
             "extensions/types.ts",
             "The omp approval-field checks were SKIPPED.",
         )
-    approval_bodies = "\n".join(body for body in carriers.values() if body)
+    # `None`, not `""`, when a carrier would not parse: the fields are matched
+    # against the JOIN, so one unreadable carrier makes every field it owns look
+    # renamed — and `declares`' suppression keys on None, which a join never is.
+    approval_bodies = (
+        None
+        if missing_carriers
+        else "\n".join(body for body in carriers.values() if body)
+    )
     ctx_body = typescript_interface_body(ext_types, "ExtensionContext")
     if ctx_body is None:
         report.add_blind(
@@ -1100,7 +1107,11 @@ def check_omp_extension_reads(
 
     # The presence matcher's `\??` cannot see required->optional, and `approved`
     # is the one field whose optionality carries semantics.
-    if "approved" in fields and re.search(r"(?m)^\s*approved\?\s*:", approval_bodies):
+    if (
+        "approved" in fields
+        and approval_bodies is not None
+        and re.search(r"(?m)^\s*approved\?\s*:", approval_bodies)
+    ):
         report.add_breaking(
             "omp's `approved` became OPTIONAL upstream — the decoder reads an "
             "absent value as a DENIAL, so every approval would drop the sprite "

--- a/scripts/check_upstream_drift.py
+++ b/scripts/check_upstream_drift.py
@@ -341,13 +341,13 @@ ANCHORS: dict[str, Anchor] = {
     OPENCODE_EVENT_URLS[1]: Anchor(r"(?m)^export const Event = \{", "the `Event` inventory"),
     # identity-grade: co-located only — a name moved out still matches, so phantom
     # renames survive it. Not upgradeable without a parser; a docs PAGE is only this.
-    OMP_AI_TYPES_URL: Anchor(r"toolCall", "the message block types"),
+    OMP_AI_TYPES_URL: Anchor(r"(?m)^export type Message\s*=", "the `Message` union"),
     OMP_ASK_URL: Anchor(r"export class AskTool", "the `AskTool` class"),
     OMP_EXIT_DIAG_URL: Anchor(r"SESSION_EXIT_CUSTOM_TYPE", "`SESSION_EXIT_CUSTOM_TYPE`"),
     OMP_SESSION_ENTRIES_URL: Anchor(r"export type SessionEntry\b", "the session-entry union"),
     OMP_EXT_SHARED_EVENTS_URL: Anchor(r"SessionShutdownEvent", "`SessionShutdownEvent`"),
     OMP_EXT_TYPES_URL: Anchor(r"ToolApprovalRequestedEvent", "`ToolApprovalRequestedEvent`"),
-    OMP_SESSION_MANAGER_URL: Anchor(r"getSessionFile", "`getSessionFile`"),
+    OMP_SESSION_MANAGER_URL: Anchor(r"(?m)^export class SessionManager\b", "`SessionManager`"),
     OMP_EXT_DISCOVERY_URL: Anchor(
         r"discoverExtensionModulePaths", "`discoverExtensionModulePaths`"
     ),
@@ -1733,7 +1733,21 @@ def run_checks(ours: OurNames, *, report: Report) -> None:
         text = fetch_anchored(GROK_NOTIFICATION_URL, "grok notification source", report)
         if text is not None:
             upstream = upstream_codex_enum_types(text, "SessionUpdate")
-            if upstream is not None:
+            if upstream is None:
+                # The codex loops survive the same silent `continue` only because
+                # their vanish check files blind for the same enum first; grok's
+                # reads the document with a different parser, so nothing else
+                # notices. xAI already moved `HookEventName` behind a macro —
+                # `upstream_grok_hooks` carries a `hook_events!` arm for it — and
+                # the same move here returns the macro DEFINITION's body.
+                report.add_blind(
+                    "grok's xAI `SessionUpdate` variants",
+                    GROK_NOTIFICATION_URL,
+                    "The appearance sweep and the ledger staleness check were both "
+                    "SKIPPED — most likely the enum moved behind a declarative "
+                    "macro, as `HookEventName` already did.",
+                )
+            else:
                 families = {n.split("_", 1)[0] for n in ours.grok_xai_tags if "_" in n}
                 report_stale_ledger(
                     "GROK_XAI_KNOWN_OMITTED",

--- a/scripts/check_upstream_drift.py
+++ b/scripts/check_upstream_drift.py
@@ -280,6 +280,14 @@ class Anchor(typing.NamedTuple):
 
     pattern: str
     owns: str
+    # A SECOND pattern that must ALSO be present, for an owning declaration whose
+    # halves a sibling member can separate: dsh's `session/index.ts` puts
+    # `interface Context` between `declare module '@deepseek-ai/cordis' {` and the
+    # `interface Events {` that owns the event keys, so no single adjacency regex
+    # spans it. Both-present is weaker than adjacency — it cannot prove the two
+    # halves nest — but each half is unique per document, and it is strictly
+    # stronger than anchoring on one of the checked names.
+    also: str | None = None
 
 
 # The three JSON Schemas are parsed STRUCTURALLY, so a text anchor would add
@@ -301,10 +309,25 @@ ANCHORS: dict[str, Anchor] = {
     CODEX_MODELS_URL: Anchor(r"pub enum ResponseItem\b", "`ResponseItem`"),
     CODEX_PROTOCOL_URL: Anchor(r"pub enum HookEventName\b", "`HookEventName`"),
     CODEX_ROLLOUT_ITEM_URL: Anchor(r"pub enum RolloutItem\b", "`RolloutItem`"),
-    DSH_RUNTIME_TYPES_URL: Anchor(r"'agent/pre-step'", "`agent/pre-step`"),
+    # dsh declares its event keys as cordis module augmentations, so the owner is
+    # the augmented interface, never a key inside it — an event-key anchor is a
+    # SIBLING of the names it guards and vanishes with them. That is exactly what
+    # the v2 reshape did to `assistant/chunk` (#981), aborting the check that would
+    # have reported it.
+    DSH_RUNTIME_TYPES_URL: Anchor(
+        r"declare module '@deepseek-ai/cordis' \{\s*\n\s*interface Events \{",
+        "the cordis `Events` augmentation",
+    ),
     DSH_SESSION_TYPES_URL: Anchor(r"export interface SessionEventMap\b", "`SessionEventMap`"),
-    DSH_APPROVAL_TYPES_URL: Anchor(r"ApprovalRequestId", "`ApprovalRequestId`"),
-    DSH_SESSION_INDEX_URL: Anchor(r"'session/created'", "`session/created`"),
+    DSH_APPROVAL_TYPES_URL: Anchor(
+        r"declare module '@deepseek-ai/dsh-session/types' \{\s*\n\s*interface SessionEventMap \{",
+        "the `SessionEventMap` augmentation",
+    ),
+    DSH_SESSION_INDEX_URL: Anchor(
+        r"declare module '@deepseek-ai/cordis' \{",
+        "the cordis `Events` augmentation",
+        also=r"(?m)^  interface Events \{",
+    ),
     GROK_HOOK_URL: Anchor(r"pub enum HookEventName\b", "`HookEventName`"),
     GROK_NOTIFICATION_URL: Anchor(r"pub enum SessionUpdate\b", "`SessionUpdate`"),
     GROK_SESSION_STORAGE_URL: Anchor(
@@ -495,7 +518,9 @@ def fetch_anchored(url: str, label: str, report: Report) -> str | None:
     text = try_fetch(url, label, report)
     if text is None:
         return None
-    if not re.search(anchor.pattern, text):
+    if not re.search(anchor.pattern, text) or (
+        anchor.also is not None and not re.search(anchor.also, text)
+    ):
         report.add_blind(
             f"{label}: the document no longer contains {anchor.owns}",
             url,
@@ -927,6 +952,30 @@ def strip_rust_comments(body: str) -> str:
         out.append(body[i])
         i += 1
     return "".join(out)
+
+
+def report_stale_ledger(
+    ledger_name: str,
+    ledger: dict[str, str],
+    upstream: set[str],
+    enum_label: str,
+    report: "Report",
+) -> None:
+    """Report ledger rows naming a variant upstream no longer declares.
+
+    Both sibling sweeps compute `upstream - mine - ledger`, so a row whose variant
+    upstream DELETED drops out of the subtrahend and is never mentioned again: it
+    sits there forever, carrying a WHY for a decision that no longer exists and
+    silently exempting the name if upstream ever reuses it. Only the caller knows
+    whether every document feeding `upstream` was actually fetched — call this
+    ONLY when they were, or a transient 404 reads as an upstream deletion."""
+    for name in sorted(set(ledger) - upstream):
+        report.add_review(
+            f"{ledger_name} still ledgers `{name}`, which {enum_label} no longer "
+            f"declares — upstream removed it. Delete the row: it documents a "
+            f"decision about a variant that is gone, and would silently exempt the "
+            f"name from the sibling sweep if upstream ever reused it."
+        )
 
 
 def rust_block_after(src: str, anchor_re: str) -> str | None:
@@ -1674,6 +1723,13 @@ def run_checks(ours: OurNames, *, report: Report) -> None:
             upstream = upstream_codex_enum_types(text, "SessionUpdate")
             if upstream is not None:
                 families = {n.split("_", 1)[0] for n in ours.grok_xai_tags if "_" in n}
+                report_stale_ledger(
+                    "GROK_XAI_KNOWN_OMITTED",
+                    GROK_XAI_KNOWN_OMITTED,
+                    upstream,
+                    "grok's xAI `SessionUpdate`",
+                    report,
+                )
                 gap = upstream - ours.grok_xai_tags - set(GROK_XAI_KNOWN_OMITTED)
                 for name in sorted(gap):
                     if name.split("_", 1)[0] in families:
@@ -1700,6 +1756,11 @@ def run_checks(ours: OurNames, *, report: Report) -> None:
                         f"so a codex session sits Active through every prompt."
                     )
 
+    # `CODEX_KNOWN_OMITTED` exempts a name from EITHER enum, so a stale-row check
+    # must see both before it can call a row dead — hence the union, and the count
+    # that proves both sweeps actually ran.
+    codex_seen: set[str] = set()
+    codex_swept = 0
     for field, url, enum in (
         ("codex_response_item", CODEX_MODELS_URL, "ResponseItem"),
         ("codex_outers", CODEX_ROLLOUT_ITEM_URL, "RolloutItem"),
@@ -1713,6 +1774,8 @@ def run_checks(ours: OurNames, *, report: Report) -> None:
         upstream = upstream_codex_enum_types(text, enum)
         if upstream is None:
             continue
+        codex_seen |= upstream
+        codex_swept += 1
         families = sibling_families(mine)
         for name in sorted(upstream - mine - set(CODEX_KNOWN_OMITTED)):
             if name.rsplit("_", 1)[-1] in families:
@@ -1722,6 +1785,10 @@ def run_checks(ours: OurNames, *, report: Report) -> None:
                     f"we already decode, and source/codex.rs decodes it to nothing. "
                     f"Decode it, or add it to CODEX_KNOWN_OMITTED with the reason."
                 )
+    if codex_swept == 2:
+        report_stale_ledger(
+            "CODEX_KNOWN_OMITTED", CODEX_KNOWN_OMITTED, codex_seen, "`ResponseItem`/`RolloutItem`", report
+        )
 
     if ours.grok_xai_method is not None:
         text = fetch_anchored(GROK_SESSION_STORAGE_URL, "grok session storage", report)

--- a/scripts/check_upstream_drift.py
+++ b/scripts/check_upstream_drift.py
@@ -280,13 +280,9 @@ class Anchor(typing.NamedTuple):
 
     pattern: str
     owns: str
-    # A SECOND pattern that must ALSO be present, for an owning declaration whose
-    # halves a sibling member can separate: dsh's `session/index.ts` puts
-    # `interface Context` between `declare module '@deepseek-ai/cordis' {` and the
-    # `interface Events {` that owns the event keys, so no single adjacency regex
-    # spans it. Both-present is weaker than adjacency — it cannot prove the two
-    # halves nest — but each half is unique per document, and it is strictly
-    # stronger than anchoring on one of the checked names.
+    # A second required pattern, for an owning declaration a sibling member splits
+    # (dsh puts `interface Context` inside the module the `Events` keys live in).
+    # Both-present cannot prove the halves nest; each half is unique per document.
     also: str | None = None
 
 
@@ -310,10 +306,7 @@ ANCHORS: dict[str, Anchor] = {
     CODEX_PROTOCOL_URL: Anchor(r"pub enum HookEventName\b", "`HookEventName`"),
     CODEX_ROLLOUT_ITEM_URL: Anchor(r"pub enum RolloutItem\b", "`RolloutItem`"),
     # dsh declares its event keys as cordis module augmentations, so the owner is
-    # the augmented interface, never a key inside it — an event-key anchor is a
-    # SIBLING of the names it guards and vanishes with them. That is exactly what
-    # the v2 reshape did to `assistant/chunk` (#981), aborting the check that would
-    # have reported it.
+    # the augmented interface: a key would be a SIBLING of the names it guards.
     DSH_RUNTIME_TYPES_URL: Anchor(
         r"declare module '@deepseek-ai/cordis' \{\s*\n\s*interface Events \{",
         "the cordis `Events` augmentation",
@@ -372,11 +365,8 @@ class Report:
     review: list[str] = dataclasses.field(default_factory=list)
     blind: list[str] = dataclasses.field(default_factory=list)
     errors: list[str] = dataclasses.field(default_factory=list)
-    # One run's anchored fetches, keyed by URL. A document is upstream's answer
-    # for the whole run, and several checks legitimately read the same one — three
-    # read codex's protocol.rs — so without this a single dead pin spends three
-    # requests and files the SAME blind line three times under three labels, which
-    # the workflow then renders as repeated bullets in the issue it opens.
+    # One run's anchored fetches. A document is upstream's answer for the whole
+    # run, and several checks read the same one — three read codex's protocol.rs.
     fetched: dict[str, str | None] = dataclasses.field(default_factory=dict)
 
     def add_breaking(self, line: str) -> None:
@@ -967,12 +957,8 @@ def strip_rust_comments(body: str) -> str:
 def fetch_all_anchored(targets: list[tuple[str, str]], report: Report) -> str | None:
     """Every `(url, label)` joined, or `None` the moment one misses.
 
-    Where a checked name is declared in exactly one half, the UNION is the
-    document, so a single fetch failure must read as probe health and never as a
-    vanish. Counting survivors against a literal instead — `len(docs) == 2` beside
-    an inline 2-tuple — goes False on a fully successful run the day a third URL
-    joins the tuple, and the whole check then goes dark with no blind line and
-    exit 0 (the #454 shape the `exit_code` docstring names)."""
+    A checked name may be declared in exactly one half, so the UNION is the
+    document: one fetch failure is probe health, never a vanish."""
     docs = [fetch_anchored(url, label, report) for url, label in targets]
     return "\n".join(d for d in docs if d is not None) if all(docs) else None
 
@@ -984,14 +970,11 @@ def report_stale_ledger(
     enum_label: str,
     report: Report,
 ) -> None:
-    """Report ledger rows naming a variant upstream no longer declares.
+    """Ledger rows naming a variant upstream no longer declares.
 
-    Both sibling sweeps compute `upstream - mine - ledger`, so a row whose variant
-    upstream DELETED drops out of the subtrahend and is never mentioned again: it
-    sits there forever, carrying a WHY for a decision that no longer exists and
-    silently exempting the name if upstream ever reuses it. Only the caller knows
-    whether every document feeding `upstream` was actually fetched — call this
-    ONLY when they were, or a transient 404 reads as an upstream deletion."""
+    Both sibling sweeps compute `upstream - mine - ledger`, so a deleted variant
+    drops out of the subtrahend and is never mentioned again. Call this only once
+    every document feeding `upstream` was fetched, or a 404 reads as a deletion."""
     for name in sorted(set(ledger) - upstream):
         report.add_review(
             f"{ledger_name} still ledgers `{name}`, which {enum_label} no longer "
@@ -1087,9 +1070,8 @@ def check_omp_extension_reads(
             "extensions/types.ts",
             "The omp approval-field checks were SKIPPED.",
         )
-    # `None`, not `""`, when a carrier would not parse: the fields are matched
-    # against the JOIN, so one unreadable carrier makes every field it owns look
-    # renamed — and `declares`' suppression keys on None, which a join never is.
+    # `None`, not `""`: fields match against the JOIN, and `declares`' suppression
+    # keys on None, which a join never is.
     approval_bodies = (
         None
         if missing_carriers
@@ -1755,12 +1737,8 @@ def run_checks(ours: OurNames, *, report: Report) -> None:
         if text is not None:
             upstream = upstream_codex_enum_types(text, "SessionUpdate")
             if upstream is None:
-                # The codex loops survive the same silent `continue` only because
-                # their vanish check files blind for the same enum first; grok's
-                # reads the document with a different parser, so nothing else
-                # notices. xAI already moved `HookEventName` behind a macro —
-                # `upstream_grok_hooks` carries a `hook_events!` arm for it — and
-                # the same move here returns the macro DEFINITION's body.
+                # Unlike the codex loops, no vanish check files blind for this
+                # enum first, so a silent `continue` here is covered by nothing.
                 report.add_blind(
                     "grok's xAI `SessionUpdate` variants",
                     GROK_NOTIFICATION_URL,

--- a/scripts/check_upstream_drift.py
+++ b/scripts/check_upstream_drift.py
@@ -319,7 +319,7 @@ ANCHORS: dict[str, Anchor] = {
     DSH_SESSION_INDEX_URL: Anchor(
         r"declare module '@deepseek-ai/cordis' \{",
         "the cordis `Events` augmentation",
-        also=r"(?m)^  interface Events \{",
+        also=r"(?m)^\s+interface Events \{",
     ),
     GROK_HOOK_URL: Anchor(r"pub enum HookEventName\b", "`HookEventName`"),
     GROK_NOTIFICATION_URL: Anchor(r"pub enum SessionUpdate\b", "`SessionUpdate`"),

--- a/scripts/check_upstream_drift_selftest.py
+++ b/scripts/check_upstream_drift_selftest.py
@@ -108,10 +108,18 @@ ANCHOR_SAMPLES: dict[str, str] = {
     d.OMP_EXT_TYPES_URL:
         'export interface ToolApprovalRequestedEvent { type: "tool_approval_requested"; }\n',
     d.OMP_SESSION_MANAGER_URL: 'getSessionFile(): string | undefined {\n',
-    d.DSH_RUNTIME_TYPES_URL: "    'agent/pre-step'(payload: {}): void\n",
+    d.DSH_RUNTIME_TYPES_URL:
+        "declare module '@deepseek-ai/cordis' {\n  interface Events {\n"
+        "    'agent/pre-step'(payload: {}): void\n  }\n}\n",
     d.DSH_SESSION_TYPES_URL: "export interface SessionEventMap {\n  'assistant/message': { text: string }\n}\n",
-    d.DSH_APPROVAL_TYPES_URL: "export type ApprovalRequestId = string\n",
-    d.DSH_SESSION_INDEX_URL: "  register('session/created', header)\n",
+    d.DSH_APPROVAL_TYPES_URL:
+        "declare module '@deepseek-ai/dsh-session/types' {\n  interface SessionEventMap {\n"
+        "    'approval/asked': { id: ApprovalRequestId }\n  }\n}\n",
+    # The `also` shape: upstream puts `interface Context` between the module
+    # header and the `Events` the keys live in, so the sample must too.
+    d.DSH_SESSION_INDEX_URL:
+        "declare module '@deepseek-ai/cordis' {\n  interface Context {\n    session: Session\n  }\n"
+        "  interface Events {\n    'session/created'(session: Session): void\n  }\n}\n",
     d.OMP_EXT_DISCOVERY_URL:
         'export async function discoverExtensionModulePaths() {}\n',
     d.OMP_DIRS_URL:
@@ -167,6 +175,24 @@ def test_anchor_gate_fires_in_both_directions() -> None:
                 out == sample and not r.blind and not r.errors,
                 f"{anchor.owns}: anchor present -> body returned, got blind={r.blind}",
             )
+
+            # Half an `also` anchor is NOT an anchor. Without this, `also` could
+            # regress to decorative — the sample above satisfies both halves, so
+            # only deleting one proves the second is load-bearing.
+            if anchor.also is None:
+                continue
+            for drop, half in (("pattern", anchor.pattern), ("also", anchor.also)):
+                maimed = re.sub(half, "", sample, count=1)
+                check(
+                    maimed != sample,
+                    f"{anchor.owns}: the {drop} half must occur in its own sample",
+                )
+                d.fetch = lambda _u, _s=maimed: _s
+                r = d.Report()
+                check(
+                    d.fetch_anchored(url, "T", r) is None and len(r.blind) == 1,
+                    f"{anchor.owns}: {drop} missing -> blind, got blind={r.blind}",
+                )
     finally:
         d.fetch = real
 
@@ -563,6 +589,89 @@ def test_an_undecoded_sibling_is_reported_and_a_stranger_is_not() -> None:
         d.fetch = real
         d.CODEX_KNOWN_OMITTED.clear()
         d.CODEX_KNOWN_OMITTED.update(saved)
+
+
+def test_a_ledger_row_upstream_deleted_is_reported_once_every_doc_was_fetched() -> None:
+    """The direction both sibling sweeps are blind to. They compute
+    `upstream - mine - ledger`, so a row whose variant upstream DELETED simply
+    drops out of the subtrahend — it then explains a decision about a name that
+    no longer exists, and would silently exempt the name if upstream reused it.
+    `CODEX_KNOWN_OMITTED` exempts EITHER enum, so staleness is only knowable once
+    BOTH were fetched: a run that saw one must stay quiet, or a 404 reads as a
+    deletion."""
+    real = d.fetch
+    saved_codex = dict(d.CODEX_KNOWN_OMITTED)
+    saved_grok = dict(d.GROK_XAI_KNOWN_OMITTED)
+    phantom = "pxd_upstream_deleted_this"
+    try:
+        rep0 = d.Report()
+        ours = d.read_our_names(rep0)
+        response_item = sorted(ours.codex_response_item or ())
+        outers = sorted(ours.codex_outers or ())
+        tags = sorted(ours.grok_xai_tags or ())
+        check(bool(response_item and outers and tags), "the fragment supplies all three sets")
+
+        def serve(docs: dict[str, str]) -> d.Report:
+            def stub(u: str, _d: dict[str, str] = docs) -> str:
+                if u in _d:
+                    return _d[u]
+                raise urllib.error.URLError("offline: not this case's document")
+
+            d.fetch = stub
+            rep = d.Report()
+            d.run_checks(d.read_our_names(rep), report=rep)
+            return rep
+
+        def codex_enum(enum: str, names: list[str]) -> str:
+            rows = "".join(
+                f'    #[serde(rename = "{n}")]\n    Pxv{i},\n' for i, n in enumerate(names)
+            )
+            return f"pub enum {enum} {{\n{rows}}}\n"
+
+        both = {
+            d.CODEX_MODELS_URL: codex_enum("ResponseItem", response_item),
+            d.CODEX_ROLLOUT_ITEM_URL: codex_enum("RolloutItem", outers),
+        }
+        d.CODEX_KNOWN_OMITTED.clear()
+        d.CODEX_KNOWN_OMITTED[phantom] = "test"
+        loud = serve(both)
+        check(any(phantom in x for x in loud.review),
+              f"a ledger row upstream no longer declares must be reported; got {loud.review}")
+
+        half = serve({d.CODEX_MODELS_URL: both[d.CODEX_MODELS_URL]})
+        check(not any(phantom in x for x in half.review),
+              f"one enum unfetched cannot prove staleness; got {half.review}")
+
+        # EITHER enum exempts, so the check must union them. Ledger a name only the
+        # FIRST-swept enum has: a last-wins accumulator drops it and cries stale.
+        only_response = sorted(set(response_item) - set(outers))
+        check(bool(only_response), "ResponseItem has a name RolloutItem does not")
+        d.CODEX_KNOWN_OMITTED.clear()
+        d.CODEX_KNOWN_OMITTED[only_response[0]] = "test"
+        live = serve(both)
+        check(not any(f"ledgers `{only_response[0]}`" in x for x in live.review),
+              f"a row only the FIRST enum declares stays quiet; got {live.review}")
+
+        pas = lambda n: "".join(p.title() for p in n.split("_"))
+        grok_doc = ("pub enum SessionUpdate {\n"
+                    + "".join(f"    {pas(n)},\n" for n in tags) + "}\n")
+        d.GROK_XAI_KNOWN_OMITTED.clear()
+        d.GROK_XAI_KNOWN_OMITTED[phantom] = "test"
+        gl = serve({d.GROK_NOTIFICATION_URL: grok_doc})
+        check(any(phantom in x for x in gl.review),
+              f"the grok ledger gets the same sweep; got {gl.review}")
+
+        d.GROK_XAI_KNOWN_OMITTED.clear()
+        d.GROK_XAI_KNOWN_OMITTED[tags[0]] = "test"
+        gq = serve({d.GROK_NOTIFICATION_URL: grok_doc})
+        check(not any(f"ledgers `{tags[0]}`" in x for x in gq.review),
+              f"a live grok row stays quiet; got {gq.review}")
+    finally:
+        d.fetch = real
+        d.CODEX_KNOWN_OMITTED.clear()
+        d.CODEX_KNOWN_OMITTED.update(saved_codex)
+        d.GROK_XAI_KNOWN_OMITTED.clear()
+        d.GROK_XAI_KNOWN_OMITTED.update(saved_grok)
 
 
 def test_the_prefix_sweeps_flag_a_family_sibling_and_ignore_a_stranger() -> None:
@@ -1252,11 +1361,16 @@ def test_every_source_check_fires_on_a_vanish_and_stays_silent_otherwise() -> No
                 (d.ACP_V1_SCHEMA_URL, d.ACP_V1_SCHEMA_UNSTABLE_URL),
                 acp_schema(full["acp_decoded_tags"], ns))),
             ("dsh_plugin_events", str, lambda ns: {
-                d.DSH_RUNTIME_TYPES_URL: "'agent/pre-step'\n"
-                + "\n".join(f"'{n}'" for n in ns),
+                d.DSH_RUNTIME_TYPES_URL:
+                    "declare module '@deepseek-ai/cordis' {\n  interface Events {\n"
+                    + "\n".join(f"'{n}'" for n in ns),
                 d.DSH_SESSION_TYPES_URL: "export interface SessionEventMap {\n",
-                d.DSH_APPROVAL_TYPES_URL: "ApprovalRequestId\n",
-                d.DSH_SESSION_INDEX_URL: "'session/created'\n"}),
+                d.DSH_APPROVAL_TYPES_URL:
+                    "declare module '@deepseek-ai/dsh-session/types' {\n"
+                    "  interface SessionEventMap {\n",
+                d.DSH_SESSION_INDEX_URL:
+                    "declare module '@deepseek-ai/cordis' {\n  interface Context {\n  }\n"
+                    "  interface Events {\n"}),
             ("copilot", str, lambda ns: {
                 d.COPILOT_SCHEMA_URL: copilot_schema(ns, full["copilot_fields"])}),
             ("copilot_fields", str, lambda ns: {

--- a/scripts/check_upstream_drift_selftest.py
+++ b/scripts/check_upstream_drift_selftest.py
@@ -1335,7 +1335,14 @@ def test_every_source_check_fires_on_a_vanish_and_stays_silent_otherwise() -> No
                     if iface == "SessionSwitchEvent" and "previousSessionFile" in reads
                     else ""
                 )
-                shared += f"export interface {iface} {{\n{tag}{prev}}}\n"
+                # Prose ALWAYS quotes the name, whether or not the declaration
+                # survives — the only shape that distinguishes the `type: "…"`
+                # matcher from a bare `"…"` one ("bare quoted names also live in
+                # prose", the matcher's own comment).
+                shared += (
+                    f'/** Emitted as "{name}". */\n'
+                    f"export interface {iface} {{\n{tag}{prev}}}\n"
+                )
             approval_fields = {
                 "toolCallId": "string",
                 "toolName": "string",
@@ -1351,7 +1358,10 @@ def test_every_source_check_fires_on_a_vanish_and_stays_silent_otherwise() -> No
                 body = "".join(
                     f"\t{f}: {t};\n" for f, t in approval_fields.items() if f in reads
                 )
-                ext += f"export interface {iface} {{\n{tag}{body}}}\n"
+                ext += (
+                    f'/** Emitted as "{name}". */\n'
+                    f"export interface {iface} {{\n{tag}{body}}}\n"
+                )
             cwd = '\tcwd: string;\n' if "cwd" in reads else ""
             ext += (
                 "export interface ExtensionContext {\n"
@@ -1521,7 +1531,11 @@ def test_every_source_check_fires_on_a_vanish_and_stays_silent_otherwise() -> No
             victims = pool if field == "dispatch_names" else pool[:1]
             # The vanish arm ADDS as it drops, in the name's own shape — below the
             # floor the check SKIPS. `_` not case is the axis (cursor's lone `stop`).
-            stem = spell(names[-1])
+            # The decoy is built from the VICTIM, so the mutated document carries the
+            # dropped name's spelling in a NON-declaration position: that is the only
+            # shape that can tell `f'"{name}"' not in text` from `name not in text`,
+            # and eight matchers exist for exactly that distinction.
+            stem = spell(victims[0])
             if stem.isdigit():
                 # A numeric VALUE row: a `Pxd` suffix leaves our digits at the front,
                 # where the reader's `(\d+)` finds them and the arm reads unchanged.

--- a/scripts/check_upstream_drift_selftest.py
+++ b/scripts/check_upstream_drift_selftest.py
@@ -102,12 +102,15 @@ ANCHOR_SAMPLES: dict[str, str] = {
     d.HERMES_SHELL_HOOK_URL: '_BLOCKING_EVENTS = frozenset({"pre_tool_call"})\n',
     d.OMP_SESSION_ENTRIES_URL: 'export type SessionEntry = { type: "session" }\n',
     d.OMP_EXIT_DIAG_URL: 'const SESSION_EXIT_CUSTOM_TYPE = "session_exit";\n',
-    d.OMP_AI_TYPES_URL: 'export type Block = { type: "toolCall" };\n',
+    d.OMP_AI_TYPES_URL:
+        'export type Message = UserMessage | AssistantMessage;\n'
+        'export interface ToolCall { type: "toolCall" }\n',
     d.OMP_EXT_SHARED_EVENTS_URL:
         'export interface SessionShutdownEvent { type: "session_shutdown"; }\n',
     d.OMP_EXT_TYPES_URL:
         'export interface ToolApprovalRequestedEvent { type: "tool_approval_requested"; }\n',
-    d.OMP_SESSION_MANAGER_URL: 'getSessionFile(): string | undefined {\n',
+    d.OMP_SESSION_MANAGER_URL:
+        'export class SessionManager {\n\tgetSessionFile(): string | undefined {}\n}\n',
     d.DSH_RUNTIME_TYPES_URL:
         "declare module '@deepseek-ai/cordis' {\n  interface Events {\n"
         "    'agent/pre-step'(payload: {}): void\n  }\n}\n",
@@ -195,6 +198,76 @@ def test_anchor_gate_fires_in_both_directions() -> None:
                 )
     finally:
         d.fetch = real
+
+
+def test_an_unreadable_grok_enum_files_probe_health_rather_than_nothing() -> None:
+    """A reader that returns None must SAY so. The anchor still matches when the
+    enum moves behind a declarative macro — xAI already did this to
+    `HookEventName`, which is why `upstream_grok_hooks` carries a `hook_events!`
+    arm — so the document passes identity while the parser reads the macro
+    DEFINITION's body. Both directions riding this reader then skip, and without a
+    blind line the run is green with the checks dead."""
+    real = d.fetch
+    try:
+        rep0 = d.Report()
+        tags = sorted(d.read_our_names(rep0).grok_xai_tags or ())
+        check(bool(tags), "the fragment supplies the xai tag set")
+        pas = lambda n: "".join(p.title() for p in n.split("_"))
+        variants = "".join(f"    {pas(n)},\n" for n in tags)
+
+        def drive(doc: str) -> d.Report:
+            def stub(u: str, _d: str = doc) -> str:
+                if u == d.GROK_NOTIFICATION_URL:
+                    return _d
+                raise urllib.error.URLError("offline: not this case's document")
+
+            d.fetch = stub
+            rep = d.Report()
+            d.run_checks(d.read_our_names(rep), report=rep)
+            return rep
+
+        plain = drive(f"pub enum SessionUpdate {{\n{variants}}}\n")
+        check(not any("SessionUpdate` variants" in b for b in plain.blind),
+              f"a readable enum files no probe health; got {plain.blind}")
+
+        macro = drive(
+            "macro_rules! session_updates {\n    ($($variant:ident,)*) => {\n"
+            "        pub enum SessionUpdate { $($variant,)* }\n    };\n}\n"
+            f"session_updates! {{\n{variants}}}\n"
+        )
+        check(any("SessionUpdate` variants" in b for b in macro.blind),
+              f"an unreadable enum must file probe health; got blind={macro.blind}")
+    finally:
+        d.fetch = real
+
+
+def test_no_anchor_is_a_name_the_watcher_checks() -> None:
+    """`Anchor`'s docstring bans this in prose; prose has no failure mode.
+
+    An anchor that IS one of the guarded names vanishes WITH them on the very
+    rename it exists to tell apart from a stale pin — and the blind line then
+    argues the maintainer OUT of the fix ("do NOT change a decoder on this
+    alone"). dsh's `'agent/pre-step'` was this shape, and so were omp's
+    `toolCall` and `getSessionFile`."""
+    rep = d.Report()
+    ours = d.read_our_names(rep)
+    names = {
+        n
+        for f in ours.__dataclass_fields__
+        if isinstance(v := getattr(ours, f), set)
+        for n in v
+    }
+    # A floor: an empty vocabulary would make every `re.search` below vacuous.
+    check(len(names) > 100, f"the fragments supply the swept vocabulary, got {len(names)}")
+    circular = sorted(
+        (a.owns, p, n)
+        for a in d.ANCHORS.values()
+        for p in (a.pattern, a.also)
+        if p is not None
+        for n in names
+        if re.search(p, n)
+    )
+    check(not circular, f"an anchor must not match a name it guards: {circular}")
 
 
 def test_a_multi_document_check_is_all_or_nothing() -> None:
@@ -1285,11 +1358,11 @@ def test_every_source_check_fires_on_a_vanish_and_stays_silent_otherwise() -> No
                 + cwd
                 + "\tsessionManager: ReadonlySessionManager;\n}\n"
             )
-            sm = "// ReadonlySessionManager picks getSessionFile / getSessionId\n" + "".join(
+            sm = "export class SessionManager {\n" + "".join(
                 f"\t{g}(): string {{\n\t}}\n"
                 for g in ("getSessionFile", "getSessionId")
                 if g in reads
-            )
+            ) + "}\n"
             return {
                 d.OMP_EXT_SHARED_EVENTS_URL: shared,
                 d.OMP_EXT_TYPES_URL: ext,
@@ -1361,8 +1434,8 @@ def test_every_source_check_fires_on_a_vanish_and_stays_silent_otherwise() -> No
                     "pub enum SessionUpdate {\n" + "".join(f"    {n},\n" for n in ns) + "}\n"}),
             ("omp_message_vocab", str, lambda ns: {
                 d.OMP_AI_TYPES_URL:
-                    "export type Block = {\n"
-                    + "".join(f'  | "{n}"\n' for n in ns if n != "ask") + "};\n",
+                    "export type Message = UserMessage | AssistantMessage;\n"
+                    + "".join(f'  | "{n}"\n' for n in ns if n != "ask"),
                 d.OMP_ASK_URL:
                     "export class AskTool {\n"
                     + "".join(f'  name = "{n}";\n' for n in ns if n == "ask") + "}\n"}),

--- a/scripts/check_upstream_drift_selftest.py
+++ b/scripts/check_upstream_drift_selftest.py
@@ -381,6 +381,14 @@ def test_the_anchor_requirement_cannot_be_waived_quietly() -> None:
     )
     # Pinned BY URL: with `also` gone the loop in the anchor test just skips, which
     # is indistinguishable from an anchor that never needed a second half.
+    # `\s+`, not `\s*`: indentation is the only nesting signal a both-present
+    # anchor has, so a flush-left `interface Events` on ANOTHER module must fail.
+    a = d.ANCHORS[d.DSH_SESSION_INDEX_URL]
+    for indent, want in ((" ", True), ("\t", True), ("    ", True), ("", False)):
+        body = f"declare module '@deepseek-ai/cordis' {{\n{indent}interface Events {{\n}}\n}}\n"
+        got = bool(re.search(a.pattern, body)) and bool(re.search(a.also or "", body))
+        check(got is want, f"indent {indent!r}: anchored={got}, want {want}")
+
     for url in (d.DSH_SESSION_INDEX_URL,):
         check(
             d.ANCHORS[url].also is not None,

--- a/scripts/check_upstream_drift_selftest.py
+++ b/scripts/check_upstream_drift_selftest.py
@@ -275,14 +275,17 @@ def test_the_omp_extension_router_flags_a_name_it_cannot_place() -> None:
         f"an unplaceable name is probe health, never a rename; got {rep.breaking}",
     )
 
-    # A carrier that will not parse must suppress its fields, not rename them.
-    rep = d.Report()
-    d.check_omp_extension_reads(shared, "", sm, {"toolCallId"}, rep)
-    check(
-        any("carrier" in b for b in rep.blind) and not rep.breaking,
-        f"an unreadable carrier is blind and suppresses its fields; "
-        f"blind={rep.blind} breaking={rep.breaking}",
-    )
+    # A carrier that will not parse must suppress its fields, not rename them —
+    # `approved` included, whose OPTIONALITY arm reads the same value and would
+    # raise on None, killing every check after this one.
+    for fields in ({"toolCallId"}, {"approved", "toolCallId"}):
+        rep = d.Report()
+        d.check_omp_extension_reads(shared, "", sm, fields, rep)
+        check(
+            any("carrier" in b for b in rep.blind) and not rep.breaking,
+            f"an unreadable carrier is blind and suppresses {sorted(fields)}; "
+            f"blind={rep.blind} breaking={rep.breaking}",
+        )
 
 
 def test_a_redirected_omp_agent_dir_is_breaking() -> None:

--- a/scripts/check_upstream_drift_selftest.py
+++ b/scripts/check_upstream_drift_selftest.py
@@ -200,6 +200,158 @@ def test_anchor_gate_fires_in_both_directions() -> None:
         d.fetch = real
 
 
+def test_the_omp_extension_router_flags_a_name_it_cannot_place() -> None:
+    """The router's own documented promise: "A name this router does not know
+    means the template grew a read without a check — flagged blind, never silently
+    green." Replacing that whole `else` arm with a bare `continue` left the suite
+    green, so the promise was prose. Its two missing-carrier arms were unreachable
+    too, which is the case where an unverifiable carrier must NOT be re-reported as
+    a rename of every field it holds."""
+    shared = "export interface SessionSwitchEvent {\n\tpreviousSessionFile: string;\n}\n"
+    ext = (
+        "export interface ToolApprovalRequestedEvent {\n\ttoolCallId: string;\n}\n"
+        "export interface ToolApprovalResolvedEvent {\n\tapproved: boolean;\n}\n"
+        "export interface ExtensionContext {\n\tcwd: string;\n}\n"
+    )
+    sm = "export class SessionManager {\n\tgetSessionFile(): string {}\n}\n"
+
+    rep = d.Report()
+    d.check_omp_extension_reads(shared, ext, sm, {"cwd", "toolCallId"}, rep)
+    check(
+        not rep.blind and not rep.breaking,
+        f"names the router can place stay silent; blind={rep.blind} breaking={rep.breaking}",
+    )
+
+    rep = d.Report()
+    d.check_omp_extension_reads(shared, ext, sm, {"pxdNewlyRead"}, rep)
+    check(
+        any("pxdNewlyRead" in b for b in rep.blind),
+        f"a read with no declaration site must go BLIND, not green; blind={rep.blind}",
+    )
+    check(
+        not rep.breaking,
+        f"an unplaceable name is probe health, never a rename; got {rep.breaking}",
+    )
+
+    # A carrier that will not parse must suppress its fields, not rename them.
+    rep = d.Report()
+    d.check_omp_extension_reads(shared, "", sm, {"toolCallId"}, rep)
+    check(
+        any("carrier" in b for b in rep.blind) and not rep.breaking,
+        f"an unreadable carrier is blind and suppresses its fields; "
+        f"blind={rep.blind} breaking={rep.breaking}",
+    )
+
+
+def test_a_redirected_omp_agent_dir_is_breaking() -> None:
+    """The arm no test fired. `omp_agent_dir()`'s no-flatten rule rests on this
+    function returning the resolver's dir verbatim, and the check's own message
+    says NO LOCAL CHECK can see the failure — so nothing would notice this arm
+    going dark either. Replacing its regex with one that always matches left the
+    suite green."""
+    real = d.fetch
+    try:
+
+        def drive(body: str) -> d.Report:
+            def stub(u: str, _b: str = body) -> str:
+                if u == d.OMP_DIRS_URL:
+                    return _b
+                raise urllib.error.URLError("offline: not this case's document")
+
+            d.fetch = stub
+            rep = d.Report()
+            d.run_checks(d.read_our_names(rep), report=rep)
+            return rep
+
+        verbatim = drive("export function getAgentDir(): string {\n\treturn dirs.agentDir;\n}\n")
+        check(
+            not any("getAgentDir" in x for x in verbatim.breaking),
+            f"the verbatim resolver is silent; got {verbatim.breaking}",
+        )
+
+        redirected = drive(
+            "export function getAgentDir(): string {\n"
+            "\treturn process.env.XDG_DATA_HOME ?? dirs.agentDir;\n}\n"
+        )
+        check(
+            any("getAgentDir" in x for x in redirected.breaking),
+            f"a redirect must be BREAKING, not silence; breaking={redirected.breaking} "
+            f"blind={redirected.blind}",
+        )
+    finally:
+        d.fetch = real
+
+
+def test_two_declarations_are_probe_health_not_a_first_match() -> None:
+    """`sole_match`'s rule as a gate, not a docstring. Relaxing `len(found) == 1`
+    to `bool(found)` reads the FIRST declaration — so the day upstream grows a
+    `#[cfg(test)]` twin or a `macro_rules!` body above the real one, the watcher
+    compares our value against the decoy's and files BREAKING drift against a
+    perfectly healthy upstream."""
+    check(d.sole_match(r"P\s*=\s*(\d+)", "P = 7777\n") is not None, "one match -> the match")
+    check(d.sole_match(r"P\s*=\s*(\d+)", "nothing here\n") is None, "no match -> None")
+    check(d.sole_match(r"P\s*=\s*(\d+)", "P = 1\nP = 7777\n") is None,
+          "two matches -> None, never the first")
+
+    real = d.fetch
+    try:
+        rep0 = d.Report()
+        ports = sorted(d.read_our_names(rep0).openclaw_gateway_port or ())
+        check(bool(ports), "the fragment supplies the gateway port")
+
+        def drive(doc: str) -> d.Report:
+            def stub(u: str, _d: str = doc) -> str:
+                if u == d.OPENCLAW_PATHS_URL:
+                    return _d
+                raise urllib.error.URLError("offline: not this case's document")
+
+            d.fetch = stub
+            rep = d.Report()
+            d.run_checks(d.read_our_names(rep), report=rep)
+            return rep
+
+        sole = drive(f"export const DEFAULT_GATEWAY_PORT = {ports[0]};\n")
+        check(not sole.breaking, f"one declaration matching ours is silent; got {sole.breaking}")
+
+        twin = drive(
+            "const DEFAULT_GATEWAY_PORT = 1234; // a fixture twin, ABOVE the real one\n"
+            f"export const DEFAULT_GATEWAY_PORT = {ports[0]};\n"
+        )
+        check(
+            not twin.breaking and any("DEFAULT_GATEWAY_PORT" in b for b in twin.blind),
+            f"ambiguity must abstain, never report the decoy's port as drift; "
+            f"breaking={twin.breaking} blind={twin.blind}",
+        )
+    finally:
+        d.fetch = real
+
+
+def test_the_anchor_requirement_cannot_be_waived_quietly() -> None:
+    """Two one-line edits reopen the gate with every existing test still green.
+
+    Dropping `also=` makes the half-anchor check below SKIP rather than fail, so a
+    split owning declaration silently goes back to being half-proven. Adding a URL
+    to `UNANCHORED_BY_DESIGN` exempts it from needing an anchor at all, and the
+    census that reads that set treats membership as the answer."""
+    # The three schemas are parsed STRUCTURALLY, so a failed parse already says
+    # what a text anchor would; nothing else may join them without saying why.
+    check(
+        d.UNANCHORED_BY_DESIGN
+        == frozenset({d.ACP_V1_SCHEMA_URL, d.ACP_V1_SCHEMA_UNSTABLE_URL, d.COPILOT_SCHEMA_URL}),
+        f"the anchor requirement is waived only for the JSON Schemas, got "
+        f"{sorted(d.UNANCHORED_BY_DESIGN)}",
+    )
+    # Pinned BY URL: with `also` gone the loop in the anchor test just skips, which
+    # is indistinguishable from an anchor that never needed a second half.
+    for url in (d.DSH_SESSION_INDEX_URL,):
+        check(
+            d.ANCHORS[url].also is not None,
+            f"{url}: `interface Context` sits between this module header and the "
+            f"`Events` that owns the keys, so one pattern cannot span it — `also` "
+            f"is what makes the anchor whole",
+        )
+
+
 def test_an_unreadable_grok_enum_files_probe_health_rather_than_nothing() -> None:
     """A reader that returns None must SAY so. The anchor still matches when the
     enum moves behind a declarative macro — xAI already did this to

--- a/scripts/check_upstream_drift_selftest.py
+++ b/scripts/check_upstream_drift_selftest.py
@@ -197,6 +197,49 @@ def test_anchor_gate_fires_in_both_directions() -> None:
         d.fetch = real
 
 
+def test_a_multi_document_check_is_all_or_nothing() -> None:
+    """Where a name is declared in exactly one half, the UNION is the document: a
+    partial join would read a still-present name as VANISHED and file breaking
+    drift against a fetch failure. The count-against-a-literal spelling this
+    replaced also went False on a fully successful run once a third URL joined the
+    tuple, taking the whole check dark at exit 0."""
+    real = d.fetch
+    try:
+        urls = [(f"https://x.invalid/{i}", f"doc {i}") for i in range(3)]
+        bodies = {u: f"pub enum HookEvent {{ Pxv{i} }}\n" for i, (u, _) in enumerate(urls)}
+        anchor = d.Anchor(r"pub enum HookEvent\b", "`HookEvent`")
+        saved = {u: d.ANCHORS.get(u) for u, _ in urls}
+        try:
+            for u, _ in urls:
+                d.ANCHORS[u] = anchor
+
+            d.fetch = lambda u, _b=bodies: _b[u]
+            r = d.Report()
+            joined = d.fetch_all_anchored(urls, r)
+            check(joined is not None and all(b.strip() in joined for b in bodies.values()),
+                  f"every document present -> all of them joined, got {joined!r}")
+            check(not r.blind and not r.errors, f"a clean run files nothing, got {r.blind}")
+
+            # Exactly one short, and the whole check must abstain — never join the rest.
+            for drop, _ in urls:
+                d.fetch = lambda u, _d=drop, _b=bodies: (
+                    _UNANCHORED if u == _d else _b[u]
+                )
+                r = d.Report()
+                check(d.fetch_all_anchored(urls, r) is None,
+                      f"{drop} unanchored -> the whole check abstains")
+                check(len(r.blind) == 1 and not r.errors,
+                      f"{drop} unanchored -> one blind line, got {r.blind}")
+        finally:
+            for u, prev in saved.items():
+                if prev is None:
+                    d.ANCHORS.pop(u, None)
+                else:
+                    d.ANCHORS[u] = prev
+    finally:
+        d.fetch = real
+
+
 def test_report_is_the_only_way_to_file_a_finding() -> None:
     """`Report` owns the buckets, their wording, their order, and the exit code."""
     empty = d.Report()

--- a/scripts/check_upstream_drift_selftest.py
+++ b/scripts/check_upstream_drift_selftest.py
@@ -200,6 +200,55 @@ def test_anchor_gate_fires_in_both_directions() -> None:
         d.fetch = real
 
 
+def test_one_document_is_fetched_once_per_run() -> None:
+    """Three checks read codex's `protocol.rs`, two read hermes' `plugins.py`, and
+    a document is upstream's answer for the whole run. Without a per-run cache a
+    dead pin spent one request per reader and filed the SAME blind line once per
+    reader under a different label each time — which the workflow renders as
+    repeated bullets in the issue it opens."""
+    real = d.fetch
+    try:
+        calls: list[str] = []
+
+        def dead(u: str) -> str:
+            calls.append(u)
+            raise urllib.error.HTTPError(u, 404, "gone", {}, None)  # type: ignore[arg-type]
+
+        d.fetch = dead
+        rep = d.Report()
+        d.run_checks(d.read_our_names(rep), report=rep)
+        # A floor: a run that swept nothing would satisfy every check below.
+        check(len(calls) > 20, f"the run actually swept, got {len(calls)} fetches")
+        check(
+            not (dupes := sorted({u for u in calls if calls.count(u) > 1})),
+            f"each document is fetched once per run; repeated: {dupes}",
+        )
+        check(
+            not (twice := sorted({b for b in rep.blind if rep.blind.count(b) > 1})),
+            f"a dead pin files ONE blind line, not one per reader; repeated: {twice}",
+        )
+
+        # A SUCCESSFUL document is reused as well, not only a failed one.
+        served: list[str] = []
+
+        def live(u: str, _s: str = ANCHOR_SAMPLES[d.CODEX_PROTOCOL_URL]) -> str:
+            served.append(u)
+            if u == d.CODEX_PROTOCOL_URL:
+                return _s
+            raise urllib.error.URLError("offline: not this case's document")
+
+        d.fetch = live
+        rep = d.Report()
+        d.run_checks(d.read_our_names(rep), report=rep)
+        check(
+            served.count(d.CODEX_PROTOCOL_URL) == 1,
+            f"a document that ANSWERED is cached too, got "
+            f"{served.count(d.CODEX_PROTOCOL_URL)} fetches of protocol.rs",
+        )
+    finally:
+        d.fetch = real
+
+
 def test_the_omp_extension_router_flags_a_name_it_cannot_place() -> None:
     """The router's own documented promise: "A name this router does not know
     means the template grew a read without a check — flagged blind, never silently

--- a/scripts/check_upstream_drift_selftest.py
+++ b/scripts/check_upstream_drift_selftest.py
@@ -179,9 +179,8 @@ def test_anchor_gate_fires_in_both_directions() -> None:
                 f"{anchor.owns}: anchor present -> body returned, got blind={r.blind}",
             )
 
-            # Half an `also` anchor is NOT an anchor. Without this, `also` could
-            # regress to decorative — the sample above satisfies both halves, so
-            # only deleting one proves the second is load-bearing.
+            # The sample above satisfies both halves, so only deleting one
+            # proves the second is load-bearing rather than decorative.
             if anchor.also is None:
                 continue
             for drop, half in (("pattern", anchor.pattern), ("also", anchor.also)):
@@ -201,11 +200,8 @@ def test_anchor_gate_fires_in_both_directions() -> None:
 
 
 def test_one_document_is_fetched_once_per_run() -> None:
-    """Three checks read codex's `protocol.rs`, two read hermes' `plugins.py`, and
-    a document is upstream's answer for the whole run. Without a per-run cache a
-    dead pin spent one request per reader and filed the SAME blind line once per
-    reader under a different label each time — which the workflow renders as
-    repeated bullets in the issue it opens."""
+    """A document is upstream's answer for the whole run, and several checks read
+    the same one — three read codex's `protocol.rs`."""
     real = d.fetch
     try:
         calls: list[str] = []
@@ -250,12 +246,9 @@ def test_one_document_is_fetched_once_per_run() -> None:
 
 
 def test_the_omp_extension_router_flags_a_name_it_cannot_place() -> None:
-    """The router's own documented promise: "A name this router does not know
-    means the template grew a read without a check — flagged blind, never silently
-    green." Replacing that whole `else` arm with a bare `continue` left the suite
-    green, so the promise was prose. Its two missing-carrier arms were unreachable
-    too, which is the case where an unverifiable carrier must NOT be re-reported as
-    a rename of every field it holds."""
+    """The router's documented promise, as a gate: a name it cannot place goes
+    blind, and an unverifiable carrier suppresses its fields rather than renaming
+    every one of them."""
     shared = "export interface SessionSwitchEvent {\n\tpreviousSessionFile: string;\n}\n"
     ext = (
         "export interface ToolApprovalRequestedEvent {\n\ttoolCallId: string;\n}\n"
@@ -293,11 +286,9 @@ def test_the_omp_extension_router_flags_a_name_it_cannot_place() -> None:
 
 
 def test_a_redirected_omp_agent_dir_is_breaking() -> None:
-    """The arm no test fired. `omp_agent_dir()`'s no-flatten rule rests on this
-    function returning the resolver's dir verbatim, and the check's own message
-    says NO LOCAL CHECK can see the failure — so nothing would notice this arm
-    going dark either. Replacing its regex with one that always matches left the
-    suite green."""
+    """`omp_agent_dir()`'s no-flatten rule rests on this returning the resolver's
+    dir verbatim, and the check's own message says no local check can see the
+    failure it guards."""
     real = d.fetch
     try:
 
@@ -332,11 +323,9 @@ def test_a_redirected_omp_agent_dir_is_breaking() -> None:
 
 
 def test_two_declarations_are_probe_health_not_a_first_match() -> None:
-    """`sole_match`'s rule as a gate, not a docstring. Relaxing `len(found) == 1`
-    to `bool(found)` reads the FIRST declaration — so the day upstream grows a
-    `#[cfg(test)]` twin or a `macro_rules!` body above the real one, the watcher
-    compares our value against the decoy's and files BREAKING drift against a
-    perfectly healthy upstream."""
+    """A first-match read picks the decoy the day upstream grows a `#[cfg(test)]`
+    twin above the real declaration, and then files breaking drift against a
+    healthy upstream."""
     check(d.sole_match(r"P\s*=\s*(\d+)", "P = 7777\n") is not None, "one match -> the match")
     check(d.sole_match(r"P\s*=\s*(\d+)", "nothing here\n") is None, "no match -> None")
     check(d.sole_match(r"P\s*=\s*(\d+)", "P = 1\nP = 7777\n") is None,
@@ -376,12 +365,9 @@ def test_two_declarations_are_probe_health_not_a_first_match() -> None:
 
 
 def test_the_anchor_requirement_cannot_be_waived_quietly() -> None:
-    """Two one-line edits reopen the gate with every existing test still green.
-
-    Dropping `also=` makes the half-anchor check below SKIP rather than fail, so a
-    split owning declaration silently goes back to being half-proven. Adding a URL
-    to `UNANCHORED_BY_DESIGN` exempts it from needing an anchor at all, and the
-    census that reads that set treats membership as the answer."""
+    """Two one-line edits reopen the gate with every other test still green:
+    dropping `also=` makes the half-anchor check SKIP rather than fail, and
+    `UNANCHORED_BY_DESIGN` membership IS the exemption."""
     # The three schemas are parsed STRUCTURALLY, so a failed parse already says
     # what a text anchor would; nothing else may join them without saying why.
     check(
@@ -402,12 +388,9 @@ def test_the_anchor_requirement_cannot_be_waived_quietly() -> None:
 
 
 def test_an_unreadable_grok_enum_files_probe_health_rather_than_nothing() -> None:
-    """A reader that returns None must SAY so. The anchor still matches when the
-    enum moves behind a declarative macro — xAI already did this to
-    `HookEventName`, which is why `upstream_grok_hooks` carries a `hook_events!`
-    arm — so the document passes identity while the parser reads the macro
-    DEFINITION's body. Both directions riding this reader then skip, and without a
-    blind line the run is green with the checks dead."""
+    """The anchor still matches when the enum moves behind a macro — xAI already
+    did this to `HookEventName` — so the document passes identity while the parser
+    reads the macro DEFINITION's body, and both directions riding it skip."""
     real = d.fetch
     try:
         rep0 = d.Report()
@@ -443,13 +426,11 @@ def test_an_unreadable_grok_enum_files_probe_health_rather_than_nothing() -> Non
 
 
 def test_no_anchor_is_a_name_the_watcher_checks() -> None:
-    """`Anchor`'s docstring bans this in prose; prose has no failure mode.
+    """`Anchor`'s docstring bans this in prose, and prose has no failure mode.
 
-    An anchor that IS one of the guarded names vanishes WITH them on the very
-    rename it exists to tell apart from a stale pin — and the blind line then
-    argues the maintainer OUT of the fix ("do NOT change a decoder on this
-    alone"). dsh's `'agent/pre-step'` was this shape, and so were omp's
-    `toolCall` and `getSessionFile`."""
+    Such an anchor vanishes WITH the names on the very rename it exists to tell
+    apart from a stale pin, and the blind line then argues the maintainer out of
+    the fix."""
     rep = d.Report()
     ours = d.read_our_names(rep)
     names = {
@@ -472,11 +453,9 @@ def test_no_anchor_is_a_name_the_watcher_checks() -> None:
 
 
 def test_a_multi_document_check_is_all_or_nothing() -> None:
-    """Where a name is declared in exactly one half, the UNION is the document: a
-    partial join would read a still-present name as VANISHED and file breaking
-    drift against a fetch failure. The count-against-a-literal spelling this
-    replaced also went False on a fully successful run once a third URL joined the
-    tuple, taking the whole check dark at exit 0."""
+    """Where a name is declared in exactly one half, a partial join reads a
+    still-present name as VANISHED and files breaking drift against what was only
+    a fetch failure."""
     real = d.fetch
     try:
         urls = [(f"https://x.invalid/{i}", f"doc {i}") for i in range(3)]
@@ -909,13 +888,9 @@ def test_an_undecoded_sibling_is_reported_and_a_stranger_is_not() -> None:
 
 
 def test_a_ledger_row_upstream_deleted_is_reported_once_every_doc_was_fetched() -> None:
-    """The direction both sibling sweeps are blind to. They compute
-    `upstream - mine - ledger`, so a row whose variant upstream DELETED simply
-    drops out of the subtrahend — it then explains a decision about a name that
-    no longer exists, and would silently exempt the name if upstream reused it.
-    `CODEX_KNOWN_OMITTED` exempts EITHER enum, so staleness is only knowable once
-    BOTH were fetched: a run that saw one must stay quiet, or a 404 reads as a
-    deletion."""
+    """The direction both sibling sweeps are blind to: `upstream - mine - ledger`
+    drops a deleted variant out of the subtrahend. `CODEX_KNOWN_OMITTED` exempts
+    EITHER enum, so staleness is knowable only once both were fetched."""
     real = d.fetch
     saved_codex = dict(d.CODEX_KNOWN_OMITTED)
     saved_grok = dict(d.GROK_XAI_KNOWN_OMITTED)


### PR DESCRIPTION
## Summary

The #981 post-mortem left one lesson unfinished: the watcher's *anchors* — the declarations that prove a fetched document is the right one — were themselves drift-prone. Auditing all 31 found the same defect in three more places, two of them worse than the original. No decoder changes; the watcher exits 0 against live upstream throughout.

## Related issue

Follow-up to #987 (#981's fix), which surfaced these.

## Type of change

- [x] Bug fix (the watcher reporting green while a check is dead, or red when upstream is healthy)

## What was wrong

**An anchor that IS one of the guarded names is circular** — `Anchor`'s own docstring bans it in those words, but four rows did it:

| document | was | now |
|---|---|---|
| dsh `runtime-types.ts` | `'agent/pre-step'` | `declare module '@deepseek-ai/cordis' { interface Events {` |
| dsh `session/index.ts` | `'session/created'` | the same, via `also` (`interface Context` sits between) |
| dsh `approval/types.ts` | `ApprovalRequestId` | `declare module '@deepseek-ai/dsh-session/types' { interface SessionEventMap {` |
| omp `ai/types.ts` | **`toolCall`** — a name it guards | `export type Message` |
| omp `session-manager.ts` | **`getSessionFile`** — a name it guards | `export class SessionManager` |

On the coordinated rename these exist to detect, the anchor vanishes *with* the name and the watcher emits "this is NOT evidence that upstream changed … do NOT change a decoder on this alone" — it argues the maintainer out of the fix. `getSessionFile` takes every other extension-read down with it. Live upstream saves both only by accident (`types.ts` still has `toolCallId`; `session-manager.ts` keeps a `{@link getSessionFile}` reference).

Mapping all nine dsh plugin events back to their declaring files showed every dsh row could become genuinely owner-grade, so the proposed reorder under `# identity-grade:` is moot.

**A carrier that would not parse reported every field it owns as renamed.** `declares()` suppresses a field check when its carrier body is `None` — "do not double-report every field as a rename" — but `approval_bodies` is `"\n".join(...)`, which yields `""` and never `None`. So a parse failure filed its blind line *and* reported `toolCallId`, `toolName`, `reason`, `approved` as gone. That is #793 inverted: not a check going quiet, but probe failure manufacturing breaking drift.

**grok's `SessionUpdate` reader could fail in total silence** — `if upstream is not None:` with no `else`, the only such site. xAI already moved `HookEventName` behind a macro (`upstream_grok_hooks` carries a `hook_events!` arm); the same move here leaves the anchor matching while the parser reads the macro *definition's* body. Driven: plain enum → 3 review lines; macro-generated → **0 review, 0 blind**, with the sibling sweep and the ledger check both dead behind a green run.

**`len(docs) == 2` beside an inline 2-tuple**, at two of four multi-document sites (a third spelled it `all(...)`, a fourth correctly used `len(OPENCODE_EVENT_URLS)`). Add a third URL and the guard is False on a *fully successful* run — the check goes dark at exit 0. `fetch_all_anchored` removes the literal rather than correcting it.

**A dead ledger row is inert forever.** Both sibling sweeps compute `upstream - mine - ledger`, so a `*_KNOWN_OMITTED` entry whose variant upstream deleted drops out of the subtrahend and is never mentioned again — and would silently exempt the name if upstream reused it. `report_stale_ledger` closes that direction, firing only once every feeding document was fetched (else a 404 reads as a deletion).

## What got faster

One document is now fetched once per run. Measured against an all-404 upstream: **40 → 33 requests**, **40 → 33 blind lines**, zero duplicates of either. Three checks read codex's `protocol.rs`, so a dead pin used to file the same line three times under three labels, which the workflow renders as repeated bullets.

The review suggested splitting `run_checks` (620 lines; three sources each checked in two non-adjacent blocks) so duplicate pairs become impossible to write. That treats the layout rather than the cause — caching makes a repeated read cost nothing however the blocks are arranged. **The split is left SURFACED.**

## How I tested it

Every fix is mutation-verified — the test fails with the fix reverted:

| property | mutation that must go red |
|---|---|
| `also` is load-bearing | delete either half of a two-pattern anchor |
| no anchor is a guarded name | restore `getSessionFile` as an anchor |
| grok reader speaks up | restore the silent `if upstream is not None:` |
| multi-doc is all-or-nothing | join the survivors instead |
| stale-ledger guard | delete it; drop the both-fetched condition; degrade the union to last-wins |
| carrier suppression | restore the `"".join` |
| `sole_match` ambiguity | `len(found) == 1` → `bool(found)` |
| `getAgentDir` verbatim | a regex that always matches |
| router's unknown-name arm | `else` → bare `continue` |
| one fetch per run | remove the cache lookup |

Also closed two routes that reopened the anchor gate with every other test green: deleting an `also=`, and adding a URL to `UNANCHORED_BY_DESIGN`.

**The vanish battery was structurally blind.** Each case drops a name and asserts it is reported gone, but the decoys added alongside derived from a *kept* name — so the dropped name's spelling never appeared anywhere, and eight matchers written specifically to resist a bare substring hit (three carrying a comment naming the masking failure they prevent) were never exercised in that direction. Deriving the decoy from the victim flips all of them; degrading each matcher in turn now goes red.

- `just drift-selftest`: green. `just lint`: green.
- `python3 scripts/check_upstream_drift.py` against live upstream: **no drift**, exit 0, throughout.
- Every upstream `path:line` cited above was fetched this session.

## Surfaced — owner's call

- **Split `run_checks`** (620 lines, three sources in six blocks). Real, but a large mechanical refactor of the file's hottest function; the duplicate-fetch cost it was aimed at is now zero.
- Two anchors are still the *carrier* of a name rather than its owner — `SessionShutdownEvent` declares `type: "session_shutdown"`, `ToolApprovalRequestedEvent` declares `type: "tool_approval_requested"`. A commit renaming event and interface together takes both down. Not circular, so a notch below the two fixed here.
- `PARSE_SOURCES`' `OurNames` half is proven for exactly one key (the census takes `sorted(callers)[0]`); a key that is not an `OurNames` field raises inside the gate and is filed transient.
- CC marker tables are pinned by exactly one row each.

## Visual verification

- [x] Not a visual change.

## Checklist

- [x] I read the relevant `CLAUDE.md`.
- [x] New behavior has a test — every item above, mutation-verified.
- [x] No `unwrap()` in non-test code. No new `println!`/`eprintln!`.
- [x] Docs updated in the same commit — the declarations' own comments are the doc.
- [x] External-surface claims fetched this session, not recalled.
- [ ] `just preflight` — runs on push via pre-push.

## AI assistance

- [x] This PR was written/heavily-assisted by an AI agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B875vtxMVrdmypiEZgDNSX
