### PR TITLE
feat(capture): blank every subtree no decoder reads — allowlist derived by probe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ cargo run --release --example snapshot -- /tmp/snap.png   # render TUI to PNG
 - Renamed a decoded/registered wire name → `just gen-drift-surface`, commit both `crates/*/drift-surface.json` — the crate's own test fails on a stale fragment; regenerate, don't hand-edit.
 - Look-changing PR → `just gen`, commit `docs/images/` + `site/public/demos/`; a scene/web change ALSO needs `just gen-wasm` + commit `site/public/wasm/` (`gen` deliberately excludes it, and nothing catches a skip).
 - Real wire bytes ride ONE pipeline: `pixtuoid_core::harness::Drive` (dev-only `harness` feature). A driver keyed off anything but the source's registry row registers NOTHING.
-- Fixtures are RECORDED, never composed (`just capture-fixture` — BILLED); every scenario declares `provenance.json`. Rules: [`fixtures/README.md`](crates/pixtuoid-core/tests/sources/fixtures/README.md). `just corpus-all` censuses local corpora; `just fixture-age` is advisory/local.
+- Fixtures are RECORDED, never composed (`just capture-fixture` — BILLED), and the recorder blanks every subtree no decoder reads (derived by probe, never listed); every scenario declares `provenance.json`. Rules: [`fixtures/README.md`](crates/pixtuoid-core/tests/sources/fixtures/README.md). `just corpus-all` censuses local corpora; `just fixture-age` is advisory/local.
 - Visual verification for sprite work: snapshot example → `scripts/crop-snapshot.py` → READ the PNG; loop in `.claude/skills/beautify-decoration/SKILL.md`.
 - CI-only gates preflight can't see (a green preflight is NOT a green PR): [`CONTRIBUTING.md#ci-gates`](docs/CONTRIBUTING.md#ci-gates) lists them and what each catches.
 - On-demand advisory (never gates): `just mutants`, `just coverage`, `just bench`, CodSpeed.

--- a/crates/pixtuoid-core/examples/capture_fixture.rs
+++ b/crates/pixtuoid-core/examples/capture_fixture.rs
@@ -641,7 +641,7 @@ mod recorder {
     }
 
     /// A hook envelope's top-level `_` keys are the shim's stamps, kept by namespace:
