### PR TITLE
chore(publish): keep the recorded fixture corpus out of the crates.io tarball

### DIFF
--- a/crates/pixtuoid-core/Cargo.toml
+++ b/crates/pixtuoid-core/Cargo.toml
@@ -16,11 +16,12 @@ categories.workspace   = true
 # but not `cargo test` on an extracted crate. They stay FLAT so they can be
 # excluded at all: a grouped binary's submodule cannot be excluded on its own.
 exclude                = [
-    # The recorded fixture corpus is a test-only input to the grouped `sources`
-    # binary (`tests/sources/main.rs`), which its `/`-in-path already keeps out of
-    # the tarball; the DATA it reads was still shipping. It carries captured wire
-    # bytes, so an immutable crates.io copy is the wrong home for it — the corpus
-    # lives in the public repo, not the published crate.
+    # The recorded fixture corpus is captured wire bytes — an operator's plugin
+    # roster, instructions, home paths — and a crates.io tarball is immutable
+    # where the repo copy can still be redacted. The grouped `sources` binary
+    # that reads it goes with it. `tests/watcher/sources.rs` still ships and
+    # reads one scenario, so the extracted crate's `cargo test` fails there —
+    # as it already does at `tests/render/format.rs`'s outside-crate reads.
     "tests/sources",
     "tests/pinned_by_claims.rs",
     "tests/socket_path_parity.rs",

--- a/crates/pixtuoid-core/Cargo.toml
+++ b/crates/pixtuoid-core/Cargo.toml
@@ -16,6 +16,12 @@ categories.workspace   = true
 # but not `cargo test` on an extracted crate. They stay FLAT so they can be
 # excluded at all: a grouped binary's submodule cannot be excluded on its own.
 exclude                = [
+    # The recorded fixture corpus is a test-only input to the grouped `sources`
+    # binary (`tests/sources/main.rs`), which its `/`-in-path already keeps out of
+    # the tarball; the DATA it reads was still shipping. It carries captured wire
+    # bytes, so an immutable crates.io copy is the wrong home for it — the corpus
+    # lives in the public repo, not the published crate.
+    "tests/sources",
     "tests/pinned_by_claims.rs",
     "tests/socket_path_parity.rs",
     "tests/supported_sources_manifest.rs",

--- a/crates/pixtuoid-core/Cargo.toml
+++ b/crates/pixtuoid-core/Cargo.toml
@@ -16,12 +16,11 @@ categories.workspace   = true
 # but not `cargo test` on an extracted crate. They stay FLAT so they can be
 # excluded at all: a grouped binary's submodule cannot be excluded on its own.
 exclude                = [
-    # The recorded fixture corpus is captured wire bytes — an operator's plugin
-    # roster, instructions, home paths — and a crates.io tarball is immutable
-    # where the repo copy can still be redacted. The grouped `sources` binary
-    # that reads it goes with it. `tests/watcher/sources.rs` still ships and
-    # reads one scenario, so the extracted crate's `cargo test` fails there —
-    # as it already does at `tests/render/format.rs`'s outside-crate reads.
+    # Recorded wire bytes — an operator's roster, instructions, session content —
+    # that a crates.io tarball would freeze where the repo copy can still be
+    # redacted; the grouped `sources` binary shares the dir and goes with them.
+    # A tarball-contents choice, not a green-test one: the extracted crate's
+    # `cargo test` is red regardless (`tests/watcher/sources.rs`, `tests/render/format.rs`).
     "tests/sources",
     "tests/pinned_by_claims.rs",
     "tests/socket_path_parity.rs",

--- a/crates/pixtuoid-core/tests/CLAUDE.md
+++ b/crates/pixtuoid-core/tests/CLAUDE.md
@@ -45,7 +45,7 @@ tests/
 ├── render/main.rs       blit + format (+ sprite fixtures)
 └── socket_path_parity.rs · supported_sources_manifest.rs ·
     proof_fixture_disjointness.rs · pinned_by_claims.rs
-                         FLAT + publish-excluded (see Cargo.toml's `exclude`)
+                         FLAT + publish-excluded (see Cargo.toml's `exclude`; `sources/` is excluded whole)
 ```
 
 Data scopes to the binary that reads it — a module-owned fixture lives with


### PR DESCRIPTION
## Summary

The recorded fixture corpus — 176 files of captured CLI wire bytes — shipped inside the published crates.io tarball. This removes it with one `exclude` entry.

## Why it matters

Those fixtures carry an operator's fingerprint: installed plugin/skill/agent rosters, global-instruction attachments, home paths, git identity. Three re-records (#988/#989/#993) leaked one of these classes each, caught and redacted after the fact. **A crates.io tarball is immutable** — the repo copy can be redacted in a later commit, the published `.crate` cannot. Keeping the corpus out of the tarball removes the one irreversible distribution channel.

## What changed

One line: `"tests/sources"` added to `pixtuoid-core`'s `exclude`. It removes the fixture **data** and the grouped `sources` test binary (`tests/sources/main.rs`) that reads it — cargo autodiscovers that binary, and both shipped on base.

## How I verified it

- `cargo package --list`: `tests/sources/` entries in the tarball go **176 → 0**. Nothing else drops: `src/`, benches, examples, and the other packaged test binaries (`reducer`, `render`, `transport`, `watcher`, `e2e.rs`) all still ship.
- `cargo package` with the verify build: **exit 0** — the extracted crate compiles. This is the check the `exclude` block's own comment exists for.
- No `include_str!`/`include_bytes!` points under `tests/sources/`, so no compile-time break.
- `just lint` green, `just test` 3259 passed; every workspace/CI test reads the git checkout, which is untouched. Homebrew's formula asserts the binary's CLI output; the site build reads none of this.

**One packaged reader survives**, surfaced by review and now recorded on the exclude: `tests/watcher/sources.rs:729` reads the codex `permission-flow` fixture, so `cargo test` on the *extracted* crate fails there. Latent — no gate runs the extracted crate's tests, and that suite is already red from `tests/render/format.rs`'s reads outside the crate. Excluding a real test binary to chase it would be the wrong fix; left as an owner call.

## Scope

This is the **irreversibility** half of the de-identification work. The **in-repo** exposure (the corpus is still readable in the public repo) is handled separately by deriving a capture-time allowlist from the decoders — a follow-up PR, deliberately not bundled here because it touches the recorder, not the publish config.

## Type of change

- [x] Chore (publish configuration)

## Checklist

- [x] I read the relevant `CLAUDE.md`.
- [x] `cargo package` verify-build passes.
- [x] No behavior change to the library or tests; `just test` 3259 pass.
- [ ] `just preflight` — runs on push via pre-push.

## AI assistance

- [x] This PR was written/heavily-assisted by an AI agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B875vtxMVrdmypiEZgDNSX