-    /// no decoder reads them, but `captures.rs` dates a capture by `_shim_ts_ms`.
+    /// `_shim_ts_ms` is read by no decoder, only by `captures.rs`, which dates a capture by it.
     fn probe(
         drive: &pixtuoid_core::harness::Drive,
         lines: &mut [serde_json::Value],

--- a/crates/pixtuoid-core/examples/capture_fixture.rs
+++ b/crates/pixtuoid-core/examples/capture_fixture.rs
@@ -267,9 +267,8 @@ mod recorder {
     fn prepare_workspace() -> std::io::Result<PathBuf> {
         let ws = PathBuf::from(WORKSPACE);
         let base = ws.parent().expect("WORKSPACE has a parent");
-        // A fixed name in shared temp is pre-plantable, so a foreign owner is
-        // REFUSED rather than removed: under /tmp's sticky bit the remove would fail
-        // and the capture would land inside their directory.
+        // A fixed name in shared temp is pre-plantable; a foreign owner is refused, not
+        // removed — under the sticky bit the remove fails and the capture lands in theirs.
         if base.exists() && !owned_by_us(base) {
             eprintln!(
                 "{} exists and is not yours — remove it or run as its owner",
@@ -341,9 +340,8 @@ mod recorder {
         c.args(&cmd[1..])
             .current_dir(ws)
             .env("PIXTUOID_SOCKET", sock);
-        // The driver and the per-CLI cycle scripts write their transcripts beside the
-        // socket, in this run's private sandbox — a fixed shared-temp name is
-        // symlink-followable and two concurrent captures would interleave into it.
+        // Transcripts go beside the socket in this run's private sandbox: a fixed
+        // shared-temp name is symlink-followable and two concurrent captures interleave.
         if let Some(dir) = sock.parent() {
             c.env("TUIDRIVE_LOG", dir.join("tuidrive.log"));
         }
@@ -392,9 +390,8 @@ mod recorder {
             "command": raw.join(" "),
             "deidentified": { "method": "decoder-allowlist", "blanked": blanked },
         });
-        // `command` is the UN-expanded argv, so a scenario driven by an override
-        // records a `{prompt}` placeholder and nothing else says what ran. Only
-        // written when set, so the already-committed records stay schema-clean.
+        // `command` is the UN-expanded argv, so an override-driven scenario records a
+        // `{prompt}` placeholder; written only when set, so committed records stay schema-clean.
         if let Some(map) = prov.as_object_mut() {
             for (key, value) in overrides {
                 if let Some(v) = value {
@@ -404,10 +401,8 @@ mod recorder {
         }
         let out = no_clobber(dest.join("provenance.json"));
         std::fs::write(&out, format!("{}\n", serde_json::to_string_pretty(&prov)?))?;
-        // Keyed on the PROBE's outcome, not on the name looking like a script: a
-        // pty driver is `python3`, passes the name test, and its "unknown" then
-        // disarms `a_recorded_capture_anchors_its_sources_verified_version` for
-        // that whole source. Loud, because the record it just wrote is unusable.
+        // Keyed on the probe's outcome, not the name: a pty driver is `python3` and
+        // passes a name test. Loud, because the record just written is unusable.
         if version.trim() == "unknown" {
             eprintln!(
                 "WARNING: {} records version \"unknown\" — `{cli} --version` did not \
@@ -464,19 +459,14 @@ mod recorder {
         (y % 4 == 0 && y % 100 != 0) || y % 400 == 0
     }
 
-    /// PII is not always a key you can drop — kimi's arrived as the owner column
-    /// inside a captured `ls -la`, and a CLI's ACCOUNT identity is a different
-    /// namespace from the host's (`user_email` slipped past a `$HOME|$USER` grep).
-    /// Identity/inventory keys whose VALUES are the capturer's, not the wire's.
-    /// `user_email` alone was the first cut and it saw none of the MCP-server and
-    /// skill roster that shipped in nine fixtures — a different namespace, same
-    /// class. `just fixture-pii` re-scans the committed tree for the same class
-    /// but matches VALUE shapes, not this list — as gitleaks rules these KEYS fire
-    /// on the tree's own `dev@example.com` redactions. A key with no value shape
-    /// (`obsidian`, `account_id`) is refused only at capture time.
-    /// Both cases of each spelling, because a CLI picks one and its next version
-    /// may pick the other: `userEmail` arrived at claude-code 2.1.261 beside the
-    /// `user_email` already here, and slipped past.
+    /// Identity and inventory keys whose VALUES are the capturer's, not the wire's,
+    /// refused on the stripped bytes — so they guard the fields a decoder reads.
+    /// Not a `$HOME|$USER` grep: a CLI's ACCOUNT identity is a different namespace
+    /// from the host's. `just fixture-pii` matches VALUE shapes instead (as gitleaks
+    /// rules these keys would fire on the tree's own `dev@example.com`), so a key
+    /// with no value shape (`obsidian`, `account_id`) is refused only here. Both
+    /// cases of each spelling: a CLI's next version may pick the other, as
+    /// `userEmail` did beside `user_email`.
     const PII_MARKERS: &[&str] = &[
         "user_email",
         "userEmail",
@@ -557,13 +547,12 @@ mod recorder {
         found
     }
 
-    /// Blank every subtree of the recorded bytes that no decoder reads, so an
-    /// operator's roster, instructions, and paths leave without anyone naming
-    /// them. The allowlist is DERIVED — a subtree is blanked when blanking it
-    /// leaves the file's decoded events identical — because a hand-kept list
-    /// drifts from the decoder in the one direction nothing catches: a field the
-    /// decoder stopped reading stays in the bytes. Probed top-down so an unread
-    /// container collapses whole, taking its element count with it.
+    /// Blank every subtree no decoder reads, so an operator's roster, instructions
+    /// and paths leave without anyone naming them. DERIVED, never listed — a subtree
+    /// is blanked when blanking it leaves the decoded events identical — because a
+    /// hand-kept list drifts in the one direction nothing catches: a field the
+    /// decoder stopped reading stays in the bytes. Top-down, so an unread container
+    /// collapses whole, element count included.
     fn strip_unread(source: &str, files: &[PathBuf]) -> std::io::Result<usize> {
         let mut blanked = 0;
         for file in files {
@@ -628,9 +617,9 @@ mod recorder {
         Vec<Option<pixtuoid_core::source::daemon::DecodedPresence>>,
     );
 
-    /// A daemon's envelopes decode to no `AgentEvent` by design — presence rides
-    /// the registry's `presence_decoder` — so it is part of the signature, or a
-    /// daemon capture would strip down to nothing that decodes.
+    /// A daemon's envelopes decode to no `AgentEvent` by design — presence rides the
+    /// registry's `presence_decoder` — so it joins the signature, or a daemon capture
+    /// strips to nothing.
     fn events_of(drive: &pixtuoid_core::harness::Drive, lines: &[serde_json::Value]) -> Decoded {
         let d = drive.lines(lines.iter().map(serde_json::Value::to_string));
         let presence = lines
@@ -651,9 +640,8 @@ mod recorder {
         )
     }
 
-    /// A hook envelope's top-level `_` keys are the shim's own stamps, kept by
-    /// namespace: no decoder reads them, but `captures.rs` dates a capture by
-    /// `_shim_ts_ms`, and the probe cannot see that test.
+    /// A hook envelope's top-level `_` keys are the shim's stamps, kept by namespace:
+    /// no decoder reads them, but `captures.rs` dates a capture by `_shim_ts_ms`.
     fn probe(
         drive: &pixtuoid_core::harness::Drive,
         lines: &mut [serde_json::Value],
@@ -729,19 +717,15 @@ mod recorder {
         Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/sources")
     }
 
-    /// Where this scenario's bytes ALREADY live, else the conformance root.
-    ///
-    /// A module keeps its own rounds out of conformance's reach (omp's hook keys
-    /// fold on Windows), and a re-record sent to the conformance root instead lands
-    /// as a NEW directory that `conformance.rs` auto-scans with no committed bytes
-    /// beside it for `.new` to protect.
-    ///
+    /// Where this scenario's bytes ALREADY live, else the conformance root: a module
+    /// keeps its own rounds out of conformance's reach (omp's hook keys fold on
+    /// Windows), and a re-record sent to the root instead lands as a NEW directory
+    /// `conformance.rs` auto-scans, with no committed bytes for `.new` to protect.
     /// Keyed on the SOURCE, never a search across modules: scenario names repeat
-    /// (`approval-recorded` is both hermes' and omp's), so a search finds one match
-    /// for the wrong module and the ambiguity guard never fires — a billed hermes
-    /// capture would land as `.new` files inside omp's directory. `claude/` owning
-    /// `claude-code` is the one name mismatch, and it holds no scenario
-    /// subdirectory, so it cannot reach here.
+    /// (`approval-recorded` is hermes' and omp's), so a search finds the wrong
+    /// module's single match and a billed capture lands as `.new` files inside it.
+    /// `claude/` owning `claude-code` is the one name mismatch, and it holds no
+    /// scenario subdirectory, so it cannot reach here.
     fn scenario_dest(sources: &Path, source: &str, scenario: &str) -> PathBuf {
         let owned = sources.join(source).join("fixtures").join(scenario);
         if owned.join("provenance.json").is_file() {
@@ -1105,13 +1089,12 @@ mod recorder {
             );
         }
 
+        /// A link PLANTED by another user cannot be created in a unit test, so this
+        /// pins the discriminator instead: a link WE own pointing at a root-owned dir
+        /// reads as ours — `fs::metadata` would stat the target and read as root's,
+        /// which is how a planted link would have slipped past the refusal.
         #[test]
         fn ownership_is_judged_on_the_link_itself_not_on_what_it_points_at() {
-            // The squat this refuses is a link PLANTED by another user, which a
-            // unit test cannot create — so pin the discriminator instead: a link
-            // WE own pointing at a root-owned dir must read as ours. Under
-            // `fs::metadata` it would stat the target and read as root's, which
-            // is how a planted link would have slipped past the refusal.
             let d = tempfile::tempdir().expect("tempdir");
             let link = d.path().join("to-root-owned");
             std::os::unix::fs::symlink("/usr", &link).expect("symlink");
@@ -1123,9 +1106,8 @@ mod recorder {
 
         #[test]
         fn provenance_records_an_override_only_when_it_was_actually_set() {
-            // Both directions: the already-committed records predate these
-            // fields and must stay schema-clean, so an unset override writes
-            // nothing at all.
+            // Both directions: committed records predate these fields and must stay
+            // schema-clean, so an unset override writes nothing at all.
             let read = |d: &Path| -> serde_json::Value {
                 serde_json::from_str(
                     &std::fs::read_to_string(d.join("provenance.json")).expect("read"),

--- a/crates/pixtuoid-core/examples/capture_fixture.rs
+++ b/crates/pixtuoid-core/examples/capture_fixture.rs
@@ -556,6 +556,25 @@ mod recorder {
     /// A REFUSAL, not a warning. The old form printed to stderr and left the exit
     /// code at 0 on a run that had already written into the repo tree, so the
     /// capturer had to notice a line scrolling past — and twice did not.
+    fn strip_unread(_source: &str, _files: &[PathBuf]) -> std::io::Result<usize> {
+        Ok(0)
+    }
+
+    fn scenario_events(source: &str, files: &[PathBuf]) -> Vec<Vec<pixtuoid_core::AgentEvent>> {
+        files
+            .iter()
+            .filter_map(|f| {
+                let drive = if f.file_name()?.to_str()?.starts_with("hook-payloads") {
+                    pixtuoid_core::harness::Drive::hooks()
+                } else {
+                    pixtuoid_core::harness::Drive::transcript(source, &f.to_string_lossy())?
+                };
+                let text = std::fs::read_to_string(f).ok()?;
+                Some(drive.lines(text.lines()).events)
+            })
+            .collect()
+    }
+
     fn refuse_on_pii(files: &[PathBuf]) -> std::io::Result<()> {
         let found = scan_for_pii(files);
         if found.is_empty() {
@@ -635,6 +654,46 @@ mod recorder {
             assert_eq!(
                 scenario_dest(root, "hermes", "approval-recorded"),
                 root.join("fixtures/hermes/approval-recorded")
+            );
+        }
+
+        /// The whole de-identification claim on real bytes: a subtree no decoder
+        /// reads is blanked — the roster and every carrier nobody has named yet —
+        /// and what the decoders DO read decodes to the same events afterwards.
+        #[test]
+        fn stripping_blanks_what_no_decoder_reads_and_changes_no_event() {
+            let d = tempfile::tempdir().expect("tempdir");
+            let src = sources_root().join("fixtures/codex/tool-run-recorded");
+            let files: Vec<PathBuf> = [
+                "rollout-2026-09-10T12-11-07-01a08cbb-1b7f-7ce3-b924-1a501c380856.jsonl",
+                "hook-payloads.jsonl",
+            ]
+            .iter()
+            .map(|name| {
+                let to = d.path().join(name);
+                std::fs::copy(src.join(name), &to).expect("copy");
+                to
+            })
+            .collect();
+
+            let before = scenario_events("codex", &files);
+            let blanked = strip_unread("codex", &files).expect("strip");
+            assert!(blanked > 0, "the codex rollout carries unread subtrees");
+            assert_eq!(scenario_events("codex", &files), before);
+
+            let transcript = std::fs::read_to_string(&files[0]).expect("read");
+            assert!(
+                !transcript.contains("example-skill"),
+                "the roster rides a field no decoder reads, so it leaves"
+            );
+            assert!(
+                transcript.contains("gpt-5.6-sol"),
+                "the model is read, so it stays"
+            );
+            let hooks = std::fs::read_to_string(&files[1]).expect("read");
+            assert!(
+                hooks.contains("01a08cbb-1b7f-7ce3-b924-1a501c380856"),
+                "the hook's session_id keys coalescing, so it stays"
             );
         }
 

--- a/crates/pixtuoid-core/examples/capture_fixture.rs
+++ b/crates/pixtuoid-core/examples/capture_fixture.rs
@@ -120,10 +120,12 @@ mod recorder {
             std::process::exit(1);
         }
 
+        let blanked = strip_unread(&source, &wrote)?;
         write_provenance(
             &dest,
             &cmd,
             &args[2..],
+            blanked,
             &[
                 ("prompt", nonempty_env("CAPTURE_PROMPT")),
                 ("seed", nonempty_env("CAPTURE_SEED")),
@@ -132,6 +134,7 @@ mod recorder {
         for p in &wrote {
             println!("wrote {} ({} lines)", p.display(), count_lines(p));
         }
+        println!("blanked {blanked} subtrees no decoder reads");
         refuse_on_pii(&wrote)?;
         if !status.success() {
             eprintln!("WARNING: the CLI exited {status} — this capture may be truncated");
@@ -355,7 +358,7 @@ mod recorder {
         let out = no_clobber(dest.join("hook-payloads.jsonl"));
         let mut f = std::fs::File::create(&out)?;
         for p in payloads {
-            // The shim already stamped `_pixtuoid_source`; nothing here edits the bytes.
+            // The shim already stamped `_pixtuoid_source`.
             let v: serde_json::Value = serde_json::from_str(p.trim())
                 .unwrap_or_else(|e| panic!("a captured payload is not JSON: {e}: {p:?}"));
             writeln!(f, "{}", serde_json::to_string(&v)?)?;
@@ -367,6 +370,7 @@ mod recorder {
         dest: &Path,
         cmd: &[String],
         raw: &[String],
+        blanked: usize,
         overrides: &[(&str, Option<String>)],
     ) -> std::io::Result<()> {
         let cli = Path::new(&cmd[0])
@@ -387,6 +391,7 @@ mod recorder {
             "version": version.trim(),
             "captured": today(),
             "command": raw.join(" "),
+            "deidentified": { "method": "decoder-allowlist", "blanked": blanked },
         });
         // `command` is the UN-expanded argv, so a scenario driven by an override
         // records a `{prompt}` placeholder and nothing else says what ran. Only
@@ -556,23 +561,112 @@ mod recorder {
     /// A REFUSAL, not a warning. The old form printed to stderr and left the exit
     /// code at 0 on a run that had already written into the repo tree, so the
     /// capturer had to notice a line scrolling past — and twice did not.
-    fn strip_unread(_source: &str, _files: &[PathBuf]) -> std::io::Result<usize> {
-        Ok(0)
+    /// Blank every subtree of the recorded bytes that no decoder reads, so an
+    /// operator's roster, instructions, and paths leave without anyone naming
+    /// them. The allowlist is DERIVED — a subtree is blanked when blanking it
+    /// leaves the file's decoded events identical — because a hand-kept list
+    /// drifts from the decoder in the one direction nothing catches: a field the
+    /// decoder stopped reading stays in the bytes. Probed top-down so an unread
+    /// container collapses whole; 67 blanked entries would still say "67".
+    fn strip_unread(source: &str, files: &[PathBuf]) -> std::io::Result<usize> {
+        let mut blanked = 0;
+        for file in files {
+            let Some(drive) = drive_for(source, file) else {
+                continue;
+            };
+            let Some(mut lines) = parsed_lines(file)? else {
+                continue;
+            };
+            let base = events_of(&drive, &lines);
+            for i in 0..lines.len() {
+                blanked += probe(&drive, &mut lines, &base, i, "");
+            }
+            let mut out = String::new();
+            for line in &lines {
+                out.push_str(&serde_json::to_string(line)?);
+                out.push('\n');
+            }
+            std::fs::write(file, out)?;
+        }
+        Ok(blanked)
     }
 
-    fn scenario_events(source: &str, files: &[PathBuf]) -> Vec<Vec<pixtuoid_core::AgentEvent>> {
-        files
+    fn drive_for(source: &str, file: &Path) -> Option<pixtuoid_core::harness::Drive> {
+        if file.file_name()?.to_str()?.starts_with("hook-payloads") {
+            Some(pixtuoid_core::harness::Drive::hooks())
+        } else {
+            pixtuoid_core::harness::Drive::transcript(source, &file.to_string_lossy())
+        }
+    }
+
+    /// `None` when a line is not JSON: the file is left as recorded rather than
+    /// half-rewritten, and `refuse_on_pii` still reads it.
+    fn parsed_lines(file: &Path) -> std::io::Result<Option<Vec<serde_json::Value>>> {
+        let text = std::fs::read_to_string(file)?;
+        let mut lines = Vec::new();
+        for line in text.lines().filter(|l| !l.trim().is_empty()) {
+            match serde_json::from_str(line) {
+                Ok(v) => lines.push(v),
+                Err(e) => {
+                    eprintln!("not stripping {}: a line is not JSON: {e}", file.display());
+                    return Ok(None);
+                }
+            }
+        }
+        Ok(Some(lines))
+    }
+
+    type Decoded = (Vec<pixtuoid_core::AgentEvent>, usize, usize);
+
+    fn events_of(drive: &pixtuoid_core::harness::Drive, lines: &[serde_json::Value]) -> Decoded {
+        let d = drive.lines(lines.iter().map(serde_json::Value::to_string));
+        (d.events, d.decode_errors.len(), d.panics.len())
+    }
+
+    fn probe(
+        drive: &pixtuoid_core::harness::Drive,
+        lines: &mut [serde_json::Value],
+        base: &Decoded,
+        i: usize,
+        at: &str,
+    ) -> usize {
+        use serde_json::Value;
+        let Some(node) = lines[i].pointer(at) else {
+            return 0;
+        };
+        let neutral = match node {
+            Value::Null => return 0,
+            Value::Bool(_) => Value::Bool(false),
+            Value::Number(_) => Value::from(0),
+            Value::String(_) => Value::String(String::new()),
+            Value::Array(_) => Value::Array(Vec::new()),
+            Value::Object(_) => Value::Object(serde_json::Map::new()),
+        };
+        if *node == neutral {
+            return 0;
+        }
+        let Some(slot) = lines[i].pointer_mut(at) else {
+            return 0;
+        };
+        let kept = std::mem::replace(slot, neutral);
+        if events_of(drive, lines) == *base {
+            return 1;
+        }
+        let children: Vec<String> = match &kept {
+            Value::Array(a) => (0..a.len()).map(|k| format!("{at}/{k}")).collect(),
+            Value::Object(m) => m
+                .keys()
+                .map(|k| format!("{at}/{}", k.replace('~', "~0").replace('/', "~1")))
+                .collect(),
+            _ => Vec::new(),
+        };
+        if let Some(slot) = lines[i].pointer_mut(at) {
+            *slot = kept;
+        }
+        children
             .iter()
-            .filter_map(|f| {
-                let drive = if f.file_name()?.to_str()?.starts_with("hook-payloads") {
-                    pixtuoid_core::harness::Drive::hooks()
-                } else {
-                    pixtuoid_core::harness::Drive::transcript(source, &f.to_string_lossy())?
-                };
-                let text = std::fs::read_to_string(f).ok()?;
-                Some(drive.lines(text.lines()).events)
-            })
-            .collect()
+            .map(|child| probe(drive, lines, base, i, child))
+            .sum()
     }
 
     fn refuse_on_pii(files: &[PathBuf]) -> std::io::Result<()> {
@@ -624,6 +718,16 @@ mod recorder {
     mod tests {
         use super::*;
 
+        fn scenario_events(source: &str, files: &[PathBuf]) -> Vec<Vec<pixtuoid_core::AgentEvent>> {
+            files
+                .iter()
+                .filter_map(|f| {
+                    let text = std::fs::read_to_string(f).ok()?;
+                    Some(drive_for(source, f)?.lines(text.lines()).events)
+                })
+                .collect()
+        }
+
         #[test]
         fn a_module_owned_scenario_is_re_recorded_where_it_lives() {
             let d = tempfile::tempdir().expect("tempdir");
@@ -657,9 +761,6 @@ mod recorder {
             );
         }
 
-        /// The whole de-identification claim on real bytes: a subtree no decoder
-        /// reads is blanked — the roster and every carrier nobody has named yet —
-        /// and what the decoders DO read decodes to the same events afterwards.
         #[test]
         fn stripping_blanks_what_no_decoder_reads_and_changes_no_event() {
             let d = tempfile::tempdir().expect("tempdir");
@@ -695,6 +796,78 @@ mod recorder {
                 hooks.contains("01a08cbb-1b7f-7ce3-b924-1a501c380856"),
                 "the hook's session_id keys coalescing, so it stays"
             );
+        }
+
+        #[test]
+        fn every_committed_scenario_decodes_the_same_once_stripped() {
+            let root = sources_root();
+            let dirs = |p: PathBuf| {
+                std::fs::read_dir(p)
+                    .into_iter()
+                    .flatten()
+                    .flatten()
+                    .map(|e| e.path())
+                    .filter(|p| p.is_dir())
+            };
+            let mut targets: Vec<(String, PathBuf)> = Vec::new();
+            for source in dirs(root.join("fixtures")) {
+                let name = source
+                    .file_name()
+                    .expect("name")
+                    .to_string_lossy()
+                    .into_owned();
+                targets.extend(dirs(source.clone()).map(|s| (name.clone(), s)));
+            }
+            for module in dirs(root.clone()) {
+                let name = module
+                    .file_name()
+                    .expect("name")
+                    .to_string_lossy()
+                    .into_owned();
+                if registry::descriptor_for(&name).is_some() {
+                    targets.extend(dirs(module.join("fixtures")).map(|s| (name.clone(), s)));
+                }
+            }
+
+            let mut walked = BTreeSet::new();
+            for (source, scenario) in targets {
+                let jsonl: Vec<PathBuf> = std::fs::read_dir(&scenario)
+                    .expect("scenario")
+                    .flatten()
+                    .map(|e| e.path())
+                    .filter(|p| p.extension().is_some_and(|x| x == "jsonl"))
+                    .collect();
+                if jsonl.is_empty() {
+                    continue;
+                }
+                let d = tempfile::tempdir().expect("tempdir");
+                let files: Vec<PathBuf> = jsonl
+                    .iter()
+                    .map(|from| {
+                        let to = d.path().join(from.file_name().expect("name"));
+                        std::fs::copy(from, &to).expect("copy");
+                        to
+                    })
+                    .collect();
+                let label = format!(
+                    "{source}/{}",
+                    scenario.file_name().expect("name").to_string_lossy()
+                );
+                let before = scenario_events(&source, &files);
+                strip_unread(&source, &files).expect("strip");
+                assert_eq!(scenario_events(&source, &files), before, "{label}");
+                walked.insert(label);
+            }
+            for sentinel in [
+                "codex/tool-run-recorded",
+                "claude-code/tool-run-recorded",
+                "omp/bridge-run-recorded",
+            ] {
+                assert!(
+                    walked.contains(sentinel),
+                    "walk missed {sentinel}: {walked:?}"
+                );
+            }
         }
 
         /// Every shape that has actually reached a committed fixture past this gate.
@@ -874,7 +1047,7 @@ mod recorder {
             let argv = ["true".to_string()];
 
             let bare = tempfile::tempdir().expect("tempdir");
-            write_provenance(bare.path(), &argv, &argv, &[("prompt", None)]).expect("write");
+            write_provenance(bare.path(), &argv, &argv, 0, &[("prompt", None)]).expect("write");
             assert!(read(bare.path()).get("prompt").is_none());
 
             let set = tempfile::tempdir().expect("tempdir");
@@ -882,6 +1055,7 @@ mod recorder {
                 set.path(),
                 &argv,
                 &argv,
+                0,
                 &[("prompt", Some("read NOTE.txt".into()))],
             )
             .expect("write");

--- a/crates/pixtuoid-core/examples/capture_fixture.rs
+++ b/crates/pixtuoid-core/examples/capture_fixture.rs
@@ -44,9 +44,8 @@ mod recorder {
         "Read NOTE.txt, then list this directory, then read NOTE.txt again.";
 
     /// The workspace path is FIXED and generic on purpose: every payload embeds its
-    /// own cwd and transcript_path, so capturing somewhere already generic is what
-    /// lets the bytes ship unedited. A random sandbox would bake a per-run path into
-    /// them.
+    /// own cwd, the decoders read it, so the strip keeps it — capturing somewhere
+    /// already generic is what keeps a per-run path out of the bytes.
     const WORKSPACE: &str = "/tmp/pixtuoid-capture/proj";
 
     /// A hook can still be in flight when the CLI's own process exits, so the wait
@@ -558,16 +557,13 @@ mod recorder {
         found
     }
 
-    /// A REFUSAL, not a warning. The old form printed to stderr and left the exit
-    /// code at 0 on a run that had already written into the repo tree, so the
-    /// capturer had to notice a line scrolling past — and twice did not.
     /// Blank every subtree of the recorded bytes that no decoder reads, so an
     /// operator's roster, instructions, and paths leave without anyone naming
     /// them. The allowlist is DERIVED — a subtree is blanked when blanking it
     /// leaves the file's decoded events identical — because a hand-kept list
     /// drifts from the decoder in the one direction nothing catches: a field the
     /// decoder stopped reading stays in the bytes. Probed top-down so an unread
-    /// container collapses whole; 67 blanked entries would still say "67".
+    /// container collapses whole, taking its element count with it.
     fn strip_unread(source: &str, files: &[PathBuf]) -> std::io::Result<usize> {
         let mut blanked = 0;
         for file in files {
@@ -578,21 +574,30 @@ mod recorder {
                 continue;
             };
             let base = events_of(&drive, &lines);
+            let stamped = is_hook_envelope(file);
             for i in 0..lines.len() {
-                blanked += probe(&drive, &mut lines, &base, i, "");
+                blanked += probe(&drive, &mut lines, &base, i, "", stamped);
             }
             let mut out = String::new();
             for line in &lines {
                 out.push_str(&serde_json::to_string(line)?);
                 out.push('\n');
             }
-            std::fs::write(file, out)?;
+            let mut tmp = tempfile::NamedTempFile::new_in(file.parent().unwrap_or(Path::new(".")))?;
+            tmp.write_all(out.as_bytes())?;
+            tmp.persist(file).map_err(|e| e.error)?;
         }
         Ok(blanked)
     }
 
+    fn is_hook_envelope(file: &Path) -> bool {
+        file.file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.starts_with("hook-payloads"))
+    }
+
     fn drive_for(source: &str, file: &Path) -> Option<pixtuoid_core::harness::Drive> {
-        if file.file_name()?.to_str()?.starts_with("hook-payloads") {
+        if is_hook_envelope(file) {
             Some(pixtuoid_core::harness::Drive::hooks())
         } else {
             pixtuoid_core::harness::Drive::transcript(source, &file.to_string_lossy())
@@ -616,19 +621,46 @@ mod recorder {
         Ok(Some(lines))
     }
 
-    type Decoded = (Vec<pixtuoid_core::AgentEvent>, usize, usize);
+    type Decoded = (
+        Vec<pixtuoid_core::AgentEvent>,
+        Vec<String>,
+        Vec<String>,
+        Vec<Option<pixtuoid_core::source::daemon::DecodedPresence>>,
+    );
 
+    /// A daemon's envelopes decode to no `AgentEvent` by design — presence rides
+    /// the registry's `presence_decoder` — so it is part of the signature, or a
+    /// daemon capture would strip down to nothing that decodes.
     fn events_of(drive: &pixtuoid_core::harness::Drive, lines: &[serde_json::Value]) -> Decoded {
         let d = drive.lines(lines.iter().map(serde_json::Value::to_string));
-        (d.events, d.decode_errors.len(), d.panics.len())
+        let presence = lines
+            .iter()
+            .map(|line| {
+                let src = line.get("_pixtuoid_source")?.as_str()?;
+                registry::presence_decoder_for(src)?(line).ok()
+            })
+            .collect();
+        let failures = |f: &[pixtuoid_core::harness::LineFailure]| {
+            f.iter().map(|x| format!("{x:?}")).collect::<Vec<_>>()
+        };
+        (
+            d.events,
+            failures(&d.decode_errors),
+            failures(&d.panics),
+            presence,
+        )
     }
 
+    /// A hook envelope's top-level `_` keys are the shim's own stamps, kept by
+    /// namespace: no decoder reads them, but `captures.rs` dates a capture by
+    /// `_shim_ts_ms`, and the probe cannot see that test.
     fn probe(
         drive: &pixtuoid_core::harness::Drive,
         lines: &mut [serde_json::Value],
         base: &Decoded,
         i: usize,
         at: &str,
+        stamped: bool,
     ) -> usize {
         use serde_json::Value;
         let Some(node) = lines[i].pointer(at) else {
@@ -656,6 +688,7 @@ mod recorder {
             Value::Array(a) => (0..a.len()).map(|k| format!("{at}/{k}")).collect(),
             Value::Object(m) => m
                 .keys()
+                .filter(|k| !(stamped && at.is_empty() && k.starts_with('_')))
                 .map(|k| format!("{at}/{}", k.replace('~', "~0").replace('/', "~1")))
                 .collect(),
             _ => Vec::new(),
@@ -665,10 +698,13 @@ mod recorder {
         }
         children
             .iter()
-            .map(|child| probe(drive, lines, base, i, child))
+            .map(|child| probe(drive, lines, base, i, child, stamped))
             .sum()
     }
 
+    /// A REFUSAL, not a warning. The old form printed to stderr and left the exit
+    /// code at 0 on a run that had already written into the repo tree, so the
+    /// capturer had to notice a line scrolling past — and twice did not.
     fn refuse_on_pii(files: &[PathBuf]) -> std::io::Result<()> {
         let found = scan_for_pii(files);
         if found.is_empty() {
@@ -718,14 +754,66 @@ mod recorder {
     mod tests {
         use super::*;
 
-        fn scenario_events(source: &str, files: &[PathBuf]) -> Vec<Vec<pixtuoid_core::AgentEvent>> {
+        fn scenario_events(source: &str, files: &[PathBuf]) -> Vec<Decoded> {
             files
                 .iter()
                 .filter_map(|f| {
-                    let text = std::fs::read_to_string(f).ok()?;
-                    Some(drive_for(source, f)?.lines(text.lines()).events)
+                    let lines = parsed_lines(f).ok()??;
+                    Some(events_of(&drive_for(source, f)?, &lines))
                 })
                 .collect()
+        }
+
+        fn stripped_copy(source: &str, scenario: &str, name: &str) -> (tempfile::TempDir, PathBuf) {
+            let d = tempfile::tempdir().expect("tempdir");
+            let to = d.path().join(name);
+            std::fs::copy(
+                sources_root()
+                    .join("fixtures")
+                    .join(source)
+                    .join(scenario)
+                    .join(name),
+                &to,
+            )
+            .expect("copy");
+            (d, to)
+        }
+
+        #[test]
+        fn a_daemon_capture_keeps_what_its_presence_decoder_reads() {
+            let (_d, hooks) = stripped_copy(
+                "openclaw",
+                "gateway-lifecycle-recorded",
+                "hook-payloads.jsonl",
+            );
+            let files = vec![hooks.clone()];
+            let before = scenario_events("openclaw", &files);
+            strip_unread("openclaw", &files).expect("strip");
+            assert_eq!(scenario_events("openclaw", &files), before);
+            let first = std::fs::read_to_string(&hooks).expect("read");
+            let first = first.lines().next().expect("a line");
+            assert!(
+                first.contains("gateway_start") && first.contains("19099"),
+                "{first}"
+            );
+        }
+
+        #[test]
+        fn the_shim_stamps_survive_the_strip() {
+            let (_d, hooks) =
+                stripped_copy("claude-code", "tool-run-recorded", "hook-payloads.jsonl");
+            let stamps = |p: &Path| -> Vec<serde_json::Value> {
+                parsed_lines(p)
+                    .expect("read")
+                    .expect("json")
+                    .iter()
+                    .map(|l| l["_shim_ts_ms"].clone())
+                    .collect()
+            };
+            let before = stamps(&hooks);
+            assert!(before.iter().all(|v| v.as_i64().is_some_and(|ms| ms > 0)));
+            strip_unread("claude-code", std::slice::from_ref(&hooks)).expect("strip");
+            assert_eq!(stamps(&hooks), before);
         }
 
         #[test]

--- a/crates/pixtuoid-core/tests/sources/captures.rs
+++ b/crates/pixtuoid-core/tests/sources/captures.rs
@@ -422,6 +422,8 @@ fn a_recorded_captures_cli_is_its_trees_binary() {
 /// so a redaction sentinel with a silent `note` is the one state the mechanism
 /// cannot tolerate. Sentinels, not a `/Users/dev` grep: the sweep that keyed on
 /// that alone missed kimi's, whose redaction is a captured `ls -la`'s owner column.
+/// HAND edits only: the recorder's own strip plants no sentinel and discloses
+/// itself through `deidentified` in the provenance, not through `note`.
 #[test]
 fn a_recorded_capture_that_was_edited_says_so() {
     // Placeholders READ from the scanner's own allowlist, never copied: a hand-copy

--- a/crates/pixtuoid-core/tests/sources/fixtures/README.md
+++ b/crates/pixtuoid-core/tests/sources/fixtures/README.md
@@ -24,7 +24,7 @@ redacted cwd and an invented one look alike. `origin` is one of:
 
 | origin | required | means |
 | --- | --- | --- |
-| `recorded` | `cli`, `version`, `captured`, `command` | real wire bytes; the recorder writes this file itself |
+| `recorded` | `cli`, `version`, `captured`, `command` | real wire bytes, stripped of every subtree no decoder reads; the recorder writes this file itself |
 | `composed` | `note` | hand-written, and the note says how you can tell |
 | `unknown` | `note` | predates the rule; nobody recorded where it came from |
 
@@ -36,7 +36,10 @@ the same events. The allowlist is derived by probing the decoders, never listed,
 so it cannot drift from them. `/Users/dev` remains the convention for a home
 path a decoder DOES read, and a capture redacted by hand says so in its `note`:
 without it a reader cannot tell an edited capture from an untouched one, which is
-the distinction the whole mechanism exists to make.
+the distinction the whole mechanism exists to make. A field blanked today stays
+blank in that fixture: a decoder later extended to read it meets the neutral value
+there and its golden encodes "absent" — re-record the scenario when a decoder
+grows a read.
 
 The table above is not the schema — [`provenance.schema.json`](provenance.schema.json)
 is, and both readers (this table and
@@ -91,19 +94,20 @@ and `just capture-fixture` exits 2 there. Windows wire evidence therefore cannot
 be re-recorded on demand — which is why `copilot/tool-run`, the one fixture
 carrying a real Windows `cwd`, stays `unknown` rather than being replaced.
 
-Only ONE edit to a capture is allowed: redact PII. Anything else and it stops
-being evidence. PII is not always a field you can drop — cursor's arrives as a `user_email`
-key, kimi's as the owner column inside a captured `ls -la` `tool_output`, and
-codex's as a `world_state` inventory of every skill installed on the host — so
-read a capture before committing it rather than trusting a key-name filter.
+Only ONE edit is allowed after the recorder's own strip: redact PII the strip
+left behind. Anything else and the capture stops being evidence. PII has
+arrived as cursor's `user_email` key, as the owner column inside a captured
+`ls -la` `tool_output` (kimi), and as codex's `world_state` inventory of every
+skill on the host; the strip takes whatever rides a field no decoder reads, and
+what it leaves sits inside a field one does — a `cwd`, a tool's command string —
+so read a capture before committing it rather than trusting a key-name filter.
 The recorder's `scan_for_pii` sees `$HOME`/`$USER`/`$LOGNAME` AND the
 `PII_MARKERS` identity keys, and `just fixture-pii` re-scans the committed tree
 with gitleaks — but none of them reaches a value it cannot name, which is why a
 capture still gets read. No size heuristic can stand in for that read either:
 legitimate copilot lines run to 39 KB, wider than the `world_state` dump that had
-to go. A line the decoder IGNORES is
-the cheap case — drop it and re-run the golden; byte-identical means the
-redaction cost no evidence.
+to go. Redacting a READ field is the expensive case — re-run the golden;
+byte-identical means the redaction cost no evidence.
 
 **Capture only what pixtuoid's OWN hook registration receives.** A machine can
 carry other tools' hooks on the same events — a debug tee, another integration —

--- a/crates/pixtuoid-core/tests/sources/fixtures/README.md
+++ b/crates/pixtuoid-core/tests/sources/fixtures/README.md
@@ -28,10 +28,15 @@ redacted cwd and an invented one look alike. `origin` is one of:
 | `composed` | `note` | hand-written, and the note says how you can tell |
 | `unknown` | `note` | predates the rule; nobody recorded where it came from |
 
-**A redacted capture says so in its `note`.** The convention is `/Users/dev` for
-the home path; the bytes are otherwise verbatim. Without the note a reader cannot
-tell an edited capture from an untouched one, which is the distinction the whole
-mechanism exists to make.
+**The recorder blanks what no decoder reads before the bytes land**, and
+`deidentified` in the provenance says how many subtrees went. A plugin roster, a
+global-instruction attachment, a stray home path all ride fields the decoders
+never touch, so they leave without anyone naming them, and what stays decodes to
+the same events. The allowlist is derived by probing the decoders, never listed,
+so it cannot drift from them. `/Users/dev` remains the convention for a home
+path a decoder DOES read, and a capture redacted by hand says so in its `note`:
+without it a reader cannot tell an edited capture from an untouched one, which is
+the distinction the whole mechanism exists to make.
 
 The table above is not the schema — [`provenance.schema.json`](provenance.schema.json)
 is, and both readers (this table and

--- a/crates/pixtuoid-core/tests/sources/fixtures/provenance.schema.json
+++ b/crates/pixtuoid-core/tests/sources/fixtures/provenance.schema.json
@@ -3,7 +3,8 @@
   "origins": {
     "recorded": {
       "required": ["cli", "version", "captured", "command"],
-      "means": "real wire bytes; the recorder writes this file itself"
+      "optional": ["prompt", "seed", "deidentified"],
+      "means": "real wire bytes, stripped of every subtree no decoder reads; the recorder writes this file itself"
     },
     "composed": {
       "required": ["note"],


### PR DESCRIPTION
## Summary

The recorder now blanks every subtree of a capture that no decoder reads, before the bytes land. The allowlist is **derived by probing the decoders**, never written down.

## Why

Three re-records in a row (#988, #989, #993) leaked a different class of the operator's fingerprint — the installed plugin/skill/agent roster, a global-instruction attachment, a home path — each caught after the fact and redacted by a new blocklist entry (`PII_MARKERS`, five gitleaks rules, the #995 cardinality gate). Every one of those chases an **open set**: the carrier is whatever the CLI vendor adds next week. #995 is left open as the evidence.

Flip the question. Not "is this field sensitive?" (vendor decides, open) but "does a decoder read it?" (our `source/*.rs` decides, closed). The roster leaves because no decoder reads `payload.content[].text` — not because anyone recognised it as a roster. That covers the carriers nobody has named yet, which is the property no blocklist has.

This is the record-time filter VCR uses (`before_record_response`), with the allowlist-over-blocklist stance the PII literature recommends.

## How

`strip_unread` in `capture_fixture.rs`, after every file is on disk and before `refuse_on_pii`:

- For each recorded file, decode the whole file through its registry drive (`Drive::transcript` / `Drive::hooks`) → the baseline event stream.
- Walk each record **top-down**: replace the subtree with a type-neutral value (`""`/`0`/`false`/`[]`/`{}`); if the whole file still decodes to the same events (and the same decode-error/panic counts), keep it blanked and stop; otherwise restore and descend into the children.
- Top-down matters: an unread container collapses to `[]`, so **cardinality goes too** — 67 blanked entries would still say "67", which is exactly the fingerprint #995 was built to catch.
- Whole-file, not per-line: a cross-line key (codex hook `session_id`, CC hook `session_id`) shows up in every event's agent id, so blanking it changes the stream and it stays. (CC's `transcript_path` is a fallback key only, so on the happy path the probe blanks it — review caught the earlier claim that it survives.)
- **The signature is everything the repo asserts on the bytes, not just `AgentEvent`s.** A daemon's envelopes decode to zero events by design — presence rides the registry's `presence_decoder` — so presence is part of the signature, or an openclaw capture would strip to `{}` lines. Decode errors and panics are compared as values, not counts.
- **A hook envelope's top-level `_` keys are kept by namespace.** They are the shim's own stamps (`_pixtuoid_source`, `_shim_ts_ms`, `_pid`); no decoder reads them, but the provenance-falsifiability test dates a capture by `_shim_ts_ms`, and the probe cannot see that test. No list to drift: the namespace is the rule.
- A hand-kept list would drift from the decoder in the one direction nothing catches (a field the decoder stopped reading stays in the bytes). A probe can't drift: it asks the decoder.
- **A line nothing was blanked in is written back byte-for-byte**, and a rewritten line keeps the wire's key order: the `harness` feature now enables `serde_json/preserve_order`, so the recorder's own `-p pixtuoid-core` build and a workspace build agree (the bot caught the recorder alphabetizing every line — untouched ones included — in the fold head). Write-back is atomic (temp file + rename), so a failed strip leaves the recorded bytes intact.

`provenance.json` gains `"deidentified": {"method": "decoder-allowlist", "blanked": N}`. The schema has no `additionalProperties` restriction, so committed provenance stays valid.

## Evidence

- `stripping_blanks_what_no_decoder_reads_and_changes_no_event` — on the committed codex rollout + hooks (temp copy): decode identical before/after; the placeholder roster is gone; the model name (read) and the hook `session_id` (coalescing key) survive.
- `every_committed_scenario_decodes_the_same_once_stripped` — walks **both** fixture roots (conformance + module-owned), every registered source, comparing the full signature (events, failures, presence): 33+ scenarios strip identically. Whole corpus in 3.4 s; the slowest single scenario (cursor/tool-run, 528 subtrees) takes 725 ms.
- `a_daemon_capture_keeps_what_its_presence_decoder_reads` — openclaw's `gateway_start`/port survive; the review lens reproduced the pre-fix strip reducing that line to `{"_pixtuoid_source":"openclaw", …everything else neutral}`.
- `the_shim_stamps_survive_the_strip` — every `_shim_ts_ms` on the CC hook file is byte-identical after the strip; pre-fix they went to `0` and the provenance date gate would have read `1970-01-01`.
- Byte fidelity: openclaw's `gateway_start` line (every field read or a shim stamp) comes back byte-identical; the first rewritten codex line still starts with `timestamp`, where an alphabetized rewrite starts with `ordinal`.
- On the codex rollout: 216 subtrees blanked; the decoder's own read set is 9 fields (effort/model/name/type/token counts), all structural.

What a stripped file looks like: unread record types become `{}`; a read record keeps its read fields and its siblings are neutralised in place. Sparse by design — conformance, not the fixture, documents the wire.

## What the strip does NOT do

It keeps every field a decoder reads, and some of those carry identity: `cwd` (a real path), a tool's command string, a `session_id` that happens to be a path. `refuse_on_pii` and the gitleaks identity rules stay as the live backstop for exactly that residue; the README now says so in one sentence.

A field blanked today stays blank in that fixture. A decoder later extended to read it meets the neutral value and its golden encodes "absent" — re-record the scenario when a decoder grows a read (README).

## Scope

- Only NEW captures are stripped. The committed corpus is untouched here; re-stripping it offline (no billed turn — the strip is local) is a follow-up, as is retiring #995's gate once the corpus has been through this.
- `refuse_on_pii` stays as the key-level backstop.
- The rule relaxation is the owner's call, made in-thread: "fixtures are recorded, never composed" holds — nothing is invented — but a recorded byte the decoders never read no longer ships. README and CLAUDE.md say so in the same commit.

## Comments

18 added comment lines across the two commits, each delete-tested: the derived-not-listed constraint and the top-down/cardinality reason (`strip_unread`); why presence is in the signature (`events_of`); why the `_` namespace is kept (`probe`); the not-JSON fallback (`parsed_lines`); hand-vs-machine edits on the edited-capture test. Two pre-existing docs were corrected because the strip made them false (`WORKSPACE`, `write_payloads`), and one that my insertion had stolen from `refuse_on_pii` was put back.

## Type of change

- [x] New feature (recorder)
- [x] Docs (README, CLAUDE.md bullet)

## Checklist

- [x] TDD: red commit then green.
- [x] `just lint`, `just test` green locally.
- [ ] `just preflight` runs on push.

## AI assistance

- [x] Written by an AI agent under the owner's direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B875vtxMVrdmypiEZgDNSX
